### PR TITLE
Perform correct dialog dismiss

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1317,7 +1317,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 if (backExitsForm) {
                     FormEntryActivity.this.triggerUserQuitInput();
                 } else {
-                    dismissAlertDialog();
+                    dialog.dismiss();
                     FormEntryActivity.this.refreshCurrentView(false);
                 }
             }
@@ -1334,7 +1334,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         View.OnClickListener addAnotherListener = new OnClickListener() {
             @Override
             public void onClick(View v) {
-                dismissAlertDialog();
+                dialog.dismiss();
                 try {
                     mFormController.newRepeat();
                 } catch (XPathUnhandledException | XPathTypeMismatchException | XPathArityException e) {
@@ -1351,7 +1351,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         View.OnClickListener skipListener = new OnClickListener() {
             @Override
             public void onClick(View v) {
-                dismissAlertDialog();
+                dialog.dismiss();
                 if (!nextExitsForm) {
                     showNextView();
                 } else {


### PR DESCRIPTION
A few of the changes in https://github.com/dimagi/commcare-android/pull/1343 where incorrect. 

The repeat dialog can't be persistent due to form entry/controller state restoration limitations, so the dialog must be dismissed directly not via the fragment framework.

fix for http://manage.dimagi.com/default.asp?234496