### PR TITLE
Fix for bug with new progress dialogs

### DIFF
--- a/app/src/org/commcare/android/framework/CommCareActivity.java
+++ b/app/src/org/commcare/android/framework/CommCareActivity.java
@@ -629,7 +629,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity implements Co
 	public void dismissProgressDialog() {
 		CustomProgressDialog mProgressDialog = getCurrentDialog();
 		if (mProgressDialog != null && mProgressDialog.isAdded()) {
-			mProgressDialog.dismiss();
+			mProgressDialog.dismissAllowingStateLoss();
 		}
 	}
 	


### PR DESCRIPTION
Bug fix- Changed dismiss() to dismissAllowingStateLoss(), so that dialog can be dismissed at end of AsyncTask without causing crash. (This is how I had it for a long and at some point switched for experimentation purposes, and forgot to switch back).
