### PR TITLE
Don't auto-advance signature widget if in question list

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -489,7 +489,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 break;
             case SIGNATURE_CAPTURE:
                 boolean saved = ImageCaptureProcessing.processCaptureResponse(this, getInstanceFolder(), false);
-                if (saved) {
+                if (saved && !questionsView.isQuestionList()) {
                     // attempt to auto-advance if a signature was captured
                     advance();
                 }


### PR DESCRIPTION
Meryn was asking if this was expected behavior.

Follow up to revert done in https://github.com/dimagi/commcare-android/pull/1342 for https://github.com/dimagi/commcare-android/pull/1126

Probably worth including in a hotfix.