### PR TITLE
Allow configuration of GPS auto-capture accuracy via HQ

### DIFF
--- a/app/src/org/commcare/android/javarosa/PollSensorController.java
+++ b/app/src/org/commcare/android/javarosa/PollSensorController.java
@@ -15,6 +15,7 @@ import android.os.Looper;
 import android.support.v4.content.ContextCompat;
 
 import org.commcare.CommCareApplication;
+import org.commcare.preferences.CommCarePreferences;
 import org.commcare.utils.GeoUtils;
 
 import java.util.ArrayList;
@@ -106,7 +107,7 @@ public enum PollSensorController implements LocationListener {
                     action.updateReference(location);
                 }
 
-                if (location.getAccuracy() <= GeoUtils.GOOD_ACCURACY) {
+                if (location.getAccuracy() <= CommCarePreferences.getGpsCaptureAccuracy()) {
                     stopLocationPolling();
                 }
             }

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -26,6 +26,7 @@ import org.commcare.dalvik.R;
 import org.commcare.logging.analytics.GoogleAnalyticsFields;
 import org.commcare.logging.analytics.GoogleAnalyticsUtils;
 import org.commcare.utils.FileUtil;
+import org.commcare.utils.GeoUtils;
 import org.commcare.utils.TemplatePrinterUtils;
 import org.commcare.utils.UriToFilePath;
 import org.commcare.views.dialogs.StandardAlertDialog;
@@ -93,6 +94,7 @@ public class CommCarePreferences
     public final static String BRAND_BANNER_LOGIN = "brand-banner-login";
     public final static String BRAND_BANNER_HOME = "brand-banner-home";
     public final static String LOGIN_DURATION = "cc-login-duration-seconds";
+    public final static String GPS_AUTO_CAPTURE_ACCURACY = "cc-gps-auto-capture-accuracy";
     public final static String LOG_ENTITY_DETAIL = "cc-log-entity-detail-enabled";
     public final static String CONTENT_VALIDATED = "cc-content-valid";
     public static final String DUMP_FOLDER_PATH = "dump-folder-path";
@@ -394,6 +396,20 @@ public class CommCarePreferences
                     Integer.toString(oneDayInSecs)));
         } catch (NumberFormatException e) {
             return oneDayInSecs;
+        }
+    }
+
+    /**
+     * @return Accuracy needed for GPS auto-capture to stop polling during form entry
+     */
+    public static double getGpsCaptureAccuracy() {
+        SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
+
+        try {
+            return Double.parseDouble(properties.getString(GPS_AUTO_CAPTURE_ACCURACY,
+                    Double.toString(GeoUtils.GOOD_ACCURACY)));
+        } catch (NumberFormatException e) {
+            return GeoUtils.GOOD_ACCURACY;
         }
     }
 


### PR DESCRIPTION
Allows one to configure the GPS auto-capture accuracy cutoff by setting the `cc-gps-auto-capture-accuracy` property (to a double) using the ['custom properties' HQ feature flag](https://confluence.dimagi.com/display/ccinternal/CommCare+Android+Developer+Options). If not set, defaults to 10.0 meters.

@dimagi/product Might be nice to consider making this more widely available for configuration on HQ. Like exposing a value box when auto-capture is enabled on HQ that lets you set the accuracy. This configuration is helpful because the desired GPS accuracy varies from project to project and if misconfigured has negative effects on device battery life.