### PR TITLE
Recover form view state after rotation or callout

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1038,6 +1038,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
         }
 
+        // Any info stored about the last changed widget is useless when we move to a new view
+        resetLastChangedWidget();
+
         FormIndex startIndex = mFormController.getFormIndex();
         FormIndex lastValidIndex = startIndex;
 

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -415,13 +415,11 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         outState.putString(KEY_RESIZING_ENABLED, ResizingImageView.resizeMethod);
         saveFormEntrySession(outState);
         outState.putBoolean(KEY_RECORD_FORM_ENTRY_SESSION, recordEntrySession);
+        outState.putInt(KEY_LAST_CHANGED_WIDGET, indexOfLastChangedWidget);
 
         if (indexOfWidgetWithVideoPlaying != -1) {
             outState.putInt(KEY_WIDGET_WITH_VIDEO_PLAYING, indexOfWidgetWithVideoPlaying);
             outState.putInt(KEY_POSITION_OF_VIDEO_PLAYING, positionOfVideoProgress);
-        }
-        if (indexOfLastChangedWidget != -1) {
-            outState.putInt(KEY_LAST_CHANGED_WIDGET, indexOfLastChangedWidget);
         }
 
         if(symetricKey != null) {
@@ -967,6 +965,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             }
         }
 
+        // Any info stored about the last changed widget is useless when we move to a new view
         resetLastChangedWidget();
 
         if (mFormController.getEvent() != FormEntryController.EVENT_END_OF_FORM) {

--- a/app/src/org/commcare/interfaces/WidgetChangedListener.java
+++ b/app/src/org/commcare/interfaces/WidgetChangedListener.java
@@ -1,5 +1,8 @@
 package org.commcare.interfaces;
 
+import org.commcare.views.widgets.QuestionWidget;
+
 public interface WidgetChangedListener {
-    void widgetEntryChanged();
+
+    void widgetEntryChanged(QuestionWidget changedWidget);
 }

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.os.Build;
+import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -139,7 +140,7 @@ public class QuestionsView extends ScrollView
             qw.setChangedListener(this);
         }
         
-        updateLastQuestion();
+        markLastStringWidget();
 
         addView(mView);
     }
@@ -231,9 +232,9 @@ public class QuestionsView extends ScrollView
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
     
-    private void updateConstraintRelevancies(){
-        if(hasListener){
-            wcListener.widgetEntryChanged();
+    private void updateConstraintRelevancies(QuestionWidget changedWidget) {
+        if (hasListener) {
+            wcListener.widgetEntryChanged(changedWidget);
         }
     }
 
@@ -320,8 +321,10 @@ public class QuestionsView extends ScrollView
         }
     }
 
-    public void setFocus(Context context) {
-        if (widgets.size() > 0) {
+    public void setFocus(Context context, int indexOfLastChangedWidget) {
+        if (indexOfLastChangedWidget != -1) {
+            widgets.get(indexOfLastChangedWidget).setFocus(context);
+        } else if (widgets.size() > 0) {
             widgets.get(0).setFocus(context);
         }
     }
@@ -399,18 +402,16 @@ public class QuestionsView extends ScrollView
     }
 
     @Override
-    public void widgetEntryChanged() {
-        updateConstraintRelevancies();
-        updateLastQuestion();
+    public void widgetEntryChanged(QuestionWidget changedWidget) {
+        updateConstraintRelevancies(changedWidget);
+        markLastStringWidget();
     }
-    
-    private void updateLastQuestion(){
+
+    private void markLastStringWidget() {
         StringWidget last = null;
-        
-        for(QuestionWidget q: widgets){
-            
-            if(q instanceof StringWidget){
-                if(last != null){
+        for (QuestionWidget q: widgets) {
+            if (q instanceof StringWidget) {
+                if (last != null) {
                     last.setLastQuestion(false);
                 }
                 last = (StringWidget)q;
@@ -430,13 +431,13 @@ public class QuestionsView extends ScrollView
 
     /**
      * Takes in a form entry prompt that is obtained generically and if there
-     * is already one on screen (which, for isntance, may have cached some of its data)
+     * is already one on screen (which, for instance, may have cached some of its data)
      * returns the object in use currently.
      */
     public FormEntryPrompt getOnScreenPrompt(FormEntryPrompt prompt) {
         FormIndex index = prompt.getIndex();
-        for(QuestionWidget widget : this.getWidgets()) {
-            if(widget.getFormId().equals(index)) {
+        for (QuestionWidget widget : this.getWidgets()) {
+            if (widget.getFormId().equals(index)) {
                 return widget.getPrompt();
             }
         }

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -341,7 +341,8 @@ public class QuestionsView extends ScrollView
         new Handler().post(new Runnable() {
             @Override
             public void run() {
-                QuestionsView.this.scrollTo(0, widget.getBottom());
+                //QuestionsView.this.scrollTo(0, (widget.getTop()-widget.getBottom())/2);
+                QuestionsView.this.scrollTo(0, widget.getTop());
             }
         });
     }

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -345,11 +345,10 @@ public class QuestionsView extends ScrollView
     }
 
     /**
-     *
-     * @param context
-     * @param pendingIntentWidget
+     * @param pendingIntentWidget - the widget for which a callout from form entry just occurred,
+     *                            if there is one
      * @return the index of the widget that focus was restored to, or -1 if there was no
-     * widget that just called out to restore to
+     * widget that just called out
      */
     public int restoreFocusToQuestionThatCalledOut(Context context, QuestionWidget pendingIntentWidget) {
         if (pendingIntentWidget != null) {

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -64,8 +64,6 @@ public class QuestionsView extends ScrollView
 
     private SpannableStringBuilder mGroupLabel;
 
-    //private int indexOfCalloutWidgetJustAnswered;
-
     /**
      * If enabled, we use dividers between question prompts
      */
@@ -341,7 +339,6 @@ public class QuestionsView extends ScrollView
         new Handler().post(new Runnable() {
             @Override
             public void run() {
-                //QuestionsView.this.scrollTo(0, (widget.getTop()-widget.getBottom())/2);
                 QuestionsView.this.scrollTo(0, widget.getTop());
             }
         });
@@ -359,10 +356,7 @@ public class QuestionsView extends ScrollView
             int index = widgets.indexOf(pendingIntentWidget);
             setFocus(context, index);
             return index;
-        } /*else if (indexOfCalloutWidgetJustAnswered != -1) {
-            indexToFocusOn = indexOfCalloutWidgetJustAnswered;
-            indexOfCalloutWidgetJustAnswered = -1;
-        }*/
+        }
         return -1;
     }
 
@@ -380,8 +374,6 @@ public class QuestionsView extends ScrollView
         for (QuestionWidget q : widgets) {
             if (questionFormIndex.equals(q.getFormId())) {
                 q.setBinaryData(answer);
-                //pendingCalloutInterface.setPendingCalloutFormIndex(null);
-                //indexOfCalloutWidgetJustAnswered = widgets.indexOf(q);
                 return;
             }
         }

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -62,6 +63,8 @@ public class QuestionsView extends ScrollView
     private int mViewBannerCount = 0;
 
     private SpannableStringBuilder mGroupLabel;
+
+    //private int indexOfCalloutWidgetJustAnswered;
 
     /**
      * If enabled, we use dividers between question prompts
@@ -322,11 +325,44 @@ public class QuestionsView extends ScrollView
     }
 
     public void setFocus(Context context, int indexOfLastChangedWidget) {
+        QuestionWidget widgetToFocus = null;
         if (indexOfLastChangedWidget != -1) {
-            widgets.get(indexOfLastChangedWidget).setFocus(context);
+            widgetToFocus = widgets.get(indexOfLastChangedWidget);
         } else if (widgets.size() > 0) {
-            widgets.get(0).setFocus(context);
+            widgetToFocus = widgets.get(0);
         }
+        if (widgetToFocus != null) {
+            scrollToWidget(widgetToFocus);
+            widgetToFocus.setFocus(context);
+        }
+    }
+
+    private void scrollToWidget(final QuestionWidget widget) {
+        new Handler().post(new Runnable() {
+            @Override
+            public void run() {
+                QuestionsView.this.scrollTo(0, widget.getBottom());
+            }
+        });
+    }
+
+    /**
+     *
+     * @param context
+     * @param pendingIntentWidget
+     * @return the index of the widget that focus was restored to, or -1 if there was no
+     * widget that just called out to restore to
+     */
+    public int restoreFocusToQuestionThatCalledOut(Context context, QuestionWidget pendingIntentWidget) {
+        if (pendingIntentWidget != null) {
+            int index = widgets.indexOf(pendingIntentWidget);
+            setFocus(context, index);
+            return index;
+        } /*else if (indexOfCalloutWidgetJustAnswered != -1) {
+            indexToFocusOn = indexOfCalloutWidgetJustAnswered;
+            indexOfCalloutWidgetJustAnswered = -1;
+        }*/
+        return -1;
     }
 
     /**
@@ -343,7 +379,8 @@ public class QuestionsView extends ScrollView
         for (QuestionWidget q : widgets) {
             if (questionFormIndex.equals(q.getFormId())) {
                 q.setBinaryData(answer);
-                pendingCalloutInterface.setPendingCalloutFormIndex(null);
+                //pendingCalloutInterface.setPendingCalloutFormIndex(null);
+                //indexOfCalloutWidgetJustAnswered = widgets.indexOf(q);
                 return;
             }
         }

--- a/app/src/org/commcare/views/widgets/DateTimeWidget.java
+++ b/app/src/org/commcare/views/widgets/DateTimeWidget.java
@@ -113,7 +113,7 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
         }
 
         if (hasListener()) {
-            widgetChangedListener.widgetEntryChanged();
+            widgetChangedListener.widgetEntryChanged(this);
         }
     }
 

--- a/app/src/org/commcare/views/widgets/DateTimeWidget.java
+++ b/app/src/org/commcare/views/widgets/DateTimeWidget.java
@@ -112,9 +112,7 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
             clearAnswer();
         }
 
-        if (hasListener()) {
-            widgetChangedListener.widgetEntryChanged(this);
-        }
+        widgetEntryChanged();
     }
 
 

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -606,13 +606,13 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
         setChangedListener(null);
     }
 
-    public void widgetEntryChanged(){
+    public void widgetEntryChanged() {
         if (this.warningView != null) {
             this.warningView.setVisibility(View.GONE);
             ViewUtil.setBackgroundRetainPadding(this, null);
         }
         if (hasListener()) {
-            widgetChangedListener.widgetEntryChanged();
+            widgetChangedListener.widgetEntryChanged(this);
         }
     }
 

--- a/app/src/org/commcare/views/widgets/SpinnerMultiWidget.java
+++ b/app/src/org/commcare/views/widgets/SpinnerMultiWidget.java
@@ -98,9 +98,7 @@ public class SpinnerMultiWidget extends QuestionWidget {
                                     }
                                 }
 
-                                if (hasListener()) {
-                                    widgetChangedListener.widgetEntryChanged(SpinnerMultiWidget.this);
-                                }
+                                widgetEntryChanged();
                             }
                         });
 
@@ -110,9 +108,7 @@ public class SpinnerMultiWidget extends QuestionWidget {
                             public void onClick(DialogInterface dialog, int which, boolean isChecked) {
                                 selections[which] = isChecked;
 
-                                if (hasListener()) {
-                                    widgetChangedListener.widgetEntryChanged(SpinnerMultiWidget.this);
-                                }
+                                widgetEntryChanged();
                             }
                         });
                 AlertDialog alert = alert_builder.create();

--- a/app/src/org/commcare/views/widgets/SpinnerMultiWidget.java
+++ b/app/src/org/commcare/views/widgets/SpinnerMultiWidget.java
@@ -99,7 +99,7 @@ public class SpinnerMultiWidget extends QuestionWidget {
                                 }
 
                                 if (hasListener()) {
-                                    widgetChangedListener.widgetEntryChanged();
+                                    widgetChangedListener.widgetEntryChanged(SpinnerMultiWidget.this);
                                 }
                             }
                         });
@@ -111,7 +111,7 @@ public class SpinnerMultiWidget extends QuestionWidget {
                                 selections[which] = isChecked;
 
                                 if (hasListener()) {
-                                    widgetChangedListener.widgetEntryChanged();
+                                    widgetChangedListener.widgetEntryChanged(SpinnerMultiWidget.this);
                                 }
                             }
                         });

--- a/app/src/org/commcare/views/widgets/SpinnerWidget.java
+++ b/app/src/org/commcare/views/widgets/SpinnerWidget.java
@@ -74,9 +74,7 @@ public class SpinnerWidget extends QuestionWidget {
         spinner.setOnItemSelectedListener(new OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parentView, View selectedItemView, int position, long id) {
-                if (hasListener()) {
-                    widgetChangedListener.widgetEntryChanged(SpinnerWidget.this);
-                }
+                widgetEntryChanged();
             }
 
             @Override

--- a/app/src/org/commcare/views/widgets/SpinnerWidget.java
+++ b/app/src/org/commcare/views/widgets/SpinnerWidget.java
@@ -75,7 +75,7 @@ public class SpinnerWidget extends QuestionWidget {
             @Override
             public void onItemSelected(AdapterView<?> parentView, View selectedItemView, int position, long id) {
                 if (hasListener()) {
-                    widgetChangedListener.widgetEntryChanged();
+                    widgetChangedListener.widgetEntryChanged(SpinnerWidget.this);
                 }
             }
 


### PR DESCRIPTION
-After rotating the screen during form entry, restores focus to the most recently updated widget 
-After performing a callout during form entry, restores focus to the widget that the callout was for (i.e.  image/video/sound capture/choose)