### PR TITLE
Change max accuracy for GPS question widget

### DIFF
--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -407,9 +407,9 @@ public class CommCarePreferences
 
         try {
             return Double.parseDouble(properties.getString(GPS_AUTO_CAPTURE_ACCURACY,
-                    Double.toString(GeoUtils.GOOD_ACCURACY)));
+                    Double.toString(GeoUtils.AUTO_CAPTURE_GOOD_ACCURACY)));
         } catch (NumberFormatException e) {
-            return GeoUtils.GOOD_ACCURACY;
+            return GeoUtils.AUTO_CAPTURE_GOOD_ACCURACY;
         }
     }
 

--- a/app/src/org/commcare/utils/GeoUtils.java
+++ b/app/src/org/commcare/utils/GeoUtils.java
@@ -27,7 +27,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class GeoUtils {
     // Good enough accuracy to stop pinging the GPS altogether
-    public static final double GOOD_ACCURACY = 10;
+    public static final double GOOD_ACCURACY = 5;
+    public static final double AUTO_CAPTURE_GOOD_ACCURACY = 10;
 
     // Good enough accuracy to ask user if they want to record
     public static final double ACCEPTABLE_ACCURACY = 1600;


### PR DESCRIPTION
In 2.29 I changed the `GOOD_ACCURACY` value from `5` to `10` to prevent autocapture from running for a long time. I didn't realize this value was also used by the GPS capture question widget, thus lowering the accuracy of GPS coordinates captured in that way.

This PR adapts that change to make GPS capture questions accurate to `5` meters again.