### PR TITLE
Include IMEI in key fetch URL

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -24,6 +24,7 @@ import android.os.Looper;
 import android.os.Message;
 import android.preference.PreferenceManager;
 import android.provider.Settings.Secure;
+import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.util.Pair;
@@ -410,7 +411,7 @@ public class CommCareApplication extends Application {
         }
     }
 
-    public String getPhoneId() {
+    public @NonNull String getPhoneId() {
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_DENIED) {
             return "000000000000000";
         }
@@ -419,6 +420,9 @@ public class CommCareApplication extends Application {
         String imei = manager.getDeviceId();
         if (imei == null) {
             imei = Secure.getString(getContentResolver(), Secure.ANDROID_ID);
+        }
+        if (imei == null) {
+            imei = "----";
         }
         return imei;
     }

--- a/app/src/org/commcare/network/HttpRequestGenerator.java
+++ b/app/src/org/commcare/network/HttpRequestGenerator.java
@@ -197,6 +197,10 @@ public class HttpRequestGenerator implements HttpRequestEndpoints {
             url = url.buildUpon().appendQueryParameter("last_issued", DateUtils.formatTime(lastRequest, DateUtils.FORMAT_ISO8601)).build();
         }
 
+        // include IMEI in key fetch request for auditing large deployments
+        url = url.buildUpon().appendQueryParameter("device_id",
+                CommCareApplication.instance().getPhoneId()).build();
+
         HttpGet get = new HttpGet(url.toString());
 
         return execute(client, get);


### PR DESCRIPTION
Adding IMEI as a query parameter into the key fetch url for auditing large deployments .

Feture requested in http://manage.dimagi.com/default.asp?242009

