### PR TITLE
Show case name in saved form for registration cases

### DIFF
--- a/app/src/org/commcare/android/database/user/models/SessionStateDescriptor.java
+++ b/app/src/org/commcare/android/database/user/models/SessionStateDescriptor.java
@@ -6,11 +6,8 @@ import org.commcare.models.framework.Persisting;
 import org.commcare.models.framework.Table;
 import org.commcare.modern.models.EncryptedModel;
 import org.commcare.modern.models.MetaField;
-import org.commcare.session.CommCareSession;
-import org.commcare.session.SessionFrame;
-import org.commcare.suite.model.StackFrameStep;
+import org.commcare.session.SessionDescriptorUtil;
 import org.javarosa.core.util.MD5;
-
 
 /**
  * A Session State Descriptor contains all of the information that can be persisted
@@ -46,7 +43,7 @@ public class SessionStateDescriptor extends Persisted implements EncryptedModel 
     public static SessionStateDescriptor buildFromSessionWrapper(AndroidSessionWrapper state) {
         SessionStateDescriptor descriptor = new SessionStateDescriptor();
         descriptor.formRecordId = state.getFormRecordId();
-        descriptor.sessionDescriptor = createSessionDescriptor(state.getSession());
+        descriptor.sessionDescriptor = SessionDescriptorUtil.createSessionDescriptor(state.getSession());
         return descriptor;
     }
 
@@ -77,52 +74,5 @@ public class SessionStateDescriptor extends Persisted implements EncryptedModel 
 
     public String getSessionDescriptor() {
         return this.sessionDescriptor;
-    }
-
-    /**
-     * Serializes the session into a string which is unique for a
-     * given path through the application, and which can be deserialzied
-     * back into a live session.
-     *
-     * NOTE: Currently we rely on this state being semantically unique,
-     * but it may change in the future. Rely on the specific format as
-     * little as possible.
-     */
-    private static String createSessionDescriptor(CommCareSession session) {
-        StringBuilder descriptor = new StringBuilder();
-        for (StackFrameStep step : session.getFrame().getSteps()) {
-            String type = step.getType();
-            if ((SessionFrame.STATE_QUERY_REQUEST.equals(type) ||
-                    SessionFrame.STATE_SYNC_REQUEST.equals(type))) {
-                // Skip adding remote server query/sync steps to the descriptor.
-                // They are hard to replay (requires serializing query results)
-                // and shouldn't be needed for incomplete forms
-                continue;
-            }
-            descriptor.append(type).append(" ");
-            if (SessionFrame.STATE_COMMAND_ID.equals(type)) {
-                descriptor.append(step.getId()).append(" ");
-            } else if (SessionFrame.STATE_DATUM_VAL.equals(type)
-                    || SessionFrame.STATE_DATUM_COMPUTED.equals(type)) {
-                descriptor.append(step.getId()).append(" ").append(step.getValue()).append(" ");
-            }
-        }
-        return descriptor.toString().trim();
-    }
-
-    public void loadSessionFromDescriptor(CommCareSession session) {
-        String[] tokenStream = sessionDescriptor.split(" ");
-
-        int current = 0;
-        while (current < tokenStream.length) {
-            String action = tokenStream[current];
-            if (action.equals(SessionFrame.STATE_COMMAND_ID)) {
-                session.setCommand(tokenStream[++current]);
-            } else if (action.equals(SessionFrame.STATE_DATUM_VAL) ||
-                    action.equals(SessionFrame.STATE_DATUM_COMPUTED)) {
-                session.setDatum(tokenStream[++current], tokenStream[++current]);
-            }
-            current++;
-        }
     }
 }

--- a/app/src/org/commcare/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/models/AndroidSessionWrapper.java
@@ -7,6 +7,7 @@ import org.commcare.models.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.database.user.models.SessionStateDescriptor;
 import org.commcare.session.CommCareSession;
+import org.commcare.session.SessionDescriptorUtil;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.ComputedDatum;
 import org.commcare.suite.model.EntityDatum;
@@ -51,7 +52,7 @@ public class AndroidSessionWrapper {
         this.reset();
         this.sessionStateRecordId = descriptor.getID();
         this.formRecordId = descriptor.getFormRecordId();
-        descriptor.loadSessionFromDescriptor(session);
+        SessionDescriptorUtil.loadSessionFromDescriptor(descriptor.getSessionDescriptor(), session);
     }
 
     /**

--- a/app/src/org/commcare/tasks/FormRecordLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormRecordLoaderTask.java
@@ -284,7 +284,9 @@ public class FormRecordLoaderTask extends ManagedAsyncTask<FormRecord, Pair<Form
             SessionDatum datum = session.getNeededDatum();
             if (datum instanceof EntityDatum && ((EntityDatum)datum).getLongDetail() != null) {
                 entityDatum = (EntityDatum)datum;
-                break;
+                if (datum.getValue().startsWith("case_id")) {
+                    break;
+                }
             }
             session.stepBack(androidSessionWrapper.getEvaluationContext());
         }
@@ -300,7 +302,9 @@ public class FormRecordLoaderTask extends ManagedAsyncTask<FormRecord, Pair<Form
         //Now determine what nodeset that was going to be used to load this select
         TreeReference nodesetRef = entityDatum.getNodeset().clone();
         Vector<XPathExpression> predicates = nodesetRef.getPredicate(nodesetRef.size() - 1);
-        predicates.add(new XPathEqExpr(XPathEqExpr.EQ, XPathReference.getPathExpr(entityDatum.getValue()), new XPathStringLiteral(value)));
+        XPathEqExpr caseIdSelection =
+                new XPathEqExpr(XPathEqExpr.EQ, XPathReference.getPathExpr(entityDatum.getValue()), new XPathStringLiteral(value));
+        predicates.insertElementAt(caseIdSelection, 0);
 
         Vector<TreeReference> elements = ec.expandReference(nodesetRef);
 

--- a/app/src/org/commcare/tasks/FormRecordLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormRecordLoaderTask.java
@@ -300,22 +300,13 @@ public class FormRecordLoaderTask extends ManagedAsyncTask<FormRecord, Pair<Form
         String value = session.getPoppedStep().getValue();
 
         //Now determine what nodeset that was going to be used to load this select
-        TreeReference nodesetRef = entityDatum.getNodeset().clone();
-        Vector<XPathExpression> predicates = nodesetRef.getPredicate(nodesetRef.size() - 1);
-        XPathEqExpr caseIdSelection =
-                new XPathEqExpr(XPathEqExpr.EQ, XPathReference.getPathExpr(entityDatum.getValue()), new XPathStringLiteral(value));
-        predicates.insertElementAt(caseIdSelection, 0);
-
-        Vector<TreeReference> elements = ec.expandReference(nodesetRef);
-
-        //If we got our ref, awesome. Otherwise we need to bail.
-        if (elements.size() != 1) {
+        TreeReference elem = entityDatum.getEntityFromID(ec, value);
+        if (elem == null) {
             return null;
         }
 
         //Now generate a context for our element
-        EvaluationContext element = new EvaluationContext(ec, elements.firstElement());
-
+        EvaluationContext element = new EvaluationContext(ec, elem);
 
         //Ok, so get our Text.
         Text t = session.getDetail(entityDatum.getLongDetail()).getTitle().getText();


### PR DESCRIPTION
Moves a lot of session descriptor and title loading logic into `commcare-core` so it can be more easily tested and potentially shared with CloudCare (not sure if this is something that is actually useful to CloudCare)

cross-request: https://github.com/dimagi/commcare-core/pull/343