### PR TITLE
Fix BarcodeWidget getAnswer implementation and unify codepath with IntentWidget

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -738,6 +738,7 @@ intent.callout.get=Get Data
 intent.callout.update=Update Data
 intent.callout.cancelled=Question callout cancelled
 intent.callout.unable.to.process=Unable to process callout result
+intent.callout.activity.missing=Couldn't find intent for callout!
 fingerprints.scanned=Fingerprints scanned: ${0}
 
 settings.server.listing=Server Settings

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -600,7 +600,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
         IntentWidget pendingIntentWidget = (IntentWidget)getPendingWidget();
         if (pendingIntentWidget != null) {
-
             // get the original intent callout
             IntentCallout ic = pendingIntentWidget.getIntentCallout();
 
@@ -623,7 +622,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 }
             }
 
-            ic.setCancelled(wasIntentCancelled);
+            if (wasIntentCancelled) {
+                mFormController.setPendingCalloutAsCancelled();
+            }
         }
 
         // auto advance if we got a good result and are in quick mode

--- a/app/src/org/commcare/android/javarosa/IntentCallout.java
+++ b/app/src/org/commcare/android/javarosa/IntentCallout.java
@@ -95,7 +95,7 @@ public class IntentCallout implements Externalizable {
         this.appearance = appearance;
     }
 
-    protected void attachToForm(FormDef form) {
+    public void attachToForm(FormDef form) {
         this.formDef = form;
     }
 

--- a/app/src/org/commcare/android/javarosa/IntentCallout.java
+++ b/app/src/org/commcare/android/javarosa/IntentCallout.java
@@ -144,6 +144,10 @@ public class IntentCallout implements Externalizable {
         }
     }
 
+    public void processBarcodeResponse(TreeReference intentQuestionRef, String scanResult) {
+        setNodeValue(formDef, intentQuestionRef, scanResult);
+    }
+
     private static boolean intentInvalid(Intent intent) {
         if (intent == null) {
             return true;

--- a/app/src/org/commcare/android/javarosa/IntentCallout.java
+++ b/app/src/org/commcare/android/javarosa/IntentCallout.java
@@ -57,7 +57,6 @@ public class IntentCallout implements Externalizable {
     private String buttonLabel;
     private String updateButtonLabel;
     private String appearance;
-    private boolean isCancelled;
 
     // Generic Extra from intent callout extensions
     public static final String INTENT_RESULT_VALUE = "odk_intent_data";
@@ -307,13 +306,5 @@ public class IntentCallout implements Externalizable {
 
     public String getAppearance() {
         return appearance;
-    }
-
-    public void setCancelled(boolean cancelled) {
-        this.isCancelled = cancelled;
-    }
-
-    public boolean getCancelled() {
-        return isCancelled;
     }
 }

--- a/app/src/org/commcare/logic/FormController.java
+++ b/app/src/org/commcare/logic/FormController.java
@@ -1,5 +1,7 @@
 package org.commcare.logic;
 
+import android.support.annotation.NonNull;
+
 import org.commcare.views.QuestionsView;
 import org.commcare.views.widgets.WidgetFactory;
 import org.javarosa.core.model.FormDef;
@@ -34,7 +36,7 @@ public class FormController implements PendingCalloutInterface {
     private final FormEntryController mFormEntryController;
 
     private FormIndex mPendingCalloutFormIndex = null;
-    private boolean mPendingCalloutIsBulk = false;
+    private boolean wasPendingCalloutCancelled;
 
     private final boolean mReadOnly;
 
@@ -566,7 +568,18 @@ public class FormController implements PendingCalloutInterface {
 
     @Override
     public void setPendingCalloutFormIndex(FormIndex pendingCalloutFormIndex) {
+        wasPendingCalloutCancelled = false;
         mPendingCalloutFormIndex = pendingCalloutFormIndex;
+    }
+
+    @Override
+    public boolean wasCalloutPendingAndCancelled(@NonNull FormIndex calloutFormIndex) {
+        return wasPendingCalloutCancelled && calloutFormIndex.equals(mPendingCalloutFormIndex);
+    }
+
+    @Override
+    public void setPendingCalloutAsCancelled() {
+        wasPendingCalloutCancelled = true;
     }
 
     //CTS: Added this to protect the JR internal classes, although it's not awesome that

--- a/app/src/org/commcare/logic/PendingCalloutInterface.java
+++ b/app/src/org/commcare/logic/PendingCalloutInterface.java
@@ -17,4 +17,8 @@ public interface PendingCalloutInterface {
     FormIndex getPendingCalloutFormIndex();
 
     void setPendingCalloutFormIndex(FormIndex pendingCalloutFormIndex);
+
+    boolean wasCalloutPendingAndCancelled(FormIndex calloutFormIndex);
+
+    void setPendingCalloutAsCancelled();
 }

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -1,7 +1,6 @@
 package org.commcare.views;
 
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.os.Build;
@@ -16,7 +15,6 @@ import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
-import org.commcare.android.javarosa.IntentCallout;
 import org.commcare.dalvik.R;
 import org.commcare.interfaces.WidgetChangedListener;
 import org.commcare.logging.AndroidLogger;

--- a/app/src/org/commcare/views/widgets/BarcodeWidget.java
+++ b/app/src/org/commcare/views/widgets/BarcodeWidget.java
@@ -22,7 +22,8 @@ public class BarcodeWidget extends IntentWidget implements TextWatcher {
     public BarcodeWidget(Context context, FormEntryPrompt prompt, Intent i, IntentCallout ic,
                          PendingCalloutInterface pendingCalloutInterface) {
         super(context, prompt, i, ic, pendingCalloutInterface,
-                "intent.barcode.get", "intent.barcode.update", "barcode.reader.missing");
+                "intent.barcode.get", "intent.barcode.update", "barcode.reader.missing",
+                ic.getAppearance() != null && ic.getAppearance().contains("editable"));
     }
 
     @Override

--- a/app/src/org/commcare/views/widgets/BarcodeWidget.java
+++ b/app/src/org/commcare/views/widgets/BarcodeWidget.java
@@ -14,8 +14,6 @@ import org.javarosa.form.api.FormEntryPrompt;
 
 /**
  * Widget that allows user to scan barcodes and add them to the form.
- *
- * @author Yaw Anokwa (yanokwa@gmail.com)
  */
 public class BarcodeWidget extends IntentWidget implements TextWatcher {
 

--- a/app/src/org/commcare/views/widgets/BarcodeWidget.java
+++ b/app/src/org/commcare/views/widgets/BarcodeWidget.java
@@ -6,8 +6,6 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.TypedValue;
 import android.view.Gravity;
-import android.widget.EditText;
-import android.widget.TextView;
 
 import org.commcare.android.javarosa.IntentCallout;
 import org.commcare.logic.PendingCalloutInterface;
@@ -21,7 +19,6 @@ import org.javarosa.form.api.FormEntryPrompt;
  */
 public class BarcodeWidget extends IntentWidget implements TextWatcher {
 
-    private TextView mStringAnswer;
     private boolean hasTextChanged;
 
     public BarcodeWidget(Context context, FormEntryPrompt prompt, Intent i, IntentCallout ic,
@@ -33,7 +30,6 @@ public class BarcodeWidget extends IntentWidget implements TextWatcher {
     @Override
     public void setupTextView() {
         if (isEditable) {
-            mStringAnswer = new EditText(getContext());
             mStringAnswer.addTextChangedListener(this);
             mStringAnswer.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mAnswerFontsize);
             mStringAnswer.setGravity(Gravity.CENTER);

--- a/app/src/org/commcare/views/widgets/BarcodeWidget.java
+++ b/app/src/org/commcare/views/widgets/BarcodeWidget.java
@@ -1,23 +1,16 @@
 package org.commcare.views.widgets;
 
-import android.app.Activity;
-import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
-import android.text.SpannableString;
 import android.util.TypedValue;
 import android.view.Gravity;
-import android.view.View;
-import android.widget.Button;
 import android.widget.EditText;
-import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
-import org.commcare.activities.FormEntryActivity;
 import org.commcare.android.javarosa.IntentCallout;
 import org.commcare.logic.PendingCalloutInterface;
-import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 
 /**
@@ -25,57 +18,23 @@ import org.javarosa.form.api.FormEntryPrompt;
  *
  * @author Yaw Anokwa (yanokwa@gmail.com)
  */
-
 public class BarcodeWidget extends IntentWidget {
 
     private TextView mStringAnswer;
+    private final boolean isEditable;
+    private boolean hasTextChanged;
 
     public BarcodeWidget(Context context, FormEntryPrompt prompt, Intent i, IntentCallout ic,
                          PendingCalloutInterface pendingCalloutInterface) {
-        // todo: I don't think pendingCalloutInterface is actually useful for BarcodeWidget
-        // todo: it's only here because it subclasses IntentWidget
-        super(context, prompt, i, ic, pendingCalloutInterface, FormEntryActivity.BARCODE_CAPTURE);
+        super(context, prompt, i, ic, pendingCalloutInterface,
+                "intent.barcode.get", "intent.barcode.update", "barcode.reader.missing");
 
-        setOrientation(LinearLayout.VERTICAL);
-    }
-
-    @Override
-    protected void setupButton() {
-        setOrientation(LinearLayout.VERTICAL);
-        WidgetUtils.setupButton(launchIntentButton,
-                getButtonLabel(),
-                mAnswerFontsize,
-                !mPrompt.isReadOnly());
-
-        // launch barcode capture intent on click
-        launchIntentButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent i = new Intent("com.google.zxing.client.android.SCAN");
-                try {
-                    ((Activity)getContext()).startActivityForResult(i,
-                            FormEntryActivity.BARCODE_CAPTURE);
-                    pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
-                } catch (ActivityNotFoundException e) {
-                    Toast.makeText(getContext(),
-                            Localization.get("barcode.reader.missing"),
-                            Toast.LENGTH_SHORT).show();
-                }
-            }
-        });
-        addView(launchIntentButton);
-    }
-
-    @Override
-    public void clearAnswer() {
-        mStringAnswer.setText(null);
-        launchIntentButton.setText(new SpannableString(Localization.get("intent.barcode.get")));
+        isEditable = ic.getAppearance().contains("editable");
     }
 
     @Override
     public void setupTextView() {
-        if ("editable".equals(ic.getAppearance())) {
-            // set text formatting
+        if (isEditable) {
             mStringAnswer = new EditText(getContext());
             mStringAnswer.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mAnswerFontsize);
             mStringAnswer.setGravity(Gravity.CENTER);
@@ -84,10 +43,29 @@ public class BarcodeWidget extends IntentWidget {
             if (s != null) {
                 mStringAnswer.setText(s);
             }
-            // finish complex layout
             addView(mStringAnswer);
         } else {
             super.setupTextView();
         }
+    }
+
+    @Override
+    public IAnswerData getAnswer() {
+        if (isEditable && hasTextChanged) {
+            hasTextChanged = false;
+            String s = mStringAnswer.getText().toString();
+            if ("".equals(s)) {
+                return null;
+            } else {
+                return new StringData(s);
+            }
+        } else {
+            return mPrompt.getAnswerValue();
+        }
+    }
+
+    @Override
+    protected void loadCurrentAnswerToIntent() {
+        // zero out super class implementation
     }
 }

--- a/app/src/org/commcare/views/widgets/IntentWidget.java
+++ b/app/src/org/commcare/views/widgets/IntentWidget.java
@@ -79,11 +79,10 @@ public class IntentWidget extends QuestionWidget {
         addView(mStringAnswer);
 
         //only auto advance if 1) we have no data 2) its quick 3) we weren't just cancelled
-        if (s == null && "quick".equals(ic.getAppearance()) && !ic.getCancelled()) {
+        if (s == null
+                && "quick".equals(ic.getAppearance())
+                && !pendingCalloutInterface.wasCalloutPendingAndCancelled(mPrompt.getIndex())) {
             performCallout();
-        } else if (ic.getCancelled()) {
-            // reset the cancelled flag
-            ic.setCancelled(false);
         }
     }
 

--- a/app/src/org/commcare/views/widgets/IntentWidget.java
+++ b/app/src/org/commcare/views/widgets/IntentWidget.java
@@ -11,6 +11,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -30,7 +31,7 @@ import org.javarosa.form.api.FormEntryPrompt;
  */
 public class IntentWidget extends QuestionWidget {
 
-    private final TextView mStringAnswer;
+    protected final TextView mStringAnswer;
     private final Intent intent;
     private final String getButtonLocalizationKey;
     private final String updateButtonLocalizationKey;
@@ -61,7 +62,11 @@ public class IntentWidget extends QuestionWidget {
         this.updateButtonLocalizationKey = updateButtonLocalizationKey;
         isEditable = ic.getAppearance().contains("editable");
 
-        mStringAnswer = new TextView(getContext());
+        if (isEditable) {
+            mStringAnswer = new EditText(getContext());
+        } else {
+            mStringAnswer = new TextView(getContext());
+        }
         launchIntentButton = new Button(getContext());
         setupTextView();
         setupButton();
@@ -144,6 +149,7 @@ public class IntentWidget extends QuestionWidget {
 
     @Override
     public void clearAnswer() {
+        ic.processBarcodeResponse(mPrompt.getIndex().getReference(), null);
         mStringAnswer.setText(null);
         setButtonLabel();
     }
@@ -151,12 +157,6 @@ public class IntentWidget extends QuestionWidget {
     @Override
     public IAnswerData getAnswer() {
         return mPrompt.getAnswerValue();
-    }
-
-    @Override
-    public void setBinaryData(Object answer) {
-        mStringAnswer.setText((String)answer);
-        setButtonLabel();
     }
 
     @Override

--- a/app/src/org/commcare/views/widgets/IntentWidget.java
+++ b/app/src/org/commcare/views/widgets/IntentWidget.java
@@ -45,13 +45,14 @@ public class IntentWidget extends QuestionWidget {
     public IntentWidget(Context context, FormEntryPrompt prompt,
                         Intent in, IntentCallout ic, PendingCalloutInterface pendingCalloutInterface) {
         this(context, prompt, in, ic, pendingCalloutInterface,
-                "intent.callout.get", "intent.callout.update", "intent.callout.activity.missing");
+                "intent.callout.get", "intent.callout.update", "intent.callout.activity.missing",
+                false);
     }
 
     protected IntentWidget(Context context, FormEntryPrompt prompt, Intent in, IntentCallout ic,
                          PendingCalloutInterface pendingCalloutInterface,
                          String getButtonLocalizationKey, String updateButtonLocalizationKey,
-                         String missingCalloutKey) {
+                         String missingCalloutKey, boolean isEditable) {
         super(context, prompt);
 
         this.missingCalloutKey = missingCalloutKey;
@@ -60,7 +61,7 @@ public class IntentWidget extends QuestionWidget {
         this.pendingCalloutInterface = pendingCalloutInterface;
         this.getButtonLocalizationKey = getButtonLocalizationKey;
         this.updateButtonLocalizationKey = updateButtonLocalizationKey;
-        isEditable = ic.getAppearance() != null && ic.getAppearance().contains("editable");
+        this.isEditable = isEditable;
 
         if (isEditable) {
             mStringAnswer = new EditText(getContext());

--- a/app/src/org/commcare/views/widgets/IntentWidget.java
+++ b/app/src/org/commcare/views/widgets/IntentWidget.java
@@ -39,6 +39,7 @@ public class IntentWidget extends QuestionWidget {
     protected final PendingCalloutInterface pendingCalloutInterface;
     protected final IntentCallout ic;
     protected final String missingCalloutKey;
+    protected final boolean isEditable;
 
     public IntentWidget(Context context, FormEntryPrompt prompt,
                         Intent in, IntentCallout ic, PendingCalloutInterface pendingCalloutInterface) {
@@ -58,6 +59,7 @@ public class IntentWidget extends QuestionWidget {
         this.pendingCalloutInterface = pendingCalloutInterface;
         this.getButtonLocalizationKey = getButtonLocalizationKey;
         this.updateButtonLocalizationKey = updateButtonLocalizationKey;
+        isEditable = ic.getAppearance().contains("editable");
 
         mStringAnswer = new TextView(getContext());
         launchIntentButton = new Button(getContext());

--- a/app/src/org/commcare/views/widgets/IntentWidget.java
+++ b/app/src/org/commcare/views/widgets/IntentWidget.java
@@ -60,7 +60,7 @@ public class IntentWidget extends QuestionWidget {
         this.pendingCalloutInterface = pendingCalloutInterface;
         this.getButtonLocalizationKey = getButtonLocalizationKey;
         this.updateButtonLocalizationKey = updateButtonLocalizationKey;
-        isEditable = ic.getAppearance().contains("editable");
+        isEditable = ic.getAppearance() != null && ic.getAppearance().contains("editable");
 
         if (isEditable) {
             mStringAnswer = new EditText(getContext());

--- a/app/src/org/commcare/views/widgets/WidgetFactory.java
+++ b/app/src/org/commcare/views/widgets/WidgetFactory.java
@@ -111,11 +111,12 @@ public class WidgetFactory {
             case Constants.DATATYPE_GEOPOINT:
                 return new GeoPointWidget(context, fep, pendingCalloutInterface);
             case Constants.DATATYPE_BARCODE:
-                IntentCallout mIntentCallout = new IntentCallout("com.google.zxing.client.android.SCAN", null, null,
+                IntentCallout intentCallout = new IntentCallout("com.google.zxing.client.android.SCAN", null, null,
                         null, null, null, Localization.get("intent.barcode.get"),
                         Localization.get("intent.barcode.update"), appearance);
-                Intent mIntent = mIntentCallout.generate(formDef.getEvaluationContext());
-                return new BarcodeWidget(context, fep, mIntent, mIntentCallout, pendingCalloutInterface);
+                intentCallout.attachToForm(formDef);
+                Intent intent = intentCallout.generate(formDef.getEvaluationContext());
+                return new BarcodeWidget(context, fep, intent, intentCallout, pendingCalloutInterface);
             case Constants.DATATYPE_TEXT:
                 if (appearance != null && (appearance.equalsIgnoreCase("numbers") || appearance.equalsIgnoreCase("numeric"))) {
                     return new StringNumberWidget(context, fep, fep.getControlType() == Constants.CONTROL_SECRET);

--- a/unit-tests/resources/commcare-apps/case_search_and_claim/profile.ccpr
+++ b/unit-tests/resources/commcare-apps/case_search_and_claim/profile.ccpr
@@ -14,7 +14,7 @@
     <property key="PostURL" value="https://www.commcarehq.org/a/flipper/receiver/secure/0983304cd2c0760178fed759e3a7dcf9/" force="true"/>
     <property key="PostTestURL" value="https://www.commcarehq.org/a/flipper/receiver/secure/0983304cd2c0760178fed759e3a7dcf9/" force="true"/>
     <property key="key_server" value="https://www.commcarehq.org/a/flipper/phone/keys/"/>
-    <property key="cur_locale" value="en"/>
+    <property key="cur_locale" value="default"/>
     <property key="cc_user_domain" value="flipper.commcarehq.org"/>
     <property key="jr_openrosa_api" value="1.0"/>
 


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?234487
Came up due to fixes in https://github.com/dimagi/commcare-android/pull/1372

- Fix `quick` functionality for barcode widget
- Make it so a barcode widget can be `editable` and have other appearance attributes.
- Move intent cancellation flag to outside of `IntentCallout` because the lifecycle of `IntentCallout` doesn't persist past the parent `BarcodeWidget`, so `"quick"` wasn't working