### PR TITLE
Enable showing actions in the app bar

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -642,24 +642,19 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     /**
      * Interface to perform additional setup code when adding an ActionBar
-     * using the {@link #tryToAddActionSearchBar(android.app.Activity,
-     * android.view.Menu,
-     * CommCareActivity.ActionBarInstantiator)}
-     * tryToAddActionSearchBar} method.
      */
     public interface ActionBarInstantiator {
         void onActionBarFound(MenuItem searchItem, SearchView searchView, MenuItem barcodeItem);
     }
 
     /**
-     * Tries to add actionBar to current Activity and hides the current search
-     * widget and runs ActionBarInstantiator if it exists. Used in
-     * EntitySelectActivity and FormRecordListActivity.
+     * Tries to add a SearchView action to the action bar of the current Activity,
+     * hides the current search widget, and runs ActionBarInstantiator if it exists.
+     * Used in EntitySelectActivity and FormRecordListActivity.
      *
      * @param act          Current activity
      * @param menu         Menu passed through onCreateOptionsMenu
-     * @param instantiator Optional ActionBarInstantiator for additional setup
-     *                     code.
+     * @param instantiator Optional ActionBarInstantiator for additional setup code.
      */
     protected void tryToAddActionSearchBar(Activity act, Menu menu,
                                            ActionBarInstantiator instantiator) {
@@ -667,9 +662,9 @@ public abstract class CommCareActivity<R> extends FragmentActivity
             MenuInflater inflater = act.getMenuInflater();
             inflater.inflate(org.commcare.dalvik.R.menu.action_bar_search_view, menu);
 
-            MenuItem searchItem = menu.findItem(org.commcare.dalvik.R.id.search_action_bar);
+            MenuItem searchMenuItem = menu.findItem(org.commcare.dalvik.R.id.search_action_bar);
             SearchView searchView =
-                    (SearchView) searchItem.getActionView();
+                    (SearchView) searchMenuItem.getActionView();
             MenuItem barcodeItem = menu.findItem(org.commcare.dalvik.R.id.barcode_scan_action_bar);
             if (searchView != null) {
                 int[] searchViewStyle =
@@ -681,7 +676,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
                 TextView textView = (TextView) searchView.findViewById(id);
                 textView.setTextColor(searchViewStyle[0]);
                 if (instantiator != null) {
-                    instantiator.onActionBarFound(searchItem, searchView, barcodeItem);
+                    instantiator.onActionBarFound(searchMenuItem, searchView, barcodeItem);
                 }
             }
 

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -648,8 +648,8 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     }
 
     /**
-     * Tries to add a SearchView action to the app bar of the current Activity,
-     * hides the current search widget, and runs ActionBarInstantiator if it exists.
+     * Tries to add a SearchView action to the app bar of the current Activity. If it is added,
+     * the alternative search widget is removed, and ActionBarInstantiator is run, if it exists.
      * Used in EntitySelectActivity and FormRecordListActivity.
      *
      * @param activity          Current activity

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -648,18 +648,18 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     }
 
     /**
-     * Tries to add a SearchView action to the action bar of the current Activity,
+     * Tries to add a SearchView action to the app bar of the current Activity,
      * hides the current search widget, and runs ActionBarInstantiator if it exists.
      * Used in EntitySelectActivity and FormRecordListActivity.
      *
-     * @param act          Current activity
+     * @param activity          Current activity
      * @param menu         Menu passed through onCreateOptionsMenu
      * @param instantiator Optional ActionBarInstantiator for additional setup code.
      */
-    protected void tryToAddActionSearchBar(Activity act, Menu menu,
-                                           ActionBarInstantiator instantiator) {
+    protected void tryToAddSearchActionToAppBar(Activity activity, Menu menu,
+                                                ActionBarInstantiator instantiator) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            MenuInflater inflater = act.getMenuInflater();
+            MenuInflater inflater = activity.getMenuInflater();
             inflater.inflate(org.commcare.dalvik.R.menu.action_bar_search_view, menu);
 
             MenuItem searchMenuItem = menu.findItem(org.commcare.dalvik.R.id.search_action_bar);
@@ -680,7 +680,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
                 }
             }
 
-            View bottomSearchWidget = act.findViewById(org.commcare.dalvik.R.id.searchfooter);
+            View bottomSearchWidget = activity.findViewById(org.commcare.dalvik.R.id.searchfooter);
             if (bottomSearchWidget != null) {
                 bottomSearchWidget.setVisibility(View.GONE);
             }

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -112,8 +112,8 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     private EntityListAdapter adapter;
     private LinearLayout header;
     private SearchView searchView;
-    private MenuItem searchItem;
-    private MenuItem barcodeItem;
+    private MenuItem searchMenuItem;
+    private MenuItem barcodeMenuItem;
 
     private EntityDatum selectDatum;
 
@@ -140,7 +140,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     private Detail shortSelect;
 
     private DataSetObserver mListStateObserver;
-    private OnClickListener barcodeScanOnClickListener;
+    public OnClickListener barcodeScanOnClickListener;
     private boolean isCalloutAutoLaunching;
 
     private boolean resuming = false;
@@ -756,9 +756,9 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             @TargetApi(Build.VERSION_CODES.HONEYCOMB)
             @Override
             public void onActionBarFound(MenuItem searchItem, SearchView searchView, MenuItem barcodeItem) {
-                EntitySelectActivity.this.searchItem = searchItem;
+                EntitySelectActivity.this.searchMenuItem = searchItem;
                 EntitySelectActivity.this.searchView = searchView;
-                EntitySelectActivity.this.barcodeItem = barcodeItem;
+                EntitySelectActivity.this.barcodeMenuItem = barcodeItem;
                 // restore last query string in the searchView if there is one
                 if (lastQueryString != null && lastQueryString.length() > 0) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
@@ -803,7 +803,8 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
                 }
             }
             if (shortSelect.getCallout() != null && shortSelect.getCallout().getImage() != null) {
-                EntitySelectCalloutSetup.setupImageLayout(this, barcodeItem, shortSelect.getCallout().getImage());
+                // Replace the barcode scan callout with our custom callout
+                EntitySelectCalloutSetup.setupImageLayout(this, barcodeMenuItem, shortSelect.getCallout().getImage());
             }
         }
     }
@@ -828,7 +829,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     private void setSearchText(CharSequence text) {
         if (isUsingActionBar()) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-                searchItem.expandActionView();
+                searchMenuItem.expandActionView();
             }
             searchView.setQuery(text, false);
         } else {

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -159,7 +159,9 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     private static final HereFunctionHandler hereFunctionHandler = new HereFunctionHandler();
     private boolean containsHereFunction = false;
     private boolean locationChangedWhileLoading = false;
-    private boolean hideActions;
+
+    private boolean hideActionsFromOptionsMenu;
+    private boolean hideActionsFromEntityList;
 
     // Handler for displaying alert dialog when no location providers are found
     private final LocationNotificationHandler locationNotificationHandler =
@@ -191,11 +193,12 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             mNoDetailMode = selectDatum.getLongDetail() == null;
             mViewMode = session.isViewCommand(session.getCommand());
 
-            // Don't show actions (e.g. 'register patient', 'claim patient') when
-            // in the middle on workflow triggered by a (sync) action, or if our entity list is
-            // being shown in a grid
-            hideActions = session.isRemoteRequestCommand(session.getCommand()) ||
+            // Don't show actions at all (e.g. 'register patient', 'claim patient') when in the
+            // middle of workflow triggered by a (sync) action. Also hide them from the entity
+            // list (but not the options menu) when we are showing the entity list in grid mode
+            hideActionsFromEntityList = session.isRemoteRequestCommand(session.getCommand()) ||
                     shortSelect.shouldBeLaidOutInGrid();
+            hideActionsFromOptionsMenu = session.isRemoteRequestCommand(session.getCommand());
 
             boolean isOrientationChange = savedInstanceState != null;
             setupUI(isOrientationChange);
@@ -794,7 +797,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     }
 
     private void setupActionOptionsMenu(Menu menu) {
-        if (shortSelect != null && !hideActions) {
+        if (shortSelect != null && !hideActionsFromOptionsMenu) {
             int indexToAddActionAt = MENU_ACTION;
             for (Action action : shortSelect.getCustomActions(asw.getEvaluationContext())) {
                 if (action != null) {
@@ -968,7 +971,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         }
 
         adapter = new EntityListAdapter(this, shortSelect, references, entities,
-                order, factory, hideActions,
+                order, factory, hideActionsFromEntityList,
                 shortSelect.getCustomActions(asw.getEvaluationContext()), inAwesomeMode);
         visibleView.setAdapter(adapter);
         adapter.registerDataSetObserver(this.mListStateObserver);

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -269,9 +269,9 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         }
         visibleView.setOnItemClickListener(this);
 
-        persistAdapterState(visibleView);
-        restoreLastQueryString();
         initUIComponents();
+        restoreLastQueryString();
+        persistAdapterState(visibleView);
         setupPreHoneycombFooter(attemptInitCallout());
         setupMapNav();
     }

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -751,7 +751,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
                     android.R.drawable.ic_menu_mapmode);
         }
 
-        tryToAddActionSearchBar(this, menu, new ActionBarInstantiator() {
+        tryToAddSearchActionToAppBar(this, menu, new ActionBarInstantiator() {
             // again, this should be unnecessary...
             @TargetApi(Build.VERSION_CODES.HONEYCOMB)
             @Override
@@ -795,12 +795,16 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
     private void setupActionOptionsMenu(Menu menu) {
         if (shortSelect != null && !hideActions) {
-            int actionIndex = MENU_ACTION;
+            int indexToAddActionAt = MENU_ACTION;
             for (Action action : shortSelect.getCustomActions(asw.getEvaluationContext())) {
                 if (action != null) {
-                    ViewUtil.addDisplayToMenu(this, menu, actionIndex, MENU_ACTION_GROUP,
-                            action.getDisplay().evaluate());
-                    actionIndex += 1;
+                    if (action.hasActionBarIcon()) {
+                        //TODO: start here
+                    } else {
+                        ViewUtil.addDisplayToMenu(this, menu, indexToAddActionAt, MENU_ACTION_GROUP,
+                                action.getDisplay().evaluate());
+                        indexToAddActionAt += 1;
+                    }
                 }
             }
             if (shortSelect.getCallout() != null && shortSelect.getCallout().getImage() != null) {
@@ -949,11 +953,10 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
                                   List<TreeReference> references,
                                   NodeEntityFactory factory, int focusTargetIndex) {
         loader = null;
-        Detail detail = session.getDetail(selectDatum.getShortDetail());
-        int[] order = detail.getSortOrder();
 
-        for (int i = 0; i < detail.getFields().length; ++i) {
-            String header = detail.getFields()[i].getHeader().evaluate();
+        int[] order = shortSelect.getSortOrder();
+        for (int i = 0; i < shortSelect.getFields().length; ++i) {
+            String header = shortSelect.getFields()[i].getHeader().evaluate();
             if (order.length == 0 && !"".equals(header)) {
                 order = new int[]{i};
             }
@@ -968,9 +971,9 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             visibleView = listView;
         }
 
-        adapter = new EntityListAdapter(this, detail, references, entities,
+        adapter = new EntityListAdapter(this, shortSelect, references, entities,
                 order, factory, hideActions,
-                detail.getCustomActions(asw.getEvaluationContext()), inAwesomeMode);
+                shortSelect.getCustomActions(asw.getEvaluationContext()), inAwesomeMode);
         visibleView.setAdapter(adapter);
         adapter.registerDataSetObserver(this.mListStateObserver);
         containerFragment.setData(adapter);

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -193,7 +193,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             mNoDetailMode = selectDatum.getLongDetail() == null;
             mViewMode = session.isViewCommand(session.getCommand());
 
-            // Don't show actions at all (e.g. 'register patient', 'claim patient') when in the
+            // Don't show actions (e.g. 'register patient', 'claim patient') at all  when in the
             // middle of workflow triggered by a (sync) action. Also hide them from the entity
             // list (but not the options menu) when we are showing the entity list in grid mode
             hideActionsFromEntityList = session.isRemoteRequestCommand(session.getCommand()) ||

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -190,8 +190,10 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             mNoDetailMode = selectDatum.getLongDetail() == null;
 
             // Don't show actions (e.g. 'register patient', 'claim patient') when
-            // in the middle on workflow triggered by an (sync) action.
-            hideActions = session.isRemoteRequestCommand(session.getCommand());
+            // in the middle on workflow triggered by a (sync) action, or if our entity list is
+            // being shown in a grid
+            hideActions = session.isRemoteRequestCommand(session.getCommand()) ||
+                    shortSelect.shouldBeLaidOutInGrid();
 
             boolean isOrientationChange = savedInstanceState != null;
             setupUI(isOrientationChange);

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -798,13 +798,8 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             int indexToAddActionAt = MENU_ACTION;
             for (Action action : shortSelect.getCustomActions(asw.getEvaluationContext())) {
                 if (action != null) {
-                    if (action.hasActionBarIcon()) {
-                        //TODO: start here
-                    } else {
-                        ViewUtil.addDisplayToMenu(this, menu, indexToAddActionAt, MENU_ACTION_GROUP,
-                                action.getDisplay().evaluate());
-                        indexToAddActionAt += 1;
-                    }
+                    ViewUtil.addActionToMenu(this, action, menu, indexToAddActionAt, MENU_ACTION_GROUP);
+                    indexToAddActionAt += 1;
                 }
             }
             if (shortSelect.getCallout() != null && shortSelect.getCallout().getImage() != null) {

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -290,7 +290,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
                 searchBanner.setVisibility(View.GONE);
                 if (isUsingActionBar()) {
                     searchView.setQuery("", false);
-                } else {
+                } else if (preHoneycombSearchBox != null) {
                     preHoneycombSearchBox.setText("");
                 }
                 ViewUtil.hideVirtualKeyboard(EntitySelectActivity.this);

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -273,7 +273,8 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         initUIComponents();
         restoreLastQueryString();
         persistAdapterState(visibleView);
-        setupPreHoneycombFooter(attemptInitCallout());
+        attemptInitCallout();
+        setupPreHoneycombFooter();
         setupMapNav();
     }
 
@@ -300,7 +301,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         clearSearchButton.setVisibility(View.GONE);
     }
 
-    private Callout attemptInitCallout() {
+    private void attemptInitCallout() {
         Callout callout = shortSelect.getCallout();
         if (callout == null) {
             barcodeScanOnClickListener = EntitySelectCalloutSetup.makeBarcodeClickListener(this);
@@ -308,7 +309,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             isCalloutAutoLaunching = callout.isAutoLaunching();
             barcodeScanOnClickListener = EntitySelectCalloutSetup.makeCalloutClickListener(this, callout);
         }
-        return callout;
     }
 
     private void setupLandscapeDualPaneView() {
@@ -345,7 +345,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         }
     }
 
-    private void setupPreHoneycombFooter(Callout callout) {
+    private void setupPreHoneycombFooter() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
             TextView preHoneycombSearchLabel =
                     (TextView)findViewById(R.id.screen_entity_select_search_label);
@@ -373,6 +373,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
             ImageButton preHoneycombBarcodeButton = (ImageButton)findViewById(R.id.barcodeButton);
             preHoneycombBarcodeButton.setOnClickListener(barcodeScanOnClickListener);
+            Callout callout = shortSelect.getCallout();
             if (callout != null && callout.getImage() != null) {
                 EntitySelectCalloutSetup.setupImageLayout(this, preHoneycombBarcodeButton,
                         callout.getImage());

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -217,9 +217,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     }
 
     private void setSearchBannerState() {
-        if (!"".equals(adapter.getSearchQuery())) {
-            showSearchBanner();
-        } else if (adapter.isFilteringByCalloutResult()) {
+        if (!"".equals(adapter.getSearchQuery()) || adapter.isFilteringByCalloutResult()) {
             showSearchBanner();
             clearSearchButton.setVisibility(View.VISIBLE);
         } else {
@@ -279,6 +277,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         setupMapNav();
     }
 
+    @SuppressWarnings("NewApi")
     private void initUIComponents() {
         searchBanner = findViewById(R.id.search_result_banner);
         searchResultStatus = (TextView) findViewById(R.id.search_results_status);
@@ -288,6 +287,13 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             @Override
             public void onClick(View v) {
                 adapter.clearCalloutResponseData();
+                searchBanner.setVisibility(View.GONE);
+                if (isUsingActionBar()) {
+                    searchView.setQuery("", false);
+                } else {
+                    preHoneycombSearchBox.setText("");
+                }
+                ViewUtil.hideVirtualKeyboard(EntitySelectActivity.this);
                 refreshView();
             }
         });
@@ -358,7 +364,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
                 }
             });
 
-            preHoneycombSearchBox = (EditText) findViewById(R.id.searchbox);
+            preHoneycombSearchBox = (EditText)findViewById(R.id.searchbox);
             preHoneycombSearchBox.setMaxLines(3);
             preHoneycombSearchBox.setHorizontallyScrolling(false);
             preHoneycombSearchBox.addTextChangedListener(this);
@@ -722,7 +728,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     public void afterTextChanged(Editable incomingEditable) {
         final String incomingString = incomingEditable.toString();
         final String currentSearchText = getSearchText().toString();
-        if (!"".equals(currentSearchText) && incomingString.equals(currentSearchText)) {
+        if (incomingString.equals(currentSearchText)) {
             filterString = currentSearchText;
             if (adapter != null) {
                 adapter.filterByString(filterString);

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -217,7 +217,11 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     }
 
     private void setSearchBannerState() {
-        if (!"".equals(adapter.getSearchQuery()) || adapter.isFilteringByCalloutResult()) {
+        if (!"".equals(adapter.getSearchQuery())) {
+            showSearchBanner();
+            // Android's native SearchView has its own clear search button, so need to add our own
+            clearSearchButton.setVisibility(View.GONE);
+        } else if (adapter.isFilteringByCalloutResult()) {
             showSearchBanner();
             clearSearchButton.setVisibility(View.VISIBLE);
         } else {
@@ -278,7 +282,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         setupMapNav();
     }
 
-    @SuppressWarnings("NewApi")
     private void initUIComponents() {
         searchBanner = findViewById(R.id.search_result_banner);
         searchResultStatus = (TextView) findViewById(R.id.search_results_status);
@@ -288,13 +291,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             @Override
             public void onClick(View v) {
                 adapter.clearCalloutResponseData();
-                searchBanner.setVisibility(View.GONE);
-                if (isUsingActionBar()) {
-                    searchView.setQuery("", false);
-                } else if (preHoneycombSearchBox != null) {
-                    preHoneycombSearchBox.setText("");
-                }
-                ViewUtil.hideVirtualKeyboard(EntitySelectActivity.this);
                 refreshView();
             }
         });

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -470,7 +470,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         boolean parent = super.onCreateOptionsMenu(menu);
-        tryToAddActionSearchBar(this, menu, new ActionBarInstantiator() {
+        tryToAddSearchActionToAppBar(this, menu, new ActionBarInstantiator() {
             // this should be unnecessary...
             @TargetApi(Build.VERSION_CODES.HONEYCOMB)
             @Override

--- a/app/src/org/commcare/views/ViewUtil.java
+++ b/app/src/org/commcare/views/ViewUtil.java
@@ -15,6 +15,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 
+import org.commcare.suite.model.Action;
 import org.commcare.suite.model.DisplayData;
 import org.commcare.utils.MediaUtil;
 import org.javarosa.core.services.locale.Localizer;
@@ -22,20 +23,22 @@ import org.javarosa.core.services.locale.Localizer;
 import java.util.ArrayList;
 
 /**
- * Utilities for converting CommCare UI diplsay details into Android objects
+ * Utilities for converting CommCare UI display details into Android objects
  *
  * @author ctsims
  */
 public final class ViewUtil {
 
-    // This is silly and isn't really what we want here, but it's a start.
-    // (We'd like to be able to add a displayunit to a menu in a super
-    // easy/straightforward way.
-    public static void addDisplayToMenu(Context context, Menu menu,
-                                        int menuId, int menuGroupId, DisplayData display) {
+    public static void addActionToMenu(Context context, Action action, Menu menu, int menuId,
+                                       int menuGroupId) {
+        DisplayData display = action.getDisplay().evaluate();
         MenuItem item = menu.add(menuGroupId, menuId, menuId,
                 Localizer.clearArguments(display.getName()).trim());
-        if (display.getImageURI() != null) {
+        if (action.hasActionBarIcon() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            Bitmap b = MediaUtil.inflateDisplayImage(context, action.getActionBarIconReference());
+            item.setIcon(new BitmapDrawable(context.getResources(), b));
+            item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        } else if (display.getImageURI() != null) {
             Bitmap b = MediaUtil.inflateDisplayImage(context, display.getImageURI());
             if (b != null) {
                 item.setIcon(new BitmapDrawable(context.getResources(), b));

--- a/unit-tests/src/org/commcare/android/tests/caselist/EntityListCalloutDataTest.java
+++ b/unit-tests/src/org/commcare/android/tests/caselist/EntityListCalloutDataTest.java
@@ -2,6 +2,8 @@ package org.commcare.android.tests.caselist;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Build;
+import android.view.MenuItem;
 import android.widget.ImageButton;
 
 import com.simprints.libsimprints.Identification;
@@ -27,6 +29,7 @@ import org.commcare.views.EntityView;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
@@ -112,9 +115,7 @@ public class EntityListCalloutDataTest {
 
     private void performFingerprintCallout() {
         // make entity list callout to 'fingerprint identification'
-        ImageButton calloutButton =
-                (ImageButton)entitySelectActivity.findViewById(R.id.barcodeButton);
-        calloutButton.performClick();
+        entitySelectActivity.barcodeScanOnClickListener.onClick(null);
 
         // receive the (faked) callout result
         Callout identificationScanCallout = getEntitySelectCallout();

--- a/unit-tests/src/org/commcare/android/tests/caselist/EntityListCalloutDataTest.java
+++ b/unit-tests/src/org/commcare/android/tests/caselist/EntityListCalloutDataTest.java
@@ -2,8 +2,6 @@ package org.commcare.android.tests.caselist;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.os.Build;
-import android.view.MenuItem;
 import android.widget.ImageButton;
 
 import com.simprints.libsimprints.Identification;
@@ -29,7 +27,6 @@ import org.commcare.views.EntityView;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;


### PR DESCRIPTION
Currently, any actions that are defined within a `<detail>` block are shown as an item at the end of the entity list, and as an item in the options menu of the entity select screen. This PR makes it so that:

-If the entity list is being shown in grid view, actions are NOT shown as items at the end of the list, since that results in a very poor UI
-To compensate for that, actions are now configurable such that they can show up as an icon in the app bar. If the `<action>` block is defined with an `action-bar-icon` attribute, the specified icon will show up in the app bar of the entity select screen, in place of there being an item hidden in the options menu.

Screenshot below with an example of how this looks.

The last 2 commits also fix a couple of bugs that I found while working on this.

cross-request: https://github.com/dimagi/commcare-core/pull/411