### PR TITLE
Don't swallow exceptions that occur during media validation

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -21,7 +21,7 @@ install.current.version=Current version: ${0}
 
 verify.retry=Retry
 verify.checking=Verifying media...
-verify.check.failed=Validation failed for an unknown reason
+exception.during.verification=Verification could not complete due to the following exception. This error must be resolved before verification can proceed:\n\n${0}
 
 barcode.reader.missing=No barcode reader available! You can install one from the android market.
 

--- a/app/src/org/commcare/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/activities/CommCareVerificationActivity.java
@@ -187,7 +187,7 @@ public class CommCareVerificationActivity
                     }
                 };
         task.connect(this);
-        task.executeParallel((String[])null);
+        task.executeParallel();
     }
 
     @Override

--- a/app/src/org/commcare/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/activities/CommCareVerificationActivity.java
@@ -183,7 +183,7 @@ public class CommCareVerificationActivity
                     @Override
                     protected void deliverError(CommCareVerificationActivity receiver,
                                                 Exception e) {
-                        receiver.missingMediaPrompt.setText(Localization.get("verify.check.failed"));
+                        receiver.missingMediaPrompt.setText(Localization.get("exception.during.verification", e.getMessage()));
                     }
                 };
         task.connect(this);

--- a/app/src/org/commcare/tasks/VerificationTask.java
+++ b/app/src/org/commcare/tasks/VerificationTask.java
@@ -16,7 +16,7 @@ import org.javarosa.core.util.SizeBoundVector;
  * @author ctsims
  */
 public abstract class VerificationTask<Reciever>
-        extends CommCareTask<String, int[], SizeBoundVector<MissingMediaException>, Reciever>
+        extends CommCareTask<Void, int[], SizeBoundVector<MissingMediaException>, Reciever>
         implements TableStateListener, InstallCancelled {
 
     public VerificationTask(int taskId) {
@@ -24,7 +24,7 @@ public abstract class VerificationTask<Reciever>
     }
 
     @Override
-    protected SizeBoundVector<MissingMediaException> doTaskBackground(String... profileRefs) {
+    protected SizeBoundVector<MissingMediaException> doTaskBackground(Void... params) {
         AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
 
         try {

--- a/app/src/org/commcare/tasks/VerificationTask.java
+++ b/app/src/org/commcare/tasks/VerificationTask.java
@@ -27,24 +27,19 @@ public abstract class VerificationTask<Reciever>
     protected SizeBoundVector<MissingMediaException> doTaskBackground(Void... params) {
         AndroidCommCarePlatform platform = CommCareApplication._().getCommCarePlatform();
 
-        try {
-            // This is replicated in the application in a few places.
-            ResourceTable global = platform.getGlobalResourceTable();
-            SizeBoundUniqueVector<MissingMediaException> problems =
-                    new SizeBoundUniqueVector<>(10);
+        // This is replicated in the application in a few places.
+        ResourceTable global = platform.getGlobalResourceTable();
+        SizeBoundUniqueVector<MissingMediaException> problems =
+                new SizeBoundUniqueVector<>(10);
 
-            setTableListeners(global);
-            global.verifyInstallation(problems);
-            unsetTableListeners(global);
+        setTableListeners(global);
+        global.verifyInstallation(problems);
+        unsetTableListeners(global);
 
-            if (problems.size() > 0) {
-                return problems;
-            }
-            return null;
-        } catch (Exception e) {
-            // TODO: make non-resource missing failures have a better exception
-            return null;
+        if (problems.size() > 0) {
+            return problems;
         }
+        return null;
     }
 
     private void setTableListeners(ResourceTable table) {


### PR DESCRIPTION
Fixes 2 problems:
1. Exceptions that occurred during `VerificationTask` were being swallowed, 
2. The way in which they were swallowed actually resulted in the `VerificationTask` _always_ succeeding if there was a swallowed exception, even if there had been media validation failures as well.

Partial fix for http://manage.dimagi.com/default.asp?240552 (Partial because I haven't figured out what's actually causing the underlying exception there)