### PR TITLE
Tell user when their attachment is too large to upload

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -154,6 +154,7 @@ Some images in CommCare are graciously used under Creative Commons Licensing fro
     <string name="advance" cc:translatable="true">forward to\nnext\nprompt</string>
     <string name="altitude" cc:translatable="true">Altitude</string>
     <string name="attachment_oversized" cc:translatable="true">Warning: attached large file of size %s kb. This could cause problems with submitting to the server depending on your network conditions.</string>
+    <string name="attachment_above_size_limit" formatted="false" cc:translatable="true">Media attachment too large (%s mb). Max allowed size is %s mb.</string>
     <string name="audio_file_error" cc:translatable="true">No audio file was specified.</string>
     <string name="audio_file_invalid" cc:translatable="true">File: %s is not a valid audio file.</string>
     <string name="backup" cc:translatable="true">back to\nprevious\nprompt</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -83,10 +83,7 @@ Some images in CommCare are graciously used under Creative Commons Licensing fro
 * “Antenna” symbol by Dima \n
 * “Map Marker” symbol by P.J. Onori \n
 * broken screen by Sam Martin from the Noun Project \n\n
-
-_Android MapView Balloons_ project used under the Apache Software License 2.0. \n
-Author: Jeff Gilfelt \n
-Copyright © 2012 readyState Software Ltd.</string>
+</string>
     <string name="notification_message_title">CommCare Notification</string>
 
     <string-array name="frequency_vals">

--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -540,7 +540,7 @@ public class FileUtil {
         return mf.length() / 1024;
     }
 
-    public static boolean isFileToLargeToUploade(File mf) {
+    public static boolean isFileToLargeToUpload(File mf) {
         return mf.length() > FormUploadUtil.MAX_BYTES;
     }
 

--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -540,6 +540,16 @@ public class FileUtil {
         return mf.length() / 1024;
     }
 
+    public static double getFileSizeInMegs(File mf) {
+        return bytesToMeg(mf.length());
+    }
+
+    private static final long MEGABYTE_IN_BYTES = 1024L * 1024L;
+
+    public static long bytesToMeg(long bytes) {
+        return bytes / MEGABYTE_IN_BYTES;
+    }
+
     public static boolean isFileToLargeToUpload(File mf) {
         return mf.length() > FormUploadUtil.MAX_BYTES;
     }

--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -537,7 +537,11 @@ public class FileUtil {
     }
 
     public static double getFileSize(File mf) {
-        return mf.length() / (1024);
+        return mf.length() / 1024;
+    }
+
+    public static boolean isFileToLargeToUploade(File mf) {
+        return mf.length() > FormUploadUtil.MAX_BYTES;
     }
 
     /**

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -55,7 +55,11 @@ public class FormUploadUtil {
      */
     public static final long RECORD_FAILURE = 8;
 
-    private static final long MAX_BYTES = (5 * 1048576) - 1024;
+    /**
+     * 15 MB size limit
+     */
+    private static final long MAX_BYTES = (15 * 1048576) - 1024;
+
     private static final String[] SUPPORTED_FILE_EXTS =
             {".xml", ".jpg", "jpeg", ".3gpp", ".3gp", ".3ga", ".3g2", ".mp3",
                     ".wav", ".amr", ".mp4", ".3gp2", ".mpg4", ".mpeg4",

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -58,7 +58,7 @@ public class FormUploadUtil {
     /**
      * 15 MB size limit
      */
-    private static final long MAX_BYTES = (15 * 1048576) - 1024;
+    public static final long MAX_BYTES = (15 * 1048576) - 1024;
 
     private static final String[] SUPPORTED_FILE_EXTS =
             {".xml", ".jpg", "jpeg", ".3gpp", ".3gp", ".3ga", ".3g2", ".mp3",

--- a/app/src/org/commcare/views/widgets/AudioWidget.java
+++ b/app/src/org/commcare/views/widgets/AudioWidget.java
@@ -138,7 +138,7 @@ public class AudioWidget extends MediaWidget {
 
     @Override
     public void setBinaryData(Object binaryuri) {
-        String binaryPath = checkBinarySize(binaryuri);
+        String binaryPath = getBinaryPathWithSizeCheck(binaryuri);
         if (binaryPath == null) {
             return;
         }
@@ -185,9 +185,11 @@ public class AudioWidget extends MediaWidget {
         mBinaryName = newAudio.getName();
     }
 
-    //If file is chosen by user, the file selection intent will return an URI
-    //If file is auto-selected after recording_fragment, then the recordingfragment will provide a string file path
-    //Set value of customFileTag if the file is a recent recording from the RecordingFragment
+    /**
+     * If file is chosen by user, the file selection intent will return an URI
+     * If file is auto-selected after recording_fragment, then the recordingfragment will provide a string file path
+     * Set value of customFileTag if the file is a recent recording from the RecordingFragment
+     */
     @Override
     protected String createFilePath(Object binaryuri){
         String path;

--- a/app/src/org/commcare/views/widgets/AudioWidget.java
+++ b/app/src/org/commcare/views/widgets/AudioWidget.java
@@ -9,9 +9,7 @@ import android.net.Uri;
 import android.provider.MediaStore.Audio;
 import android.util.Log;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
-import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
@@ -37,70 +35,41 @@ public class AudioWidget extends MediaWidget {
     private static final String TAG = AudioWidget.class.getSimpleName();
     protected static final String CUSTOM_TAG = "custom";
 
-    private Button mCaptureButton;
-    private Button mPlayButton;
-    private Button mChooseButton;
-    protected final PendingCalloutInterface pendingCalloutInterface;
-
     protected String recordedFileName;
     private String customFileTag;
 
     public AudioWidget(Context context, final FormEntryPrompt prompt, PendingCalloutInterface pic) {
-        super(context, prompt);
-
-        initializeButtons(prompt);
-        setupLayout();
-
-        this.pendingCalloutInterface = pic;
-
-        setOrientation(LinearLayout.VERTICAL);
-
-        // retrieve answer from data model and update ui
-        mBinaryName = prompt.getAnswerText();
-        if (mBinaryName != null) {
-            reloadFile();
-        } else {
-            togglePlayButton(false);
-        }
+        super(context, prompt, pic);
     }
 
-    protected void reloadFile() {
-        togglePlayButton(true);
-        File f = new File(mInstanceFolder + mBinaryName);
-        checkFileSize(f);
-    }
-
-    protected void togglePlayButton(boolean enabled) {
-        mPlayButton.setEnabled(enabled);
-    }
-
-    protected void initializeButtons(final FormEntryPrompt prompt){
+    @Override
+    protected void initializeButtons(){
         // setup capture button
         mCaptureButton = new Button(getContext());
         WidgetUtils.setupButton(mCaptureButton,
                 StringUtils.getStringSpannableRobust(getContext(), R.string.capture_audio),
                 mAnswerFontsize,
-                !prompt.isReadOnly());
+                !mPrompt.isReadOnly());
 
         // setup audio filechooser button
         mChooseButton = new Button(getContext());
         WidgetUtils.setupButton(mChooseButton,
                 StringUtils.getStringSpannableRobust(getContext(), R.string.choose_sound),
                 mAnswerFontsize,
-                !prompt.isReadOnly());
+                !mPrompt.isReadOnly());
 
         // setup play button
         mPlayButton = new Button(getContext());
         WidgetUtils.setupButton(mPlayButton,
                 StringUtils.getStringSpannableRobust(getContext(), R.string.play_audio),
                 mAnswerFontsize,
-                !prompt.isReadOnly());
+                !mPrompt.isReadOnly());
 
         // launch capture intent on click
         mCaptureButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                captureAudio(prompt);
+                captureAudio(mPrompt);
             }
         });
 
@@ -112,7 +81,7 @@ public class AudioWidget extends MediaWidget {
                 i.setType("audio/*");
                 try {
                     ((Activity)getContext()).startActivityForResult(i, FormEntryActivity.AUDIO_VIDEO_FETCH);
-                    pendingCalloutInterface.setPendingCalloutFormIndex(prompt.getIndex());
+                    pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(getContext(),
                             StringUtils.getStringSpannableRobust(getContext(),
@@ -123,7 +92,7 @@ public class AudioWidget extends MediaWidget {
             }
         });
 
-        if (QuestionWidget.ACQUIREFIELD.equalsIgnoreCase(prompt.getAppearanceHint())) {
+        if (QuestionWidget.ACQUIREFIELD.equalsIgnoreCase(mPrompt.getAppearanceHint())) {
             mChooseButton.setVisibility(View.GONE);
         }
 
@@ -134,7 +103,6 @@ public class AudioWidget extends MediaWidget {
                 playAudio();
             }
         });
-
     }
 
     protected void playAudio() {
@@ -150,13 +118,6 @@ public class AudioWidget extends MediaWidget {
                             "play audio"),
                     Toast.LENGTH_SHORT).show();
         }
-    }
-
-    protected void setupLayout() {
-        // finish complex layout
-        addView(mCaptureButton);
-        addView(mChooseButton);
-        addView(mPlayButton);
     }
 
     protected void captureAudio(FormEntryPrompt prompt) {
@@ -241,37 +202,5 @@ public class AudioWidget extends MediaWidget {
         }
 
         return path;
-    }
-
-    @Override
-    public void setFocus(Context context) {
-        // Hide the soft keyboard if it's showing.
-        InputMethodManager inputManager =
-                (InputMethodManager)context.getSystemService(Context.INPUT_METHOD_SERVICE);
-        inputManager.hideSoftInputFromWindow(this.getWindowToken(), 0);
-    }
-
-    @Override
-    public void setOnLongClickListener(OnLongClickListener l) {
-        mCaptureButton.setOnLongClickListener(l);
-        mChooseButton.setOnLongClickListener(l);
-        mPlayButton.setOnLongClickListener(l);
-    }
-
-    @Override
-    public void unsetListeners() {
-        super.unsetListeners();
-
-        mCaptureButton.setOnLongClickListener(null);
-        mChooseButton.setOnLongClickListener(null);
-        mPlayButton.setOnLongClickListener(null);
-    }
-
-    @Override
-    public void cancelLongPress() {
-        super.cancelLongPress();
-        mCaptureButton.cancelLongPress();
-        mChooseButton.cancelLongPress();
-        mPlayButton.cancelLongPress();
     }
 }

--- a/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
+++ b/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
@@ -51,7 +51,7 @@ public class CommCareAudioWidget extends AudioWidget
     }
 
     @Override
-    protected void initializeButtons(final FormEntryPrompt prompt) {
+    protected void initializeButtons() {
         LayoutInflater vi = LayoutInflater.from(getContext());
         layout = (LinearLayout)vi.inflate(R.layout.audio_prototype, null);
 
@@ -63,7 +63,7 @@ public class CommCareAudioWidget extends AudioWidget
             @Override
             public void onClick(View v) {
                 GoogleAnalyticsUtils.reportRecordingPopupOpened();
-                captureAudio(prompt);
+                captureAudio(mPrompt);
             }
         });
 
@@ -77,7 +77,7 @@ public class CommCareAudioWidget extends AudioWidget
                 try {
                     ((Activity)getContext()).startActivityForResult(i, FormEntryActivity.AUDIO_VIDEO_FETCH);
                     recordingNameText.setTextColor(getResources().getColor(R.color.black));
-                    pendingCalloutInterface.setPendingCalloutFormIndex(prompt.getIndex());
+                    pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(getContext(),
                             StringUtils.getStringSpannableRobust(getContext(),

--- a/app/src/org/commcare/views/widgets/MediaWidget.java
+++ b/app/src/org/commcare/views/widgets/MediaWidget.java
@@ -17,6 +17,8 @@ import org.javarosa.form.api.FormEntryPrompt;
 import java.io.File;
 
 /**
+ * Generic logic for capturing or choosing audio/video/image media
+ *
  * @author Phillip Mates (pmates@dimagi.com)
  */
 public abstract class MediaWidget extends QuestionWidget {
@@ -25,17 +27,18 @@ public abstract class MediaWidget extends QuestionWidget {
     protected Button mCaptureButton;
     protected Button mPlayButton;
     protected Button mChooseButton;
+    protected String mBinaryName;
 
     protected final PendingCalloutInterface pendingCalloutInterface;
-
-    protected String mBinaryName;
     protected final String mInstanceFolder;
+
     private int oversizedMediaSize;
 
-    public MediaWidget(Context context, FormEntryPrompt p, PendingCalloutInterface pic) {
-        super(context, p);
+    public MediaWidget(Context context, FormEntryPrompt prompt,
+                       PendingCalloutInterface pendingCalloutInterface) {
+        super(context, prompt);
 
-        this.pendingCalloutInterface = pic;
+        this.pendingCalloutInterface = pendingCalloutInterface;
 
         mInstanceFolder =
                 FormEntryActivity.mInstancePath.substring(0,
@@ -45,12 +48,13 @@ public abstract class MediaWidget extends QuestionWidget {
         initializeButtons();
         setupLayout();
 
-        // retrieve answer from data model and update ui
+        loadAnswerFromDataModel();
+    }
+
+    private void loadAnswerFromDataModel() {
         mBinaryName = mPrompt.getAnswerText();
         if (mBinaryName != null) {
-            mPlayButton.setEnabled(true);
-            File f = new File(mInstanceFolder + "/" + mBinaryName);
-            checkFileSize(f);
+            reloadFile();
         } else {
             checkForOversizedMedia(mPrompt.getAnswerValue());
             togglePlayButton(false);
@@ -80,17 +84,21 @@ public abstract class MediaWidget extends QuestionWidget {
         if (mBinaryName != null) {
             return new StringData(mBinaryName);
         } else if (oversizedMediaSize > 0) {
+            // media was too big to upload, set answer as invalid data to
+            // allow showing the user a proper warning message.
             return new InvalidData("", new IntegerData(oversizedMediaSize));
         }
         return null;
     }
 
-    protected String checkBinarySize(Object binaryuri) {
-        String binaryPath = createFilePath(binaryuri);
+    /**
+     * @return resolved filepath or null if the target is too big to upload
+     */
+    protected String getBinaryPathWithSizeCheck(Object binaryURI) {
+        String binaryPath = createFilePath(binaryURI);
         File source = new File(binaryPath);
         boolean isToLargeToUpload = checkFileSize(source);
 
-        // when replacing an answer. remove the current media.
         if (mBinaryName != null) {
             deleteMedia();
         }
@@ -104,22 +112,20 @@ public abstract class MediaWidget extends QuestionWidget {
         }
     }
 
-    private void deleteMedia() {
-        // get the file path and delete the file
-        File f = new File(mInstanceFolder + "/" + mBinaryName);
-        if (!f.delete()) {
-            Log.e(TAG, "Failed to delete " + f);
-        }
-
-        // clean up variables
-        mBinaryName = null;
-    }
-
     @Override
     public void clearAnswer() {
         deleteMedia();
 
-        mPlayButton.setEnabled(false);
+        togglePlayButton(false);
+    }
+
+    private void deleteMedia() {
+        File f = new File(mInstanceFolder + mBinaryName);
+        if (!f.delete()) {
+            Log.e(TAG, "Failed to delete " + f);
+        }
+
+        mBinaryName = null;
     }
 
     protected abstract String createFilePath(Object binaryUri);
@@ -143,6 +149,7 @@ public abstract class MediaWidget extends QuestionWidget {
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();
+
         mCaptureButton.cancelLongPress();
         mChooseButton.cancelLongPress();
         mPlayButton.cancelLongPress();

--- a/app/src/org/commcare/views/widgets/MediaWidget.java
+++ b/app/src/org/commcare/views/widgets/MediaWidget.java
@@ -81,12 +81,12 @@ public abstract class MediaWidget extends QuestionWidget {
 
     @Override
     public IAnswerData getAnswer() {
-        if (mBinaryName != null) {
-            return new StringData(mBinaryName);
-        } else if (oversizedMediaSize > 0) {
+        if (oversizedMediaSize > 0) {
             // media was too big to upload, set answer as invalid data to
             // allow showing the user a proper warning message.
             return new InvalidData("", new IntegerData(oversizedMediaSize));
+        } else if (mBinaryName != null) {
+            return new StringData(mBinaryName);
         }
         return null;
     }

--- a/app/src/org/commcare/views/widgets/MediaWidget.java
+++ b/app/src/org/commcare/views/widgets/MediaWidget.java
@@ -1,0 +1,81 @@
+package org.commcare.views.widgets;
+
+import android.content.Context;
+import android.util.Log;
+
+import org.commcare.activities.FormEntryActivity;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.IntegerData;
+import org.javarosa.core.model.data.InvalidData;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.form.api.FormEntryPrompt;
+
+import java.io.File;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public abstract class MediaWidget extends QuestionWidget {
+    private static final String TAG = MediaWidget.class.getSimpleName();
+    protected String mBinaryName;
+    protected final String mInstanceFolder;
+    private int oversizedMediaSize;
+
+    public MediaWidget(Context context, FormEntryPrompt p) {
+        super(context, p);
+
+        mInstanceFolder =
+                FormEntryActivity.mInstancePath.substring(0,
+                        FormEntryActivity.mInstancePath.lastIndexOf("/") + 1);
+
+    }
+
+    @Override
+    public IAnswerData getAnswer() {
+        if (mBinaryName != null) {
+            return new StringData(mBinaryName);
+        } else if (oversizedMediaSize > 0) {
+            return new InvalidData("", new IntegerData(oversizedMediaSize));
+        }
+        return null;
+    }
+
+    protected String checkBinarySize(Object binaryuri) {
+        String binaryPath = createFilePath(binaryuri);
+        File source = new File(binaryPath);
+        boolean isToLargeToUpload = checkFileSize(source);
+
+        // when replacing an answer. remove the current media.
+        if (mBinaryName != null) {
+            deleteMedia();
+        }
+
+        if (isToLargeToUpload) {
+            oversizedMediaSize = (int)source.length() / (1024 * 1024);
+            return null;
+        } else {
+            oversizedMediaSize = -1;
+            return binaryPath;
+        }
+    }
+
+    private void deleteMedia() {
+        // get the file path and delete the file
+        File f = new File(mInstanceFolder + "/" + mBinaryName);
+        if (!f.delete()) {
+            Log.e(TAG, "Failed to delete " + f);
+        }
+
+        // clean up variables
+        mBinaryName = null;
+    }
+
+    @Override
+    public void clearAnswer() {
+        deleteMedia();
+
+        mPlayButton.setEnabled(false);
+    }
+
+    protected abstract String createFilePath(Object binaryUri);
+}

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -248,11 +248,10 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
     }
 
     private void showOversizedMediaWarning(String fileSizeString) {
-        String maxAcceptable = (FormUploadUtil.MAX_BYTES / (1024 * 1024)) + "";
+        String maxAcceptable = FileUtil.bytesToMeg(FormUploadUtil.MAX_BYTES) + "";
         String[] args = new String[]{fileSizeString, maxAcceptable};
         notifyInvalid(StringUtils.getStringRobust(getContext(), R.string.attachment_above_size_limit, args), true);
     }
-
 
     /**
      * Use to signal that there's a portion of this view that wants to be 
@@ -644,7 +643,7 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
      */
     protected boolean checkFileSize(File file){
         if (FileUtil.isFileToLargeToUpload(file)) {
-            String fileSize = FileUtil.getFileSize(file) / 1024 + "";
+            String fileSize = FileUtil.getFileSizeInMegs(file) + "";
             showOversizedMediaWarning(fileSize);
             return true;
         } else if (FileUtil.isFileOversized(file)) {

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -7,7 +7,6 @@ import android.content.SharedPreferences;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.preference.PreferenceManager;
-import android.support.annotation.IdRes;
 import android.text.Spannable;
 import android.text.TextPaint;
 import android.text.method.LinkMovementMethod;
@@ -643,8 +642,8 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
     /**
      * @return True if file is too big to upload.
      */
-    public boolean checkFileSize(File file){
-        if (FileUtil.isFileToLargeToUploade(file)) {
+    protected boolean checkFileSize(File file){
+        if (FileUtil.isFileToLargeToUpload(file)) {
             String fileSize = FileUtil.getFileSize(file) / 1024 + "";
             showOversizedMediaWarning(fileSize);
             return true;

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.preference.PreferenceManager;
+import android.support.annotation.IdRes;
 import android.text.Spannable;
 import android.text.TextPaint;
 import android.text.method.LinkMovementMethod;
@@ -32,6 +33,7 @@ import org.commcare.logging.AndroidLogger;
 import org.commcare.models.ODKStorage;
 import org.commcare.preferences.FormEntryPreferences;
 import org.commcare.utils.FileUtil;
+import org.commcare.utils.FormUploadUtil;
 import org.commcare.utils.MarkupUtil;
 import org.commcare.utils.StringUtils;
 import org.commcare.views.ShrinkingTextView;
@@ -43,6 +45,7 @@ import org.javarosa.core.model.QuestionExtensionReceiver;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.AnswerDataFactory;
 import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.InvalidData;
 import org.javarosa.core.services.Logger;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -237,6 +240,20 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
     public void notifyInvalid(String text, boolean requestFocus) {
         notifyOnScreen(text, true, requestFocus);
     }
+
+    protected void checkForOversizedMedia(IAnswerData widgetAnswer) {
+        if (widgetAnswer instanceof InvalidData) {
+            String fileSizeString = widgetAnswer.getValue() + "";
+            showOversizedMediaWarning(fileSizeString);
+        }
+    }
+
+    private void showOversizedMediaWarning(String fileSizeString) {
+        String maxAcceptable = (FormUploadUtil.MAX_BYTES / (1024 * 1024)) + "";
+        String[] args = new String[]{fileSizeString, maxAcceptable};
+        notifyInvalid(StringUtils.getStringRobust(getContext(), R.string.attachment_above_size_limit, args), true);
+    }
+
 
     /**
      * Use to signal that there's a portion of this view that wants to be 
@@ -623,10 +640,18 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
         return widgetChangedListener != null;
     }
 
-    public void checkFileSize(File file){
-        if (FileUtil.isFileOversized(file)) {
+    /**
+     * @return True if file is too big to upload.
+     */
+    public boolean checkFileSize(File file){
+        if (FileUtil.isFileToLargeToUploade(file)) {
+            String fileSize = FileUtil.getFileSize(file) / 1024 + "";
+            showOversizedMediaWarning(fileSize);
+            return true;
+        } else if (FileUtil.isFileOversized(file)) {
             notifyWarning(StringUtils.getStringRobust(getContext(), R.string.attachment_oversized, FileUtil.getFileSize(file) + ""));
         }
+        return false;
     }
 
     /*

--- a/app/src/org/commcare/views/widgets/VideoWidget.java
+++ b/app/src/org/commcare/views/widgets/VideoWidget.java
@@ -130,7 +130,7 @@ public class VideoWidget extends MediaWidget {
 
     @Override
     public void setBinaryData(Object binaryuri) {
-        String binaryPath = checkBinarySize(binaryuri);
+        String binaryPath = getBinaryPathWithSizeCheck(binaryuri);
         if (binaryPath == null) {
             return;
         }

--- a/app/src/org/commcare/views/widgets/VideoWidget.java
+++ b/app/src/org/commcare/views/widgets/VideoWidget.java
@@ -36,7 +36,7 @@ import java.io.IOException;
  * @author Yaw Anokwa (yanokwa@gmail.com)
  */
 public class VideoWidget extends QuestionWidget {
-    private final static String t = "MediaWidget";
+    private final static String TAG = VideoWidget.class.getSimpleName();
 
     private final Button mCaptureButton;
     private final Button mPlayButton;
@@ -159,28 +159,23 @@ public class VideoWidget extends QuestionWidget {
         addView(mPlayButton);
     }
 
-
     private void deleteMedia() {
         // get the file path and delete the file
         File f = new File(mInstanceFolder + "/" + mBinaryName);
         if (!f.delete()) {
-            Log.e(t, "Failed to delete " + f);
+            Log.e(TAG, "Failed to delete " + f);
         }
 
         // clean up variables
         mBinaryName = null;
     }
 
-
     @Override
     public void clearAnswer() {
-        // remove the file
         deleteMedia();
 
-        // reset buttons
         mPlayButton.setEnabled(false);
     }
-
 
     @Override
     public IAnswerData getAnswer() {
@@ -210,7 +205,7 @@ public class VideoWidget extends QuestionWidget {
         try {
             FileUtil.copyFile(source, newVideo);
         } catch (IOException e) {
-            Log.e(t, "IOExeception while video audio");
+            Log.e(TAG, "IOExeception while video audio");
             e.printStackTrace();
         }
 
@@ -226,9 +221,9 @@ public class VideoWidget extends QuestionWidget {
 
             Uri VideoURI =
                     getContext().getContentResolver().insert(Video.Media.EXTERNAL_CONTENT_URI, values);
-            Log.i(t, "Inserting VIDEO returned uri = " + VideoURI.toString());
+            Log.i(TAG, "Inserting VIDEO returned uri = " + VideoURI.toString());
         } else {
-            Log.e(t, "Inserting Video file FAILED");
+            Log.e(TAG, "Inserting Video file FAILED");
         }
 
         mBinaryName = newVideo.getName();
@@ -265,5 +260,4 @@ public class VideoWidget extends QuestionWidget {
         mChooseButton.cancelLongPress();
         mPlayButton.cancelLongPress();
     }
-
 }

--- a/app/src/org/commcare/views/widgets/VideoWidget.java
+++ b/app/src/org/commcare/views/widgets/VideoWidget.java
@@ -9,10 +9,7 @@ import android.net.Uri;
 import android.provider.MediaStore.Video;
 import android.util.Log;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
 import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
@@ -36,33 +33,18 @@ import java.io.IOException;
 public class VideoWidget extends MediaWidget {
     private final static String TAG = VideoWidget.class.getSimpleName();
 
-    private final Button mCaptureButton;
-    private final Button mPlayButton;
-    private final Button mChooseButton;
-
-    private String mBinaryName;
-
-    private final String mInstanceFolder;
-    private final PendingCalloutInterface pendingCalloutInterface;
-
     public VideoWidget(Context context, final FormEntryPrompt prompt, PendingCalloutInterface pic) {
-        super(context, prompt);
-        this.pendingCalloutInterface = pic;
+        super(context, prompt, pic);
+    }
 
-        mInstanceFolder =
-                FormEntryActivity.mInstancePath.substring(0,
-                        FormEntryActivity.mInstancePath.lastIndexOf("/") + 1);
-
-        setOrientation(LinearLayout.VERTICAL);
-
-        TableLayout.LayoutParams params = new TableLayout.LayoutParams();
-        params.setMargins(7, 5, 7, 5);
+    @Override
+    protected void initializeButtons() {
         // setup capture button
         mCaptureButton = new Button(getContext());
         WidgetUtils.setupButton(mCaptureButton,
                 StringUtils.getStringSpannableRobust(getContext(), R.string.capture_video),
                 mAnswerFontsize,
-                !prompt.isReadOnly());
+                !mPrompt.isReadOnly());
 
         // launch capture intent on click
         mCaptureButton.setOnClickListener(new View.OnClickListener() {
@@ -74,7 +56,7 @@ public class VideoWidget extends MediaWidget {
                 try {
                     ((Activity)getContext()).startActivityForResult(i,
                             FormEntryActivity.AUDIO_VIDEO_FETCH);
-                    pendingCalloutInterface.setPendingCalloutFormIndex(prompt.getIndex());
+                    pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(getContext(),
                             StringUtils.getStringSpannableRobust(getContext(),
@@ -89,7 +71,7 @@ public class VideoWidget extends MediaWidget {
         WidgetUtils.setupButton(mChooseButton,
                 StringUtils.getStringSpannableRobust(getContext(), R.string.choose_video),
                 mAnswerFontsize,
-                !prompt.isReadOnly());
+                !mPrompt.isReadOnly());
 
         // launch capture intent on click
         mChooseButton.setOnClickListener(new View.OnClickListener() {
@@ -100,7 +82,7 @@ public class VideoWidget extends MediaWidget {
                 try {
                     ((Activity)getContext()).startActivityForResult(i,
                             FormEntryActivity.AUDIO_VIDEO_FETCH);
-                    pendingCalloutInterface.setPendingCalloutFormIndex(prompt.getIndex());
+                    pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(getContext(),
                             StringUtils.getStringSpannableRobust(getContext(),
@@ -115,7 +97,7 @@ public class VideoWidget extends MediaWidget {
         WidgetUtils.setupButton(mPlayButton,
                 StringUtils.getStringSpannableRobust(getContext(), R.string.play_video),
                 mAnswerFontsize,
-                !prompt.isReadOnly());
+                !mPrompt.isReadOnly());
 
         // on play, launch the appropriate viewer
         mPlayButton.setOnClickListener(new View.OnClickListener() {
@@ -135,25 +117,10 @@ public class VideoWidget extends MediaWidget {
             }
         });
 
-        // retrieve answer from data model and update ui
-        mBinaryName = prompt.getAnswerText();
-        if (mBinaryName != null) {
-            mPlayButton.setEnabled(true);
-            File f = new File(mInstanceFolder + "/" + mBinaryName);
-            checkFileSize(f);
-        } else {
-            checkForOversizedMedia(prompt.getAnswerValue());
-            mPlayButton.setEnabled(false);
-        }
-
-        // finish complex layout
-        addView(mCaptureButton);
-        addView(mChooseButton);
-        String acq = prompt.getAppearanceHint();
+        String acq = mPrompt.getAppearanceHint();
         if (QuestionWidget.ACQUIREFIELD.equalsIgnoreCase(acq)) {
             mChooseButton.setVisibility(View.GONE);
         }
-        addView(mPlayButton);
     }
 
     @Override
@@ -196,37 +163,5 @@ public class VideoWidget extends MediaWidget {
         }
 
         mBinaryName = newVideo.getName();
-    }
-
-    @Override
-    public void setFocus(Context context) {
-        // Hide the soft keyboard if it's showing.
-        InputMethodManager inputManager =
-                (InputMethodManager)context.getSystemService(Context.INPUT_METHOD_SERVICE);
-        inputManager.hideSoftInputFromWindow(this.getWindowToken(), 0);
-    }
-
-    @Override
-    public void setOnLongClickListener(OnLongClickListener l) {
-        mCaptureButton.setOnLongClickListener(l);
-        mChooseButton.setOnLongClickListener(l);
-        mPlayButton.setOnLongClickListener(l);
-    }
-
-    @Override
-    public void unsetListeners() {
-        super.unsetListeners();
-
-        mCaptureButton.setOnLongClickListener(null);
-        mChooseButton.setOnLongClickListener(null);
-        mPlayButton.setOnLongClickListener(null);
-    }
-
-    @Override
-    public void cancelLongPress() {
-        super.cancelLongPress();
-        mCaptureButton.cancelLongPress();
-        mChooseButton.cancelLongPress();
-        mPlayButton.cancelLongPress();
     }
 }


### PR DESCRIPTION
| Media is large but not too large | Media is to large to upload |
| ----- | ---- |
| ![warning](https://cloud.githubusercontent.com/assets/94817/17568746/0376865a-5f13-11e6-9dab-b0c423eb3b4c.png) | ![oversized](https://cloud.githubusercontent.com/assets/94817/17568750/075a6d86-5f13-11e6-8f2a-713b7af25040.png) |

Implementing this fix is complicated by the fact that we don't want to store the oversized attachment if we aren't going to upload it because that would force the user to clear it, which requires a long click. 
Hence when the widget gets recreated when resuming from the callout, that state gets lost because the widget gets all its state from the associated `FormEntryPrompt`. Thus, my approach is to check the filesize in `setBinaryData`, which is called in `onActivityResult`, and set the `oversizedMediaSize` value. Then when the value is committed to the form instance in `getAnswer` we check `oversizedMediaSize` and return `InvalidData` if it is set. The next time the widget is recreated we check if the prompt is storing an `InvalidData` value and reshow the warning. At this point `oversizedMediaSize` is also cleared, so `getAnswer` returns `null` until reset.


Fix for http://manage.dimagi.com/default.asp?234483