### PR TITLE
Fix update error message processing NPE from ACRA

### DIFF
--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.v4.util.Pair;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -218,9 +219,9 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
         } else {
             // Gives user generic failure warning; even if update staging
             // failed for a specific reason like xml syntax
-            if (!"".equals(result.errorMessage)) {
-                String[] resouceAndMessage = result.errorMessage.split("==", 2);
-                CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(AppInstallStatus.InvalidResource, new String[]{null, resouceAndMessage[0], resouceAndMessage[1]}), true);
+            if (UpdateTask.isCombinedErrorMessage(result.errorMessage)) {
+                Pair<String, String> resouceAndMessage = UpdateTask.splitCombinedErrorMessage(result.errorMessage);
+                CommCareApplication._().reportNotificationMessage(NotificationMessageFactory.message(AppInstallStatus.InvalidResource, new String[]{null, resouceAndMessage.first, resouceAndMessage.second}), true);
             }
             uiController.checkFailedUiState();
             if (proceedAutomatically) {

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -162,12 +162,12 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Uri, String, FormLo
         try {
             fis = new FileInputStream(formXmlFile);
         } catch (FileNotFoundException e) {
-            throw new RuntimeException("Error reading XForm file");
+            throw new RuntimeException("Error reading XForm file", e);
         }
         XFormAndroidInstaller.registerAndroidLevelFormParsers();
         FormDef fd = XFormExtensionUtils.getFormFromInputStream(fis);
         if (fd == null) {
-            throw new RuntimeException("Error reading XForm file");
+            throw new RuntimeException("Error reading XForm file: FormDef is null");
         }
         return fd;
     }

--- a/app/src/org/commcare/tasks/UpdateTask.java
+++ b/app/src/org/commcare/tasks/UpdateTask.java
@@ -1,6 +1,7 @@
 package org.commcare.tasks;
 
 import android.content.Context;
+import android.support.v4.util.Pair;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
@@ -107,12 +108,7 @@ public class UpdateTask
         } catch (InvalidResourceException e) {
             ResourceInstallUtils.logInstallError(e,
                     "Structure error ocurred during install|");
-            // Put both the resource in question and a detailed error message into one string for
-            // ease of transport, which will be split out later and formatted into a user-readable
-            // pinned notification
-            String combinedMessage = e.resourceName + "==" + e.getMessage();
-
-            return new ResultAndError<>(AppInstallStatus.UnknownFailure, combinedMessage);
+            return new ResultAndError<>(AppInstallStatus.UnknownFailure, buildCombinedErrorMessage(e.resourceName, e.getMessage()));
         } catch (Exception e) {
             ResourceInstallUtils.logInstallError(e,
                     "Unknown error ocurred during install|");
@@ -264,5 +260,22 @@ public class UpdateTask
         taskWasCancelledByUser = true;
     }
 
+    public static boolean isCombinedErrorMessage(String message) {
+        return message != null && message.startsWith("||");
+    }
+
+    /**
+     * Put both the resource in question and a detailed error message into one string for
+     * ease of transport, which will be split out later and formatted into a user-readable
+     * pinned notification
+     */
+    private static String buildCombinedErrorMessage(String head, String tail) {
+        return "||" + head + "==" + tail;
+    }
+
+    public static Pair<String, String> splitCombinedErrorMessage(String message) {
+        String[] splitMessage = message.split("==", 2);
+        return Pair.create(splitMessage[0].substring(2), splitMessage[1]);
+    }
 
 }


### PR DESCRIPTION
Fix for the following stacktrace
```
java.lang.NullPointerException
at org.commcare.activities.UpdateActivity.handleTaskCompletion(UpdateActivity.java:222)
at org.commcare.activities.UpdateActivity.handleTaskCompletion(UpdateActivity.java:37)
at org.commcare.tasks.SingletonTask.onPostExecute(SingletonTask.java:35)
at org.commcare.tasks.UpdateTask.onPostExecute(UpdateTask.java:162)
at org.commcare.tasks.UpdateTask.onPostExecute(UpdateTask.java:33)
at android.os.AsyncTask.finish(AsyncTask.java:632)
at android.os.AsyncTask.access$600(AsyncTask.java:177)
at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:645)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:136)
at android.app.ActivityThread.main(ActivityThread.java:5584)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:515)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1268)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1084)
at dalvik.system.NativeStart.main(Native Method)
```