### PR TITLE
Don't persist new repeat dialog

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -107,6 +107,7 @@ import org.javarosa.model.xform.XFormsModule;
 import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathTypeMismatchException;
+import org.javarosa.xpath.XPathUnhandledException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -1241,7 +1242,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 dialog.dismiss();
                 try {
                     mFormController.newRepeat();
-                } catch (XPathTypeMismatchException | XPathArityException e) {
+                } catch (XPathUnhandledException | XPathTypeMismatchException | XPathArityException e) {
                     Logger.exception(e);
                     UserfacingErrorHandling.logErrorAndShowDialog(FormEntryActivity.this, e, EXIT);
                     return;
@@ -1281,7 +1282,12 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                     }
                 }
         );
-        showAlertDialog(dialog);
+        // Purposefully don't persist this dialog accross rotation! Rotation
+        // refreshes the view, which steps the form index back from the repeat
+        // event. This can be fixed, but the dialog click listeners closures
+        // capture refences to the old activity, so we need to redo our
+        // infrastructure to forward new activities.
+        dialog.showNonPersistentDialog();
     }
 
     private void saveFormToDisk(boolean exit) {


### PR DESCRIPTION
If you rotate the new repeat dialog during form entry, the `onClick` closures hold a reference to the old activity, while a new activity has been created due to the screen rotation. 

This is usually fine (if you call `finish` on an old activity, it strangely still finishes the new activity). In the case where an error occurs and the `onClick` handler tries to launch a new dialog, it can't because it is pointing to the old activity.

In the long run, we should build up infrastructure similar to how the `CommCareTask.deliverResult` passes around the new activity receiver in. We could do this by recreating the `onClick` closures every time we reshow the dialog in `AlertDialogFragment.onCreateDialog`. Will be big lift given how annoying Java is with closures and how many dialogs we have.

For now, just disable persistence of this dialog...

Includes fix for https://github.com/dimagi/commcare-android/pull/1341