### PR TITLE
Don't setup sandbox on app update

### DIFF
--- a/app/src/org/commcare/tasks/UpdateTask.java
+++ b/app/src/org/commcare/tasks/UpdateTask.java
@@ -119,8 +119,6 @@ public class UpdateTask
 
         resourceManager.incrementUpdateAttempts();
 
-        app.setupSandbox();
-
         Logger.log(AndroidLogger.TYPE_RESOURCES,
                 "Beginning install attempt for profile " + profileRef);
     }


### PR DESCRIPTION
Remove unnecessary sandbox setup in app update task code. Hoping to prevent the following crash:

```
Totally Unexpected Error during form submissionjava.lang.NullPointerException:
Attempt to invoke virtual method 'org.commcare.android.database.global.models.ApplicationRecord
org.commcare.dalvik.application.CommCareApp.getAppRecord()' on a null object reference at
org.commcare.dalvik.odk.provider.ProviderUtils.getSandboxedAppId(ProviderUtils.java:42) at
org.commcare.dalvik.odk.provider.InstanceProvider.init(InstanceProvider.java:108) at
org.commcare.dalvik.odk.provider.InstanceProvider.query(InstanceProvider.java:118) at
android.content.ContentProvider.query(ContentProvider.java:984) at
android.content.ContentProvider$Transport.query(ContentProvider.java:213) at
android.content.ContentResolver.query(ContentResolver.java:478) at
android.content.ContentResolver.query(ContentResolver.java:422) at
org.commcare.android.database.user.models.FormRecord.getPath(FormRecord.java:177) at
org.commcare.android.tasks.ProcessAndSendTask.sendForms(ProcessAndSendTask.java:255) at
org.commcare.android.tasks.ProcessAndSendTask.doTaskBackground(ProcessAndSendTask.java:132) at
org.commcare.android.tasks.ProcessAndSendTask.doTaskBackground(ProcessAndSendTask.java:35) at
org.commcare.android.tasks.templates.CommCareTask.doInBackground(CommCareTask.java:35) at
android.os.AsyncTask$2.call(AsyncTask.java:288) at
java.util.concurrent.FutureTask.run(FutureTask.java:237) at
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
```