### PR TITLE
2.28 consumer apps tweaks

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -299,14 +299,15 @@ public class CommCareApplication extends Application {
         }
     }
 
-    public void startUserSession(byte[] symetricKey, UserKeyRecord record, boolean restoreSession) {
+    public void startUserSession(byte[] symmetricKey, UserKeyRecord record, boolean restoreSession) {
         synchronized (serviceLock) {
             // if we already have a connection established to
             // CommCareSessionService, close it and open a new one
+            SessionActivityRegistration.unregisterSessionExpiration();
             if (this.mIsBound) {
                 releaseUserResourcesAndServices();
             }
-            bindUserSessionService(symetricKey, record, restoreSession);
+            bindUserSessionService(symmetricKey, record, restoreSession);
         }
     }
 

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -172,10 +172,6 @@ public class CommCareHomeActivity
         processFromExternalLaunch(savedInstanceState);
         processFromShortcutLaunch();
         processFromLoginLaunch();
-
-        if (CommCareApplication._().isConsumerApp()) {
-            ConsumerAppsUtil.checkForChangedLocalRestoreFile(this);
-        }
     }
 
     private void loadInstanceState(Bundle savedInstanceState) {

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -1120,7 +1120,6 @@ public class CommCareHomeActivity
             handlePendingSync();
         } else if (CommCareApplication._().isConsumerApp() && !sessionNavigationProceedingAfterOnResume) {
             // so that the user never sees the real home screen in a consumer app
-            sessionNavigationProceedingAfterOnResume = false;
             enterRootModule();
         } else {
             // Display the normal home screen!

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -374,9 +374,9 @@ public class CommCareHomeActivity
     void enterRootModule() {
         Intent i;
         if (useGridMenu(org.commcare.suite.model.Menu.ROOT_MENU_ID)) {
-            i = new Intent(getApplicationContext(), MenuGrid.class);
+            i = new Intent(this, MenuGrid.class);
         } else {
-            i = new Intent(getApplicationContext(), MenuList.class);
+            i = new Intent(this, MenuList.class);
         }
         addPendingDataExtra(i, CommCareApplication._().getCurrentSessionWrapper().getSession());
         startActivityForResult(i, GET_COMMAND);
@@ -863,9 +863,9 @@ public class CommCareHomeActivity
         String command = asw.getSession().getCommand();
 
         if (useGridMenu(command)) {
-            i = new Intent(getApplicationContext(), MenuGrid.class);
+            i = new Intent(this, MenuGrid.class);
         } else {
-            i = new Intent(getApplicationContext(), MenuList.class);
+            i = new Intent(this, MenuList.class);
         }
         i.putExtra(SessionFrame.STATE_COMMAND_ID, command);
         addPendingDataExtra(i, asw.getSession());
@@ -1121,7 +1121,7 @@ public class CommCareHomeActivity
             handlePendingSync();
         } else if (CommCareApplication._().isConsumerApp() && !sessionNavigationProceedingAfterOnResume) {
             // so that the user never sees the real home screen in a consumer app
-            enterRootModule();
+            //enterRootModule();
         } else {
             // Display the normal home screen!
             uiController.refreshView();

--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -1099,7 +1099,6 @@ public class CommCareHomeActivity
             refreshActionBar();
         }
         attemptDispatchHomeScreen();
-
         sessionNavigationProceedingAfterOnResume = false;
     }
 
@@ -1121,7 +1120,8 @@ public class CommCareHomeActivity
             handlePendingSync();
         } else if (CommCareApplication._().isConsumerApp() && !sessionNavigationProceedingAfterOnResume) {
             // so that the user never sees the real home screen in a consumer app
-            //enterRootModule();
+            sessionNavigationProceedingAfterOnResume = false;
+            enterRootModule();
         } else {
             // Display the normal home screen!
             uiController.refreshView();

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -35,6 +35,7 @@ public class DispatchActivity extends FragmentActivity {
     private static final int LOGIN_USER = 0;
     private static final int HOME_SCREEN = 1;
     public static final int INIT_APP = 2;
+    public static final int UPDATE_CONSUMER_APP = 3;
 
     /**
      * Request code for automatically validating media.
@@ -114,8 +115,8 @@ public class DispatchActivity extends FragmentActivity {
 
     private void checkForChangedCCZ() {
         alreadyCheckedForAppFilesChange = true;
-        Intent i = new Intent(getApplicationContext(), UpdateActivity.class);
-        startActivity(i);
+        Intent i = new Intent(this, UpdateActivity.class);
+        startActivityForResult(i, UPDATE_CONSUMER_APP);
     }
 
     private void dispatch() {

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -124,11 +124,6 @@ public class DispatchActivity extends FragmentActivity {
             return;
         }
 
-        if (CommCareApplication._().isConsumerApp() && !alreadyCheckedForAppFilesChange) {
-            checkForChangedCCZ();
-            return;
-        }
-
         CommCareApp currentApp = CommCareApplication._().getCurrentApp();
 
         if (currentApp == null) {
@@ -136,12 +131,17 @@ public class DispatchActivity extends FragmentActivity {
                 CommCareApplication._().initFirstUsableAppRecord();
                 // Recurse in order to make the correct decision based on the new state
                 dispatch();
+                return;
             } else {
                 Intent i = new Intent(getApplicationContext(), CommCareSetupActivity.class);
                 this.startActivityForResult(i, INIT_APP);
             }
         } else {
             // Note that the order in which these conditions are checked matters!!
+            if (CommCareApplication._().isConsumerApp() && !alreadyCheckedForAppFilesChange) {
+                checkForChangedCCZ();
+                return;
+            }
 
             ApplicationRecord currentRecord = currentApp.getAppRecord();
             try {

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -126,6 +126,7 @@ public class DispatchActivity extends FragmentActivity {
 
         if (CommCareApplication._().isConsumerApp() && !alreadyCheckedForAppFilesChange) {
             checkForChangedCCZ();
+            return;
         }
 
         CommCareApp currentApp = CommCareApplication._().getCurrentApp();

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -35,7 +35,6 @@ public class DispatchActivity extends FragmentActivity {
     private static final int LOGIN_USER = 0;
     private static final int HOME_SCREEN = 1;
     public static final int INIT_APP = 2;
-    public static final int UPDATE_CONSUMER_APP = 3;
 
     /**
      * Request code for automatically validating media.
@@ -116,7 +115,7 @@ public class DispatchActivity extends FragmentActivity {
     private void checkForChangedCCZ() {
         alreadyCheckedForAppFilesChange = true;
         Intent i = new Intent(this, UpdateActivity.class);
-        startActivityForResult(i, UPDATE_CONSUMER_APP);
+        startActivity(i);
     }
 
     private void dispatch() {
@@ -132,7 +131,6 @@ public class DispatchActivity extends FragmentActivity {
                 CommCareApplication._().initFirstUsableAppRecord();
                 // Recurse in order to make the correct decision based on the new state
                 dispatch();
-                return;
             } else {
                 Intent i = new Intent(getApplicationContext(), CommCareSetupActivity.class);
                 this.startActivityForResult(i, INIT_APP);

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -247,6 +247,10 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
         uiController.downloadingUiState();
     }
 
+    /**
+     * Since updates in a consumer app do not use the normal UpdateActivity UI, use an
+     * alternative method of displaying the update check's progress in that case
+     */
     private void initUpdateTaskProgressDisplay() {
         if (CommCareApplication._().isConsumerApp()) {
             showProgressDialog(DIALOG_CONSUMER_APP_UPGRADE);
@@ -330,11 +334,11 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
                     + "any valid possibilities in CommCareSetupActivity");
             return null;
         } else {
-            return generateNormalUpdateDialog(taskId);
+            return generateNormalUpdateInstallDialog(taskId);
         }
     }
 
-    private static CustomProgressDialog generateNormalUpdateDialog(int taskId) {
+    private static CustomProgressDialog generateNormalUpdateInstallDialog(int taskId) {
         String title = Localization.get("updates.installing.title");
         String message = Localization.get("updates.installing.message");
         CustomProgressDialog dialog =

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -38,6 +38,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
     private static final String IS_APPLYING_UPDATE_KEY = "applying_update_task_running";
 
     private static final int DIALOG_UPGRADE_INSTALL = 6;
+    private static final int DIALOG_CONSUMER_APP_UPGRADE = 7;
 
     private boolean taskIsCancelling;
     private boolean isApplyingUpdate;
@@ -183,27 +184,26 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
 
     @Override
     public void handleTaskCompletion(AppInstallStatus result) {
+        if (CommCareApplication._().isConsumerApp()) {
+            dismissProgressDialog();
+        }
+
         if (result == AppInstallStatus.UpdateStaged) {
             uiController.unappliedUpdateAvailableUiState();
             if (proceedAutomatically) {
                 launchUpdateInstallTask();
-                return;
             }
         } else if (result == AppInstallStatus.UpToDate) {
             uiController.upToDateUiState();
             if (proceedAutomatically) {
-                unregisterTask();
                 finishWithResult(RefreshToLatestBuildActivity.ALREADY_UP_TO_DATE);
-                return;
             }
         } else {
             // Gives user generic failure warning; even if update staging
             // failed for a specific reason like xml syntax
             uiController.checkFailedUiState();
             if (proceedAutomatically) {
-                unregisterTask();
                 finishWithResult(RefreshToLatestBuildActivity.UPDATE_ERROR);
-                return;
             }
         }
 
@@ -228,7 +228,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
     protected void startUpdateCheck() {
         try {
             updateTask = UpdateTask.getNewInstance();
-            updateTask.startPinnedNotification(this);
+            initUpdateTaskProgressDisplay();
             if (isLocalUpdate) {
                 updateTask.setLocalAuthority();
             }
@@ -245,6 +245,14 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
         String ref = ResourceInstallUtils.getDefaultProfileRef();
         updateTask.executeParallel(ref);
         uiController.downloadingUiState();
+    }
+
+    private void initUpdateTaskProgressDisplay() {
+        if (CommCareApplication._().isConsumerApp()) {
+            showProgressDialog(DIALOG_CONSUMER_APP_UPGRADE);
+        } else {
+            updateTask.startPinnedNotification(this);
+        }
     }
 
     private void connectToRunningTask() {
@@ -315,13 +323,12 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
 
     @Override
     public CustomProgressDialog generateProgressDialog(int taskId) {
-        if (taskId != DIALOG_UPGRADE_INSTALL) {
+        if (CommCareApplication._().isConsumerApp()) {
+            return ConsumerAppsUtil.getGenericConsumerAppsProgressDialog(taskId, false);
+        } else if (taskId != DIALOG_UPGRADE_INSTALL) {
             Log.w(TAG, "taskId passed to generateProgressDialog does not match "
                     + "any valid possibilities in CommCareSetupActivity");
             return null;
-        }
-        if (CommCareApplication._().isConsumerApp()) {
-            return ConsumerAppsUtil.getGenericConsumerAppsProgressDialog(taskId, false);
         } else {
             return generateNormalUpdateDialog(taskId);
         }

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -280,21 +280,25 @@ public class CommCareSessionService extends Service {
 
             this.sessionExpireDate = new Date(new Date().getTime() + sessionLength);
 
-            // Display a notification about us starting.  We put an icon in the status bar.
             if (!CommCareApplication._().isConsumerApp()) {
+                // Put an icon in the status bar for the session, and set up session expiration
+                // (unless this is a consumer app)
                 showLoggedInNotification(user);
+                setUpSessionExpirationTimer();
+            }
+        }
+    }
+
+    private void setUpSessionExpirationTimer() {
+        maintenanceTimer = new Timer("CommCareService");
+        maintenanceTimer.schedule(new TimerTask() {
+
+            @Override
+            public void run() {
+                timeToExpireSession();
             }
 
-            maintenanceTimer = new Timer("CommCareService");
-            maintenanceTimer.schedule(new TimerTask() {
-
-                @Override
-                public void run() {
-                    timeToExpireSession();
-                }
-
-            }, MAINTENANCE_PERIOD, MAINTENANCE_PERIOD);
-        }
+        }, MAINTENANCE_PERIOD, MAINTENANCE_PERIOD);
     }
 
     /**
@@ -303,11 +307,6 @@ public class CommCareSessionService extends Service {
      * progess then don't do anything.
      */
     private void timeToExpireSession() {
-        if (CommCareApplication._().isConsumerApp()) {
-            // Never expire the session if this is a consumer app
-            return;
-        }
-
         long currentTime = new Date().getTime();
 
         // If logout process started and has taken longer than the logout

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -281,7 +281,9 @@ public class CommCareSessionService extends Service {
             this.sessionExpireDate = new Date(new Date().getTime() + sessionLength);
 
             // Display a notification about us starting.  We put an icon in the status bar.
-            showLoggedInNotification(user);
+            if (!CommCareApplication._().isConsumerApp()) {
+                showLoggedInNotification(user);
+            }
 
             maintenanceTimer = new Timer("CommCareService");
             maintenanceTimer.schedule(new TimerTask() {
@@ -301,6 +303,11 @@ public class CommCareSessionService extends Service {
      * progess then don't do anything.
      */
     private void timeToExpireSession() {
+        if (CommCareApplication._().isConsumerApp()) {
+            // Never expire the session if this is a consumer app
+            return;
+        }
+
         long currentTime = new Date().getTime();
 
         // If logout process started and has taken longer than the logout

--- a/app/src/org/commcare/utils/SessionActivityRegistration.java
+++ b/app/src/org/commcare/utils/SessionActivityRegistration.java
@@ -74,6 +74,12 @@ public class SessionActivityRegistration {
         }
     }
 
+    public static void unregisterSessionExpiration() {
+        synchronized (registrationLock) {
+            unredirectedSessionExpiration = false;
+        }
+    }
+
     /**
      * Launch the DispatchActivity, clearing the activity backstack down
      * to its first occurrence, which should be at the very bottom of the


### PR DESCRIPTION
Final changes for consumer apps:
-Show a progress dialog during the update check portion of an update, so that the screen isn't just blank
-Fix an activity navigation bug that was occurring after updating to a new .ccz 
-At least for v1 release, don't do anything with the new restore file on an upgrade
-Don't show the logged in notification for a consumer apps session, and never time out the session