### PR TITLE
Fix for API level 8 compatibility

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -11,7 +11,6 @@
      
     <application
         android:name=".application.CommCareApplication"
-        android:debuggable="true"
         android:icon="@drawable/icon"
         android:label="@string/application_name"
         android:theme="@style/AppBaseTheme" >
@@ -306,7 +305,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-sdk
-        android:minSdkVersion="9"
+        android:minSdkVersion="8"
         android:targetSdkVersion="14" >
     </uses-sdk>
 


### PR DESCRIPTION
Moved one of the string normalization calls in search matching behind a version flag so the app will still work on API versions pre-8.
