### PR TITLE
Session threading fix

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -22,6 +22,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.Message;
 import android.preference.PreferenceManager;
 import android.provider.Settings.Secure;
@@ -1164,8 +1165,14 @@ public class CommCareApplication extends Application {
         long started = System.currentTimeMillis();
         //If binding is currently in process, just wait for it.
         while (mIsBinding) {
+            if (Looper.getMainLooper().getThread() == Thread.currentThread()) {
+                throw new SessionUnavailableException(
+                        "Trying to access session on UI thread while session is binding");
+            }
             if (System.currentTimeMillis() - started > mCurrentServiceBindTimeout) {
-                //Something bad happened
+                // Something bad happened
+                Log.e(TAG, "WARNING: Timed out while binding to session service, " +
+                        "this may cause serious problems.");
                 unbindUserSessionService();
                 throw new SessionUnavailableException("Timeout binding to session service");
             }


### PR DESCRIPTION
Master version of fix for http://manage.dimagi.com/default.asp?231794, which was committed directly to 2.28 branch. 

The fix is to throw a `SessionUnavailableException` immediately if the UI thread tries to access the session while it is binding, because otherwise that scenario will always lead to a time-out and subsequent throwing of the same exception anyway, so we want to short-circuit the time-out and just do it right away.