### PR TITLE
Rename and refactor GridEntityView

### DIFF
--- a/app/src/org/commcare/adapters/EntityListAdapter.java
+++ b/app/src/org/commcare/adapters/EntityListAdapter.java
@@ -25,7 +25,7 @@ import org.commcare.utils.CachingAsyncImageLoader;
 import org.commcare.utils.StringUtils;
 import org.commcare.views.EntityActionViewUtils;
 import org.commcare.views.EntityView;
-import org.commcare.views.GridEntityView;
+import org.commcare.views.EntityViewTile;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.OrderedHashtable;
@@ -257,16 +257,16 @@ public class EntityListAdapter implements ListAdapter {
 
         if (usesGridView) {
             // if we use a <grid>, setup an AdvancedEntityView
-            return getGridView(entity, (GridEntityView)convertView);
+            return getGridView(entity, (EntityViewTile)convertView);
         } else {
             return getListEntityView(entity, (EntityView)convertView, position);
         }
     }
 
-    private View getGridView(Entity<TreeReference> entity, GridEntityView emv) {
+    private View getGridView(Entity<TreeReference> entity, EntityViewTile emv) {
         int[] titleColor = AndroidUtil.getThemeColorIDs(commCareActivity, new int[]{R.attr.entity_select_title_text_color});
         if (emv == null) {
-            emv = new GridEntityView(commCareActivity, detail, entity, currentSearchTerms, mImageLoader, mFuzzySearchEnabled);
+            emv = new EntityViewTile(commCareActivity, detail, entity, currentSearchTerms, mImageLoader, mFuzzySearchEnabled);
         } else {
             emv.setSearchTerms(currentSearchTerms);
             emv.setViews(commCareActivity, detail, entity);

--- a/app/src/org/commcare/adapters/EntityListAdapter.java
+++ b/app/src/org/commcare/adapters/EntityListAdapter.java
@@ -266,10 +266,11 @@ public class EntityListAdapter implements ListAdapter {
     private View getGridView(Entity<TreeReference> entity, EntityViewTile emv) {
         int[] titleColor = AndroidUtil.getThemeColorIDs(commCareActivity, new int[]{R.attr.entity_select_title_text_color});
         if (emv == null) {
-            emv = new EntityViewTile(commCareActivity, detail, entity, currentSearchTerms, mImageLoader, mFuzzySearchEnabled);
+            emv = EntityViewTile.createTileForListDisplay(commCareActivity, detail, entity,
+                    currentSearchTerms, mImageLoader, mFuzzySearchEnabled);
         } else {
             emv.setSearchTerms(currentSearchTerms);
-            emv.setViews(commCareActivity, detail, entity);
+            emv.addFieldViews(commCareActivity, detail, entity);
         }
         emv.setTitleTextColor(titleColor[0]);
         return emv;

--- a/app/src/org/commcare/fragments/BreadcrumbBarFragment.java
+++ b/app/src/org/commcare/fragments/BreadcrumbBarFragment.java
@@ -38,7 +38,7 @@ import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.StackFrameStep;
 import org.commcare.utils.AndroidUtil;
 import org.commcare.utils.SessionStateUninitException;
-import org.commcare.views.GridEntityView;
+import org.commcare.views.EntityViewTile;
 import org.commcare.views.TabbedDetailView;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
@@ -411,7 +411,7 @@ public class BreadcrumbBarFragment extends Fragment {
         Entity entity = nef.getEntity(ref);
 
         Log.v("DEBUG-v", "Creating new GridEntityView for text header text");
-        GridEntityView tile = new GridEntityView(this.getActivity(), detail, entity);
+        EntityViewTile tile = new EntityViewTile(this.getActivity(), detail, entity);
         int[] textColor = AndroidUtil.getThemeColorIDs(getActivity(), new int[]{R.attr.drawer_pulldown_text_color, R.attr.menu_tile_title_text_color});
         tile.setTextColor(textColor[0]);
         tile.setTitleTextColor(textColor[1]);

--- a/app/src/org/commcare/fragments/BreadcrumbBarFragment.java
+++ b/app/src/org/commcare/fragments/BreadcrumbBarFragment.java
@@ -411,8 +411,10 @@ public class BreadcrumbBarFragment extends Fragment {
         Entity entity = nef.getEntity(ref);
 
         Log.v("DEBUG-v", "Creating new GridEntityView for text header text");
-        EntityViewTile tile = new EntityViewTile(this.getActivity(), detail, entity);
-        int[] textColor = AndroidUtil.getThemeColorIDs(getActivity(), new int[]{R.attr.drawer_pulldown_text_color, R.attr.menu_tile_title_text_color});
+        EntityViewTile tile = EntityViewTile.createTileForIndividualDisplay(this.getActivity(),
+                detail, entity);
+        int[] textColor = AndroidUtil.getThemeColorIDs(getActivity(),
+                new int[]{R.attr.drawer_pulldown_text_color, R.attr.menu_tile_title_text_color});
         tile.setTextColor(textColor[0]);
         tile.setTitleTextColor(textColor[1]);
         return Pair.create(((View)tile), ref);

--- a/app/src/org/commcare/views/EntityViewTile.java
+++ b/app/src/org/commcare/views/EntityViewTile.java
@@ -99,14 +99,6 @@ public class EntityViewTile extends GridLayout {
         return new EntityViewTile(context, detail, entity, searchTerms, loader, fuzzySearchEnabled, 1);
     }
 
-    public static EntityViewTile createTileForGridDisplay(Context context, Detail detail, Entity entity,
-                                                          String[] searchTerms,
-                                                          CachingAsyncImageLoader loader,
-                                                          boolean fuzzySearchEnabled, int numRowsPerGrid) {
-        return new EntityViewTile(context, detail, entity, searchTerms, loader,
-                fuzzySearchEnabled, numRowsPerGrid);
-    }
-
     /**
      * Constructor for an entity tile in a managed context, like a list of entities being displayed
      * all at once for searching.

--- a/app/src/org/commcare/views/EntityViewTile.java
+++ b/app/src/org/commcare/views/EntityViewTile.java
@@ -43,7 +43,7 @@ import java.util.Arrays;
  *         Each panel is defined by a Detail and an Entity
  *         Significant axis of configuration are NUMBER_ROWS, NUMBER_COLUMNS, AND CELL_HEIGHT_DIVISOR defined below
  */
-public class GridEntityView extends GridLayout {
+public class EntityViewTile extends GridLayout {
 
     private String[] searchTerms;
     private View[] mRowViews;
@@ -79,7 +79,7 @@ public class GridEntityView extends GridLayout {
      * Used to create a entity view tile outside of a managed context (like
      * for an individual entity out of a search context).
      */
-    public GridEntityView(Context context, Detail detail, Entity entity) {
+    public EntityViewTile(Context context, Detail detail, Entity entity) {
         this(context, detail, entity, new String[0], new CachingAsyncImageLoader(context), false);
     }
 
@@ -87,7 +87,8 @@ public class GridEntityView extends GridLayout {
      * Constructor for an entity tile in a managed context, like a list of entities being displayed
      * all at once for searching.
      */
-    public GridEntityView(Context context, Detail detail, Entity entity, String[] searchTerms, CachingAsyncImageLoader mLoader, boolean fuzzySearchEnabled) {
+    public EntityViewTile(Context context, Detail detail, Entity entity, String[] searchTerms,
+                          CachingAsyncImageLoader mLoader, boolean fuzzySearchEnabled) {
         super(context);
         this.searchTerms = searchTerms;
         this.mIsAsynchronous = entity instanceof AsyncEntity;

--- a/app/src/org/commcare/views/EntityViewTile.java
+++ b/app/src/org/commcare/views/EntityViewTile.java
@@ -75,7 +75,6 @@ public class EntityViewTile extends GridLayout {
     private static final int NUMBER_COLUMNS_PER_GRID = 12;
 
     private final int numRowsPerGrid;
-    private final int numTilesPerRow;
 
     private final double cellWidth;
     private final double cellHeight;
@@ -89,14 +88,14 @@ public class EntityViewTile extends GridLayout {
     public static EntityViewTile createTileForIndividualDisplay(Context context, Detail detail,
                                                                 Entity entity) {
         return new EntityViewTile(context, detail, entity, new String[0],
-                new CachingAsyncImageLoader(context), false, 1);
+                new CachingAsyncImageLoader(context), false);
     }
 
     public static EntityViewTile createTileForListDisplay(Context context, Detail detail, Entity entity,
                                                           String[] searchTerms,
                                                           CachingAsyncImageLoader loader,
                                                           boolean fuzzySearchEnabled) {
-        return new EntityViewTile(context, detail, entity, searchTerms, loader, fuzzySearchEnabled, 1);
+        return new EntityViewTile(context, detail, entity, searchTerms, loader, fuzzySearchEnabled);
     }
 
     /**
@@ -104,14 +103,13 @@ public class EntityViewTile extends GridLayout {
      * all at once for searching.
      */
     private EntityViewTile(Context context, Detail detail, Entity entity, String[] searchTerms,
-                          CachingAsyncImageLoader loader, boolean fuzzySearchEnabled, int numTilesPerRow) {
+                          CachingAsyncImageLoader loader, boolean fuzzySearchEnabled) {
         super(context);
         this.searchTerms = searchTerms;
         this.mIsAsynchronous = entity instanceof AsyncEntity;
         this.mImageLoader = loader;
         this.mFuzzySearchEnabled = fuzzySearchEnabled;
         this.numRowsPerGrid = getMaxRows(detail);
-        this.numTilesPerRow = numTilesPerRow;
 
         setEssentialGridLayoutValues();
 
@@ -179,7 +177,7 @@ public class EntityViewTile extends GridLayout {
             tileHeight = screenHeight / (numTilesPerScreenPortrait * densityRowMultiplier);
         }
 
-        double tileWidth = screenWidth / numTilesPerRow;
+        double tileWidth = screenWidth;
 
         return new Pair(tileWidth, tileHeight);
     }


### PR DESCRIPTION
Prefactoring for the flexible-width case tiles work for UATBC

I confirmed that the case tiles in parto look identical before and after the refactor.