### PR TITLE
Catch another session expiration crash in home button logic

### DIFF
--- a/app/src/org/commcare/activities/HomeButtons.java
+++ b/app/src/org/commcare/activities/HomeButtons.java
@@ -11,6 +11,7 @@ import org.commcare.adapters.SquareButtonViewHolder;
 import org.commcare.dalvik.R;
 import org.commcare.logging.analytics.GoogleAnalyticsFields;
 import org.commcare.logging.analytics.GoogleAnalyticsUtils;
+import org.commcare.utils.SessionUnavailableException;
 import org.commcare.utils.StorageUtils;
 import org.commcare.utils.SyncDetailCalculations;
 import org.javarosa.core.services.locale.Localization;
@@ -157,7 +158,14 @@ public class HomeButtons {
                                SquareButtonViewHolder squareButtonViewHolder,
                                Context context,
                                String notificationText) {
-                int numIncompleteForms = StorageUtils.getNumIncompleteForms();
+                int numIncompleteForms;
+                try {
+                    numIncompleteForms = StorageUtils.getNumIncompleteForms();
+                } catch (SessionUnavailableException e) {
+                    // stop button setup, since redirection to login is imminent
+                    return;
+                }
+
                 if (numIncompleteForms > 0) {
                     Spannable incompleteIndicator =
                             (activity.localize("home.forms.incomplete.indicator",


### PR DESCRIPTION
Yet another crash due to home screen button setup code not handling session expiration correctly.

```
org.commcare.utils.SessionUnavailableException
at org.commcare.CommCareApplication.getSession(CommCareApplication.java:1190)
at org.commcare.CommCareApplication.getUserDbHandle(CommCareApplication.java:737)
at org.commcare.CommCareApplication$3.getHandle(CommCareApplication.java:791)
at org.commcare.models.database.SqlStorage.getIDsForValues(SqlStorage.java:87)
at org.commcare.utils.StorageUtils.getNumIncompleteForms(StorageUtils.java:47)
at org.commcare.activities.HomeButtons$6.update(HomeButtons.java:160)
at org.commcare.adapters.SquareButtonAdapter.bindCard(SquareButtonAdapter.java:78)
at org.commcare.adapters.SquareButtonAdapter.onBindViewHolder(SquareButtonAdapter.java:63)
at org.commcare.adapters.HomeScreenAdapter.onBindViewHolder(HomeScreenAdapter.java:84)
at android.support.v7.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:5801)
at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5037)
at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:4913)
at android.support.v7.widget.LayoutState.next(LayoutState.java:100)
at android.support.v7.widget.StaggeredGridLayoutManager.fill(StaggeredGridLayoutManager.java:1555)
at android.support.v7.widget.StaggeredGridLayoutManager.onLayoutChildren(StaggeredGridLayoutManager.java:665)
at android.support.v7.widget.StaggeredGridLayoutManager.onLayoutChildren(StaggeredGridLayoutManager.java:597)
at android.support.v7.widget.RecyclerView.dispatchLayoutStep2(RecyclerView.java:3260)
at android.support.v7.widget.RecyclerView.dispatchLayout(RecyclerView.java:3069)
at android.support.v7.widget.RecyclerView.onLayout(RecyclerView.java:3518)
at android.view.View.layout(View.java:17938)
at android.view.ViewGroup.layout(ViewGroup.java:5814)
at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1742)
at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1585)
at android.widget.LinearLayout.onLayout(LinearLayout.java:1494)
at android.view.View.layout(View.java:17938)
at android.view.ViewGroup.layout(ViewGroup.java:5814)
at android.widget.FrameLayout.layoutChildren(FrameLayout.java:344)
at android.widget.FrameLayout.onLayout(FrameLayout.java:281)
at android.view.View.layout(View.java:17938)
at android.view.ViewGroup.layout(ViewGroup.java:5814)
at com.android.internal.widget.ActionBarOverlayLayout.onLayout(ActionBarOverlayLayout.java:493)
at android.view.View.layout(View.java:17938)
at android.view.ViewGroup.layout(ViewGroup.java:5814)
at android.widget.FrameLayout.layoutChildren(FrameLayout.java:344)
at android.widget.FrameLayout.onLayout(FrameLayout.java:281)
at com.android.internal.policy.PhoneWindow$DecorView.onLayout(PhoneWindow.java:3193)
at android.view.View.layout(View.java:17938)
at android.view.ViewGroup.layout(ViewGroup.java:5814)
at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:2666)
at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2367)
at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1437)
at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7397)
at android.view.Choreographer$CallbackRecord.run(Choreographer.java:920)
at android.view.Choreographer.doCallbacks(Choreographer.java:695)
at android.view.Choreographer.doFrame(Choreographer.java:631)
at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:906)
at android.os.Handler.handleCallback(Handler.java:739)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:158)
at android.app.ActivityThread.main(ActivityThread.java:7224)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
```