### PR TITLE
Make menu list/grid use onCreateSessionSafe

### DIFF
--- a/app/src/org/commcare/activities/MenuBase.java
+++ b/app/src/org/commcare/activities/MenuBase.java
@@ -18,8 +18,8 @@ public abstract class MenuBase
     protected String menuId;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onCreateSessionSafe(Bundle savedInstanceState) {
+        super.onCreateSessionSafe(savedInstanceState);
 
         menuId = getIntent().getStringExtra(SessionFrame.STATE_COMMAND_ID);
 

--- a/app/src/org/commcare/activities/MenuGrid.java
+++ b/app/src/org/commcare/activities/MenuGrid.java
@@ -32,8 +32,8 @@ public class MenuGrid extends MenuBase implements OnItemLongClickListener {
     private GridView grid;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onCreateSessionSafe(Bundle savedInstanceState) {
+        super.onCreateSessionSafe(savedInstanceState);
 
        adapter = new GridMenuAdapter(this, CommCareApplication._().getCommCarePlatform(), menuId);
        adapter.showAnyLoadErrors(this);

--- a/app/src/org/commcare/activities/MenuList.java
+++ b/app/src/org/commcare/activities/MenuList.java
@@ -23,8 +23,8 @@ public class MenuList extends MenuBase {
     private TextView header;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void onCreateSessionSafe(Bundle savedInstanceState) {
+        super.onCreateSessionSafe(savedInstanceState);
 
         if (header == null) {
             header = (TextView)getLayoutInflater().inflate(R.layout.menu_list_header, null);


### PR DESCRIPTION
Fixing ACRA crash that I assume happens when trying to open CommCare at a module/form list after the session has expired.

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{org.commcare.dalvik/org.commcare.activities.MenuList}: org.commcare.utils.SessionUnavailableException
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2339)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2413)
at android.app.ActivityThread.access$800(ActivityThread.java:155)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1317)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:135)
at android.app.ActivityThread.main(ActivityThread.java:5343)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:905)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:700)
Caused by: org.commcare.utils.SessionUnavailableException
at org.commcare.CommCareApplication.getSession(CommCareApplication.java:1187)
at org.commcare.CommCareApplication.getUserDbHandle(CommCareApplication.java:736)
at org.commcare.models.database.user.models.CaseIndexTable.<init>(CaseIndexTable.java:51)
at org.commcare.engine.cases.AndroidCaseInstanceTreeElement.<init>(AndroidCaseInstanceTreeElement.java:37)
at org.commcare.utils.AndroidInstanceInitializer.setupCaseData(AndroidInstanceInitializer.java:48)
at org.commcare.core.process.CommCareInstanceInitializer.generateRoot(CommCareInstanceInitializer.java:70)
at org.javarosa.core.model.instance.ExternalDataInstance.initialize(ExternalDataInstance.java:91)
at org.commcare.session.CommCareSession.getEvaluationContext(CommCareSession.java:515)
at org.commcare.models.AndroidSessionWrapper.getEvaluationContext(AndroidSessionWrapper.java:188)
at org.commcare.adapters.MenuAdapter.menuIsRelevant(MenuAdapter.java:112)
at org.commcare.adapters.MenuAdapter.<init>(MenuAdapter.java:73)
at org.commcare.activities.MenuList.onCreate(MenuList.java:39)
at android.app.Activity.performCreate(Activity.java:6010)
at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1129)
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2292)
```