### PR TITLE
Remove padding from case list columns that have small widths

### DIFF
--- a/app/res/layout/component_text.xml
+++ b/app/res/layout/component_text.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                style="@style/EntityItemTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/entity_view_text"
-        style="@style/EntityItemTextView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"

--- a/app/src/org/commcare/views/EntityView.java
+++ b/app/src/org/commcare/views/EntityView.java
@@ -589,6 +589,7 @@ public class EntityView extends LinearLayout {
         int i = 0;
         for (View view : views) {
             if (view != null) {
+                adjustPadding(view, widths[i]);
                 LayoutParams params = (LinearLayout.LayoutParams) view.getLayoutParams();
                 params.width = widths[i];
                 view.setLayoutParams(params);
@@ -603,5 +604,15 @@ public class EntityView extends LinearLayout {
 
         // Re-calculate the view's measurements based on the percentage adjustments above
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+    }
+
+    /**
+     * Remove view's if the padding is greater than or close to the view's width.
+     */
+    private static void adjustPadding(View view, int width) {
+        int horizontalPadding = view.getPaddingLeft() + view.getPaddingRight();
+        if (horizontalPadding >= width || horizontalPadding / (float)width > 0.9f) {
+            view.setPadding(0, 0, 0, 0);
+        }
     }
 }


### PR DESCRIPTION
Case list columns have the ability to set width percentages. On small devices, it might turn out that the width calculated for a column is smaller or super close to the padding size of that column. 

This PR removes the column's horizontal padding when its size is too close to the width allotted for the column.

Before:
![screenshot_20160628-170653](https://cloud.githubusercontent.com/assets/94817/16432387/b7ee4a38-3d52-11e6-897b-ca9f66d1bc8b.png)

After:
![screenshot_20160628-170528](https://cloud.githubusercontent.com/assets/94817/16432368/99744864-3d52-11e6-80ef-41ef657b38b4.png)

Ticket: http://manage.dimagi.com/default.asp?230152