### PR TITLE
Make pin create/reset keyboard action button proceed through UI

### DIFF
--- a/app/res/layout/pin_text_entry.xml
+++ b/app/res/layout/pin_text_entry.xml
@@ -8,5 +8,6 @@
           android:layout_centerVertical="true"
           android:gravity="center_horizontal"
           android:inputType="numberPassword"
+          android:maxLines="1"
           android:maxLength="4">
 </EditText>

--- a/app/src/org/commcare/activities/CreatePinActivity.java
+++ b/app/src/org/commcare/activities/CreatePinActivity.java
@@ -4,10 +4,14 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.InputType;
 import android.text.TextWatcher;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -93,6 +97,16 @@ public class CreatePinActivity extends SessionAwareCommCareActivity<CreatePinAct
 
     private void setListeners() {
         enterPinBox.addTextChangedListener(getPinTextWatcher(continueButton));
+        enterPinBox.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if (actionId == EditorInfo.IME_ACTION_DONE || actionId == EditorInfo.IME_ACTION_NEXT) {
+                    continueButton.performClick();
+                    return true;
+                }
+                return false;
+            }
+        });
 
         cancelButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -134,6 +148,7 @@ public class CreatePinActivity extends SessionAwareCommCareActivity<CreatePinAct
     private void setInitialEntryMode() {
         enterPinBox.setText("");
         enterPinBox.requestFocus();
+        enterPinBox.setImeOptions(EditorInfo.IME_ACTION_NEXT);
         continueButton.setText(Localization.get("pin.continue.button"));
         if (userRecord.hasPinSet()) {
             promptText.setText(Localization.get("pin.directive.reset"));
@@ -146,9 +161,23 @@ public class CreatePinActivity extends SessionAwareCommCareActivity<CreatePinAct
     private void setConfirmMode() {
         enterPinBox.setText("");
         enterPinBox.requestFocus();
+
+        // open up the keyboard if it was dismissed
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+
+        setTextEntryKeyboardAction(enterPinBox, EditorInfo.IME_ACTION_DONE);
+
         continueButton.setText(Localization.get("pin.confirm.button"));
         promptText.setText(Localization.get("pin.directive.confirm"));
         inConfirmMode = true;
+    }
+
+    private static void setTextEntryKeyboardAction(EditText textEntry, int action) {
+        // bug/feature that requires setting the input type to null then changing the action type
+        int inputType = textEntry.getInputType();
+        textEntry.setInputType(InputType.TYPE_NULL);
+        textEntry.setImeOptions(action);
+        textEntry.setInputType(inputType);
     }
 
     private void assignPin(String pin) {

--- a/app/src/org/commcare/activities/CreatePinActivity.java
+++ b/app/src/org/commcare/activities/CreatePinActivity.java
@@ -1,5 +1,6 @@
 package org.commcare.activities;
 
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -10,8 +11,8 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -163,7 +164,8 @@ public class CreatePinActivity extends SessionAwareCommCareActivity<CreatePinAct
         enterPinBox.requestFocus();
 
         // open up the keyboard if it was dismissed
-        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+        InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.toggleSoftInput(InputMethodManager.SHOW_FORCED,0);
 
         setTextEntryKeyboardAction(enterPinBox, EditorInfo.IME_ACTION_DONE);
 

--- a/app/src/org/commcare/activities/PinAuthenticationActivity.java
+++ b/app/src/org/commcare/activities/PinAuthenticationActivity.java
@@ -1,7 +1,9 @@
 package org.commcare.activities;
 
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -80,6 +82,16 @@ public class PinAuthenticationActivity extends
         }
 
         pinEntry.addTextChangedListener(CreatePinActivity.getPinTextWatcher(enterButton));
+        pinEntry.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if (actionId == EditorInfo.IME_ACTION_NEXT) {
+                    enterButton.performClick();
+                    return true;
+                }
+                return false;
+            }
+        });
 
         enterButton.setOnClickListener(new View.OnClickListener() {
 
@@ -106,6 +118,7 @@ public class PinAuthenticationActivity extends
     private void setPinAuthModeUI() {
         promptText.setText(Localization.get("pin.auth.prompt.pin"));
         pinEntry.setVisibility(View.VISIBLE);
+        pinEntry.setImeOptions(EditorInfo.IME_ACTION_NEXT);
         passwordEntry.setVisibility(View.GONE);
         enterButton.setEnabled(false);
     }


### PR DESCRIPTION
If you are creating or resetting the login pin, it would be nice to have the keyboard action button do the same thing as pressing the `confirm` / `enter` / `continue` buttons.

Also pop up the keyboard if it has been dismissed between pin set and confirm screens

Fix for http://manage.dimagi.com/default.asp?239780