### PR TITLE
Move 'Enable Updating to Un-Starred Builds' to normal preferences

### DIFF
--- a/app/res/xml/commcare_preferences.xml
+++ b/app/res/xml/commcare_preferences.xml
@@ -33,7 +33,7 @@
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-newest-version-from-hq"
-        android:title="Use Newest App Version From HQ"/>
+        android:title="Enable Updating to Un-Starred Builds"/>
     <Preference
         android:key="disable-analytics"/>
     <Preference

--- a/app/res/xml/commcare_preferences.xml
+++ b/app/res/xml/commcare_preferences.xml
@@ -27,6 +27,13 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-fuzzy-search-enabled"
         android:title="Fuzzy Search Matches"/>
+    <ListPreference
+        android:enabled="true"
+        android:defaultValue="no"
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
+        android:key="cc-newest-version-from-hq"
+        android:title="Use Newest App Version From HQ"/>
     <Preference
         android:key="disable-analytics"/>
     <Preference

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -29,12 +29,6 @@
         android:enabled="true"
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
-        android:key="cc-newest-version-from-hq"
-        android:title="Use Newest App Version From HQ"/>
-    <ListPreference
-        android:enabled="true"
-        android:entries="@array/pref_enabled_labels"
-        android:entryValues="@array/pref_enabled_vals"
         android:key="cc-enable-auto-login"
         android:title="Auto-login While Debugging"/>
     <ListPreference

--- a/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
+++ b/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
@@ -8,7 +8,6 @@ import org.commcare.engine.resource.installers.SingleAppInstallation;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.preferences.CommCarePreferences;
 import org.commcare.preferences.CommCareServerPreferences;
-import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.resources.ResourceManager;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
@@ -218,7 +217,7 @@ public class ResourceInstallUtils {
         // If we want to be using/updating to the latest build of the
         // app (instead of latest release), add it to the query tags of
         // the profile reference
-        if (DeveloperPreferences.isNewestAppVersionEnabled()) {
+        if (CommCarePreferences.isNewestAppVersionEnabled()) {
             if (profileUrl.getQuery() != null) {
                 // url already has query strings, so add a new one to the end
                 return profileRef + "&target=build";

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
@@ -122,6 +122,7 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_FUZZY_SEARCH = "Fuzzy Search Matches";
     public static final String LABEL_PRINT_TEMPLATE = "Set Print Template";
     public static final String LABEL_DEVELOPER_OPTIONS = "Developer Options";
+    public static final String LABEL_NEWEST_APP_VERSION = "Use Newest App Version From HQ";
 
     // Labels for ACTION_VIEW_PREF and ACTION_EDIT_PREF in CATEGORY_FORM_PREFS
     public static final String LABEL_FONT_SIZE = "Font Size";
@@ -133,7 +134,6 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_GRID_MENUS = "Grid Menus Enabled";
     public static final String LABEL_NAV_UI = "Navigation UI";
     public static final String LABEL_ENTITY_LIST_REFRESH = "Entity List Screen Auto-Refresh";
-    public static final String LABEL_NEWEST_APP_VERSION = "Use Newest App Version From HQ";
     public static final String LABEL_AUTO_LOGIN = "Auto-login While Debugging";
     public static final String LABEL_SESSION_SAVING = "Enable Session Saving";
     public static final String LABEL_EDIT_SAVED_SESSION = "Edit Saved Session";

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -82,6 +82,12 @@ public class CommCarePreferences
     private final static String PREFS_FUZZY_SEARCH_KEY = "cc-fuzzy-search-enabled";
     public final static String GRID_MENUS_ENABLED = "cc-grid-menus";
 
+    /**
+     * Does the user want to download the latest app version deployed (built),
+     * not just the latest app version released (starred)?
+     */
+    public final static String NEWEST_APP_VERSION_ENABLED = "cc-newest-version-from-hq";
+
     // Preferences that are set incidentally/automatically by CommCare, based upon a user's workflow
     public final static String HAS_DISMISSED_PIN_CREATION = "has-dismissed-pin-creation";
     public final static String LAST_LOGGED_IN_USER = "last_logged_in_user";
@@ -120,6 +126,7 @@ public class CommCarePreferences
         prefKeyToAnalyticsEvent.put(AUTO_UPDATE_FREQUENCY, GoogleAnalyticsFields.LABEL_AUTO_UPDATE);
         prefKeyToAnalyticsEvent.put(PREFS_FUZZY_SEARCH_KEY, GoogleAnalyticsFields.LABEL_FUZZY_SEARCH);
         prefKeyToAnalyticsEvent.put(GRID_MENUS_ENABLED, GoogleAnalyticsFields.LABEL_GRID_MENUS);
+        prefKeyToAnalyticsEvent.put(NEWEST_APP_VERSION_ENABLED, GoogleAnalyticsFields.LABEL_NEWEST_APP_VERSION);
     }
 
     @Override
@@ -486,5 +493,22 @@ public class CommCarePreferences
         } else {
             return CommCareApplication._().getCurrentApp().getAppPreferences().getString("key_server", null);
         }
+    }
+
+    /**
+     * @return true if developer option to download the latest app version
+     * deployed (built) is enabled.  Otherwise the latest released (starred)
+     * app version will be downloaded on upgrade.
+     */
+    public static boolean isNewestAppVersionEnabled() {
+        SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
+        return properties.getString(NEWEST_APP_VERSION_ENABLED, CommCarePreferences.NO).equals(CommCarePreferences.YES);
+    }
+
+    public static void enableNewestAppVersion() {
+        CommCareApplication._().getCurrentApp().getAppPreferences()
+                .edit()
+                .putString(NEWEST_APP_VERSION_ENABLED, CommCarePreferences.YES)
+                .apply();
     }
 }

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -45,12 +45,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
      * Spacer to distinguish between the saved navigation session and form entry session
      */
     private static final String NAV_AND_FORM_SESSION_SPACER = "@@@@@";
-
-    /**
-     * Does the user want to download the latest app version deployed (built),
-     * not just the latest app version released (starred)?
-     */
-    public final static String NEWEST_APP_VERSION_ENABLED = "cc-newest-version-from-hq";
     /**
      * The current default for constraint checking during form saving (as of
      * CommCare 2.24) is to re-answer all the questions, causing a lot of
@@ -91,7 +85,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
         prefKeyToAnalyticsEvent.put(ACTION_BAR_ENABLED, GoogleAnalyticsFields.LABEL_ACTION_BAR);
         prefKeyToAnalyticsEvent.put(NAV_UI_ENABLED, GoogleAnalyticsFields.LABEL_NAV_UI);
         prefKeyToAnalyticsEvent.put(LIST_REFRESH_ENABLED, GoogleAnalyticsFields.LABEL_ENTITY_LIST_REFRESH);
-        prefKeyToAnalyticsEvent.put(NEWEST_APP_VERSION_ENABLED, GoogleAnalyticsFields.LABEL_NEWEST_APP_VERSION);
         prefKeyToAnalyticsEvent.put(ENABLE_AUTO_LOGIN, GoogleAnalyticsFields.LABEL_AUTO_LOGIN);
         prefKeyToAnalyticsEvent.put(ENABLE_SAVE_SESSION, GoogleAnalyticsFields.LABEL_SESSION_SAVING);
         prefKeyToAnalyticsEvent.put(EDIT_SAVE_SESSION, GoogleAnalyticsFields.LABEL_EDIT_SAVED_SESSION);
@@ -244,23 +237,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static boolean isListRefreshEnabled() {
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
         return properties.getString(LIST_REFRESH_ENABLED, CommCarePreferences.NO).equals(CommCarePreferences.YES);
-    }
-
-    /**
-     * @return true if developer option to download the latest app version
-     * deployed (built) is enabled.  Otherwise the latest released (starred)
-     * app version will be downloaded on upgrade.
-     */
-    public static boolean isNewestAppVersionEnabled() {
-        SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
-        return properties.getString(NEWEST_APP_VERSION_ENABLED, CommCarePreferences.NO).equals(CommCarePreferences.YES);
-    }
-
-    public static void enableNewestAppVersion() {
-        CommCareApplication._().getCurrentApp().getAppPreferences()
-                .edit()
-                .putString(DeveloperPreferences.NEWEST_APP_VERSION_ENABLED, CommCarePreferences.YES)
-                .apply();
     }
 
     public static boolean shouldFireTriggersOnSave() {

--- a/app/src/org/commcare/provider/RefreshToLatestBuildReceiver.java
+++ b/app/src/org/commcare/provider/RefreshToLatestBuildReceiver.java
@@ -6,7 +6,7 @@ import android.content.Intent;
 import android.util.Log;
 
 import org.commcare.activities.RefreshToLatestBuildActivity;
-import org.commcare.preferences.DeveloperPreferences;
+import org.commcare.preferences.CommCarePreferences;
 
 /**
  * Receiver for the RefreshToLatestBuildAction broadcast. Trigger from command line with:
@@ -25,7 +25,7 @@ public class RefreshToLatestBuildReceiver extends BroadcastReceiver {
         Log.d(TAG, "Processing test latest build broadcast");
 
         if (intent.getBooleanExtra("useLatestBuild", false)) {
-            DeveloperPreferences.enableNewestAppVersion();
+            CommCarePreferences.enableNewestAppVersion();
         }
 
         Intent i = new Intent(context, RefreshToLatestBuildActivity.class);


### PR DESCRIPTION
@dimagi/product How do you feel about the text of this feature?  <strike>I feel like 'Use latest HQ build' might be better than 'Use Newest App Version from HQ'. </strike> Went with @amstone326 suggestion of 'Enable Updating to Un-Starred Buildes'.

![screen](https://cloud.githubusercontent.com/assets/94817/18302379/8fdc1888-74a5-11e6-9245-5f1d5efdc574.png)
