### PR TITLE
Add language analytics

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -283,7 +283,11 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         org.javarosa.core.services.PropertyManager.setPropertyManager(new PropertyManager(
                 getApplicationContext()));
 
-        loadStateFromBundle(savedInstanceState);
+        if (savedInstanceState == null) {
+            GoogleAnalyticsUtils.reportLanguageAtPointOfFormEntry(Localization.getCurrentLocale());
+        } else {
+            loadStateFromBundle(savedInstanceState);
+        }
 
         // Need to override CalendarUtil's month localizer
         CalendarUtils.setArrayDataSource(new AndroidArrayDataSource(this));

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
@@ -23,6 +23,7 @@ public final class GoogleAnalyticsFields {
     public static final String CATEGORY_FEATURE_USAGE = "Feature Usage";
     public static final String CATEGORY_APP_MANAGER = "App Manager";
     public static final String CATEGORY_AUDIO_WIDGET = "Audio Widget Prototype";
+    public static final String CATEGORY_LANGUAGE_STATS = "Language Statistics";
 
     //Actions for CATEGORY_AUDIO_WIDGET only
     public static final String ACTION_START_RECORDING_DIALOG = "Click the button to open recording popup";
@@ -99,6 +100,9 @@ public final class GoogleAnalyticsFields {
     public static final String ACTION_OFFLINE_INSTALL = "Offline Install";
     public static final String ACTION_URL_INSTALL = "URL Install";
     public static final String ACTION_SMS_INSTALL = "SMS Install";
+
+    // Actions for CATEGORY_LANGUAGE_STATS
+    public static final String ACTION_LANGUAGE_AT_FORM_ENTRY = "Language at Time of Form Entry";
 
     // Labels for ACTION_BUTTON
     public static final String LABEL_START_BUTTON = "Start Button";

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsUtils.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsUtils.java
@@ -314,6 +314,12 @@ public class GoogleAnalyticsUtils {
         reportEvent(GoogleAnalyticsFields.CATEGORY_PRIVILEGE_ENABLED, privilegeName, username);
     }
 
+    public static void reportLanguageAtPointOfFormEntry(String language) {
+        System.out.println("Language at time of form entry: " + language);
+        reportEvent(GoogleAnalyticsFields.CATEGORY_LANGUAGE_STATS,
+                GoogleAnalyticsFields.ACTION_LANGUAGE_AT_FORM_ENTRY, language);
+    }
+
     /**
      * Report the length of a certain user event/action/concept
      *

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsUtils.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsUtils.java
@@ -315,7 +315,6 @@ public class GoogleAnalyticsUtils {
     }
 
     public static void reportLanguageAtPointOfFormEntry(String language) {
-        System.out.println("Language at time of form entry: " + language);
         reportEvent(GoogleAnalyticsFields.CATEGORY_LANGUAGE_STATS,
                 GoogleAnalyticsFields.ACTION_LANGUAGE_AT_FORM_ENTRY, language);
     }


### PR DESCRIPTION
Kevin asked me to sneak this into 2.29 so that the product team can start figuring out what the most commonly-used languages on CommCare are (for purposes of developing default translations).

cross-request: https://github.com/dimagi/commcare-core/pull/355