### PR TITLE
Feature flag to allow showing password text

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -125,6 +125,8 @@ login.sync=Synchronize with server
 login.bad.password=We couldn't find a user with this password. Please try another!
 login.welcome.single=Welcome back! Please log in.
 login.welcome.multiple=Welcome back! Please select an app and log in.
+login.show.password=SHOW
+login.hide.password=HIDE
 
 login.update.install.success=App update successfully applied!
 login.update.install.failure=App update failed to apply!

--- a/app/res/layout/screen_login.xml
+++ b/app/res/layout/screen_login.xml
@@ -94,27 +94,47 @@
                                 android:background="@drawable/login_edit_text"
                                 android:drawableLeft="@drawable/icon_user_neutral50"
                                 android:hint="Username"
-                                android:inputType="text"
                                 android:imeOptions="actionNext"
+                                android:inputType="text"
                                 android:nextFocusDown="@+id/edit_password"
                                 android:textSize="@dimen/text_medium">
 
                                 <requestFocus/>
                             </AutoCompleteTextView>
 
-                            <EditText
-                                android:id="@+id/edit_password"
-                                style="@style/LoginEditTextV2"
-                                android:layout_width="fill_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginBottom="@dimen/content_start"
-                                android:background="@drawable/login_edit_text"
-                                android:drawableLeft="@drawable/icon_lock_neutral50"
-                                android:hint="Password"
-                                android:inputType="textPassword"
-                                android:nextFocusUp="@+id/edit_username"
-                                android:imeOptions="actionDone"
-                                android:textSize="@dimen/text_medium"/>
+                            <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                            android:layout_width="wrap_content"
+                                            android:layout_height="wrap_content">
+
+                                <EditText
+                                    android:id="@+id/edit_password"
+                                    style="@style/LoginEditTextV2"
+                                    android:layout_width="fill_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginBottom="@dimen/content_start"
+                                    android:background="@drawable/login_edit_text"
+                                    android:drawableLeft="@drawable/icon_lock_neutral50"
+                                    android:hint="Password"
+                                    android:imeOptions="actionDone"
+                                    android:inputType="textPassword"
+                                    android:nextFocusUp="@+id/edit_username"
+                                    android:textSize="@dimen/text_medium"/>
+
+                                <Button
+                                    android:id="@+id/show_password"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_alignBottom="@+id/edit_password"
+                                    android:layout_alignRight="@+id/edit_password"
+                                    android:layout_alignTop="@+id/edit_password"
+                                    android:background="@android:color/transparent"
+                                    android:padding="@dimen/spacer_small"
+                                    android:src="@drawable/close_cross_icon"
+                                    android:textColor="@color/cc_brand_color"
+                                    android:textSize="@dimen/font_size_dp_medium"
+                                    android:visibility="invisible"/>
+
+                            </RelativeLayout>
 
                             <TextView
                                 android:id="@+id/screen_login_bad_password"
@@ -172,11 +192,11 @@
 
     <!-- Dummy item to give focus to when we want to prevent keyboard from showing -->
     <LinearLayout
-        android:focusable="true"
-        android:focusableInTouchMode="true"
-        android:orientation="horizontal"
         android:id="@+id/dummy_focusable_view"
         android:layout_width="0px"
-        android:layout_height="0px"/>
+        android:layout_height="0px"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:orientation="horizontal"/>
 
 </LinearLayout>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -104,6 +104,11 @@ Some images in CommCare are graciously used under Creative Commons Licensing fro
         <item>Enabled</item>
         <item>Disabled</item>
     </string-array>
+    <string-array name="pref_password_show_options_labels">
+        <item>Always Hidden</item>
+        <item>Default Show</item>
+        <item>Default Hide</item>
+    </string-array>
     <string-array name="pref_load_form_payload_as_vals">
         <item>incomplete</item>
         <item>unsent</item>
@@ -113,6 +118,11 @@ Some images in CommCare are graciously used under Creative Commons Licensing fro
         <item>Incomplete</item>
         <item>Unsent</item>
         <item>Saved</item>
+    </string-array>
+    <string-array name="pref_password_show_options">
+        <item>always_hidden</item>
+        <item>default_show</item>
+        <item>default_hide</item>
     </string-array>
     <string-array name="target_density_labels">
         <item>DENSITY_LOW</item>

--- a/app/res/xml/commcare_preferences.xml
+++ b/app/res/xml/commcare_preferences.xml
@@ -34,6 +34,13 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-update-to-unstarred-builds"
         android:title="Enable Updating to Un-Starred Builds"/>
+    <ListPreference
+        android:enabled="true"
+        android:defaultValue="always_hidden"
+        android:entries="@array/pref_password_show_options_labels"
+        android:entryValues="@array/pref_password_show_options"
+        android:key="cc-password-entry-show-behavior"
+        android:title="Configure Password Display"/>
     <Preference
         android:key="disable-analytics"/>
     <Preference

--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -40,8 +40,6 @@ import org.commcare.views.UiElement;
 import org.javarosa.core.services.locale.Localization;
 
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.Vector;
 
 /**
@@ -341,7 +339,7 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         manuallySwitchedToPasswordMode = true;
     }
 
-    public boolean userManuallySwitchedToPasswordMode() {
+    protected boolean userManuallySwitchedToPasswordMode() {
         return manuallySwitchedToPasswordMode;
     }
 

--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -258,16 +258,6 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         welcomeMessage.setText(Localization.get("login.welcome.multiple"));
     }
 
-    private static String[] getExistingUsernames() {
-        SqlStorage<UserKeyRecord> existingUsers =
-                CommCareApplication.instance().getCurrentApp().getStorage(UserKeyRecord.class);
-        Set<String> uniqueUsernames = new HashSet<>();
-        for (UserKeyRecord ukr : existingUsers) {
-            uniqueUsernames.add(ukr.getUsername());
-        }
-        return uniqueUsernames.toArray(new String[uniqueUsernames.size()]);
-    }
-
     private void checkEnteredUsernameForMatch() {
         UserKeyRecord matchingRecord = getActiveRecordForUsername(getEnteredUsername());
         if (matchingRecord != null) {
@@ -486,5 +476,4 @@ public class LoginActivityUIController implements CommCareActivityUIController {
     private Resources getResources() {
         return activity.getResources();
     }
-
 }

--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -35,6 +35,7 @@ import org.commcare.utils.MultipleAppsUtil;
 import org.commcare.views.CustomBanner;
 import org.commcare.views.ManagedUi;
 import org.commcare.views.ManagedUiFramework;
+import org.commcare.views.PasswordShow;
 import org.commcare.views.UiElement;
 import org.javarosa.core.services.locale.Localization;
 
@@ -59,6 +60,9 @@ public class LoginActivityUIController implements CommCareActivityUIController {
 
     @UiElement(value = R.id.edit_password)
     private EditText passwordOrPin;
+
+    @UiElement(value = R.id.show_password)
+    private Button showPasswordButton;
 
     @UiElement(R.id.screen_login_banner_pane)
     private View banner;
@@ -327,6 +331,7 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         passwordOrPin.setVisibility(View.VISIBLE);
         passwordOrPin.setHint(Localization.get("login.password"));
         passwordOrPin.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        new PasswordShow(showPasswordButton, passwordOrPin).setupPasswordVisibility();
         manuallySwitchedToPasswordMode = false;
     }
 

--- a/app/src/org/commcare/interfaces/CommCareActivityUIController.java
+++ b/app/src/org/commcare/interfaces/CommCareActivityUIController.java
@@ -13,5 +13,4 @@ public interface CommCareActivityUIController {
     void setupUI();
 
     void refreshView();
-
 }

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -29,6 +29,7 @@ import org.commcare.utils.FileUtil;
 import org.commcare.utils.GeoUtils;
 import org.commcare.utils.TemplatePrinterUtils;
 import org.commcare.utils.UriToFilePath;
+import org.commcare.views.PasswordShow;
 import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
@@ -159,7 +160,7 @@ public class CommCarePreferences
     }
 
     public static void setupLocalizedText(PreferenceActivity activity,
-                                             Map<String, String> prefToTitleMap) {
+                                          Map<String, String> prefToTitleMap) {
         PreferenceScreen screen = activity.getPreferenceScreen();
         for (int i = 0; i < screen.getPreferenceCount(); i++) {
             String key = screen.getPreference(i).getKey();
@@ -359,28 +360,9 @@ public class CommCarePreferences
         return true;
     }
 
-    public static PasswordShowOption getPasswordDisplayOption() {
+    public static PasswordShow.PasswordShowOption getPasswordDisplayOption() {
         SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        return PasswordShowOption.fromString(properties.getString(SHOW_PASSWORD_OPTION, ""));
-    }
-
-    public enum PasswordShowOption {
-        ALWAYS_HIDDEN,
-        DEFAULT_SHOW,
-        DEFAULT_HIDE;
-
-        public static PasswordShowOption fromString(String optionAsString) {
-            switch (optionAsString) {
-                case "always_hidden":
-                    return ALWAYS_HIDDEN;
-                case "default_show":
-                    return DEFAULT_SHOW;
-                case "default_hide":
-                    return DEFAULT_HIDE;
-                default:
-                    return ALWAYS_HIDDEN;
-            }
-        }
+        return PasswordShow.PasswordShowOption.fromString(properties.getString(SHOW_PASSWORD_OPTION, ""));
     }
 
     public static boolean isSavedFormsEnabled() {

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -72,6 +72,8 @@ public class CommCarePreferences
     public final static String ENABLE_SAVED_FORMS = "cc-show-saved";
     public final static String ENABLE_INCOMPLETE_FORMS = "cc-show-incomplete";
 
+    public final static String SHOW_PASSWORD_OPTION = "cc-password-entry-show-behavior";
+
     public final static String RESIZING_METHOD = "cc-resize-images";
 
     private static final String KEY_TARGET_DENSITY = "cc-inflation-target-density";
@@ -355,6 +357,30 @@ public class CommCarePreferences
         }
 
         return true;
+    }
+
+    public static PasswordShowOption getPasswordDisplayOption() {
+        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        return PasswordShowOption.fromString(properties.getString(SHOW_PASSWORD_OPTION, ""));
+    }
+
+    public enum PasswordShowOption {
+        ALWAYS_HIDDEN,
+        DEFAULT_SHOW,
+        DEFAULT_HIDE;
+
+        public static PasswordShowOption fromString(String optionAsString) {
+            switch (optionAsString) {
+                case "always_hidden":
+                    return ALWAYS_HIDDEN;
+                case "default_show":
+                    return DEFAULT_SHOW;
+                case "default_hide":
+                    return DEFAULT_HIDE;
+                default:
+                    return ALWAYS_HIDDEN;
+            }
+        }
     }
 
     public static boolean isSavedFormsEnabled() {

--- a/app/src/org/commcare/views/PasswordShow.java
+++ b/app/src/org/commcare/views/PasswordShow.java
@@ -1,0 +1,100 @@
+package org.commcare.views;
+
+import android.text.method.HideReturnsTransformationMethod;
+import android.text.method.PasswordTransformationMethod;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+
+import org.commcare.preferences.CommCarePreferences;
+import org.javarosa.core.services.locale.Localization;
+
+/**
+ * Allow password field to show/hide password text
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class PasswordShow {
+
+    private boolean isPasswordVisible;
+    private final Button showPasswordButton;
+    private final EditText passwordField;
+    private final String showText, hideText;
+
+    public PasswordShow(Button showPasswordButton, EditText passwordField) {
+        this.showPasswordButton = showPasswordButton;
+        this.passwordField = passwordField;
+
+        showText = Localization.get("login.show.password");
+        hideText = Localization.get("login.hide.password");
+    }
+
+    public void setupPasswordVisibility() {
+        switch (CommCarePreferences.getPasswordDisplayOption()) {
+            case ALWAYS_HIDDEN:
+                passwordAlwaysHiddenState();
+                break;
+            case DEFAULT_HIDE:
+                passwordHiddenState();
+                break;
+            case DEFAULT_SHOW:
+                passwordShownState();
+                break;
+        }
+        showPasswordButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                togglePasswordVisibility();
+            }
+        });
+    }
+
+    private void passwordAlwaysHiddenState() {
+        isPasswordVisible = false;
+        showPasswordButton.setVisibility(View.INVISIBLE);
+    }
+
+    private void passwordHiddenState() {
+        isPasswordVisible = false;
+        showPasswordButton.setVisibility(View.VISIBLE);
+        showPasswordButton.setText(showText);
+        passwordField.setTransformationMethod(PasswordTransformationMethod.getInstance());
+        passwordField.setSelection(passwordField.getText().length());
+    }
+
+    private void passwordShownState() {
+        isPasswordVisible = true;
+        showPasswordButton.setVisibility(View.VISIBLE);
+        showPasswordButton.setText(hideText);
+        passwordField.setTransformationMethod(HideReturnsTransformationMethod.getInstance());
+        passwordField.setSelection(passwordField.getText().length());
+    }
+
+    private void togglePasswordVisibility() {
+        if (isPasswordVisible) {
+            passwordHiddenState();
+        } else {
+            passwordShownState();
+        }
+    }
+
+    public enum PasswordShowOption {
+        ALWAYS_HIDDEN,
+        DEFAULT_SHOW,
+        DEFAULT_HIDE;
+
+        public static PasswordShowOption fromString(String optionAsString) {
+            switch (optionAsString) {
+                case "always_hidden":
+                    return ALWAYS_HIDDEN;
+                case "default_show":
+                    return DEFAULT_SHOW;
+                case "default_hide":
+                    return DEFAULT_HIDE;
+                default:
+                    return ALWAYS_HIDDEN;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
login | config
---- | ----
![login](https://cloud.githubusercontent.com/assets/94817/20481929/dbc65c5c-afd0-11e6-90c8-9e43b44ed125.png) | ![config](https://cloud.githubusercontent.com/assets/94817/20481934/e0c8c622-afd0-11e6-8a8d-0ee519f53bf1.png)

Exposes `cc-password-entry-show-behavior` preference that can be set to either `always_hidden`,`default_show`, or `default_hide`. The default setting is `always_hidden`.