### PR TITLE
Persist install error messages

### DIFF
--- a/app/res/layout/select_install_mode_fragment.xml
+++ b/app/res/layout/select_install_mode_fragment.xml
@@ -120,6 +120,20 @@
                 </LinearLayout>
 
             </LinearLayout>
+
+            <TextView
+                android:id="@+id/install_error_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:paddingBottom="2dp"
+                android:paddingLeft="5dp"
+                android:paddingRight="5dp"
+                android:paddingTop="2dp"
+                android:textColor="@color/red"
+                android:textStyle="bold"
+                android:visibility="gone" />
+
         </LinearLayout>
     </ScrollView>
 </RelativeLayout>

--- a/app/res/layout/select_install_mode_fragment.xml
+++ b/app/res/layout/select_install_mode_fragment.xml
@@ -138,8 +138,6 @@
 
             </LinearLayout>
 
-
-
         </LinearLayout>
     </ScrollView>
 </RelativeLayout>

--- a/app/res/layout/select_install_mode_fragment.xml
+++ b/app/res/layout/select_install_mode_fragment.xml
@@ -121,18 +121,24 @@
 
             </LinearLayout>
 
-            <TextView
-                android:id="@+id/install_error_text"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="center"
-                android:paddingBottom="2dp"
-                android:paddingLeft="5dp"
-                android:paddingRight="5dp"
-                android:paddingTop="2dp"
-                android:textColor="@color/red"
-                android:textStyle="bold"
-                android:visibility="gone" />
+                android:padding="@dimen/standard_spacer"
+                android:gravity="center">
+
+                <TextView
+                    android:id="@+id/install_error_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/red"
+                    android:textStyle="bold"
+                    android:gravity="center"
+                    android:visibility="gone"/>
+
+            </LinearLayout>
+
+
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -113,7 +113,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
     // Activity request codes
     public static final int BARCODE_CAPTURE = 1;
-    private static final int ARCHIVE_INSTALL = 3;
+    private static final int OFFLINE_INSTALL = 3;
     private static final int MULTIPLE_APPS_LIMIT = 4;
 
     // dialog ID
@@ -177,7 +177,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                         incomingRef = incomingRef.substring(incomingRef.indexOf("//") + 2);
                         Intent i = new Intent(this, InstallArchiveActivity.class);
                         i.putExtra(InstallArchiveActivity.ARCHIVE_FILEPATH, incomingRef);
-                        startActivityForResult(i, ARCHIVE_INSTALL);
+                        startActivityForResult(i, OFFLINE_INSTALL);
                     } else {
                         // currently down allow other locations like http://
                         fail(NotificationMessageFactory.message(NotificationMessageFactory.StockMessages.Bad_Archive_File), true);
@@ -386,7 +386,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                     lastInstallMode = INSTALL_MODE_BARCODE;
                 }
                 break;
-            case ARCHIVE_INSTALL:
+            case OFFLINE_INSTALL:
                 if (resultCode == Activity.RESULT_OK) {
                     lastInstallMode = INSTALL_MODE_OFFLINE;
                     result = data.getStringExtra(InstallArchiveActivity.ARCHIVE_JR_REFERENCE);
@@ -652,7 +652,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         if (item.getItemId() == MODE_ARCHIVE) {
             clearErrorMessage();
             Intent i = new Intent(getApplicationContext(), InstallArchiveActivity.class);
-            startActivityForResult(i, ARCHIVE_INSTALL);
+            startActivityForResult(i, OFFLINE_INSTALL);
         }
         if (item.getItemId() == MODE_SMS) {
             clearErrorMessage();

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -661,17 +661,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         return true;
     }
 
-    private void displayError(String message) {
-        errorMessageToDisplay = message;
-        installFragment.showOrHideErrorMessage();
-    }
-
-    private void fail(String message) {
-        displayError(message);
-        uiState = UiState.CHOOSE_INSTALL_ENTRY_METHOD;
-        uiStateScreenTransition();
-    }
-
     private void fail(NotificationMessage notificationMessage, boolean reportNotification) {
         String message;
         if (reportNotification) {
@@ -682,6 +671,23 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             message = notificationMessage.getTitle();
         }
         fail(message);
+    }
+
+    /**
+     * Display an error and perform a UI transition
+     */
+    private void fail(String message) {
+        displayError(message);
+        uiState = UiState.CHOOSE_INSTALL_ENTRY_METHOD;
+        uiStateScreenTransition();
+    }
+
+    /**
+     * Display an error without performing a UI transition
+     */
+    private void displayError(String message) {
+        errorMessageToDisplay = message;
+        installFragment.showOrHideErrorMessage();
     }
 
     public void clearErrorMessage() {

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -20,6 +20,8 @@ import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import org.commcare.CommCareApp;
@@ -663,18 +665,21 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     }
 
     private void fail(NotificationMessage message, boolean reportNotification) {
-        String toastMessage;
+        String displayMessage;
         if (reportNotification) {
             CommCareApplication._().reportNotificationMessage(message);
-            toastMessage = Localization.get("notification.for.details.wrapper", new String[]{message.getTitle()});
+            displayMessage = Localization.get("notification.for.details.wrapper", new String[]{message.getTitle()});
         } else {
-            toastMessage = message.getTitle();
+            displayMessage = message.getTitle();
         }
-        Toast.makeText(this, toastMessage, Toast.LENGTH_LONG).show();
+
+        //Toast.makeText(this, toastMessage, Toast.LENGTH_LONG).show();
 
         // Last install attempt failed, so restore to starting uistate to try again
         uiState = UiState.CHOOSE_INSTALL_ENTRY_METHOD;
         uiStateScreenTransition();
+
+        installFragment.showErrorMessage(displayMessage);
     }
 
     // All final paths from the Update are handled here (Important! Some

--- a/app/src/org/commcare/fragments/SelectInstallModeFragment.java
+++ b/app/src/org/commcare/fragments/SelectInstallModeFragment.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 public class SelectInstallModeFragment extends Fragment implements NsdServiceListener {
 
     private View mFetchHubContainer;
-    private TextView mErrorTextView;
+    private TextView mErrorMessageView;
     private ArrayList<Pair<String, String>> mLocalApps = new ArrayList<>();
 
     @Override
@@ -68,8 +68,11 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
             @Override
             public void onClick(View v) {
                 try {
+                    Activity currentActivity = getActivity();
+                    if (currentActivity instanceof CommCareSetupActivity) {
+                        ((CommCareSetupActivity)currentActivity).clearErrorMessage();
+                    }
                     Intent i = new Intent("com.google.zxing.client.android.SCAN");
-                    //Barcode only
                     i.putExtra("SCAN_FORMATS", "QR_CODE");
                     getActivity().startActivityForResult(i, CommCareSetupActivity.BARCODE_CAPTURE);
                 } catch (ActivityNotFoundException e) {
@@ -87,6 +90,7 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
                 Activity currentActivity = getActivity();
                 if (currentActivity instanceof CommCareSetupActivity) {
                     ((CommCareSetupActivity)currentActivity).setUiState(CommCareSetupActivity.UiState.IN_URL_ENTRY);
+                    ((CommCareSetupActivity)currentActivity).clearErrorMessage();
                 }
                 // if we use getChildFragmentManager, we're going to have a crash
                 FragmentManager fm = getActivity().getSupportFragmentManager();
@@ -108,8 +112,10 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
             }
         });
 
+        mErrorMessageView = (TextView)view.findViewById(R.id.install_error_text);
+        showOrHideErrorMessage();
+
         mFetchHubContainer = view.findViewById(R.id.btn_fetch_hub_container);
-        mErrorTextView = (TextView)view.findViewById(R.id.install_error_text);
 
         return view;
     }
@@ -160,8 +166,16 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
         }
     }
 
-    public void showErrorMessage(String msg) {
-        mErrorTextView.setText(msg);
-        mErrorTextView.setVisibility(View.VISIBLE);
+    public void showOrHideErrorMessage() {
+        Activity currentActivity = getActivity();
+        if (currentActivity instanceof CommCareSetupActivity) {
+            String msg = ((CommCareSetupActivity) currentActivity).getErrorMessageToDisplay();
+            if (msg != null && !"".equals(msg)) {
+                mErrorMessageView.setText(msg);
+                mErrorMessageView.setVisibility(View.VISIBLE);
+            } else {
+                mErrorMessageView.setVisibility(View.GONE);
+            }
+        }
     }
 }

--- a/app/src/org/commcare/fragments/SelectInstallModeFragment.java
+++ b/app/src/org/commcare/fragments/SelectInstallModeFragment.java
@@ -2,6 +2,7 @@ package org.commcare.fragments;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -12,6 +13,7 @@ import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -116,6 +118,9 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
         showOrHideErrorMessage();
 
         mFetchHubContainer = view.findViewById(R.id.btn_fetch_hub_container);
+
+        InputMethodManager inputManager = (InputMethodManager)getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+        inputManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
 
         return view;
     }

--- a/app/src/org/commcare/fragments/SelectInstallModeFragment.java
+++ b/app/src/org/commcare/fragments/SelectInstallModeFragment.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 public class SelectInstallModeFragment extends Fragment implements NsdServiceListener {
 
     private View mFetchHubContainer;
+    private TextView mErrorTextView;
     private ArrayList<Pair<String, String>> mLocalApps = new ArrayList<>();
 
     @Override
@@ -108,6 +109,7 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
         });
 
         mFetchHubContainer = view.findViewById(R.id.btn_fetch_hub_container);
+        mErrorTextView = (TextView)view.findViewById(R.id.install_error_text);
 
         return view;
     }
@@ -156,5 +158,10 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
                 }
             });
         }
+    }
+
+    public void showErrorMessage(String msg) {
+        mErrorTextView.setText(msg);
+        mErrorTextView.setVisibility(View.VISIBLE);
     }
 }


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?223803.

Instead of using toasts to show error messages during app install, place the error message on the screen itself. (The error text will disappear if you go to any other screen and then return).

Before:
![screenshot_20160727-113857](https://cloud.githubusercontent.com/assets/3723143/17181667/e9a5a44c-53ee-11e6-9a5b-20b462e2c7d7.png)

After:
![screenshot_20160727-114044](https://cloud.githubusercontent.com/assets/3723143/17181701/fee4eaf2-53ee-11e6-8951-37c615bfbe6e.png)
