### PR TITLE
Remove unnecessary extensions of SessionAware activities

### DIFF
--- a/app/src/org/commcare/activities/AppManagerAdvancedSettings.java
+++ b/app/src/org/commcare/activities/AppManagerAdvancedSettings.java
@@ -3,6 +3,7 @@ package org.commcare.activities;
 import android.content.Intent;
 import android.os.Bundle;
 import android.preference.Preference;
+import android.preference.PreferenceActivity;
 import android.view.MenuItem;
 
 import org.commcare.dalvik.R;
@@ -17,7 +18,7 @@ import java.util.Map;
 /**
  * @author Aliza Stone (astone@dimagi.com), created 6/9/16.
  */
-public class AppManagerAdvancedSettings extends SessionAwarePreferenceActivity {
+public class AppManagerAdvancedSettings extends PreferenceActivity {
 
     private final static String ENABLE_PRIVILEGE = "enable-mobile-privilege";
 

--- a/app/src/org/commcare/activities/ConnectionDiagnosticActivity.java
+++ b/app/src/org/commcare/activities/ConnectionDiagnosticActivity.java
@@ -29,7 +29,7 @@ import org.javarosa.core.services.locale.Localization;
  * @author srengesh
  */
 @ManagedUi(R.layout.connection_diagnostic)
-public class ConnectionDiagnosticActivity extends SessionAwareCommCareActivity<ConnectionDiagnosticActivity> {
+public class ConnectionDiagnosticActivity extends CommCareActivity<ConnectionDiagnosticActivity> {
     private static final String TAG = ConnectionDiagnosticActivity.class.getSimpleName();
 
     public static final String logUnsetPostURLMessage = "CCHQ ping test: post URL not set.";


### PR DESCRIPTION
Don't make activities that can be accessed from the app manager session aware, since they do not require an active session and will cause confusing, unnecessary redirects in certain cases