### PR TITLE
Dialog message fix

### DIFF
--- a/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
+++ b/app/src/org/commcare/dalvik/dialogs/CustomProgressDialog.java
@@ -114,7 +114,6 @@ public class CustomProgressDialog extends DialogFragment {
 	        this.usingCancelButton = savedInstanceState.getBoolean(KEY_USING_BUTTON);
 	        this.taskId = savedInstanceState.getInt(KEY_TASK_ID);
 	        this.isCancelable = savedInstanceState.getBoolean(KEY_CANCELABLE);
-	        
     	}
     }
 


### PR DESCRIPTION
Setting member variable 'message' to the update text, so that a dialog message is still preserved on rotation once updateMessage has been called.
