### PR TITLE
Fix for Out Of Memory Error when downsampling images

### DIFF
--- a/app/src/org/commcare/utils/MediaUtil.java
+++ b/app/src/org/commcare/utils/MediaUtil.java
@@ -3,6 +3,7 @@ package org.commcare.utils;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.provider.MediaStore;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.Pair;
@@ -25,6 +26,8 @@ import java.io.IOException;
  * @author ctsims
  */
 public class MediaUtil {
+
+    private static final String TAG = MediaUtil.class.toString();
 
     public static final String FORM_VIDEO = "video";
     public static final String FORM_AUDIO = "audio";
@@ -239,12 +242,17 @@ public class MediaUtil {
             // Not worth performance loss of creating an exact scaled bitmap in this case
             return b;
         } else {
-            // Here we want to be more precise because we have a target width and height, or
-            // specified that respecting the bounding container precisely is important
-            return Bitmap.createScaledBitmap(b, newWidth, newHeight, false);
+            try {
+                // Here we want to be more precise because we have a target width and height, or
+                // specified that respecting the bounding container precisely is important
+                return Bitmap.createScaledBitmap(b, newWidth, newHeight, false);
+            } catch (OutOfMemoryError e) {
+                Log.d(TAG, "Ran out of memory attempting to scale image at: " + imageFilepath);
+                return null;
+            }
         }
-
     }
+
 
     private static int getApproxScaleDownFactor(int newWidth, int originalWidth) {
         if (newWidth == 0) {


### PR DESCRIPTION
Fix for: http://manage.dimagi.com/default.asp?240229

There basically was no OOM protection when _down-sampling_ an image, which was causing problems because it needs to keep both images in memory. 

This approach doesn't try to do anything clever, simply replicates what would happen if we couldn't expand an image which was growing instead of shrinking. For a future release we should revisit what should occur if an image can't be loaded.