### PR TITLE
Re-enable new end-of-form navigation animation

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -74,13 +74,6 @@
         android:key="cc-fire-triggers-on-save"
         android:title="Fire triggers on form save"/>
     <ListPreference
-        android:defaultValue="no"
-        android:enabled="true"
-        android:entries="@array/pref_enabled_labels"
-        android:entryValues="@array/pref_enabled_vals"
-        android:key="cc-animate-form-submit-button"
-        android:title="Animate form submit button"/>
-    <ListPreference
         android:enabled="true"
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"

--- a/app/src/org/commcare/activities/components/FormNavigationUI.java
+++ b/app/src/org/commcare/activities/components/FormNavigationUI.java
@@ -94,20 +94,15 @@ public class FormNavigationUI {
                                      final ClippingFrame finishButton,
                                      FormNavigationController.NavigationDetails details,
                                      ProgressBar progressBar) {
-        if (DeveloperPreferences.shouldAnimateFormSubmitButton()) {
-            if (nextButton.getTag() == null) {
-                setFinishVisible(finishButton);
-            } else if (!FormEntryActivity.NAV_STATE_DONE.equals(nextButton.getTag())) {
-                nextButton.setTag(FormEntryActivity.NAV_STATE_DONE);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                    expandAndShowFinishButton(context, finishButton);
-                } else {
-                    setFinishVisible(finishButton);
-                }
-            }
-        } else {
-            nextButton.setImageResource(R.drawable.icon_chevron_right_attnpos);
+        if (nextButton.getTag() == null) {
+            setFinishVisible(finishButton);
+        } else if (!FormEntryActivity.NAV_STATE_DONE.equals(nextButton.getTag())) {
             nextButton.setTag(FormEntryActivity.NAV_STATE_DONE);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                expandAndShowFinishButton(context, finishButton);
+            } else {
+                setFinishVisible(finishButton);
+            }
         }
 
         progressBar.setProgressDrawable(context.getResources().getDrawable(R.drawable.progressbar_full));
@@ -155,16 +150,11 @@ public class FormNavigationUI {
                                               ClippingFrame finishButton,
                                               FormNavigationController.NavigationDetails details,
                                               ProgressBar progressBar) {
-        if (DeveloperPreferences.shouldAnimateFormSubmitButton()) {
-            if (!FormEntryActivity.NAV_STATE_NEXT.equals(nextButton.getTag())) {
-                nextButton.setTag(FormEntryActivity.NAV_STATE_NEXT);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                    finishButton.setVisibility(View.GONE);
-                }
-            }
-        } else {
-            nextButton.setImageResource(R.drawable.icon_chevron_right_brand);
+        if (!FormEntryActivity.NAV_STATE_NEXT.equals(nextButton.getTag())) {
             nextButton.setTag(FormEntryActivity.NAV_STATE_NEXT);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                finishButton.setVisibility(View.GONE);
+            }
         }
 
         progressBar.setProgressDrawable(context.getResources().getDrawable(R.drawable.progressbar_modern));
@@ -194,13 +184,8 @@ public class FormNavigationUI {
             }
         });
 
-        if (DeveloperPreferences.shouldAnimateFormSubmitButton()) {
-            View finishButton = activity.findViewById(R.id.nav_image_finish);
-            finishButton.startAnimation(growShrinkAnimation);
-        } else {
-            ImageButton nextButton = (ImageButton)activity.findViewById(R.id.nav_btn_next);
-            nextButton.startAnimation(growShrinkAnimation);
-        }
+        View finishButton = activity.findViewById(R.id.nav_image_finish);
+        finishButton.startAnimation(growShrinkAnimation);
     }
 
     private static void setFinishVisible(ClippingFrame finishButton) {

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -59,7 +59,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
      * triggers.
      */
     public final static String FIRE_TRIGGERS_ON_SAVE = "cc-fire-triggers-on-save";
-    public final static String ANIMATE_FORM_SUBMIT_BUTTON = "cc-animate-form-submit-button";
     public final static String ALTERNATE_QUESTION_LAYOUT_ENABLED = "cc-alternate-question-text-format";
 
     public final static String OFFER_PIN_FOR_LOGIN = "cc-offer-pin-for-login";
@@ -100,7 +99,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
         prefKeyToAnalyticsEvent.put(MARKDOWN_ENABLED, GoogleAnalyticsFields.LABEL_MARKDOWN);
         prefKeyToAnalyticsEvent.put(ALTERNATE_QUESTION_LAYOUT_ENABLED, GoogleAnalyticsFields.LABEL_IMAGE_ABOVE_TEXT);
         prefKeyToAnalyticsEvent.put(FIRE_TRIGGERS_ON_SAVE, GoogleAnalyticsFields.LABEL_TRIGGERS_ON_SAVE);
-        prefKeyToAnalyticsEvent.put(ANIMATE_FORM_SUBMIT_BUTTON, GoogleAnalyticsFields.LABEL_ANIMATE_FORM_SUBMIT_BUTTON);
         prefKeyToAnalyticsEvent.put(HOME_REPORT_ENABLED, GoogleAnalyticsFields.LABEL_REPORT_BUTTON_ENABLED);
         prefKeyToAnalyticsEvent.put(AUTO_PURGE_ENABLED, GoogleAnalyticsFields.LABEL_AUTO_PURGE);
         prefKeyToAnalyticsEvent.put(LOAD_FORM_PAYLOAD_AS, GoogleAnalyticsFields.LABEL_LOAD_FORM_PAYLOAD_AS);
@@ -261,11 +259,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static boolean shouldFireTriggersOnSave() {
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
         return properties.getString(FIRE_TRIGGERS_ON_SAVE, CommCarePreferences.NO).equals(CommCarePreferences.YES);
-    }
-
-    public static boolean shouldAnimateFormSubmitButton() {
-        SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
-        return properties.getString(ANIMATE_FORM_SUBMIT_BUTTON, CommCarePreferences.NO).equals(CommCarePreferences.YES);
     }
 
     public static boolean isAutoLoginEnabled() {


### PR DESCRIPTION
Enable @ctsims new end-of-form navigation animation / button by default. Removes the ability to turn it off in the developer options.

Undoes work by https://github.com/dimagi/commcare-android/pull/1208 and https://github.com/dimagi/commcare-android/pull/1228

**Release Notes**: new end-of-form navigation animation