### PR TITLE
Prevent question save after form completion

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -999,7 +999,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     protected void onPause() {
         super.onPause();
 
-        if (uiController.questionsView != null && currentPromptIsQuestion()) {
+
+        if (!isFinishing() && uiController.questionsView != null && currentPromptIsQuestion()) {
             saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
         }
 


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?235890

@ctsims Duncan from VaxTrac was happy with the workaround so don't think there's any need to hotfix