### PR TITLE
Update sqlcipher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     compile 'ch.acra:acra:4.9.0@aar'
     compile 'joda-time:joda-time:2.9.4'
     compile 'net.sf.kxml:kxml2:2.3.0'
-    compile 'net.zetetic:android-database-sqlcipher:3.5.2@aar'
+    compile 'net.zetetic:android-database-sqlcipher:3.5.3@aar'
     compile 'org.apache.james:apache-mime4j:0.7.2'
     compile('org.apache.httpcomponents:httpmime:4.3.6') {
         exclude module: 'httpclient'


### PR DESCRIPTION
Seems like a good idea to update sqlcipher to 3.5.3 given the [release notes](https://discuss.zetetic.net/t/sqlcipher-for-android-3-5-3-release/1549):

> SQLCipher for Android 3.5.3 was just released, it includes a fix that addresses over reads from the cursor window. The over read would occur in the scenarios addressed in the 3.5.2 release where calls such as getInt(…) and getDouble(…) for columns that have a text affinity of TEXT did not encode the content properly to the Java client. We have added further tests to the SQLCipher for Android test suite3 to prevent any regressions in the future. We recommend that you upgrade to this release immediately.
