### PR TITLE
Fix app install progress count

### DIFF
--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -70,7 +70,10 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     public abstract boolean initialize(AndroidCommCarePlatform instance) throws ResourceInitializationException;
 
     @Override
-    public boolean install(Resource r, ResourceLocation location, Reference ref, ResourceTable table, AndroidCommCarePlatform instance, boolean upgrade) throws UnresolvedResourceException, UnfullfilledRequirementsException {
+    public boolean install(Resource r, ResourceLocation location,
+                           Reference ref, ResourceTable table,
+                           AndroidCommCarePlatform instance, boolean upgrade)
+            throws UnresolvedResourceException, UnfullfilledRequirementsException {
         try {
             OutputStream os;
             Reference localReference;

--- a/app/src/org/commcare/tasks/ResourceEngineTask.java
+++ b/app/src/org/commcare/tasks/ResourceEngineTask.java
@@ -48,9 +48,6 @@ public abstract class ResourceEngineTask<R>
     // launch this task
     private final boolean shouldSleep;
 
-    // last time in system millis that we updated the status dialog
-    private long lastTime = 0;
-
     protected String vAvailable;
     protected String vRequired;
     protected boolean majorIsProblem;
@@ -129,7 +126,7 @@ public abstract class ResourceEngineTask<R>
         synchronized (statusLock) {
             // if last time isn't set or is less than our spacing count, do not
             // perform status update. Also if we are already running one, just skip this.
-            if (statusCheckRunning || System.currentTimeMillis() - lastTime < ResourceEngineTask.STATUS_UPDATE_WAIT_TIME) {
+            if (statusCheckRunning) {
                 return;
             }
 
@@ -180,7 +177,6 @@ public abstract class ResourceEngineTask<R>
                 
                 private void signalStatusCheckComplete() {
                     synchronized (statusLock) {
-                        lastTime = System.currentTimeMillis();
                         statusCheckRunning = false;
                     }
 

--- a/app/src/org/commcare/tasks/ResourceEngineTask.java
+++ b/app/src/org/commcare/tasks/ResourceEngineTask.java
@@ -32,10 +32,6 @@ public abstract class ResourceEngineTask<R>
     private static final int PHASE_CHECKING = 0;
     public static final int PHASE_DOWNLOAD = 1;
 
-    /**
-     * Wait time between dialog updates in milliseconds
-     */
-    private static final long STATUS_UPDATE_WAIT_TIME = 1000;
     private int installedResourceCountWhileUpdating = 0;
     private int installedResourceCount = 0;
     private int totalResourceCount = -1;


### PR DESCRIPTION
For for issue where the max value in the progress bar during app installs would often get stuck at `3`.