### PR TITLE
Downgrade Robolectric SDK to 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.1'
         classpath 'com.google.gms:google-services:3.0.0'
     }
 }
@@ -42,6 +42,8 @@ configurations {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.1.2'
+    testCompile 'org.robolectric:shadows-play-services:3.1.2'
+    testCompile 'org.robolectric:shadows-maps:3.1.2'
 
     testCompile project(path: ':commcare-core', configuration: 'testsAsJar')
     // release build type expects commcare jars to be in app/libs

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,6 @@ configurations {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.1.2'
-    testCompile 'org.robolectric:shadows-play-services:3.1.2'
-    testCompile 'org.robolectric:shadows-maps:3.1.2'
 
     testCompile project(path: ':commcare-core', configuration: 'testsAsJar')
     // release build type expects commcare jars to be in app/libs

--- a/unit-tests/resources/robolectric.properties
+++ b/unit-tests/resources/robolectric.properties
@@ -2,4 +2,4 @@ manifest=../app/AndroidManifest.xml
 res=../app/res
 assets=../app/assets
 shadows=org.commcare.android.shadows.SQLiteDatabaseNative,org.commcare.android.shadows.CommCareShadowLog,org.commcare.android.shadows.ShadowAsyncTaskNoExecutor,org.commcare.android.shadows.ByteEncrypterShadow
-sdk=23
+sdk=21


### PR DESCRIPTION
Revert robolectric target sdk bump from https://github.com/dimagi/commcare-android/pull/1498

Add robolectric add-on modules http://robolectric.org/using-add-on-modules/ (not entirely sure if we need these)

Bump android gradle plugin to latest Android Studio release