### PR TITLE
Prevent UI work if CommCareHomeActivity is stepping forward in session

### DIFF
--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -1097,10 +1097,12 @@ public class CommCareHomeActivity
 
     @Override
     protected void onResumeSessionSafe() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            refreshActionBar();
+        if (!sessionNavigationProceedingAfterOnResume) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                refreshActionBar();
+            }
+            attemptDispatchHomeScreen();
         }
-        attemptDispatchHomeScreen();
 
         sessionNavigationProceedingAfterOnResume = false;
     }
@@ -1121,7 +1123,7 @@ public class CommCareHomeActivity
         if (CommCareApplication._().isSyncPending(false)) {
             // There is a sync pending
             handlePendingSync();
-        } else if (CommCareApplication._().isConsumerApp() && !sessionNavigationProceedingAfterOnResume) {
+        } else if (CommCareApplication._().isConsumerApp()) {
             // so that the user never sees the real home screen in a consumer app
             enterRootModule();
         } else {


### PR DESCRIPTION
`onResume` is always called right after `onActivityResult` even when `onActivityResult` has launched a new activity. We don't want to do an UI work in `onResume` if a new activity is going to be launched, because that is slow, especially when we have to build a new case tile for the action bar.

Partial fix for http://manage.dimagi.com/default.asp?221062