### PR TITLE
Always enable session saving if using update to latest build utility

### DIFF
--- a/app/src/org/commcare/provider/RefreshToLatestBuildReceiver.java
+++ b/app/src/org/commcare/provider/RefreshToLatestBuildReceiver.java
@@ -24,9 +24,9 @@ public class RefreshToLatestBuildReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         Log.d(TAG, "Processing test latest build broadcast");
 
+        DeveloperPreferences.enableSessionSaving();
         if (intent.getBooleanExtra("useLatestBuild", false)) {
             DeveloperPreferences.enableNewestAppVersion();
-            DeveloperPreferences.enableSessionSaving();
         }
 
         Intent i = new Intent(context, RefreshToLatestBuildActivity.class);


### PR DESCRIPTION
@phillipm Sorry I didn't look closer at this https://github.com/dimagi/commcare-android/pull/1483, but I think it makes sense to turn this on whenever the refresh to latest build utility is being used, whether or not we are also enabling the newest app version flag.