### PR TITLE
Fix for Ethiopian Month names in English

### DIFF
--- a/app/assets/locales/messages_ccodk_default.txt
+++ b/app/assets/locales/messages_ccodk_default.txt
@@ -770,14 +770,14 @@ repeat.dialog.add.another=Add another "${0}" group?
 repeat.dialog.add.new=Add a new "${0}" group?
 lookup.table.missing.error=Unable to find lookup table "${0}". Make sure it exists and this user has access to it.
 
-ethiopian_months=Meskerem,Tikimt,Hidar,Tahsas,Tir,Yekatit,Megabit,Miazia,Ginbot,Senie,Hamlie,Nehasie,Pagumien
+ethiopian_months=Mäskäräm,T’ïk’ïmt,Hïdar,Tahsas,T’ïr,Yäkatit,Mägabit,Miyaziya,Gïnbot,Säne,Hämle,Nähäse,P’agume
 nepali_months=Baishakh,Jestha,Ashadh,Shrawan,Bhadra,Ashwin,Kartik,Mangsir,Poush,Magh,Falgun,Chaitra
 
 fingerprint.match.100=★★★★★
 fingerprint.match.75=★★★★
 fingerprint.match.50=★★★
 fingerprint.match.25=★★
-fingerprint.match.0=★
+fingerprint.match.0=★/
 fingerprint.match.unknown=?
 
 calendar.empty.fields=Empty fields

--- a/app/res/values/arrays.xml
+++ b/app/res/values/arrays.xml
@@ -50,19 +50,19 @@
     </string-array>
     <string-array
         name="ethiopian_months">
-        <item>Meskerem</item>
-        <item>Tikimt</item>
-        <item>Hidar</item>
+        <item>Mäskäräm</item>
+        <item>T’ïk’ïmt</item>
+        <item>Hïdar</item>
         <item>Tahsas</item>
-        <item>Tir</item>
-        <item>Yekatit</item>
-        <item>Megabit</item>
-        <item>Miazia</item>
-        <item>Ginbot</item>
-        <item>Senie</item>
-        <item>Hamlie</item>
-        <item>Nehasie</item>
-        <item>Pagumien</item>
+        <item>T’ïr</item>
+        <item>Yäkatit</item>
+        <item>Mägabit</item>
+        <item>Miyaziya</item>
+        <item>Gïnbot</item>
+        <item>Säne</item>
+        <item>Hämle</item>
+        <item>Nähäse</item>
+        <item>P’agume</item>
     </string-array>
     <string-array
         name="nepali_months">

--- a/unit-tests/src/org/commcare/android/tests/formnav/CalendarLocaleTest.java
+++ b/unit-tests/src/org/commcare/android/tests/formnav/CalendarLocaleTest.java
@@ -90,9 +90,9 @@ public class CalendarLocaleTest {
         TextView ethiopianDayText = (TextView)formEntryActivity.findViewById(R.id.daytxt);
         TextView ethiopianMonthText = (TextView)formEntryActivity.findViewById(R.id.monthtxt);
         TextView ethiopianYearText = (TextView)formEntryActivity.findViewById(R.id.yeartxt);
-        assertEquals(ethiopianMonthText.getText(), "Senie");
-        assertEquals(ethiopianDayText.getText(), "26");
-        assertEquals(ethiopianYearText.getText(), "2008");
+        assertEquals("Säne",ethiopianMonthText.getText());
+        assertEquals("26", ethiopianDayText.getText());
+        assertEquals("2008", ethiopianYearText.getText());
     }
 
 


### PR DESCRIPTION
The Transliteration that was being used for ethiopian dates in english was quite strange and was matching up poorly to the best available sources.

Fix for: http://manage.dimagi.com/default.asp?240253