### PR TITLE
Update app version number in app manager

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -586,33 +586,6 @@ public class CommCareApplication extends Application {
     }
 
     /**
-     * @return whether the user should be sent to CommCareVerificationActivity. Current logic is
-     * that this should occur only if there is exactly one visible app and it is missing its MM
-     * (because we are then assuming the user is not currently using multiple apps functionality)
-     */
-    public boolean shouldSeeMMVerification() {
-        return (CommCareApplication._().getVisibleAppRecords().size() == 1 &&
-                CommCareApplication._().getUsableAppRecords().size() == 0);
-    }
-
-    public boolean usableAppsPresent() {
-        return getUsableAppRecords().size() > 0;
-    }
-
-    /**
-     * @return the list of all installed apps as an array
-     */
-    public ApplicationRecord[] appRecordArray() {
-        ArrayList<ApplicationRecord> appList = CommCareApplication._().getInstalledAppRecords();
-        ApplicationRecord[] appArray = new ApplicationRecord[appList.size()];
-        int index = 0;
-        for (ApplicationRecord r : appList) {
-            appArray[index++] = r;
-        }
-        return appArray;
-    }
-
-    /**
      * @param uniqueId - the uniqueId of the ApplicationRecord being sought
      * @return the ApplicationRecord corresponding to the given id, if it exists. Otherwise,
      * return null

--- a/app/src/org/commcare/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/activities/SingleAppManagerActivity.java
@@ -140,6 +140,10 @@ public class SingleAppManagerActivity extends CommCareActivity {
                         Toast.makeText(this, R.string.update_canceled, Toast.LENGTH_LONG).show();
                         task.cancel(true);
                     }
+                } else if (resultCode == RESULT_OK) {
+                    // update activity may have writen to the app record storage, so get new changes
+                    appRecord = MultipleAppsUtil.getAppById(appRecord.getUniqueId());
+                    refresh();
                 }
                 return;
             case MISSING_MEDIA_ACTIVITY:


### PR DESCRIPTION
App version number on single app manager screen wasn't updating after an app update because the app record object had become stale due to it changing in the underlying storage.

Fix for http://manage.dimagi.com/default.asp?239904