### PR TITLE
Enable pan and zoom setting

### DIFF
--- a/app/src/org/commcare/android/view/GraphView.java
+++ b/app/src/org/commcare/android/view/GraphView.java
@@ -211,7 +211,11 @@ public class GraphView {
 		mRenderer.setApplyBackgroundColor(true);
 		mRenderer.setShowLegend(false);
 		mRenderer.setShowGrid(true);
-		mRenderer.setPanEnabled(false, false);
+
+        boolean panAndZoom = Boolean.valueOf(mData.getConfiguration("zoom", "false")).equals(Boolean.TRUE);
+        mRenderer.setPanEnabled(panAndZoom);
+        mRenderer.setZoomEnabled(panAndZoom);
+        mRenderer.setZoomButtonsVisible(panAndZoom);
 
 		// User-configurable options
 		mRenderer.setXTitle(mData.getConfiguration("x-axis-title", ""));


### PR DESCRIPTION
Enable basic pan and zoom. This supports pinch to zoom and drag to pan. It also turns on zoom buttons.

I'd like to do fancier things, because it can be difficult to pinch and drag when you're already on a scrolling screen, but we might as well get some feedback on just how good/bad that experience is.
