### PR TITLE
Fix NPE when removing question answer that doesn't have text

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -887,7 +887,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     private void createClearDialog(final QuestionWidget qw) {
         String title = StringUtils.getStringRobust(this, R.string.clear_answer_ask);
         String question = qw.getPrompt().getLongText();
-        if (question.length() > 50) {
+        if (question == null) {
+            question = "";
+        } else if (question.length() > 50) {
             question = question.substring(0, 50) + "...";
         }
         String msg = StringUtils.getStringSpannableRobust(this, R.string.clearanswer_confirm, question).toString();


### PR DESCRIPTION
If your select question doesn't have a label, then clearing the answer caused a null pointer exception.

New behavior
![screen](https://cloud.githubusercontent.com/assets/94817/18308342/1942b46c-74c2-11e6-8ec6-7fac5bf63dfc.png)
