### PR TITLE
Catch invalid xpath funcs in new repeat

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -107,6 +107,7 @@ import org.javarosa.model.xform.XFormsModule;
 import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathTypeMismatchException;
+import org.javarosa.xpath.XPathUnhandledException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -1241,7 +1242,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 dialog.dismiss();
                 try {
                     mFormController.newRepeat();
-                } catch (XPathTypeMismatchException | XPathArityException e) {
+                } catch (XPathUnhandledException | XPathTypeMismatchException | XPathArityException e) {
                     Logger.exception(e);
                     UserfacingErrorHandling.logErrorAndShowDialog(FormEntryActivity.this, e, EXIT);
                     return;


### PR DESCRIPTION
If an invalid xpath function is referenced in repeat creation logic, we should show that error to the user.

```
org.javarosa.xpath.XPathUnhandledException: The problem was located in calculate expression for /test/birth_history/age_calc
XPath evaluation: cannot handle function 'nt'
   at org.javarosa.xpath.expr.XPathFuncExpr.evalRaw(XPathFuncExpr.java:448)
   at org.javarosa.xpath.expr.XPathExpression.eval(XPathExpression.java:25)
   at org.javarosa.xpath.XPathConditional.evalRaw(XPathConditional.java:46)
   at org.javarosa.core.model.condition.Recalculate.eval(Recalculate.java:35)
   at org.javarosa.core.model.condition.Triggerable.apply(Triggerable.java:143)
   at org.javarosa.core.model.FormDef.evaluateTriggerable(FormDef.java:1094)
   at org.javarosa.core.model.FormDef.evaluateTriggerables(FormDef.java:1072)
   at org.javarosa.core.model.FormDef.initTriggerablesRootedBy(FormDef.java:1008)
   at org.javarosa.core.model.FormDef.createNewRepeat(FormDef.java:408)
   at org.javarosa.form.api.FormEntryController.newRepeat(FormEntryController.java:325)
   at org.javarosa.form.api.FormEntryController.newRepeat(FormEntryController.java:337)
   at org.commcare.logic.FormController.newRepeat(FormController.java:333)
   at org.commcare.activities.FormEntryActivity$7.onClick(FormEntryActivity.java:1243)
```

http://manage.dimagi.com/default.asp?231102