### PR TITLE
Show 406 error messages to user

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -601,6 +601,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
             case UNKNOWN_FAILURE:
                 raiseLoginMessageWithInfo(StockMessages.Restore_Unknown, resultAndErrorMessage.errorMessage, true);
                 break;
+            case ACTIONABLE_FAILURE:
+                raiseLoginMessageWithInfo(StockMessages.Restore_Unknown, resultAndErrorMessage.errorMessage, true);
+                break;
         }
     }
 

--- a/app/src/org/commcare/activities/SyncUIHandling.java
+++ b/app/src/org/commcare/activities/SyncUIHandling.java
@@ -48,6 +48,9 @@ public class SyncUIHandling {
             case UNKNOWN_FAILURE:
                 activity.reportFailure(Localization.get("sync.fail.unknown"), true);
                 break;
+            case ACTIONABLE_FAILURE:
+                activity.reportFailure(resultAndErrorMessage.errorMessage, true);
+                break;
         }
 
         if (userTriggeredSync) {

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
@@ -199,6 +199,7 @@ public final class GoogleAnalyticsFields {
     public static final int VALUE_UNKNOWN_FAILURE = 6;
     public static final int VALUE_STORAGE_FULL = 7;
     public static final int VALUE_BAD_DATA_REQUIRES_INTERVENTION = 8;
+    public static final int VALUE_ACTIONABLE_FAILURE = 9;
 
     // Values for LABEL_AUTO_UPDATE
     public static final int VALUE_NEVER = 0;

--- a/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
+++ b/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
@@ -40,6 +40,9 @@ public class ArchivedFormRemoteRestore {
                     case UNKNOWN_FAILURE:
                         Toast.makeText(receiver, "Failure retrieving or processing data, please try again later...", Toast.LENGTH_LONG).show();
                         break;
+                    case ACTIONABLE_FAILURE:
+                        Toast.makeText(receiver, statusAndErrorMessage.errorMessage, Toast.LENGTH_LONG).show();
+                        break;
                     case AUTH_FAILED:
                         Toast.makeText(receiver, "Authentication failure. Please logout and resync with the server and try again.", Toast.LENGTH_LONG).show();
                         break;

--- a/app/src/org/commcare/network/HttpRequestEndpointsMock.java
+++ b/app/src/org/commcare/network/HttpRequestEndpointsMock.java
@@ -5,9 +5,12 @@ import org.apache.http.client.ClientProtocolException;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.commcare.interfaces.HttpRequestEndpoints;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -20,6 +23,7 @@ import java.util.List;
  */
 public class HttpRequestEndpointsMock implements HttpRequestEndpoints {
     private final static List<Integer> caseFetchResponseCodeStack = new ArrayList<>();
+    private static String errorMessagePayload;
 
     /**
      * Set the response code for the next N requests
@@ -27,6 +31,13 @@ public class HttpRequestEndpointsMock implements HttpRequestEndpoints {
     public static void setCaseFetchResponseCodes(Integer[] responseCodes) {
         caseFetchResponseCodeStack.clear();
         Collections.addAll(caseFetchResponseCodeStack, responseCodes);
+    }
+
+    /**
+     * Set the response body for the next 406 request
+     */
+    public static void setErrorResponseBody(String body) {
+        errorMessagePayload = body;
     }
 
     @Override
@@ -40,6 +51,8 @@ public class HttpRequestEndpointsMock implements HttpRequestEndpoints {
         }
         if (responseCode == 202) {
             return HttpResponseMock.buildHttpResponseMockForAsyncRestore();
+        } else if (responseCode == 406) {
+            return HttpResponseMock.buildHttpResponseMock(responseCode, new ByteArrayInputStream(errorMessagePayload.getBytes("UTF-8")));
         } else {
             return HttpResponseMock.buildHttpResponseMock(responseCode, null);
         }

--- a/app/src/org/commcare/network/RemoteDataPullResponse.java
+++ b/app/src/org/commcare/network/RemoteDataPullResponse.java
@@ -114,6 +114,10 @@ public class RemoteDataPullResponse {
         return AndroidHttpClient.getUngzippedContent(response.getEntity());
     }
 
+    public String getShortBody() throws IOException {
+        return new String(StreamsUtil.inputStreamToByteArray(AndroidHttpClient.getUngzippedContent(response.getEntity())));
+    }
+
     /**
      * Get an estimation of how large the provided response is.
      *

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -33,11 +33,14 @@ import org.commcare.core.network.bitcache.BitCache;
 import org.commcare.xml.AndroidTransactionParserFactory;
 import org.javarosa.core.model.User;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.storage.StorageFullException;
 import org.javarosa.core.util.PropertyUtils;
 import org.javarosa.xml.util.ActionableInvalidStructureException;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -218,7 +221,7 @@ public abstract class DataPullTask<R>
     private ResultAndError<PullTaskResult> getRequestResultOrRetry(AndroidTransactionParserFactory factory) {
         while (asyncRestoreHelper.retryWaitPeriodInProgress()) {
             if (isCancelled()) {
-                return new ResultAndError<>(PullTaskResult.UNKNOWN_FAILURE, "");
+                return new ResultAndError<>(PullTaskResult.UNKNOWN_FAILURE);
             }
         }
 
@@ -260,10 +263,9 @@ public abstract class DataPullTask<R>
         return new ResultAndError<>(responseError);
     }
 
-    /*
+    /**
      * @return the proper result, or null if we have not yet been able to determine the result to
      * return
-     * @throws IOException
      */
     private ResultAndError<PullTaskResult> makeRequestAndHandleResponse(AndroidTransactionParserFactory factory)
             throws IOException, UnknownSyncError {
@@ -284,11 +286,26 @@ public abstract class DataPullTask<R>
             }
         } else if (responseCode == 412) {
             return handleBadLocalState(factory);
+        } else if (responseCode == 406) {
+            return processErrorResponseWithMessage(pullResponse);
         } else if (responseCode == 500) {
             return handleServerError();
         } else {
             throw new UnknownSyncError();
         }
+    }
+
+    private ResultAndError<PullTaskResult> processErrorResponseWithMessage(RemoteDataPullResponse pullResponse) throws IOException {
+        String message;
+        try {
+            JSONObject errorKeyAndDefault = new JSONObject(pullResponse.getShortBody());
+            message = Localization.getWithDefault(
+                    errorKeyAndDefault.getString("error"),
+                    errorKeyAndDefault.getString("default_response"));
+        } catch (JSONException e) {
+            message = "Unknown issue";
+        }
+        return new ResultAndError<>(PullTaskResult.ACTIONABLE_FAILURE, message);
     }
 
     private ResultAndError<PullTaskResult> handleAuthFailed() {
@@ -312,7 +329,7 @@ public abstract class DataPullTask<R>
 
         if (isCancelled()) {
             // About to enter data commit phase; last chance to finish early if cancelled.
-            return new ResultAndError<>(PullTaskResult.UNKNOWN_FAILURE, "");
+            return new ResultAndError<>(PullTaskResult.UNKNOWN_FAILURE);
         }
 
         this.publishProgress(PROGRESS_DOWNLOADING_COMPLETE, 0);
@@ -415,7 +432,7 @@ public abstract class DataPullTask<R>
     private ResultAndError<PullTaskResult> handleServerError() {
         wipeLoginIfItOccurred();
         Logger.log(AndroidLogger.TYPE_USER, "500 Server Error|" + username);
-        return new ResultAndError<>(PullTaskResult.SERVER_ERROR, "");
+        return new ResultAndError<>(PullTaskResult.SERVER_ERROR);
     }
 
     private void wipeLoginIfItOccurred() {
@@ -598,6 +615,7 @@ public abstract class DataPullTask<R>
         BAD_DATA(GoogleAnalyticsFields.VALUE_BAD_DATA),
         BAD_DATA_REQUIRES_INTERVENTION(GoogleAnalyticsFields.VALUE_BAD_DATA_REQUIRES_INTERVENTION),
         UNKNOWN_FAILURE(GoogleAnalyticsFields.VALUE_UNKNOWN_FAILURE),
+        ACTIONABLE_FAILURE(GoogleAnalyticsFields.VALUE_ACTIONABLE_FAILURE),
         UNREACHABLE_HOST(GoogleAnalyticsFields.VALUE_UNREACHABLE_HOST),
         CONNECTION_TIMEOUT(GoogleAnalyticsFields.VALUE_CONNECTION_TIMEOUT),
         SERVER_ERROR(GoogleAnalyticsFields.VALUE_SERVER_ERROR),

--- a/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
+++ b/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
@@ -85,6 +85,15 @@ public class DataPullTaskTest {
     }
 
     @Test
+    public void dataPullFailWithMessage() {
+        installLoginAndUseLocalKeys();
+        HttpRequestEndpointsMock.setErrorResponseBody("{\"error\": \"some.fake.locale.key\", \"default_response\": \"hello world\"}");
+        runDataPull(406, GOOD_RESTORE);
+        Assert.assertEquals(DataPullTask.PullTaskResult.ACTIONABLE_FAILURE, dataPullResult.data);
+        Assert.assertEquals("hello world", dataPullResult.errorMessage);
+    }
+
+    @Test
     public void dataPullRecoverFailLoginNeededTest() {
         installWithUserAndUseLocalKeys();
         runDataPull(new Integer[]{412, 500}, new String[]{GOOD_RESTORE, GOOD_RESTORE});


### PR DESCRIPTION
Mobile side of https://github.com/dimagi/commcare-hq/pull/12728
Show error message passed down from HQ on `406` http responses.

This will allow us to send custom messages down to our users.

![screen](https://cloud.githubusercontent.com/assets/94817/18252307/f35e58a8-735b-11e6-8155-e332dd8587a1.png)

Thanks for the HQ side of this @mkangia 🎉   