### PR TITLE
Wsp/sd fix 228

### DIFF
--- a/app/src/org/commcare/activities/CommCareFormDumpActivity.java
+++ b/app/src/org/commcare/activities/CommCareFormDumpActivity.java
@@ -79,7 +79,7 @@ public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommC
             public void onClick(View v) {
 
                 formsOnSD = getDumpFiles().length;
-                Logger.log(AndroidLogger.TYPE_FORM_DUMP, "Send task found " + formsOnSD + " forms on the SD card.");
+                Logger.log(AndroidLogger.TYPE_FORM_DUMP, "Send task found " + formsOnSD + " forms on the phone.");
 
                 //if there're no forms to dump, just return
                 if (formsOnSD == 0) {
@@ -99,7 +99,7 @@ public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommC
                             Intent i = new Intent(getIntent());
                             i.putExtra(KEY_NUMBER_DUMPED, formsOnSD);
                             receiver.setResult(BULK_SEND_ID, i);
-                            Logger.log(AndroidLogger.TYPE_FORM_DUMP, "Successfully dumped " + formsOnSD + " forms.");
+                            Logger.log(AndroidLogger.TYPE_FORM_DUMP, "Successfully submitted " + formsOnSD + " forms.");
                             receiver.finish();
                         } else {
                             //assume that we've already set the error message, but make it look scary
@@ -130,6 +130,8 @@ public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommC
         btnDumpForms.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
+
+                Logger.log(AndroidLogger.TYPE_FORM_DUMP, "Dump task found " + formsOnSD + " forms on the SD card.");
 
                 if (formsOnPhone == 0) {
                     txtInteractiveMessages.setText(Localization.get("bulk.form.no.unsynced.dump"));

--- a/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
@@ -660,8 +660,6 @@ public class CommCareWiFiDirectActivity
 
 
     private void onRecordPullCompleted(Pair<Long, FormRecord[]> result, CommCareWiFiDirectActivity receiver) {
-
-        // for the time being we're going to ignore the result of the record pull and proceed regardless
         myStatusText.setText(localize("wifi.direct.pull.successful"));
         if(result != null){
             if(result.first > 0){

--- a/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
@@ -58,6 +58,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.Vector;
 
 /**
@@ -658,11 +659,19 @@ public class CommCareWiFiDirectActivity
     }
 
 
-    private void onRecordPullCompleted(Pair<Long, FormRecord[]> result) {
+    private void onRecordPullCompleted(Pair<Long, FormRecord[]> result, CommCareWiFiDirectActivity receiver) {
+
         // for the time being we're going to ignore the result of the record pull and proceed regardless
         myStatusText.setText(localize("wifi.direct.pull.successful"));
         if(result != null){
-            // we didn't pull any form records to file system, this is fine.
+            if(result.first > 0){
+                // if we had files but they failed, we should error and block
+                receiver.myStatusText.setText(localize("wifi.direct.pull.unsuccessful",
+                        "Problem transferring forms to file system"));
+                receiver.transplantStyle(receiver.myStatusText,
+                        R.layout.template_text_notification_problem);
+                return;
+            }
             this.cachedRecords = result.second;
         }
         updateStatusText();
@@ -675,7 +684,7 @@ public class CommCareWiFiDirectActivity
         FormRecordToFileTask formRecordToFileTask = new FormRecordToFileTask(this, toBeTransferredDirectory) {
             @Override
             protected void deliverResult(CommCareWiFiDirectActivity receiver, Pair<Long, FormRecord[]> result) {
-                receiver.onRecordPullCompleted(result);
+                receiver.onRecordPullCompleted(result, receiver);
             }
 
             @Override

--- a/app/src/org/commcare/tasks/DumpTask.java
+++ b/app/src/org/commcare/tasks/DumpTask.java
@@ -6,9 +6,9 @@ import android.os.Environment;
 
 import org.commcare.CommCareApplication;
 import org.commcare.activities.CommCareFormDumpActivity;
+import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.models.database.SqlStorage;
-import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.FormUploadUtil;
@@ -22,10 +22,12 @@ import org.javarosa.core.services.locale.Localization;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileFilter;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Vector;
 
 import javax.crypto.Cipher;
@@ -39,19 +41,21 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
     private Context c;
     private Long[] results;
     private File dumpFolder;
-        
+
+    private static final String TAG = DumpTask.class.getSimpleName();
+
     public static final int BULK_DUMP_ID = 23456;
-    
+
     public DumpTask(Context c) {
         this.c = c;
         taskId = DumpTask.BULK_DUMP_ID;
     }
-    
+
     @Override
     protected void onProgressUpdate(String... values) {
         super.onProgressUpdate(values);
     }
-    
+
     @Override
     protected void onPostExecute(Boolean result) {
         super.onPostExecute(result);
@@ -59,15 +63,25 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
         c = null;
         results = null;
     }
-    
+
     private static final String[] SUPPORTED_FILE_EXTS = {".xml", ".jpg", ".3gpp", ".3gp"};
-    
+
     private long dumpInstance(File folder, SecretKeySpec key) throws FileNotFoundException {
-        File[] files = folder.listFiles();
-        
+
+        Logger.log(TAG, "Dumping form instance at folder: " + folder);
+
+        File[] files = folder.listFiles(new FileFilter() {
+            @Override
+            public boolean accept(File file) {
+                return file.isFile();
+            }
+        });
+
+        Logger.log(TAG, "Dumping files: " + Arrays.toString(files));
+
         File myDir = new File(dumpFolder, folder.getName());
         myDir.mkdirs();
-        
+
         if(files == null) {
             //make sure external storage is available to begin with.
             String state = Environment.getExternalStorageState();
@@ -77,7 +91,7 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
             } else {
                 throw new FileNotFoundException("No directory found at: " + folder.getAbsoluteFile());
             }
-        } 
+        }
 
         //If we're listening, figure out how much (roughly) we have to send
         long bytes = 0;
@@ -96,17 +110,19 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
 
             bytes += file.length();
         }
-        
+
         //this.startSubmission(submissionNumber, bytes);
-        
+
         final Cipher decrypter = FormUploadUtil.getDecryptCipher(key);
 
         for (File file : files) {
+
             // This is not the ideal long term solution for determining whether we need decryption, but works
             if (file.getName().endsWith(".xml")) {
                 try {
                     FileUtil.copyFile(file, new File(myDir, file.getName()), decrypter, null);
                 } catch (IOException ie) {
+                    Logger.log(TAG, "Error copying file: " + file + " exception: " + ie.getMessage());
                     publishProgress(("File writing failed: " + ie.getMessage()));
                     return FormUploadUtil.FAILURE;
                 }
@@ -114,6 +130,7 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
                 try {
                     FileUtil.copyFile(file, new File(myDir, file.getName()));
                 } catch (IOException ie) {
+                    Logger.log(TAG, "Error copying file: " + file + " exception: " + ie.getMessage());
                     publishProgress(("File writing failed: " + ie.getMessage()));
                     return FormUploadUtil.FAILURE;
                 }
@@ -121,20 +138,20 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
         }
         return FormUploadUtil.FULL_SUCCESS;
     }
-    
+
     @SuppressLint("NewApi")
     @Override
     protected Boolean doTaskBackground(String... params) {
-        
+
         // ensure that SD is available, writable, and not emulated
 
         boolean mExternalStorageAvailable = false;
         boolean mExternalStorageWriteable = false;
-        
+
         boolean mExternalStorageEmulated = ReflectionUtil.mIsExternalStorageEmulatedHelper();
-        
+
         String state = Environment.getExternalStorageState();
-        
+
         ArrayList<String> externalMounts = FileUtil.getExternalMounts();
 
         if (Environment.MEDIA_MOUNTED.equals(state)) {
@@ -149,7 +166,7 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
             //  to know is we can neither read nor write
             mExternalStorageAvailable = mExternalStorageWriteable = false;
         }
-        
+
         if(!mExternalStorageAvailable){
             publishProgress(Localization.get("bulk.form.sd.unavailable"));
             return false;
@@ -162,26 +179,26 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
             publishProgress(Localization.get("bulk.form.sd.emulated"));
             return false;
         }
-        
+
         String folderName = Localization.get("bulk.form.foldername");
         String directoryPath = FileUtil.getDumpDirectory(c);
-        
+
         if(directoryPath == null){
             publishProgress(Localization.get("bulk.form.sd.emulated"));
             return false;
         }
-        
+
         File dumpDirectory = new File(directoryPath+"/"+folderName);
-        
+
         if(dumpDirectory.exists() && dumpDirectory.isDirectory()){
             dumpDirectory.delete();
         }
-        
+
         dumpDirectory.mkdirs();
-        
+
         SqlStorage<FormRecord> storage = CommCareApplication._().getUserStorage(FormRecord.class);
         Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormsForCurrentApp(storage);
-        
+
         if(ids.size() > 0) {
             FormRecord[] records = new FormRecord[ids.size()];
             for(int i = 0 ; i < ids.size() ; ++i) {
@@ -196,9 +213,9 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
                     //Assume failure
                     results[i] = FormUploadUtil.FAILURE;
                 }
-                
+
                 publishProgress(Localization.get("bulk.form.start"));
-                
+
                 for(int i = 0 ; i < records.length ; ++i) {
                     FormRecord record = records[i];
                     try{
@@ -211,12 +228,12 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
                                 Logger.log(AndroidLogger.TYPE_ERROR_WORKFLOW, "Bizarre. Exception just getting the file reference. Not removing." + getExceptionText(e));
                                 continue;
                             }
-                            
+
                             //Good!
                             //Time to Send!
                             try {
                                 results[i] = dumpInstance(folder, new SecretKeySpec(record.getAesKey(), "AES"));
-                                
+
                             } catch (FileNotFoundException e) {
                                 if(CommCareApplication._().isStorageAvailable()) {
                                     //If storage is available generally, this is a bug in the app design
@@ -228,7 +245,7 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
                                 }
                                 continue;
                             }
-                        
+
                             //Check for success
                             if(results[i].intValue() == FormUploadUtil.FULL_SUCCESS) {
                                 FormRecordCleanupTask.wipeRecord(c, record);
@@ -243,14 +260,18 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
                         Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Totally Unexpected Error during form submission" + getExceptionText(e));
                     }
                 }
-                
+
                 long result = 0;
                 for(int i = 0 ; i < records.length ; ++ i) {
                     if(results[i] > result) {
                         result = results[i];
                     }
                 }
-                
+
+            if(result > 0){
+                return false;
+            }
+
             return true;
         } else {
             publishProgress(Localization.get("bulk.form.no.unsynced"));
@@ -267,7 +288,7 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
             return null;
         }
     }
-    
+
     @Override
     protected void onCancelled() {
         super.onCancelled();

--- a/app/src/org/commcare/tasks/DumpTask.java
+++ b/app/src/org/commcare/tasks/DumpTask.java
@@ -267,12 +267,9 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
                         result = results[i];
                     }
                 }
+            // if any individual send has failed the result will be > 0
+            return result <= 0;
 
-            if(result > 0){
-                return false;
-            }
-
-            return true;
         } else {
             publishProgress(Localization.get("bulk.form.no.unsynced"));
             return false;

--- a/app/src/org/commcare/tasks/FormRecordToFileTask.java
+++ b/app/src/org/commcare/tasks/FormRecordToFileTask.java
@@ -24,6 +24,7 @@ import org.javarosa.core.services.locale.Localization;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileFilter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -62,7 +63,12 @@ public abstract class FormRecordToFileTask extends CommCareTask<String, String, 
      * Return an int status code from FormUploadUtil corresponding to the outcome of the transfer
      */
     private long copyFileInstanceFromStorage(File formRecordFolder, SecretKeySpec decryptionKey) {
-        File[] files = formRecordFolder.listFiles();
+        File[] files = formRecordFolder.listFiles(new FileFilter() {
+            @Override
+            public boolean accept(File file) {
+                return file.isFile();
+            }
+        });
         Logger.log(TAG, "Trying to get instance with: " + files.length + " files.");
 
         File myDir = new File(storedFormDirectory, formRecordFolder.getName());
@@ -190,7 +196,6 @@ public abstract class FormRecordToFileTask extends CommCareTask<String, String, 
                         results[i] = copyFileInstanceFromStorage(folder, new SecretKeySpec(record.getAesKey(), "AES"));
                         if (results[i].intValue() == FormUploadUtil.FAILURE) {
                             publishProgress("Failure during zipping process");
-                            return null;
                         }
                     }
                 } catch (Exception e) {
@@ -200,7 +205,6 @@ public abstract class FormRecordToFileTask extends CommCareTask<String, String, 
             }
 
             long result = getLoopResult(results);
-
             return new Pair<>(result, records);
 
         } else {

--- a/app/src/org/commcare/tasks/ZipTask.java
+++ b/app/src/org/commcare/tasks/ZipTask.java
@@ -97,7 +97,7 @@ public abstract class ZipTask extends CommCareTask<Void, String, ZipTask.ZipTask
 
                 int pathPartsLength = pathParts.length;
 
-                String filePath = pathParts[pathPartsLength -1] + "/" + pathParts[pathPartsLength - 2];
+                String filePath = pathParts[pathPartsLength -2] + "/" + pathParts[pathPartsLength - 1];
                 Log.d(TAG, "Zipping instance folder with path: " + filePath);
 
                 ZipEntry entry = new ZipEntry(filePath);


### PR DESCRIPTION
Two bugs:
First, when there was a subdirectory in the form instance directory, the activity would fail here but create the impression that it was successful. No potential for data loss, but misleading and non functional. The solution was the filter folders out before performing the copy.

Second, the name of files to be zipped was reversed so instead of folder/name it would be name/folder. https://github.com/dimagi/commcare-android/pull/1386/files#diff-af6d6e22c0533d597d5358277debfedeR100. Not clear why this sometimes works and sometimes does not. Investigating further. Should be hotfixed ASA