### PR TITLE
Clear fixture before wiping wiping user db on 'clear user data'

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -841,13 +841,13 @@ public class CommCareApplication extends Application {
         CommCareApplication._().getCurrentApp().getAppPreferences().edit()
                 .putString(CommCarePreferences.LAST_LOGGED_IN_USER, null).commit();
 
-        // manually clear file-backed fixture storage to ensure files are removed
-        CommCareApplication._().getFileBackedUserStorage("fixture", FormInstance.class).removeAll();
-
         CommCareApplication._().closeUserSession();
     }
 
     public void wipeSandboxForUser(final String username) {
+        // manually clear file-backed fixture storage to ensure files are removed
+        CommCareApplication._().getFileBackedUserStorage("fixture", FormInstance.class).removeAll();
+
         final Set<String> dbIdsToRemove = new HashSet<>();
         CommCareApplication._().getAppStorage(UserKeyRecord.class).removeAll(new EntityFilter<UserKeyRecord>() {
             @Override


### PR DESCRIPTION
Without this change, 'clear user data' crashes.

As [described here](https://github.com/dimagi/commcare-android/pull/1500/files/75a837dabef56b15267c4e7266519c5274d93c7e#r83646913):

> Since the user db was being cleared before this was called I don't think it was doing anything, because the file paths were cleared before this code could remove the files. Hence leaving dangling fixture data (for fixtures over 1mb). Moving it here ensures that files are deleted before the db is cleared.


Here is the stacktrace of the crash:
```
FATAL EXCEPTION: main
Process: org.commcare.dalvik, PID: 14445
net.sqlcipher.database.SQLiteException: error code 8: attempt to write a readonly database
   at net.sqlcipher.database.SQLiteStatement.native_execute(Native Method)
   at net.sqlcipher.database.SQLiteStatement.execute(SQLiteStatement.java:58)
   at net.sqlcipher.database.SQLiteDatabase.delete(SQLiteDatabase.java:2047)
   at org.commcare.models.database.HybridFileBackedSqlStorage.removeAll(HybridFileBackedSqlStorage.java:474)
   at org.commcare.CommCareApplication.clearUserData(CommCareApplication.java:845)
   at org.commcare.activities.AdvancedActionsActivity$10.onClick(AdvancedActionsActivity.java:239)
   at org.commcare.views.dialogs.StandardAlertDialog$3.onClick(StandardAlertDialog.java:94)
   at android.view.View.performClick(View.java:5609)
   at android.view.View$PerformClick.run(View.java:22262)
   at android.os.Handler.handleCallback(Handler.java:751)
   at android.os.Handler.dispatchMessage(Handler.java:95)
   at android.os.Looper.loop(Looper.java:154)
   at android.app.ActivityThread.main(ActivityThread.java:6077)
   at java.lang.reflect.Method.invoke(Native Method)
   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)
```