### PR TITLE
Extend ccc script to trigger 412 recovery syncs

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -325,6 +325,10 @@
                 <action android:name="${applicationId}.api.action.LoginWithCreds"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="${applicationId}.api.action.TriggerSyncRecover"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
         </receiver>
 
         <activity android:name="org.commcare.activities.MultimediaInflaterActivity">

--- a/app/src/org/commcare/network/HttpRequestGenerator.java
+++ b/app/src/org/commcare/network/HttpRequestGenerator.java
@@ -31,6 +31,7 @@ import org.commcare.cases.util.CaseDBUtils;
 import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.models.database.SqlStorage;
+import org.commcare.provider.DebugControlsReceiver;
 import org.commcare.utils.GlobalConstants;
 import org.javarosa.core.model.User;
 import org.javarosa.core.model.utils.DateUtils;
@@ -216,8 +217,14 @@ public class HttpRequestGenerator implements HttpRequestEndpoints {
         return storage.getMetaDataFieldForRecord(users.firstElement(), User.META_SYNC_TOKEN);
     }
 
-    private String getDigest() {
-        return CaseDBUtils.computeHash(CommCareApplication._().getUserStorage(ACase.STORAGE_KEY, ACase.class));
+    private static String getDigest() {
+        String fakeHash = DebugControlsReceiver.getFakeCaseDbHash();
+        if (fakeHash != null) {
+            // For integration tests, use fake hash to trigger 412 recovery on this sync
+            return fakeHash;
+        } else {
+            return CaseDBUtils.computeCaseDbHash(CommCareApplication._().getUserStorage(ACase.STORAGE_KEY, ACase.class));
+        }
     }
 
     @Override

--- a/app/src/org/commcare/provider/DebugControlsReceiver.java
+++ b/app/src/org/commcare/provider/DebugControlsReceiver.java
@@ -3,6 +3,7 @@ package org.commcare.provider;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 
 import org.commcare.CommCareApplication;
 import org.commcare.activities.LoginActivity;
@@ -14,10 +15,12 @@ import org.commcare.preferences.DevSessionRestorer;
  * - uninstall app
  * - save the current commcare user session.
  * - log into the currently seated app
+ * - invalidate sync token to force recovery on sync
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */
 public class DebugControlsReceiver extends BroadcastReceiver {
+    private final static String FAKE_CASE_DB_HASH = "fake_case_db_hash";
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -28,6 +31,8 @@ public class DebugControlsReceiver extends BroadcastReceiver {
             uninstallApp(intent.getStringExtra("app_id"));
         } else if (action.endsWith("LoginWithCreds")) {
             login(context, intent.getStringExtra("username"), intent.getStringExtra("password"));
+        } else if (action.endsWith("TriggerSyncRecover")) {
+            storeFakeCaseDbHash();
         }
     }
 
@@ -50,5 +55,17 @@ public class DebugControlsReceiver extends BroadcastReceiver {
         Intent loginIntent = new Intent(context, LoginActivity.class);
         loginIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(loginIntent);
+    }
+
+    public static void storeFakeCaseDbHash() {
+        SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
+        prefs.edit().putString(FAKE_CASE_DB_HASH, "FAKE").apply();
+    }
+
+    public static String getFakeCaseDbHash() {
+        SharedPreferences prefs = CommCareApplication._().getCurrentApp().getAppPreferences();
+        String fakeHash = prefs.getString(FAKE_CASE_DB_HASH, null);
+        prefs.edit().remove(FAKE_CASE_DB_HASH).apply();
+        return fakeHash;
     }
 }

--- a/scripts/ccc
+++ b/scripts/ccc
@@ -14,6 +14,7 @@ HELP_MSG = """'capture' saves the current session for restoring later.
 'install some_app.ccz' pushes and installs the ccz to device.
 'uninstall app_id' uninstalls an installed app.
 'login username password' logs into the currently seated app
+'invalidate' forces recovery on next sync by providing fake case db hash.
 'remote domain app_id build' downloads an app from HQ and installs it.
                              The 'build' argument is optional
 """
@@ -41,6 +42,17 @@ def login(username, password):
     extras = {"username": username, "password": password}
     cmd = receiver_command("org.commcare.dalvik.api.action" +
                            ".LoginWithCreds", extras)
+    print(cmd)
+    subprocess.call(cmd, shell=True)
+
+
+# None -> None
+def stage_recover():
+    """
+    Alter case db hash token to trigger a recover on next sync
+    """
+    cmd = receiver_command("org.commcare.dalvik.api.action" +
+                           ".TriggerSyncRecover")
     print(cmd)
     subprocess.call(cmd, shell=True)
 
@@ -156,9 +168,9 @@ def main():
     command = sys.argv[1]
     dispatch = {'capture': lambda: capture(),
                 'uninstall': lambda: uninstall(sys.argv[2]),
-                'login': lambda: login(sys.argv[2], sys.argv[3]),
+                'invalidate': lambda: stage_recover(),
                 'remote': lambda: remote_install(*sys.argv[2:5]),
-                'help': lambda: HELP_MSG,
+                'help': lambda: print(HELP_MSG),
                 'install': lambda: install(sys.argv[2])}
 
     dispatch[command]()


### PR DESCRIPTION
`ccc invalidate` will set a fake value for the case DB hash. On the next sync this value will be used (and then removed), such that HQ will send down a 412, triggering a full recovery on the mobile device.

Will be used for integration tests.

cross-request: https://github.com/dimagi/commcare-core/pull/335