### PR TITLE
Add list bounds check in QuestionsView.setFocus

### DIFF
--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -325,7 +325,7 @@ public class QuestionsView extends ScrollView
 
     public void setFocus(Context context, int indexOfLastChangedWidget) {
         QuestionWidget widgetToFocus = null;
-        if (indexOfLastChangedWidget != -1) {
+        if (indexOfLastChangedWidget != -1 && indexOfLastChangedWidget < widgets.size()) {
             widgetToFocus = widgets.get(indexOfLastChangedWidget);
         } else if (widgets.size() > 0) {
             widgetToFocus = widgets.get(0);


### PR DESCRIPTION
Fix for an ACRA crash:
```
java.lang.IndexOutOfBoundsException: Invalid index 1, size is 1
at java.util.ArrayList.throwIndexOutOfBoundsException(ArrayList.java:255)
at java.util.ArrayList.get(ArrayList.java:308)
at org.commcare.views.QuestionsView.setFocus(QuestionsView.java:329)
at org.commcare.activities.FormEntryActivity.showView(FormEntryActivity.java:1182)
at org.commcare.activities.FormEntryActivity.refreshCurrentView(FormEntryActivity.java:736)
at org.commcare.activities.FormEntryActivity.onActivityResult(FormEntryActiv
```

@amstone326 I'm just adding a patch to prevent the crash. Not sure if it is worth digging into how this may come up. Maybe something with questions being removed after relevancy condition recalculations?