### PR TITLE
Log form record wipe exception

### DIFF
--- a/app/src/org/commcare/tasks/FormRecordCleanupTask.java
+++ b/app/src/org/commcare/tasks/FormRecordCleanupTask.java
@@ -340,6 +340,7 @@ public abstract class FormRecordCleanupTask<R> extends CommCareTask<Void, Intege
                             "Inconsistent formRecordId's in session storage");
                 }
             } catch (Exception e) {
+                Logger.exception(e);
                 Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION,
                         "Session ID exists, but with no record (or broken record)");
             }
@@ -355,7 +356,7 @@ public abstract class FormRecordCleanupTask<R> extends CommCareTask<Void, Intege
                     sessionId = loadSSDIDFromFormRecord(ssdStorage, formRecordId);
                 }
             } catch (Exception e) {
-                e.printStackTrace();
+                Logger.exception(e);
                 Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION,
                         "Session ID exists, but with no record (or broken record)");
             }

--- a/app/src/org/commcare/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/tasks/ManageKeyRecordTask.java
@@ -559,10 +559,11 @@ public abstract class ManageKeyRecordTask<R extends DataPullController> extends 
             publishProgress(Localization.get("key.manage.migrate"));
             return true;
         } catch (IOException ioe) {
-            ioe.printStackTrace();
+            Logger.exception(ioe);
             Logger.log(AndroidLogger.TYPE_MAINTENANCE, "IO Error while migrating database: " + ioe.getMessage());
             return false;
         } catch (Exception e) {
+            Logger.exception(ioe);
             Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Unexpected error while migrating database: " + ForceCloseLogger.getStackTrace(e));
             return false;
         }

--- a/app/src/org/commcare/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/tasks/ManageKeyRecordTask.java
@@ -563,7 +563,7 @@ public abstract class ManageKeyRecordTask<R extends DataPullController> extends 
             Logger.log(AndroidLogger.TYPE_MAINTENANCE, "IO Error while migrating database: " + ioe.getMessage());
             return false;
         } catch (Exception e) {
-            Logger.exception(ioe);
+            Logger.exception(e);
             Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Unexpected error while migrating database: " + ForceCloseLogger.getStackTrace(e));
             return false;
         }


### PR DESCRIPTION
Been seeing a lot of the `Session ID exists, but with no record (or broken record)` logs on HQ, but we don't actually log the exception, so it isn't very helpful.