### PR TITLE
Allow more than 2 apps by default in debug builds

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -248,7 +248,8 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
      */
     private boolean checkForMultipleAppsViolation() {
         if (CommCareApplication._().getInstalledAppRecords().size() >= 2
-                && !GlobalPrivilegesManager.isMultipleAppsPrivilegeEnabled()) {
+                && !GlobalPrivilegesManager.isMultipleAppsPrivilegeEnabled()
+                && !BuildConfig.DEBUG) {
             Intent i = new Intent(this, MultipleAppsLimitWarningActivity.class);
             i.putExtra(AppManagerActivity.KEY_LAUNCH_FROM_MANAGER, fromManager);
             startActivityForResult(i, MULTIPLE_APPS_LIMIT);


### PR DESCRIPTION
Not sure if y'all feel like this is a good idea or not, but I think it would be useful to remove the cap of 2 apps installed for debug builds of CommCare. Throughout my dev workflow I often reinstall CommCare and then want to use multiple apps, which requires me to reclaim super user multiple apps privileges every time.