### PR TITLE
Update sync button with new messages

### DIFF
--- a/app/src/org/commcare/activities/HomeActivityUIController.java
+++ b/app/src/org/commcare/activities/HomeActivityUIController.java
@@ -100,6 +100,8 @@ public class HomeActivityUIController implements CommCareActivityUIController {
             Toast.makeText(activity, message, Toast.LENGTH_LONG).show();
         }
 
-        adapter.notifyItemChanged(adapter.getSyncButtonPosition(), message);
+        // Manually route message payloads since RecyclerView payloads are a pain in the ass
+        adapter.setMessagePayload(adapter.getSyncButtonPosition(), message);
+        adapter.notifyItemChanged(adapter.getSyncButtonPosition());
     }
 }

--- a/app/src/org/commcare/adapters/HomeScreenAdapter.java
+++ b/app/src/org/commcare/adapters/HomeScreenAdapter.java
@@ -13,6 +13,8 @@ import org.commcare.activities.HomeButtons;
 import org.commcare.dalvik.R;
 import org.commcare.views.CustomBanner;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Vector;
 
@@ -29,6 +31,7 @@ public class HomeScreenAdapter
     private static final int TYPE_HEADER = 1;
     private final int screenHeight, screenWidth;
     private final int syncButtonPosition;
+    private final HashMap<Integer, String> messagePayload = new HashMap<>();
 
     public HomeScreenAdapter(CommCareHomeActivity activity,
                              Vector<String> buttonsToHide,
@@ -67,20 +70,27 @@ public class HomeScreenAdapter
     }
 
     @Override
-    public void onBindViewHolder(RecyclerView.ViewHolder holder, int i) {
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int i, List<Object> payload) {
         if (holder instanceof HeaderViewHolder) {
             bindHeader((HeaderViewHolder)holder);
         } else {
-            super.onBindViewHolder(holder, i);
+            if (payload == null || payload.isEmpty()) {
+                payload = new ArrayList<>();
+                payload.add(messagePayload.remove(i));
+            }
+
+            super.onBindViewHolder(holder, i, payload);
         }
     }
 
     @Override
-    public void onBindViewHolder(RecyclerView.ViewHolder holder,
-                                 int i, List<Object> payload) {
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int i) {
         if (holder instanceof HeaderViewHolder) {
             bindHeader((HeaderViewHolder)holder);
         } else {
+            ArrayList<Object> payload = new ArrayList<>();
+            payload.add(messagePayload.remove(i));
+
             super.onBindViewHolder(holder, i, payload);
         }
     }
@@ -124,6 +134,10 @@ public class HomeScreenAdapter
 
     public int getSyncButtonPosition() {
         return syncButtonPosition;
+    }
+
+    public void setMessagePayload(int position, String message) {
+        messagePayload.put(position, message);
     }
 
     private static class HeaderViewHolder extends RecyclerView.ViewHolder {


### PR DESCRIPTION
When we moved the home button adapter to use `RecycleView` I made use of the `onBindView` payload infrastructure. I either didn't get it working or something changed since then but when sync messages are shown they no longer update the subtext of the sync button (they only show as toast pop-ups). I spent a while trying to get `RecycleView` to properly deliver payloads, but to no avail, so this is my manual work around.

![screen](https://cloud.githubusercontent.com/assets/94817/18253819/e629981e-7365-11e6-90ab-2b3b38751695.png)
