### PR TITLE
Remove SINGLE_TOP flag from restartCommCare method

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -291,11 +291,8 @@ public class CommCareApplication extends Application {
     public static void restartCommCare(Activity originActivity, Class c, boolean systemExit) {
         Intent intent = new Intent(originActivity, c);
 
-        // Make sure that the new stack starts with the given class, and clear everything
-        // between.
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP |
-                Intent.FLAG_ACTIVITY_SINGLE_TOP |
-                Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+        // Make sure that the new stack starts with the given class, and clear everything between.
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
 
         originActivity.moveTaskToBack(true);
         originActivity.startActivity(intent);


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?239910, which came up in 2.31 QA. Since it's not a regression and we're not quite sure what side effects this change may have, we're electing to make the change for 2.32 instead.