### PR TITLE
Session Serialization fix for 2.28

### DIFF
--- a/app/src/org/commcare/android/database/user/models/SessionStateDescriptor.java
+++ b/app/src/org/commcare/android/database/user/models/SessionStateDescriptor.java
@@ -92,14 +92,14 @@ public class SessionStateDescriptor extends Persisted implements EncryptedModel 
         StringBuilder descriptor = new StringBuilder();
         for (StackFrameStep step : session.getFrame().getSteps()) {
             String type = step.getType();
-            if (!(SessionFrame.STATE_QUERY_REQUEST.equals(type) ||
+            if ((SessionFrame.STATE_QUERY_REQUEST.equals(type) ||
                     SessionFrame.STATE_SYNC_REQUEST.equals(type))) {
                 // Skip adding remote server query/sync steps to the descriptor.
                 // They are hard to replay (requires serializing query results)
                 // and shouldn't be needed for incomplete forms
-                descriptor.append(type).append(" ");
+                continue;
             }
-
+            descriptor.append(type).append(" ");
             if (SessionFrame.STATE_COMMAND_ID.equals(type)) {
                 descriptor.append(step.getId()).append(" ");
             } else if (SessionFrame.STATE_DATUM_VAL.equals(type)

--- a/app/src/org/commcare/android/database/user/models/SessionStateDescriptor.java
+++ b/app/src/org/commcare/android/database/user/models/SessionStateDescriptor.java
@@ -39,23 +39,24 @@ public class SessionStateDescriptor extends Persisted implements EncryptedModel 
         return MD5.toHex(MD5.hash(sessionDescriptor.getBytes()));
     }
 
-    //Wrapper for serialization (STILL SKETCHY)
     public SessionStateDescriptor() {
 
     }
 
-    public SessionStateDescriptor(AndroidSessionWrapper state) {
-        this.formRecordId = state.getFormRecordId();
-        sessionDescriptor = this.createSessionDescriptor(state.getSession());
+    public static SessionStateDescriptor buildFromSessionWrapper(AndroidSessionWrapper state) {
+        SessionStateDescriptor descriptor = new SessionStateDescriptor();
+        descriptor.formRecordId = state.getFormRecordId();
+        descriptor.sessionDescriptor = createSessionDescriptor(state.getSession());
+        return descriptor;
     }
 
+    @Override
     public boolean isEncrypted(String data) {
-        // TODO Auto-generated method stub
         return false;
     }
 
+    @Override
     public boolean isBlobEncrypted() {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -82,33 +83,34 @@ public class SessionStateDescriptor extends Persisted implements EncryptedModel 
      * Serializes the session into a string which is unique for a
      * given path through the application, and which can be deserialzied
      * back into a live session.
-     * <p/>
-     * TODO: Currently we rely on this state being semantically unique,
+     *
+     * NOTE: Currently we rely on this state being semantically unique,
      * but it may change in the future. Rely on the specific format as
      * little as possible.
      */
-    private String createSessionDescriptor(CommCareSession session) {
-        //TODO: Serialize into something more useful. I dunno. JSON/XML/Something
+    private static String createSessionDescriptor(CommCareSession session) {
         StringBuilder descriptor = new StringBuilder();
         for (StackFrameStep step : session.getFrame().getSteps()) {
-            descriptor.append(step.getType());
-            if (SessionFrame.STATE_COMMAND_ID.equals(step.getType())) {
-                descriptor.append(step.getId());
-            } else if (SessionFrame.STATE_DATUM_VAL.equals(step.getType()) || SessionFrame.STATE_DATUM_COMPUTED.equals(step.getType())) {
-                descriptor.append(step.getId()).append(" ").append(step.getValue());
-            } else if (SessionFrame.STATE_QUERY_REQUEST.equals(step.getType())) {
-                // for now, don't support restoring sessions that make remote server requests
-                descriptor.append( SessionFrame.STATE_QUERY_REQUEST);
-            } else if (SessionFrame.STATE_SYNC_REQUEST.equals(step.getType())) {
-                // for now, don't support restoring sessions that make remote server requests
-                descriptor.append(SessionFrame.STATE_SYNC_REQUEST);
+            String type = step.getType();
+            if (!(SessionFrame.STATE_QUERY_REQUEST.equals(type) ||
+                    SessionFrame.STATE_SYNC_REQUEST.equals(type))) {
+                // Skip adding remote server query/sync steps to the descriptor.
+                // They are hard to replay (requires serializing query results)
+                // and shouldn't be needed for incomplete forms
+                descriptor.append(type).append(" ");
             }
-            descriptor.append(" ");
+
+            if (SessionFrame.STATE_COMMAND_ID.equals(type)) {
+                descriptor.append(step.getId()).append(" ");
+            } else if (SessionFrame.STATE_DATUM_VAL.equals(type)
+                    || SessionFrame.STATE_DATUM_COMPUTED.equals(type)) {
+                descriptor.append(step.getId()).append(" ").append(step.getValue()).append(" ");
+            }
         }
         return descriptor.toString().trim();
     }
 
-    public void loadSession(CommCareSession session) {
+    public void loadSessionFromDescriptor(CommCareSession session) {
         String[] tokenStream = sessionDescriptor.split(" ");
 
         int current = 0;
@@ -116,15 +118,9 @@ public class SessionStateDescriptor extends Persisted implements EncryptedModel 
             String action = tokenStream[current];
             if (action.equals(SessionFrame.STATE_COMMAND_ID)) {
                 session.setCommand(tokenStream[++current]);
-            } else if (action.equals(SessionFrame.STATE_DATUM_VAL) || action.equals(SessionFrame.STATE_DATUM_COMPUTED)) {
+            } else if (action.equals(SessionFrame.STATE_DATUM_VAL) ||
+                    action.equals(SessionFrame.STATE_DATUM_COMPUTED)) {
                 session.setDatum(tokenStream[++current], tokenStream[++current]);
-            } else if (action.equals(SessionFrame.STATE_SYNC_REQUEST)
-                    || action.equals(SessionFrame.STATE_QUERY_REQUEST)) {
-                // Since restoring sessions with remote requests isn't support,
-                // break when encountered and force the user to proceed manually.
-                // Shouldn't come up in practice until we build workflows with
-                // remote query datums that end in form entry
-                break;
             }
             current++;
         }

--- a/app/src/org/commcare/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/models/AndroidSessionWrapper.java
@@ -47,19 +47,11 @@ public class AndroidSessionWrapper {
         this.session = session;
     }
 
-    /**
-     * Serialize the state of this session so it can be restored
-     * at a later time.
-     */
-    public SessionStateDescriptor getSessionStateDescriptor() {
-        return new SessionStateDescriptor(this);
-    }
-
     public void loadFromStateDescription(SessionStateDescriptor descriptor) {
         this.reset();
         this.sessionStateRecordId = descriptor.getID();
         this.formRecordId = descriptor.getFormRecordId();
-        descriptor.loadSession(this.session);
+        descriptor.loadSessionFromDescriptor(session);
     }
 
     /**
@@ -119,7 +111,7 @@ public class AndroidSessionWrapper {
      * otherwise null.
      */
     public SessionStateDescriptor getExistingIncompleteCaseDescriptor() {
-        SessionStateDescriptor ssd = getSessionStateDescriptor();
+        SessionStateDescriptor ssd = SessionStateDescriptor.buildFromSessionWrapper(this);
 
         if (!ssd.getSessionDescriptor().contains(SessionFrame.STATE_DATUM_VAL)) {
             // don't continue if the current session doesn't use a case
@@ -172,7 +164,7 @@ public class AndroidSessionWrapper {
         storage.write(r);
         setFormRecordId(r.getID());
 
-        SessionStateDescriptor ssd = getSessionStateDescriptor();
+        SessionStateDescriptor ssd = SessionStateDescriptor.buildFromSessionWrapper(this);
         sessionStorage.write(ssd);
         sessionStateRecordId = ssd.getID();
     }

--- a/app/src/org/commcare/tasks/FormRecordCleanupTask.java
+++ b/app/src/org/commcare/tasks/FormRecordCleanupTask.java
@@ -203,7 +203,7 @@ public abstract class FormRecordCleanupTask<R> extends CommCareTask<Void, Intege
             SqlStorage<SessionStateDescriptor> ssdStorage =
                     CommCareApplication._().getUserStorage(SessionStateDescriptor.class);
 
-            ssdStorage.write(asw.getSessionStateDescriptor());
+            ssdStorage.write(SessionStateDescriptor.buildFromSessionWrapper(asw));
         }
 
         storage.write(updated);

--- a/unit-tests/resources/commcare-apps/case_search_and_claim/user_restore.xml
+++ b/unit-tests/resources/commcare-apps/case_search_and_claim/user_restore.xml
@@ -1,0 +1,12 @@
+<OpenRosaResponse>
+    <message nature="ota_restore_success">Successfully restored account test!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>sync_token</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>test</username>
+        <password>sha1$60441$53cf77c2ac3608a944db96af177a6dfe1579e4ba</password>
+        <uuid>test_user</uuid>
+        <date>2012-04-30</date>
+    </Registration>
+</OpenRosaResponse>

--- a/unit-tests/src/org/commcare/android/database/user/models/SessionStateDescriptorTests.java
+++ b/unit-tests/src/org/commcare/android/database/user/models/SessionStateDescriptorTests.java
@@ -1,0 +1,47 @@
+package org.commcare.android.database.user.models;
+
+import org.commcare.models.AndroidSessionWrapper;
+import org.commcare.modern.session.SessionWrapper;
+import org.commcare.session.CommCareSession;
+import org.commcare.test.utilities.MockApp;
+import org.commcare.util.CommCarePlatform;
+import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.model.instance.TreeElement;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class SessionStateDescriptorTests {
+
+    @Test
+    public void testSessionStateDescriptorSerialization() throws Exception {
+        MockApp app = new MockApp("/commcare-apps/case_search_and_claim/");
+        SessionWrapper session = app.getSession();
+        session.setCommand("patient-search");
+        session.setQueryDatum(ExternalDataInstance.buildFromRemote("foo", new TreeElement()));
+        session.setDatum("case_id", "case_two");
+        serializeSessionOutToDescriptor(session);
+
+        session.clearAllState();
+        session.setCommand("m0");
+        session.setCommand("m0-f0");
+        session.setDatum("case_id", "case_two");
+        session.setComputedDatum(session.getEvaluationContext());
+
+        serializeSessionOutToDescriptor(session);
+    }
+
+    private static void serializeSessionOutToDescriptor(CommCareSession session) {
+        AndroidSessionWrapper originalSessionWrapper = new AndroidSessionWrapper(session);
+        SessionStateDescriptor oldDescriptor = SessionStateDescriptor.buildFromSessionWrapper(originalSessionWrapper);
+
+        AndroidSessionWrapper newSessionWrapper = new AndroidSessionWrapper(new CommCarePlatform(0, 0));
+        newSessionWrapper.loadFromStateDescription(oldDescriptor);
+
+        SessionStateDescriptor newDescriptor = SessionStateDescriptor.buildFromSessionWrapper(newSessionWrapper);
+        assertEquals(oldDescriptor.getSessionDescriptor(), newDescriptor.getSessionDescriptor());
+    }
+}


### PR DESCRIPTION
2.28 version of https://github.com/dimagi/commcare-android/pull/1347

@phillipm I slightly rewrote the continue logic for the sync and query requests