### PR TITLE
Catch lookup table missing on form open

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -743,3 +743,4 @@ repeat.dialog.exit=Do Not Add. I'm Finished.
 repeat.dialog.add=Add Group
 repeat.dialog.add.another=Add another "${0}" group?
 repeat.dialog.add.new=Add a new "${0}" group?
+lookup.table.missing.error=Unable to find lookup table "${0}". Make sure it exists and this user has access to it.

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -11,6 +11,7 @@ import org.commcare.CommCareApplication;
 import org.commcare.activities.FormEntryActivity;
 import org.commcare.android.logging.ForceCloseLogger;
 import org.commcare.android.resource.installers.XFormAndroidInstaller;
+import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.engine.extensions.CalendaredDateFormatHandler;
 import org.commcare.logging.UserCausedRuntimeException;
 import org.commcare.logging.XPathErrorLogger;
@@ -206,6 +207,8 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Uri, String, FormLo
             formDef.initialize(isNewFormInstance, iif, getSystemLocale());
         } catch (XPathException e) {
             XPathErrorLogger.INSTANCE.logErrorToCurrentApp(e);
+            throw new UserCausedRuntimeException(e.getMessage(), e);
+        } catch (CommCareInstanceInitializer.FixtureInitializationException e) {
             throw new UserCausedRuntimeException(e.getMessage(), e);
         }
 


### PR DESCRIPTION
Catch lookup table missing errors on form load.
Allow lookup table missing error message to be localized

| Old message (caught in other place) | New message (caught in form load) |
|---|---|
| ![old-message](https://cloud.githubusercontent.com/assets/94817/16964421/5e2ff1f4-4dc9-11e6-8aa2-68d0054b655b.png) | ![screen](https://cloud.githubusercontent.com/assets/94817/16964424/60233228-4dc9-11e6-834b-f46271d86072.png) |

cross-request: https://github.com/dimagi/commcare-core/pull/344

From ACRA crash:
```
org.commcare.core.process.CommCareInstanceInitializer$FixtureInitializationException: Could not find an lookup table for src: jr://fixture/item-list:ML_village
at org.commcare.core.process.CommCareInstanceInitializer.setupFixtureData(CommCareInstanceInitializer.java:117)
at org.commcare.core.process.CommCareInstanceInitializer.generateRoot(CommCareInstanceInitializer.java:72)
at org.javarosa.core.model.instance.ExternalDataInstance.initialize(ExternalDataInstance.java:91)
at org.javarosa.core.model.FormDef.initialize(FormDef.java:1543)
at org.javarosa.core.model.FormDef.initialize(FormDef.java:1527)
at org.commcare.tasks.FormLoaderTask.initFormDef(FormLoaderTask.java:208)
at org.commcare.tasks.FormLoaderTask.doTaskBackground(FormLoaderTask.java:128)
at org.commcare.tasks.FormLoaderTask.doTaskBackground(FormLoaderTask.java:60)
at org.commcare.tasks.templates.CommCareTask.doInBackground(CommCareTask.java:38)
```