### PR TITLE
Null check of HomeActivity's button adapter

### DIFF
--- a/app/src/org/commcare/activities/HomeActivityUIController.java
+++ b/app/src/org/commcare/activities/HomeActivityUIController.java
@@ -42,7 +42,10 @@ public class HomeActivityUIController implements CommCareActivityUIController {
 
     @Override
     public void refreshView() {
-        adapter.notifyDataSetChanged();
+        if (adapter != null) {
+            // adapter can be null if backstack was cleared for memory reasons
+            adapter.notifyDataSetChanged();
+        }
     }
 
     private static Vector<String> getHiddenButtons() {


### PR DESCRIPTION
Fix for an ACRA crash:

```
java.lang.RuntimeException: Unable to resume activity {org.commcare.dalvik/org.commcare.activities.CommCareHomeActivity}: java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=4, result=0, data=null} to activity {org.commcare.dalvik/org.commcare.activities.CommCareHomeActivity}: java.lang.NullPointerException
at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3056)
at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3085)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2498)
at android.app.ActivityThread.access$800(ActivityThread.java:166)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1283)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:136)
at android.app.ActivityThread.main(ActivityThread.java:5590)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:515)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1280)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1096)
at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=4, result=0, data=null} to activity {org.commcare.dalvik/org.commcare.activities.CommCareHomeActivity}: java.lang.NullPointerException
at android.app.ActivityThread.deliverResults(ActivityThread.java:3641)
at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3043)
... 12 more
Caused by: java.lang.NullPointerException
at org.commcare.activities.HomeActivityUIController.refreshView(HomeActivityUIController.java:45)
at org.commcare.activities.CommCareHomeActivity.clearSessionAndExit(CommCareHomeActivity.java:737)
at org.commcare.activities.CommCareHomeActivity.processReturnFromFormEntry(CommCareHomeActivity.java:610)
at org.commcare.activities.CommCareHomeActivity.onActivityResult(CommCareHomeActivity.java:499)
at android.app.Activity.dispatchActivityResult(Activity.java:5639)
```

Can only imagine it coming up if the activity is cleared from the backstack due to memory issues and returned to via `onActivityResult`

