### PR TITLE
FB125649: unregister receivers

### DIFF
--- a/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/dalvik/activities/CommCareSetupActivity.java
@@ -153,7 +153,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 	boolean resourceTableWasFresh;
 	static final long START_OVER_THRESHOLD = 604800000; //1 week in milliseconds
 	
-
+	private BroadcastReceiver purgeNotificationReceiver = null;
 	
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -288,12 +288,13 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
 		// Hide "See More" button when notification is cleared
 		// (by any method: button press, viewing from drawer, or clearing from drawer)
-		registerReceiver(new BroadcastReceiver() {
+		purgeNotificationReceiver = new BroadcastReceiver() {
 			@Override
 			public void onReceive(Context context, Intent intent) {
 				viewNotificationButton.setVisibility(View.GONE);
 			}
-		}, new IntentFilter(CommCareApplication.ACTION_PURGE_NOTIFICATIONS));
+		};
+		registerReceiver(purgeNotificationReceiver, new IntentFilter(CommCareApplication.ACTION_PURGE_NOTIFICATIONS));
 
 		// "See More" launches standard notification-viewing activity
 		viewNotificationButton.setOnClickListener(new OnClickListener() {
@@ -354,6 +355,13 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         //prevent the keyboard from popping up on entry by refocusing on the main layout
         findViewById(R.id.mainLayout).requestFocus();
         
+	}
+	
+	@Override
+	public void onDestroy() {
+		if (purgeNotificationReceiver != null) {
+			unregisterReceiver(purgeNotificationReceiver);
+		}
 	}
 	
 	public void refreshView(){


### PR DESCRIPTION
Aliza reported seeing stack traces related to leaking IntentReceiver, presumably because I never unregister the BroadcastReceiver that listens for when user clears their notifications.
