### PR TITLE
Try/catch around FormEntryActivity unregisterReceiver

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1004,7 +1004,13 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
 
         if (mLocationServiceIssueReceiver != null) {
-            unregisterReceiver(mLocationServiceIssueReceiver);
+            try {
+                unregisterReceiver(mLocationServiceIssueReceiver);
+            } catch (IllegalArgumentException e) {
+                // Thrown when given receiver isn't registered.
+                // This shouldn't ever happen, but seems to come up in production
+                Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION, e.getMessage());
+            }
         }
 
         saveInlineVideoState();


### PR DESCRIPTION
Seeing some of the following crashes on ACRA for 2.29.1
In practice, the receiver in question (`mLocationServiceIssueReceiver`) should always be registered, so I have no idea how this is coming up. Figured it is better to not crash the app though.

```
java.lang.RuntimeException: Unable to pause activity {org.commcare.dalvik/org.commcare.activities.FormEntryActivity}: java.lang.IllegalArgumentException: Receiver not registered: org.commcare.activities.FormEntryActivity$1@43ebef50
at android.app.ActivityThread.performPauseActivity(ActivityThread.java:3242)
at android.app.ActivityThread.performPauseActivity(ActivityThread.java:3193)
at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:3171)
at android.app.ActivityThread.access$1000(ActivityThread.java:151)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1338)
at android.os.Handler.dispatchMessage(Handler.java:110)
at android.os.Looper.loop(Looper.java:193)
at android.app.ActivityThread.main(ActivityThread.java:5292)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:515)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:824)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:640)
at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.IllegalArgumentException: Receiver not registered: org.commcare.activities.FormEntryActivity$1@43ebef50
at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:667)
at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1549)
at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:489)
at org.commcare.activities.FormEntryActivity.onPause(FormEntryActivity.java:1631)
at android.app.Activity.performPause(Activity.java:5368)
at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1239)
at android.app.ActivityThread.performPauseActivity(ActivityThread.java:3224)
... 12 more
java.lang.IllegalArgumentException: Receiver not registered: org.commcare.activities.FormEntryActivity$1@43ebef50
at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:667)
at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1549)
at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:489)
at org.commcare.activities.FormEntryActivity.onPause(FormEntryActivity.java:1631)
at android.app.Activity.performPause(Activity.java:5368)
at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1239)
at android.app.ActivityThread.performPauseActivity(ActivityThread.java:3224)
at android.app.ActivityThread.performPauseActivity(ActivityThread.java:3193)
at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:3171)
at android.app.ActivityThread.access$1000(ActivityThread.java:151)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1338)
at android.os.Handler.dispatchMessage(Handler.java:110)
at android.os.Looper.loop(Looper.java:193)
at android.app.ActivityThread.main(ActivityThread.java:5292)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:515)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:824)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:640)
at dalvik.system.NativeStart.main(Native Method)
```