### PR TITLE
Don't crash on xpath exception

### DIFF
--- a/app/src/org/commcare/android/models/NodeEntityFactory.java
+++ b/app/src/org/commcare/android/models/NodeEntityFactory.java
@@ -78,8 +78,11 @@ public class NodeEntityFactory {
             } catch(XPathException xpe) {
                 xpe.printStackTrace();
                 details[count] = "<invalid xpath: " + xpe.getMessage() + ">";
+                backgroundDetails[count] = "";
             } catch (XPathSyntaxException e) {
                 e.printStackTrace();
+                details[count] = "<invalid xpath: " + e.getMessage() + ">";
+                backgroundDetails[count] = "";
             }
             count++;
         }


### PR DESCRIPTION
XPath errors are causing NullPointerExceptions in GridEntityView, because backgroundDetails can't contain nulls.
