### PR TITLE
Only hide actions if there is a command to check for 'isSync'

### DIFF
--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -176,15 +176,16 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         refreshTimer = new EntitySelectRefreshTimer();
         asw = CommCareApplication._().getCurrentSessionWrapper();
         session = asw.getSession();
-        // Don't show actions (e.g. 'register patient', 'claim patient') when
-        // in the middle on workflow triggered by an (sync) action.
-        hideActions = session.isSyncCommand(session.getCommand());
 
         // avoid session dependent when there is no command
         if (session.getCommand() != null) {
             selectDatum = (EntityDatum)session.getNeededDatum();
             shortSelect = session.getDetail(selectDatum.getShortDetail());
             mNoDetailMode = selectDatum.getLongDetail() == null;
+
+            // Don't show actions (e.g. 'register patient', 'claim patient') when
+            // in the middle on workflow triggered by an (sync) action.
+            hideActions = session.isSyncCommand(session.getCommand());
 
             boolean isOrientationChange = savedInstanceState != null;
             setupUI(isOrientationChange);


### PR DESCRIPTION
Fix for ACRA crash below. Not exactly sure when `EntitySelectActivity` is launched without a session command, but there is already some logic that checks for nullity of the command, so I guess this comes up often enough.

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{org.commcare.dalvik/org.commcare.activities.EntitySelectActivity}: java.lang.NullPointerException
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2429)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2493)
at android.app.ActivityThread.access$800(ActivityThread.java:166)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1283)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:136)
at android.app.ActivityThread.main(ActivityThread.java:5584)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:515)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1268)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1084)
at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.NullPointerException
at org.commcare.session.CommCareSession.getEntriesForCommand(CommCareSession.java:131)
at org.commcare.session.CommCareSession.getEntriesForCommand(CommCareSession.java:117)
at org.commcare.session.CommCareSession.isSyncCommand(CommCareSession.java:816)
at org.commcare.activities.EntitySelectActivity.onCreate(EntitySelectActivity.java:179)
```