### PR TITLE
Add migration stragety to InstanceProvider.insert

### DIFF
--- a/app/src/org/commcare/models/database/user/UserSandboxUtils.java
+++ b/app/src/org/commcare/models/database/user/UserSandboxUtils.java
@@ -17,6 +17,7 @@ import org.commcare.models.database.AndroidDbHelper;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.user.models.FormRecord;
+import org.commcare.provider.InstanceProviderAPI;
 import org.commcare.provider.InstanceProviderAPI.InstanceColumns;
 import org.commcare.utils.FileUtil;
 import org.javarosa.core.services.Logger;
@@ -119,6 +120,7 @@ public class UserSandboxUtils {
                     values.put(InstanceColumns.CAN_EDIT_WHEN_COMPLETE, oldRecord.getString(oldRecord.getColumnIndex(InstanceColumns.CAN_EDIT_WHEN_COMPLETE)));
                     values.put(InstanceColumns.LAST_STATUS_CHANGE_DATE, oldRecord.getLong(oldRecord.getColumnIndex(InstanceColumns.LAST_STATUS_CHANGE_DATE)));
                     values.put(InstanceColumns.DISPLAY_SUBTEXT, oldRecord.getString(oldRecord.getColumnIndex(InstanceColumns.DISPLAY_SUBTEXT)));
+                    values.put(InstanceProviderAPI.SANDBOX_MIGRATION_SUBMISSION, true);
 
 
                     //Copy over the other metadata

--- a/app/src/org/commcare/provider/InstanceProvider.java
+++ b/app/src/org/commcare/provider/InstanceProvider.java
@@ -195,13 +195,7 @@ public class InstanceProvider extends ContentProvider {
             values.put(InstanceProviderAPI.InstanceColumns.STATUS, InstanceProviderAPI.STATUS_INCOMPLETE);
         }
 
-        // Should we link this instance to the session's form record, or create
-        // a new, unindexed one?
-        boolean linkToSession = true;
-        if (values.containsKey(InstanceProviderAPI.UNINDEXED_SUBMISSION)) {
-            values.remove(InstanceProviderAPI.UNINDEXED_SUBMISSION);
-            linkToSession = false;
-        }
+        InstanceProviderInsertType insertType = InstanceProviderInsertType.getInsertionType(values);
 
         SQLiteDatabase db = mDbHelper.getWritableDatabase();
         long rowId = db.insert(INSTANCES_TABLE_NAME, null, values);
@@ -211,34 +205,44 @@ public class InstanceProvider extends ContentProvider {
             Uri instanceUri = ContentUris.withAppendedId(InstanceProviderAPI.InstanceColumns.CONTENT_URI, rowId);
             notifyChangeSafe(getContext(), uri);
 
-            if (linkToSession) {
-                try {
-                    linkToSessionFormRecord(instanceUri);
-                } catch (IllegalStateException e) {
-                    throw e;
-                } catch (Exception e) {
-                    Logger.exception(e);
-                    throw new SQLException("Failed to insert row into " + uri);
-                }
-            } else {
-                // Forms with this flag are being loaded onto the phone
-                // manually and hence shouldn't be attached to the FormRecord
-                // in the current session
-                String xmlns = values.getAsString(InstanceProviderAPI.InstanceColumns.JR_FORM_ID);
-
-                SecretKey key;
-                key = CommCareApplication._().createNewSymmetricKey();
-                FormRecord r = new FormRecord(instanceUri.toString(), FormRecord.STATUS_UNINDEXED,
-                        xmlns, key.getEncoded(), null, new Date(0), mDbHelper.getAppId());
-                IStorageUtilityIndexed<FormRecord> storage =
-                        CommCareApplication._().getUserStorage(FormRecord.class);
-                storage.write(r);
+            switch (insertType) {
+                case SESSION_LINKED:
+                    finalizeSessionLinkedInsertion(instanceUri, uri);
+                    break;
+                case UNINDEXED_IMPORT:
+                    finalizeUnindexedInsertion(values, instanceUri);
+                    break;
+                case SANDBOX_MIGRATED:
+                    break;
             }
 
             return instanceUri;
         }
 
         throw new SQLException("Failed to insert row into " + uri);
+    }
+
+    private void finalizeSessionLinkedInsertion(Uri instanceUri, Uri uri) {
+        try {
+            linkToSessionFormRecord(instanceUri);
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            Logger.exception(e);
+            throw new SQLException("Failed to insert row into " + uri);
+        }
+    }
+
+    private void finalizeUnindexedInsertion(ContentValues values, Uri instanceUri) {
+        String xmlns = values.getAsString(InstanceProviderAPI.InstanceColumns.JR_FORM_ID);
+
+        SecretKey key;
+        key = CommCareApplication._().createNewSymmetricKey();
+        FormRecord r = new FormRecord(instanceUri.toString(), FormRecord.STATUS_UNINDEXED,
+                xmlns, key.getEncoded(), null, new Date(0), mDbHelper.getAppId());
+        IStorageUtilityIndexed<FormRecord> storage =
+                CommCareApplication._().getUserStorage(FormRecord.class);
+        storage.write(r);
     }
 
     /**

--- a/app/src/org/commcare/provider/InstanceProviderAPI.java
+++ b/app/src/org/commcare/provider/InstanceProviderAPI.java
@@ -24,6 +24,14 @@ public final class InstanceProviderAPI {
      */
     public static final String UNINDEXED_SUBMISSION = "unindexedSubmission";
 
+    /**
+     * If a user sandbox needs to be migrated, instances will be moved by
+     * inserting them into the new sandbox and updating existing form records
+     * to point to the newly inserted data.
+     */
+    public static final String SANDBOX_MIGRATION_SUBMISSION =
+            "sandboxMigrationSubmission";
+
     public static final class InstanceColumns implements BaseColumns {
         // This class cannot be instantiated
         private InstanceColumns() {

--- a/app/src/org/commcare/provider/InstanceProviderInsertType.java
+++ b/app/src/org/commcare/provider/InstanceProviderInsertType.java
@@ -1,0 +1,35 @@
+package org.commcare.provider;
+
+import android.content.ContentValues;
+
+/**
+ * Different types of insertions for InstanceProvider
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+enum InstanceProviderInsertType {
+    /**
+     * Instance should be linked with form record present in the session
+     */
+    SESSION_LINKED,
+    /**
+     * Instance is being (manually) imported and will attached to a form record in an indexing pass
+     */
+    UNINDEXED_IMPORT,
+    /**
+     * Instance is being moved to a new user sandbox; existing form record will be updated by migration code
+     */
+    SANDBOX_MIGRATED;
+
+    static InstanceProviderInsertType getInsertionType(ContentValues values) {
+        if (values.containsKey(InstanceProviderAPI.SANDBOX_MIGRATION_SUBMISSION)) {
+            values.remove(InstanceProviderAPI.SANDBOX_MIGRATION_SUBMISSION);
+            return InstanceProviderInsertType.SANDBOX_MIGRATED;
+        } else if (values.containsKey(InstanceProviderAPI.UNINDEXED_SUBMISSION)) {
+            values.remove(InstanceProviderAPI.UNINDEXED_SUBMISSION);
+            return InstanceProviderInsertType.UNINDEXED_IMPORT;
+        }
+
+        return InstanceProviderInsertType.SESSION_LINKED;
+    }
+}

--- a/app/src/org/commcare/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/tasks/ManageKeyRecordTask.java
@@ -281,30 +281,29 @@ public abstract class ManageKeyRecordTask<R extends DataPullController> extends 
                 newRecord.setType(UserKeyRecord.TYPE_NORMAL);
                 storage.write(newRecord);
             }
-
-
-            for (UserKeyRecord recordPendingDelete :
-                    storage.getRecordsForValue(UserKeyRecord.META_KEY_STATUS, UserKeyRecord.TYPE_PENDING_DELETE)) {
-                Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Cleaning up sandbox which is pending removal");
-
-                // See if there are more records in this sandbox. (If so, we can just wipe this record and move on)
-                if (storage.getIDsForValue(UserKeyRecord.META_SANDBOX_ID, recordPendingDelete.getUuid()).size() > 2) {
-                    Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Record for sandbox " + recordPendingDelete.getUuid() + " has siblings. Removing record");
-
-                    //TODO: Will this invalidate our iterator?
-                    storage.remove(recordPendingDelete);
-                } else {
-                    // Otherwise, we should see if we can read the data, and if so, wipe it as well as the record.
-                    if (recordPendingDelete.isPasswordValid(password)) {
-                        //TODO AMS: Changed this such that you can only wipe the record if it was a password login -- is that OK?
-                        Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Current user has access to purgable sandbox " + recordPendingDelete.getUuid() + ". Wiping that sandbox");
-                        UserSandboxUtils.purgeSandbox(this.getContext(), app, recordPendingDelete, recordPendingDelete.unWrapKey(password));
-                    }
-                    //Do we do anything here if we couldn't open the sandbox?
-                }
-            }
-            //TODO: Specifically we should never have two sandboxes which can be opened by the same password (I think...)
         }
+
+        for (UserKeyRecord recordPendingDelete :
+                storage.getRecordsForValue(UserKeyRecord.META_KEY_STATUS, UserKeyRecord.TYPE_PENDING_DELETE)) {
+            Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Cleaning up sandbox which is pending removal");
+
+            // See if there are more records in this sandbox. (If so, we can just wipe this record and move on)
+            if (storage.getIDsForValue(UserKeyRecord.META_SANDBOX_ID, recordPendingDelete.getUuid()).size() > 2) {
+                Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Record for sandbox " + recordPendingDelete.getUuid() + " has siblings. Removing record");
+
+                //TODO: Will this invalidate our iterator?
+                storage.remove(recordPendingDelete);
+            } else {
+                // Otherwise, we should see if we can read the data, and if so, wipe it as well as the record.
+                if (recordPendingDelete.isPasswordValid(password)) {
+                    //TODO AMS: Changed this such that you can only wipe the record if it was a password login -- is that OK?
+                    Logger.log(AndroidLogger.TYPE_MAINTENANCE, "Current user has access to purgable sandbox " + recordPendingDelete.getUuid() + ". Wiping that sandbox");
+                    UserSandboxUtils.purgeSandbox(this.getContext(), app, recordPendingDelete, recordPendingDelete.unWrapKey(password));
+                }
+                //Do we do anything here if we couldn't open the sandbox?
+            }
+        }
+            //TODO: Specifically we should never have two sandboxes which can be opened by the same password (I think...)
     }
 
 
@@ -410,6 +409,7 @@ public abstract class ManageKeyRecordTask<R extends DataPullController> extends 
         for (UserKeyRecord r : allRecordsWithSameUsername) {
             if (!r.getUuid().equals(uuidOfActiveRecord)) {
                 r.setInactive();
+                storage.write(r);
             }
         }
     }


### PR DESCRIPTION
2.28 version of https://github.com/dimagi/commcare-android/pull/1358 with minimal changes and no tests (since they require more changes, even though all those changes are to test files...)

Should be viewed with ?w=1

Addresses the following crash that happens when a user key record expires on HQ and HQ sends down a new one.

The underlying issue was that a while ago I moved a bunch of instance save logic into the `InstanceProvider` where it should be, but didn't realize that instances were migrated in a very specific way when key records expired. Hence, the instance migration code was handling all its form record upkeep, but the instance insert code was also trying to manage form records by linking it to the session's form record (which in this case doesn't exist).

```
Unexpected error while migrating database: android.database.SQLException: Failed to insert row into content://org.commcare.android.provider.odk.instances/instances at
org.commcare.provider.InstanceProvider.insert(InstanceProvider.java:222) at
android.content.ContentProvider$Transport.insert(ContentProvider.java:220) at
android.content.ContentResolver.insert(ContentResolver.java:1190) at
org.commcare.models.database.user.UserSandboxUtils.migrateData(UserSandboxUtils.java:147) at
org.commcare.tasks.ManageKeyRecordTask.lookForAndMigrateOldSandbox(ManageKeyRecordTask.java:556) at
org.commcare.tasks.ManageKeyRecordTask.doPostCalloutTask(ManageKeyRecordTask.java:445) at
org.commcare.network.HttpCalloutTask.doTaskBackground(HttpCalloutTask.java:107) at
org.commcare.network.HttpCalloutTask.doTaskBackground(HttpCalloutTask.java:29) at
org.commcare.tasks.templates.CommCareTask.doInBackground(CommCareTask.java:37) at
android.os.AsyncTask$2.call(AsyncTask.java:288) at
java.util.concurrent.FutureTask.run(FutureTask.java:237) at
android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:231) at
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112) at
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587) at
java.lang.Thread.run(Thread.java:841)
```