### PR TITLE
Broadcast case id on case create/update events

### DIFF
--- a/app/src/org/commcare/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/activities/EntityDetailActivity.java
@@ -235,7 +235,7 @@ public class EntityDetailActivity
     private void announceCaseSelect() {
         Intent selectIntentBroadcast = new Intent("org.commcare.dalvik.api.action.case.selected");
         selectIntentBroadcast.putExtra("case_id", getIntent().getStringExtra(SessionFrame.STATE_DATUM_VAL));
-        sendBroadcast(selectIntentBroadcast);
+        sendBroadcast(selectIntentBroadcast, "org.commcare.dalvik.provider.cases.read");
     }
 
     @Override

--- a/app/src/org/commcare/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/activities/EntityDetailActivity.java
@@ -224,6 +224,11 @@ public class EntityDetailActivity
      * Move along to form entry.
      */
     private void select() {
+        // announce that case was selected
+        Intent selectIntentBroadcast = new Intent("org.commcare.dalvik.api.action.case.selected");
+        selectIntentBroadcast.putExtra("case_id", getIntent().getStringExtra(SessionFrame.STATE_DATUM_VAL));
+        sendBroadcast(selectIntentBroadcast);
+
         Intent i = new Intent(EntityDetailActivity.this.getIntent());
         loadOutgoingIntent(i);
         setResult(RESULT_OK, i);

--- a/app/src/org/commcare/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/activities/EntityDetailActivity.java
@@ -224,15 +224,18 @@ public class EntityDetailActivity
      * Move along to form entry.
      */
     private void select() {
-        // announce that case was selected
-        Intent selectIntentBroadcast = new Intent("org.commcare.dalvik.api.action.case.selected");
-        selectIntentBroadcast.putExtra("case_id", getIntent().getStringExtra(SessionFrame.STATE_DATUM_VAL));
-        sendBroadcast(selectIntentBroadcast);
+        announceCaseSelect();
 
         Intent i = new Intent(EntityDetailActivity.this.getIntent());
         loadOutgoingIntent(i);
         setResult(RESULT_OK, i);
         finish();
+    }
+
+    private void announceCaseSelect() {
+        Intent selectIntentBroadcast = new Intent("org.commcare.dalvik.api.action.case.selected");
+        selectIntentBroadcast.putExtra("case_id", getIntent().getStringExtra(SessionFrame.STATE_DATUM_VAL));
+        sendBroadcast(selectIntentBroadcast);
     }
 
     @Override

--- a/app/src/org/commcare/models/FormRecordProcessor.java
+++ b/app/src/org/commcare/models/FormRecordProcessor.java
@@ -86,7 +86,7 @@ public class FormRecordProcessor {
         //Let anyone who is listening know!
         Intent i = new Intent("org.commcare.dalvik.api.action.data.update");
         i.putStringArrayListExtra("cases", factory.getCreatedAndUpdatedCases());
-        c.sendBroadcast(i);
+        c.sendBroadcast(i, "org.commcare.dalvik.provider.cases.read");
 
         //Update the record before trying to purge, so we don't block on this, in case
         //anything weird happens. We don't want to get into a loop

--- a/app/src/org/commcare/models/FormRecordProcessor.java
+++ b/app/src/org/commcare/models/FormRecordProcessor.java
@@ -85,7 +85,8 @@ public class FormRecordProcessor {
 
         //Let anyone who is listening know!
         Intent i = new Intent("org.commcare.dalvik.api.action.data.update");
-        this.c.sendBroadcast(i);
+        i.putStringArrayListExtra("cases", factory.getCreatedAndUpdatedCases());
+        c.sendBroadcast(i);
 
         //Update the record before trying to purge, so we don't block on this, in case
         //anything weird happens. We don't want to get into a loop

--- a/app/src/org/commcare/xml/AndroidTransactionParserFactory.java
+++ b/app/src/org/commcare/xml/AndroidTransactionParserFactory.java
@@ -12,6 +12,7 @@ import org.commcare.models.database.AndroidSandbox;
 import org.commcare.utils.GlobalConstants;
 import org.kxml2.io.KXmlParser;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Hashtable;
 
@@ -36,6 +37,7 @@ public class AndroidTransactionParserFactory extends CommCareTransactionParserFa
 
     final private Context context;
     final private HttpRequestEndpoints generator;
+    final private ArrayList<String> createdAndUpdatedCases = new ArrayList<>();
 
     private TransactionParserFactory formInstanceParser;
     private boolean caseIndexesWereDisrupted = false;
@@ -93,12 +95,21 @@ public class AndroidTransactionParserFactory extends CommCareTransactionParserFa
                         public void onIndexDisrupted(String caseId) {
                             caseIndexesWereDisrupted = true;
                         }
+
+                        @Override
+                        protected void onCaseCreateUpdate(String caseId) {
+                            createdAndUpdatedCases.add(caseId);
+                        }
                     };
                 }
 
                 return created;
             }
         };
+    }
+
+    public ArrayList<String> getCreatedAndUpdatedCases() {
+        return createdAndUpdatedCases;
     }
 
 


### PR DESCRIPTION
This is needed so that Simprints knows

- when they should mark fingerprint registration as committed.
- when a case is selected, allowing them to refine their matching algorithm

cross-request: https://github.com/dimagi/commcare-core/pull/329