### PR TITLE
Don't crash when session expires and home options menu is being created

### DIFF
--- a/app/src/org/commcare/activities/CommCareHomeActivity.java
+++ b/app/src/org/commcare/activities/CommCareHomeActivity.java
@@ -1216,14 +1216,26 @@ public class CommCareHomeActivity
         menu.findItem(MENU_PREFERENCES).setVisible(enableMenus);
         menu.findItem(MENU_ADVANCED).setVisible(enableMenus);
         menu.findItem(MENU_ABOUT).setVisible(enableMenus);
-        if (CommCareApplication._().getRecordForCurrentUser().hasPinSet()) {
+        preparePinMenu(menu, enableMenus);
+        return true;
+    }
+
+    private static void preparePinMenu(Menu menu, boolean enableMenus) {
+        boolean pinEnabled = enableMenus && DeveloperPreferences.shouldOfferPinForLogin();
+        menu.findItem(MENU_PIN).setVisible(pinEnabled);
+        boolean hasPinSet = false;
+
+        try {
+            hasPinSet = CommCareApplication._().getRecordForCurrentUser().hasPinSet();
+        } catch (SessionUnavailableException e) {
+            Log.d(TAG, "Session expired and menu is being created before redirect to login screen");
+        }
+
+        if (hasPinSet) {
             menu.findItem(MENU_PIN).setTitle(Localization.get("home.menu.pin.change"));
         } else {
             menu.findItem(MENU_PIN).setTitle(Localization.get("home.menu.pin.set"));
         }
-        menu.findItem(MENU_PIN).setVisible(enableMenus
-                && DeveloperPreferences.shouldOfferPinForLogin());
-        return true;
     }
 
     @Override


### PR DESCRIPTION
Follow up to https://github.com/dimagi/commcare-android/pull/1403

```
org.commcare.utils.SessionUnavailableException
at org.commcare.CommCareApplication.getSession(CommCareApplication.java:1187)
at org.commcare.CommCareApplication.getRecordForCurrentUser(CommCareApplication.java:1193)
at org.commcare.activities.CommCareHomeActivity.onPrepareOptionsMenu(CommCareHomeActivity.java:1218)
at android.app.Activity.onPreparePanel(Activity.java:2589)
at android.support.v4.app.FragmentActivity.onPrepareOptionsPanel(FragmentActivity.java:529)
at android.support.v4.app.FragmentActivity.onPreparePanel(FragmentActivity.java:518)
at com.android.internal.policy.impl.PhoneWindow.preparePanel(PhoneWindow.java:483)
at com.android.internal.policy.impl.PhoneWindow.doInvalidatePanelMenu(PhoneWindow.java:830)
at com.android.internal.policy.impl.PhoneWindow$1.run(PhoneWindow.java:240)
```