### PR TITLE
Allow detail to tell entity list to focus to bottom

### DIFF
--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -243,7 +243,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
     private void setupUI(boolean isOrientationChange) {
         if (this.getString(R.string.panes).equals("two") && !mNoDetailMode) {
-            //See if we're on a big 'ol screen.
             if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
                 setupLandscapeDualPaneView();
             } else {
@@ -995,7 +994,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         //In landscape we want to select something now. Either the top item, or the most recently selected one
         if (inAwesomeMode) {
             updateSelectedItem(true);
-        } else {
+        } else if (shortSelect.shouldFocusToBottomOfEntityList()) {
             visibleView.setSelection(visibleView.getAdapter().getCount()-1);
         }
 

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -995,6 +995,8 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         //In landscape we want to select something now. Either the top item, or the most recently selected one
         if (inAwesomeMode) {
             updateSelectedItem(true);
+        } else {
+            visibleView.setSelection(visibleView.getAdapter().getCount()-1);
         }
 
         refreshTimer.start(this);


### PR DESCRIPTION
Custom for UATBC adherence calendar, so that when the calendar loads they are automatically brought to today's date, rather than having to scroll all the way down to get there.

cross-request: https://github.com/dimagi/commcare-core/pull/396