### PR TITLE
Don't remove existing header text on callout result

### DIFF
--- a/app/src/org/commcare/views/EntityView.java
+++ b/app/src/org/commcare/views/EntityView.java
@@ -145,7 +145,7 @@ public class EntityView extends LinearLayout {
                 new String[columnTitles.length + 1];
         System.arraycopy(columnTitles, 0,
                 headerTextWithCalloutResponse, 0, columnTitles.length);
-        headerTextWithCalloutResponse[columnTitles.length - 1] =
+        headerTextWithCalloutResponse[columnTitles.length] =
                 calloutResponseDetailField.getHeader().evaluate();
         return headerTextWithCalloutResponse;
     }


### PR DESCRIPTION
Indexing issue with case list column headers where a fingerprint callout result would remove an existing header

Example of the bug: 

| pre-callout | post-callout |
|----|----|
| ![image](https://cloud.githubusercontent.com/assets/94817/17037535/6df4f3cc-4f5f-11e6-8fa9-14945786a1f2.png) | ![image](https://cloud.githubusercontent.com/assets/94817/17037536/70cde7d4-4f5f-11e6-9eae-cb45cee984e6.png) |

