### PR TITLE
Revert change to 'quick' attribute behavior in question list

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -2083,7 +2083,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
     @Override
     public void advance() {
-        if (!questionsView.isQuestionList() && canNavigateForward()) {
+        if (canNavigateForward()) {
             next();
         }
     }


### PR DESCRIPTION
In this PR https://github.com/dimagi/commcare-android/pull/1126, I had made it so that auto-advancing (triggered by the 'quick' attribute on a question) would not work on questions in a question list. My logic at the time was that it would be undesirable for auto-advance to occur if not all questions in the list were answered yet. However, this change caused a regression in functionality for an app of Amy's (reported here http://manage.dimagi.com/default.asp?230383), and I realized that realistically, it seems more than fine to just trust app builders to only use the 'quick' attribute on questions in a question list in contexts that make sense (such as when the auto-advancing question is the last one).