### PR TITLE
Redirect to home screen after reporting a problem

### DIFF
--- a/app/src/org/commcare/activities/AdvancedActionsActivity.java
+++ b/app/src/org/commcare/activities/AdvancedActionsActivity.java
@@ -47,6 +47,7 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
 
     private final static int WIFI_DIRECT_ACTIVITY = 1;
     private final static int DUMP_FORMS_ACTIVITY = 2;
+    private final static int REPORT_PROBLEM_ACTIVITY = 3;
 
     public final static int RESULT_DATA_RESET = CommCareHomeActivity.RESULT_RESTART + 1;
     public final static int RESULT_FORMS_PROCESSED = CommCareHomeActivity.RESULT_RESTART + 2;
@@ -191,7 +192,7 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
 
     private void startReportActivity() {
         Intent i = new Intent(this, ReportProblemActivity.class);
-        startActivity(i);
+        startActivityForResult(i, REPORT_PROBLEM_ACTIVITY);
     }
 
     private void startValidationActivity() {
@@ -250,7 +251,9 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
-        if (requestCode == WIFI_DIRECT_ACTIVITY || requestCode == DUMP_FORMS_ACTIVITY) {
+        if (requestCode == REPORT_PROBLEM_ACTIVITY) {
+            finish();
+        } else if (requestCode == WIFI_DIRECT_ACTIVITY || requestCode == DUMP_FORMS_ACTIVITY) {
             String messageKey = getBulkFormMessageKey(resultCode);
             if (messageKey == null) {
                 return;


### PR DESCRIPTION
Redirect to home screen instead of returning to the advanced actions menu after reporting a problem.
 
Fix for http://manage.dimagi.com/default.asp?239844