### PR TITLE
Catch xpath error during update relevancies logic and show user

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -105,6 +105,7 @@ import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.XPathUnhandledException;
+import org.javarosa.xpath.expr.XPathExpression;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -621,7 +622,13 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
         saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
 
-        FormEntryPrompt[] newValidPrompts = mFormController.getQuestionPrompts();
+        FormEntryPrompt[] newValidPrompts;
+        try {
+            newValidPrompts = mFormController.getQuestionPrompts();
+        } catch (XPathException e) {
+            UserfacingErrorHandling.logErrorAndShowDialog(this, e, EXIT);
+            return;
+        }
         Set<FormEntryPrompt> promptsLeftInView = new HashSet<>();
 
         ArrayList<Integer> shouldRemoveFromView = new ArrayList<>();

--- a/app/src/org/commcare/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/activities/RecoveryActivity.java
@@ -2,8 +2,6 @@ package org.commcare.activities;
 
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
-import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -16,7 +14,6 @@ import org.commcare.dalvik.R;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
-import org.commcare.preferences.CommCarePreferences;
 import org.commcare.preferences.CommCareServerPreferences;
 import org.commcare.tasks.ProcessAndSendTask;
 import org.commcare.utils.FormUploadUtil;


### PR DESCRIPTION
Show the user the following form builder error (via ACRA) instead of crashing:
```
org.javarosa.xpath.XPathException: The problem was located in calculate expression for /data/rpt_referral_details/test_type_value
XPath evaluation: Attempting to select element 0 of a list with only 0 elements.
at org.javarosa.xpath.expr.XPathFuncExpr.selectedAt(XPathFuncExpr.java:886)
at org.javarosa.xpath.expr.XPathFuncExpr.evalRaw(XPathFuncExpr.java:244)
at org.javarosa.xpath.expr.XPathExpression.eval(XPathExpression.java:25)
at org.javarosa.xpath.XPathConditional.evalRaw(XPathConditional.java:46)
at org.javarosa.core.model.condition.Recalculate.eval(Recalculate.java:35)
at org.javarosa.core.model.condition.Triggerable.apply(Triggerable.java:143)
at org.javarosa.core.model.FormDef.evaluateTriggerable(FormDef.java:1094)
at org.javarosa.core.model.FormDef.evaluateTriggerables(FormDef.java:1072)
at org.javarosa.core.model.FormDef.triggerTriggerables(FormDef.java:1037)
at org.javarosa.core.model.FormDef.createNewRepeat(FormDef.java:405)
at org.javarosa.form.api.FormEntryModel.createModelIfNecessary(FormEntryModel.java:397)
at org.javarosa.form.api.FormEntryController.expandRepeats(FormEntryController.java:192)
at org.javarosa.form.api.FormEntryController.getAdjacentIndex(FormEntryController.java:280)
at org.javarosa.form.api.FormEntryController.getNextIndex(FormEntryController.java:220)
at org.commcare.logic.FormController.getQuestionPrompts(FormController.java:390)
at org.commcare.logic.FormController.getQuestionPrompts(FormController.java:354)
at org.commcare.activities.FormEntryActivity.updateFormRelevancies(FormEntryActivity.java:619)
at org.commcare.activities.FormEntryActivity.widgetEntryChanged(FormEntryActivity.java:2094)
at org.commcare.views.QuestionsView.updateConstraintRelevancies(QuestionsView.java:236)
at org.commcare.views.QuestionsView.widgetEntryChanged(QuestionsView.java:403)
at org.commcare.views.widgets.QuestionWidget.widgetEntryChanged(QuestionWidget.java:615)
at org.commcare.views.widgets.SelectOneWidget.onCheckedChanged(SelectOneWidget.java:169)
at android.widget.CompoundButton.setChecked(CompoundButton.java:161)
at android.widget.CompoundButton.toggle(CompoundButton.java:115)
at android.widget.RadioButton.toggle(RadioButton.java:78)
at android.widget.CompoundButton.performClick(CompoundButton.java:127)
```

![screen](https://cloud.githubusercontent.com/assets/94817/16962112/54c53346-4dbe-11e6-947c-ee9c02f6234f.png)
