### PR TITLE
Async case list search deadlock fix

### DIFF
--- a/app/src/org/commcare/adapters/EntityStringFilterer.java
+++ b/app/src/org/commcare/adapters/EntityStringFilterer.java
@@ -83,7 +83,9 @@ public class EntityStringFilterer extends EntityFiltererBase {
             }
             Entity<TreeReference> e = fullEntityList.get(index);
             if (isCancelled()) {
-                break;
+                db.setTransactionSuccessful();
+                db.endTransaction();
+                return;
             }
 
             boolean add = false;

--- a/app/src/org/commcare/models/AsyncEntity.java
+++ b/app/src/org/commcare/models/AsyncEntity.java
@@ -139,6 +139,7 @@ public class AsyncEntity extends Entity<TreeReference> {
             //get our second lock.
             synchronized (mAsyncLock) {
                 if (sortData[i] == null) {
+                    // sort data not in search field cache; load and store it
                     Text sortText = fields[i].getSort();
                     if (sortText == null) {
                         db.setTransactionSuccessful();

--- a/app/src/org/commcare/models/AsyncNodeEntityFactory.java
+++ b/app/src/org/commcare/models/AsyncNodeEntityFactory.java
@@ -72,6 +72,10 @@ public class AsyncNodeEntityFactory extends NodeEntityFactory {
         return entity;
     }
 
+    /**
+     * Bulk loads search field cache from db.
+     * Note that the cache is lazily built upon first case list search.
+     */
     private void primeCache() {
         if (mTemplateIsCachable == null || !mTemplateIsCachable || mCacheHost == null) {
             return;


### PR DESCRIPTION
Fix for a bug that was coming up where searching an async case list for the first time would freeze when you typed more than 1 character in quick succession.

The solution is to be stricter about cancelling the existing search process if a new search process is started; like when you type the second character of a query.