### PR TITLE
Redirect to homescreen after performing manual multimedia validation

### DIFF
--- a/app/src/org/commcare/activities/AdvancedActionsActivity.java
+++ b/app/src/org/commcare/activities/AdvancedActionsActivity.java
@@ -48,6 +48,7 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
     private final static int WIFI_DIRECT_ACTIVITY = 1;
     private final static int DUMP_FORMS_ACTIVITY = 2;
     private final static int REPORT_PROBLEM_ACTIVITY = 3;
+    private final static int VALIDATE_MEDIA_ACTIVITY = 4;
 
     public final static int RESULT_DATA_RESET = CommCareHomeActivity.RESULT_RESTART + 1;
     public final static int RESULT_FORMS_PROCESSED = CommCareHomeActivity.RESULT_RESTART + 2;
@@ -198,7 +199,7 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
     private void startValidationActivity() {
         Intent i = new Intent(this, CommCareVerificationActivity.class);
         i.putExtra(CommCareVerificationActivity.KEY_LAUNCH_FROM_SETTINGS, true);
-        startActivity(i);
+        startActivityForResult(i, VALIDATE_MEDIA_ACTIVITY);
     }
 
     private void startWifiDirect() {
@@ -251,7 +252,7 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
-        if (requestCode == REPORT_PROBLEM_ACTIVITY) {
+        if (requestCode == REPORT_PROBLEM_ACTIVITY || requestCode == VALIDATE_MEDIA_ACTIVITY) {
             finish();
         } else if (requestCode == WIFI_DIRECT_ACTIVITY || requestCode == DUMP_FORMS_ACTIVITY) {
             String messageKey = getBulkFormMessageKey(resultCode);


### PR DESCRIPTION
Go back to home screen after manually validating multimedia from advanced menu screen.