### PR TITLE
Drop usage of new LayoutParams constructor

### DIFF
--- a/app/src/org/commcare/android/view/EntityDetailView.java
+++ b/app/src/org/commcare/android/view/EntityDetailView.java
@@ -26,6 +26,7 @@ import android.view.Display;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.FrameLayout;
@@ -223,7 +224,7 @@ public class EntityDetailView extends FrameLayout {
 
             if (current != GRAPH) {
                 // Hide field label and expand value to take up full screen width
-                LinearLayout.LayoutParams graphValueLayout = new LinearLayout.LayoutParams(origValue);
+                LinearLayout.LayoutParams graphValueLayout = new LinearLayout.LayoutParams((ViewGroup.LayoutParams)origValue);
                 graphValueLayout.weight = 10;
                 valuePane.setLayoutParams(graphValueLayout);
 
@@ -304,7 +305,7 @@ public class EntityDetailView extends FrameLayout {
         
         if (current != GRAPH) {
             label.setVisibility(View.VISIBLE);
-            LinearLayout.LayoutParams graphValueLayout = new LinearLayout.LayoutParams(origValue);
+            LinearLayout.LayoutParams graphValueLayout = new LinearLayout.LayoutParams((ViewGroup.LayoutParams)origValue);
             graphValueLayout.weight = 10;
             valuePane.setLayoutParams(origValue);
         }


### PR DESCRIPTION
Fix for FB 144840.

Pre-KitKat devices are crashing because they don't have the constructor "public LinearLayout.LayoutParams (LinearLayout.LayoutParams source)"

Fixing by adding cast so the constructor "public LinearLayout.LayoutParams (ViewGroup.LayoutParams p)" will be used instead.

See http://developer.android.com/reference/android/widget/LinearLayout.LayoutParams.html#LinearLayout.LayoutParams(android.view.ViewGroup.LayoutParams)

and http://stackoverflow.com/questions/21200522/android-java-lang-nosuchmethoderror-on-linearlayoutlayoutparams-init
