### PR TITLE
Add flag to respect exact image bounds

### DIFF
--- a/app/src/org/commcare/adapters/MenuAdapter.java
+++ b/app/src/org/commcare/adapters/MenuAdapter.java
@@ -270,9 +270,10 @@ public class MenuAdapter implements ListAdapter {
     }
 
     public void setupImageView(ImageView mIconView, MenuDisplayable menuDisplayable) {
-        String imageURI = menuDisplayable.getImageURI();
-        Bitmap image = MediaUtil.inflateDisplayImage(context, imageURI);
         if (mIconView != null) {
+            int iconDimension = (int)context.getResources().getDimension(R.dimen.menu_icon_size);
+            Bitmap image = MediaUtil.inflateDisplayImage(context, menuDisplayable.getImageURI(),
+                    iconDimension, iconDimension);
             if (image != null) {
                 mIconView.setImageBitmap(image);
                 mIconView.setAdjustViewBounds(true);

--- a/app/src/org/commcare/utils/CachingAsyncImageLoader.java
+++ b/app/src/org/commcare/utils/CachingAsyncImageLoader.java
@@ -76,7 +76,8 @@ public class CachingAsyncImageLoader implements ComponentCallbacks2 {
         }
 
         public Bitmap getImageBitmap(String filePath) {
-            Bitmap bitmap = MediaUtil.inflateDisplayImage(mContext, filePath, mBoundingWidth, mBoundingHeight);
+            Bitmap bitmap = MediaUtil.inflateDisplayImage(mContext, filePath, mBoundingWidth,
+                    mBoundingHeight, true);
 
             if (bitmap != null) {
                 synchronized (cache) {

--- a/app/src/org/commcare/utils/MediaUtil.java
+++ b/app/src/org/commcare/utils/MediaUtil.java
@@ -30,6 +30,7 @@ public class MediaUtil {
     public static final String FORM_AUDIO = "audio";
     public static final String FORM_IMAGE = "image";
 
+
     /**
      * Attempts to inflate an image from a CommCare UI definition source.
      *
@@ -96,6 +97,11 @@ public class MediaUtil {
         return null;
     }
 
+    public static Bitmap inflateDisplayImage(Context context, String jrUri,
+                                             int boundingWidth, int boundingHeight) {
+        return inflateDisplayImage(context, jrUri, boundingWidth, boundingHeight, false);
+    }
+
     public static Bitmap inflateDisplayImage(Context context, String jrUri) {
         return inflateDisplayImage(context, jrUri, -1, -1, false);
     }
@@ -130,7 +136,7 @@ public class MediaUtil {
                     containerHeight, containerWidth);
         } else  {
             return scaleDownToTargetOrContainer(imageFilepath, imageHeight, imageWidth,
-                    calculatedHeight, calculatedWidth, containerHeight, containerWidth, false);
+                    calculatedHeight, calculatedWidth, containerHeight, containerWidth, false, true);
         }
     }
 
@@ -189,10 +195,9 @@ public class MediaUtil {
     }
 
     public static Bitmap getBitmapScaledToContainer(File imageFile, int containerHeight,
-                                                    int containerWidth,
-                                                    boolean respectBoundsExactly) {
+                                                    int containerWidth) {
         return getBitmapScaledToContainer(imageFile.getAbsolutePath(), containerHeight,
-                containerWidth, respectBoundsExactly);
+                containerWidth, false);
     }
 
     /**

--- a/app/src/org/commcare/utils/MediaUtil.java
+++ b/app/src/org/commcare/utils/MediaUtil.java
@@ -36,12 +36,13 @@ public class MediaUtil {
      * @param jrUri          The image to inflate
      * @param boundingWidth  the width of the container this image is being inflated into, to serve
      *                       as a max width. If passed in as -1, gets set to screen width
-     * @param boundingHeight the height fo the container this image is being inflated into, to
+     * @param boundingHeight the height of the container this image is being inflated into, to
      *                       serve as a max height. If passed in as -1, gets set to screen height
      * @return A bitmap if one could be created. Null if error occurs or the image is unavailable.
      */
     public static Bitmap inflateDisplayImage(Context context, String jrUri,
-                                             int boundingWidth, int boundingHeight) {
+                                             int boundingWidth, int boundingHeight,
+                                             boolean respectBoundsExactly) {
         if (jrUri == null || jrUri.equals("")) {
             return null;
         }
@@ -86,7 +87,7 @@ public class MediaUtil {
             } else {
                 // just scale down if the original image is way too big for its container
                 return getBitmapScaledToContainer(imageFile.getAbsolutePath(), boundingHeight,
-                        boundingWidth);
+                        boundingWidth, respectBoundsExactly);
             }
         } catch (InvalidReferenceException e) {
             Log.e("ImageInflater", "image invalid reference exception for " + e.getReferenceString());
@@ -96,7 +97,7 @@ public class MediaUtil {
     }
 
     public static Bitmap inflateDisplayImage(Context context, String jrUri) {
-        return inflateDisplayImage(context, jrUri, -1, -1);
+        return inflateDisplayImage(context, jrUri, -1, -1, false);
     }
 
     /**
@@ -175,7 +176,7 @@ public class MediaUtil {
      * down proportionally with the width)
      */
     public static Bitmap getBitmapScaledToContainer(String imageFilepath, int containerHeight,
-                                                     int containerWidth) {
+                                                     int containerWidth, boolean respectBoundsExactly) {
         // Determine dimensions of original image
         BitmapFactory.Options o = new BitmapFactory.Options();
         o.inJustDecodeBounds = true;
@@ -184,13 +185,14 @@ public class MediaUtil {
         int imageWidth = o.outWidth;
 
         return scaleDownToTargetOrContainer(imageFilepath, imageHeight, imageWidth, -1, -1,
-                containerHeight, containerWidth, true);
+                containerHeight, containerWidth, true, respectBoundsExactly);
     }
 
     public static Bitmap getBitmapScaledToContainer(File imageFile, int containerHeight,
-                                                    int containerWidth) {
+                                                    int containerWidth,
+                                                    boolean respectBoundsExactly) {
         return getBitmapScaledToContainer(imageFile.getAbsolutePath(), containerHeight,
-                containerWidth);
+                containerWidth, respectBoundsExactly);
     }
 
     /**
@@ -211,7 +213,8 @@ public class MediaUtil {
                                                        int originalHeight, int originalWidth,
                                                        int targetHeight, int targetWidth,
                                                        int boundingHeight, int boundingWidth,
-                                                       boolean scaleByContainerOnly) {
+                                                       boolean scaleByContainerOnly,
+                                                       boolean respectBoundsExactly) {
         Pair<Integer, Integer> dimensImposedByContainer = getRoughDimensImposedByContainer(
                 originalHeight, originalWidth, boundingHeight, boundingWidth);
 
@@ -227,11 +230,12 @@ public class MediaUtil {
         int approximateScaleDownFactor = getApproxScaleDownFactor(newWidth, originalWidth);
         Bitmap b = inflateImageSafe(imageFilepath, approximateScaleDownFactor).first;
 
-        if (scaleByContainerOnly) {
+        if (scaleByContainerOnly && !respectBoundsExactly) {
             // Not worth performance loss of creating an exact scaled bitmap in this case
             return b;
         } else {
-            // Here we want to be more precise because we had a target width and height
+            // Here we want to be more precise because we have a target width and height, or
+            // specified that respecting the bounding container precisely is important
             return Bitmap.createScaledBitmap(b, newWidth, newHeight, false);
         }
 

--- a/app/src/org/commcare/views/EntityActionViewUtils.java
+++ b/app/src/org/commcare/views/EntityActionViewUtils.java
@@ -53,7 +53,7 @@ public class EntityActionViewUtils {
         if (imageURI != null) {
             ImageView icon = (ImageView)actionCardView.findViewById(R.id.icon);
             int iconDimension = (int)context.getResources().getDimension(R.dimen.menu_icon_size);
-            Bitmap b = MediaUtil.inflateDisplayImage(context, imageURI, iconDimension, iconDimension);
+            Bitmap b = MediaUtil.inflateDisplayImage(context, imageURI, iconDimension, iconDimension, true);
             if (b != null) {
                 icon.setVisibility(View.VISIBLE);
                 icon.setImageBitmap(b);

--- a/app/src/org/commcare/views/EntityView.java
+++ b/app/src/org/commcare/views/EntityView.java
@@ -352,7 +352,7 @@ public class EntityView extends LinearLayout {
         }
         if (onMeasureCalled) {
             int columnWidthInPixels = layout.getLayoutParams().width;
-            Bitmap b = MediaUtil.inflateDisplayImage(getContext(), source, columnWidthInPixels, -1);
+            Bitmap b = MediaUtil.inflateDisplayImage(getContext(), source, columnWidthInPixels, columnWidthInPixels, true);
             if (b == null) {
                 // Means the input stream could not be used to derive the bitmap, so showing
                 // error-indicating image

--- a/app/src/org/commcare/views/EntityViewTile.java
+++ b/app/src/org/commcare/views/EntityViewTile.java
@@ -345,7 +345,7 @@ public class EntityViewTile extends GridLayout {
                                 maxWidth, maxHeight);
                     } else {
                         Bitmap b = MediaUtil.inflateDisplayImage(getContext(), rowData,
-                                maxWidth, maxHeight);
+                                maxWidth, maxHeight, true);
                         ((ImageView) retVal).setImageBitmap(b);
                     }
                 }

--- a/unit-tests/src/org/commcare/android/tests/ImageInflationTest.java
+++ b/unit-tests/src/org/commcare/android/tests/ImageInflationTest.java
@@ -37,7 +37,7 @@ public class ImageInflationTest {
 
     private void testCorrectInflationWithoutDensity(int[] boundingDimens, int expectedNewDimen) {
         Bitmap b = MediaUtil.getBitmapScaledToContainer(imageFilepath, boundingDimens[0],
-                boundingDimens[1]);
+                boundingDimens[1], true);
         Assert.assertNotNull(b);
         Assert.assertEquals(expectedNewDimen, b.getWidth());
         Assert.assertEquals(expectedNewDimen, b.getHeight());


### PR DESCRIPTION
Add a flag that can indicate to us to scale an image down to more precise dimensions based on the given container dimensions, and set that flag to true in places where we are inflating a display image that should be shown within very specific dimensions. 

Fixes http://manage.dimagi.com/default.asp?235370