### PR TITLE
Enable session saving when running 'ccc update'

### DIFF
--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -279,6 +279,13 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
                 equals(CommCarePreferences.YES);
     }
 
+    public static void enableSessionSaving() {
+        CommCareApplication._().getCurrentApp().getAppPreferences()
+                .edit()
+                .putString(DeveloperPreferences.ENABLE_SAVE_SESSION, CommCarePreferences.YES)
+                .apply();
+    }
+
     public static boolean isMarkdownEnabled() {
         return doesPropertyMatch(MARKDOWN_ENABLED, CommCarePreferences.NO, CommCarePreferences.YES);
     }

--- a/app/src/org/commcare/provider/RefreshToLatestBuildReceiver.java
+++ b/app/src/org/commcare/provider/RefreshToLatestBuildReceiver.java
@@ -26,6 +26,7 @@ public class RefreshToLatestBuildReceiver extends BroadcastReceiver {
 
         if (intent.getBooleanExtra("useLatestBuild", false)) {
             DeveloperPreferences.enableNewestAppVersion();
+            DeveloperPreferences.enableSessionSaving();
         }
 
         Intent i = new Intent(context, RefreshToLatestBuildActivity.class);


### PR DESCRIPTION
The `ccc update` command is one way to trigger Aliza's 'Update to latest build and restore current location' feature. When called this way it only works if you have already set the 'enable session saving' dev preference. 

Instead of not working when it isn't set, this PR changes the behavior to automatically enable it, saving some setup/keystrokes.