### PR TITLE
Make auto GPS capture timeout configurable

### DIFF
--- a/app/src/org/commcare/android/javarosa/PollSensorController.java
+++ b/app/src/org/commcare/android/javarosa/PollSensorController.java
@@ -75,8 +75,7 @@ public enum PollSensorController implements LocationListener {
     }
 
     /**
-     * Start polling for location, based on whatever providers are given, and
-     * set up a timeout after AUTO_CAPTURE_MAXIMUM_WAIT is exceeded.
+     * Start polling for location, based on whatever providers are given, and set up a timeout
      *
      * @param providers Set of String objects that may contain
      *                  LocationManager.GPS_PROVDER and/or LocationManager.NETWORK_PROVIDER
@@ -93,7 +92,7 @@ public enum PollSensorController implements LocationListener {
 
             // Cancel polling after maximum time is exceeded
             timeoutTimer.schedule(new PollingTimeoutTask(),
-                    CommCarePreferences.getGpsAutoCaptureTimeout());
+                    CommCarePreferences.getGpsAutoCaptureTimeoutInMilliseconds());
         }
     }
 

--- a/app/src/org/commcare/android/javarosa/PollSensorController.java
+++ b/app/src/org/commcare/android/javarosa/PollSensorController.java
@@ -76,7 +76,7 @@ public enum PollSensorController implements LocationListener {
 
     /**
      * Start polling for location, based on whatever providers are given, and
-     * set up a timeout after MAXIMUM_WAIT is exceeded.
+     * set up a timeout after AUTO_CAPTURE_MAXIMUM_WAIT is exceeded.
      *
      * @param providers Set of String objects that may contain
      *                  LocationManager.GPS_PROVDER and/or LocationManager.NETWORK_PROVIDER
@@ -92,7 +92,8 @@ public enum PollSensorController implements LocationListener {
             }
 
             // Cancel polling after maximum time is exceeded
-            timeoutTimer.schedule(new PollingTimeoutTask(), GeoUtils.MAXIMUM_WAIT);
+            timeoutTimer.schedule(new PollingTimeoutTask(),
+                    CommCarePreferences.getGpsAutoCaptureTimeout());
         }
     }
 

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -35,6 +35,7 @@ import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class CommCarePreferences
         extends SessionAwarePreferenceActivity
@@ -420,13 +421,14 @@ public class CommCarePreferences
         }
     }
 
-    public static int getGpsAutoCaptureTimeout() {
+    public static int getGpsAutoCaptureTimeoutInMilliseconds() {
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
         try {
-            return Integer.parseInt(properties.getString(GPS_AUTO_CAPTURE_TIMEOUT,
-                    Integer.toString(GeoUtils.AUTO_CAPTURE_MAXIMUM_WAIT)));
+            return (int)TimeUnit.MINUTES.toMillis(Long.parseLong(
+                    properties.getString(GPS_AUTO_CAPTURE_TIMEOUT,
+                            Integer.toString(GeoUtils.AUTO_CAPTURE_MAX_WAIT_IN_MINUTES))));
         } catch (NumberFormatException e) {
-            return GeoUtils.AUTO_CAPTURE_MAXIMUM_WAIT;
+            return (int)TimeUnit.MINUTES.toMillis(GeoUtils.AUTO_CAPTURE_MAX_WAIT_IN_MINUTES);
         }
     }
 

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -101,6 +101,7 @@ public class CommCarePreferences
     public final static String BRAND_BANNER_HOME = "brand-banner-home";
     public final static String LOGIN_DURATION = "cc-login-duration-seconds";
     public final static String GPS_AUTO_CAPTURE_ACCURACY = "cc-gps-auto-capture-accuracy";
+    public final static String GPS_AUTO_CAPTURE_TIMEOUT = "cc-gps-auto-capture-timeout";
     public final static String LOG_ENTITY_DETAIL = "cc-log-entity-detail-enabled";
     public final static String CONTENT_VALIDATED = "cc-content-valid";
     public static final String DUMP_FOLDER_PATH = "dump-folder-path";
@@ -411,12 +412,21 @@ public class CommCarePreferences
      */
     public static double getGpsCaptureAccuracy() {
         SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
-
         try {
             return Double.parseDouble(properties.getString(GPS_AUTO_CAPTURE_ACCURACY,
                     Double.toString(GeoUtils.AUTO_CAPTURE_GOOD_ACCURACY)));
         } catch (NumberFormatException e) {
             return GeoUtils.AUTO_CAPTURE_GOOD_ACCURACY;
+        }
+    }
+
+    public static int getGpsAutoCaptureTimeout() {
+        SharedPreferences properties = CommCareApplication._().getCurrentApp().getAppPreferences();
+        try {
+            return Integer.parseInt(properties.getString(GPS_AUTO_CAPTURE_TIMEOUT,
+                    Integer.toString(GeoUtils.AUTO_CAPTURE_MAXIMUM_WAIT)));
+        } catch (NumberFormatException e) {
+            return GeoUtils.AUTO_CAPTURE_MAXIMUM_WAIT;
         }
     }
 

--- a/app/src/org/commcare/utils/GeoUtils.java
+++ b/app/src/org/commcare/utils/GeoUtils.java
@@ -34,7 +34,7 @@ public class GeoUtils {
     public static final double ACCEPTABLE_ACCURACY = 1600;
 
     // For passive collection, milliseconds to wait for GPS before giving up
-    public static final int MAXIMUM_WAIT = (int)TimeUnit.MINUTES.toMillis(2);
+    public static final int AUTO_CAPTURE_MAXIMUM_WAIT = (int)TimeUnit.MINUTES.toMillis(2);
 
     public static final String ACTION_CHECK_GPS_ENABLED = "org.commcare.utils.GeoUtils.check";
 

--- a/app/src/org/commcare/utils/GeoUtils.java
+++ b/app/src/org/commcare/utils/GeoUtils.java
@@ -34,7 +34,7 @@ public class GeoUtils {
     public static final double ACCEPTABLE_ACCURACY = 1600;
 
     // For passive collection, milliseconds to wait for GPS before giving up
-    public static final int AUTO_CAPTURE_MAXIMUM_WAIT = (int)TimeUnit.MINUTES.toMillis(2);
+    public static final int AUTO_CAPTURE_MAX_WAIT_IN_MINUTES = 2;
 
     public static final String ACTION_CHECK_GPS_ENABLED = "org.commcare.utils.GeoUtils.check";
 


### PR DESCRIPTION
@dimagi/product Would make sense to add this in the same place that the configurability for auto-capture accuracy is going to be placed (as per Phillip's comment [here](https://github.com/dimagi/commcare-android/pull/1474))