### PR TITLE
Fix map select feature

### DIFF
--- a/app/res/layout/geopoint_layout.xml
+++ b/app/res/layout/geopoint_layout.xml
@@ -11,7 +11,7 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:clickable="true"
-        android:apiKey="017Xo9E6R7WmcCITvo-lU2V0ERblKPqCcguwxSQ"/>
+        />
     <LinearLayout
         android:id="@+id/location_buttons"
         android:orientation="vertical"

--- a/app/res/layout/geopoint_layout.xml
+++ b/app/res/layout/geopoint_layout.xml
@@ -12,7 +12,6 @@
         android:layout_height="fill_parent"
         android:clickable="true"
         android:apiKey="017Xo9E6R7WmcCITvo-lU2V0ERblKPqCcguwxSQ"/>
-    <!-- android:apiKey="0wsgFhRvVBLVpgaFzmwaYuqfU898z_2YtlKSlkg"/> debug -->
     <LinearLayout
         android:id="@+id/location_buttons"
         android:orientation="vertical"

--- a/app/res/layout/geopoint_layout.xml
+++ b/app/res/layout/geopoint_layout.xml
@@ -1,62 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/mainlayout"
-    android:orientation="vertical"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_height="fill_parent"
+    android:orientation="vertical">
 
-    <com.google.android.gms.maps.MapView
-        android:id="@+id/mapview"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:clickable="true"
-        />
     <LinearLayout
         android:id="@+id/location_buttons"
-        android:orientation="vertical"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
+        android:background="@color/translucent_background"
         android:gravity="center_horizontal"
-        android:padding="5dip"
-        android:background="@color/translucent_background">
+        android:orientation="vertical"
+        android:padding="5dip">
+
+
+        <TextView
+            android:id="@+id/location_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/please_wait_long"
+            android:textColor="@color/white"/>
 
         <LinearLayout
-            android:orientation="horizontal"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            android:paddingTop="2dip"
-            android:paddingBottom="2dip">
+            android:orientation="horizontal"
+            android:paddingBottom="2dip"
+            android:paddingTop="2dip">
 
             <Button
                 android:id="@+id/show_location"
-                android:text="@string/go_to_location"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
                 android:layout_weight="1"
+                android:text="@string/go_to_location"
+                android:textColor="@color/white"
                 android:visibility="gone"/>
 
             <Button
                 android:id="@+id/accept_location"
-                android:text="@string/accept_location"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
-                android:layout_weight="1"/>
+                android:layout_weight="1"
+                android:text="@string/accept_location"
+                android:textColor="@color/white"/>
 
             <Button
                 android:id="@+id/cancel_location"
-                android:text="@string/cancel"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
-                android:layout_weight="1"/>
+                android:layout_weight="1"
+                android:text="@string/cancel"
+                android:textColor="@color/white"/>
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/location_status"
-            android:text="@string/please_wait_long"
-            android:textColor="#FFFFFF"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+        <com.google.android.gms.maps.MapView
+            android:id="@+id/mapview"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:clickable="true"/>
     </LinearLayout>
 </RelativeLayout>

--- a/app/res/layout/geopoint_layout.xml
+++ b/app/res/layout/geopoint_layout.xml
@@ -6,7 +6,7 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent">
 
-    <com.google.android.maps.MapView
+    <com.google.android.gms.maps.MapView
         android:id="@+id/mapview"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -77,7 +77,7 @@
     <string name="list_failed_with_error">El listado de formularios fracaso. %s.</string>
     <string name="loading_form">Cargando Formulario</string>
     <string name="load_remote_form_error">Error en Obteniendo Listado de Formularios</string>
-    <string name="location_provider_accuracy">Usando %1$s. Precision es de %2$s m.</string>
+    <string name="location_provider_accuracy">Precision es de %1$s m.</string>
     <string name="location_provider">Usando el proveedor %1$s. Por favor espere para mayor precision.</string>
     <string name="location_accuracy">Precision es de %1$s m</string>
     <string name="longitude">Longitud</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -77,7 +77,7 @@ License.
     <string name="list_failed_with_error">La liste a echoué. %s.</string>
     <string name="loading_form">Chargement du formulaire ...</string>
     <string name="load_remote_form_error">Erreur de récupération de la liste</string>
-    <string name="location_provider_accuracy">Utilisation de %1$s. La précision est de %2$s m.</string>
+    <string name="location_provider_accuracy">La précision est de %1$s m.</string>
     <string name="location_provider">Utilisation de %1$s. Attendre une meilleure précision.</string>
     <string name="location_accuracy">La précision est de %1$s métres.</string>
     <string name="longitude">Longitude</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -78,7 +78,7 @@
     <string name="list_failed_with_error">Nepavyko gauti formų sąrašo. %s.</string>
     <string name="loading_form">Įkeliama forma</string>
     <string name="load_remote_form_error">Klaida nuskaitant formų sąrašą</string>
-    <string name="location_provider_accuracy">Naudojama %1$s. Tikslumas yra %2$s m.</string>
+    <string name="location_provider_accuracy">Tikslumas yra %1$s m.</string>
     <string name="location_provider">Naudojamas %1$s tiekėjas. Norint pasiekti didesnį tikslumą reikia palaukti.</string>
     <string name="location_accuracy">Tikslumas yra %1$s m</string>
     <string name="longitude">Ilguma</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -78,7 +78,7 @@
     <string name="list_failed_with_error">Form listing failed. %s.</string>
     <string name="loading_form">Laster opp skjema</string>
     <string name="load_remote_form_error">Error Getting Form List</string>
-    <string name="location_provider_accuracy">Using %1$s. Accuracy is %2$s m.</string>
+    <string name="location_provider_accuracy">Location accuracy is %1$s m.</string>
     <string name="location_provider">Using %1$s provider. Please wait for greater accuracy.</string>
     <string name="location_accuracy">Accuracy is %1$s m</string>
     <string name="longitude">Breddegrad</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -78,7 +78,7 @@
     <string name="list_failed_with_error">Listagem de formulários falhou. %s.</string>
     <string name="loading_form">Carregando Formulário</string>
     <string name="load_remote_form_error">Erro na Listagem de Formulários</string>
-    <string name="location_provider_accuracy">Usando %1$s. Precisão de %2$s m.</string>
+    <string name="location_provider_accuracy">Precisão de %1$s m.</string>
     <string name="location_provider">Usando %1$s provedor. Por favor aguarde por uma melhor precisão.</string>
     <string name="location_accuracy">Accuracy is %1$s m</string>
     <string name="longitude">Longitude</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -78,7 +78,7 @@
     <string name="list_failed_with_error">Form listing failed. %s.</string>
     <string name="loading_form">Loading Form</string>
     <string name="load_remote_form_error">Error Getting Form List</string>
-    <string name="location_provider_accuracy">Using %1$s. Accuracy is %2$s m.</string>
+    <string name="location_provider_accuracy">Location accuracy is %1$s m.</string>
     <string name="location_provider">Using %1$s provider. Please wait for greater accuracy.</string>
     <string name="location_accuracy">Accuracy is %1$s m</string>
     <string name="longitude">Longitude</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -218,7 +218,7 @@ Some images in CommCare are graciously used under Creative Commons Licensing fro
     <string name="list_failed_with_error" cc:translatable="true">Form listing failed. %s.</string>
     <string name="loading_form" cc:translatable="true">Loading Form</string>
     <string name="load_remote_form_error" cc:translatable="true">Error Getting Form List</string>
-    <string name="location_provider_accuracy" cc:translatable="true">Location found using %1$s. Accuracy is %2$s m.</string>
+    <string name="location_provider_accuracy" cc:translatable="true">Location accuracy: %1$s m.</string>
     <string name="location_provider" cc:translatable="true">Using %1$s provider. Please wait for greater accuracy.</string>
     <string name="location_accuracy" cc:translatable="true">Location found. Accuracy is %1$s m</string>
     <string name="longitude" cc:translatable="true">Longitude</string>

--- a/app/src/org/commcare/activities/GeoPointActivity.java
+++ b/app/src/org/commcare/activities/GeoPointActivity.java
@@ -57,7 +57,6 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
             mTimer = new ODKTimer(millisToWait, this);
         }
         mTimer.start();
-
     }
 
     @Override
@@ -75,7 +74,6 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
         if (locationDialog != null && locationDialog.isShowing())
             locationDialog.dismiss();
     }
-
 
     @Override
     protected void onResume() {
@@ -121,7 +119,6 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
         }
     }
 
-
     /**
      * Sets up the look and actions for the progress dialog while the GPS is searching.
      */
@@ -153,7 +150,6 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
                 cancelButtonListener);
     }
 
-
     private void returnLocation() {
         if (location != null) {
             Intent i = new Intent();
@@ -162,7 +158,6 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
         }
         finish();
     }
-
 
     @Override
     public void onLocationChanged(Location location) {
@@ -186,24 +181,20 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
         }
     }
 
-
     private String truncateDouble(float number) {
         DecimalFormat df = new DecimalFormat("#.##");
         return df.format(number);
     }
-
 
     @Override
     public void onProviderDisabled(String provider) {
 
     }
 
-
     @Override
     public void onProviderEnabled(String provider) {
 
     }
-
 
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
@@ -211,7 +202,7 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
             case LocationProvider.AVAILABLE:
                 if (location != null) {
                     locationDialog.setMessage(StringUtils.getStringRobust(this, R.string.location_accuracy,
-                            "" + (int) location.getAccuracy()));
+                            "" + (int)location.getAccuracy()));
                 }
                 break;
             case LocationProvider.OUT_OF_SERVICE:

--- a/app/src/org/commcare/activities/GeoPointMapActivity.java
+++ b/app/src/org/commcare/activities/GeoPointMapActivity.java
@@ -5,9 +5,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.graphics.BitmapFactory;
-import android.graphics.Canvas;
-import android.graphics.Point;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
@@ -20,11 +17,15 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.android.gms.maps.CameraUpdate;
+import com.google.android.gms.maps.CameraUpdateFactory;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.MapView;
+import com.google.android.gms.maps.MapsInitializer;
+import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.maps.GeoPoint;
-import com.google.android.maps.MapController;
-import com.google.android.maps.MapView;
-import com.google.android.maps.MyLocationOverlay;
-import com.google.android.maps.Overlay;
 
 import org.commcare.dalvik.R;
 import org.commcare.utils.GeoUtils;
@@ -33,14 +34,16 @@ import org.commcare.views.widgets.GeoPointWidget;
 import java.text.DecimalFormat;
 import java.util.List;
 
-public class GeoPointMapActivity extends Activity implements LocationListener {
+/**
+ * Allows location to be chosen using a map instead of current gps coordinates
+ */
+public class GeoPointMapActivity extends Activity implements LocationListener, OnMapReadyCallback {
 
     private MapView mMapView;
+    private GoogleMap map;
     private TextView mLocationStatus;
 
-    private MapController mMapController;
     private LocationManager mLocationManager;
-    private Overlay mLocationOverlay;
 
     private GeoPoint mGeoPoint;
     private Location mLocation;
@@ -62,7 +65,7 @@ public class GeoPointMapActivity extends Activity implements LocationListener {
         loadViewModeState();
         setupButtons();
 
-        loadMapView();
+        loadMapView(savedInstanceState);
 
         mLocationStatus = (TextView)findViewById(R.id.location_status);
         if (inViewMode) {
@@ -75,34 +78,15 @@ public class GeoPointMapActivity extends Activity implements LocationListener {
                     Toast.LENGTH_SHORT).show();
             finish();
         }
-
     }
 
-    private void loadProviders() {
-        List<String> providers = mLocationManager.getProviders(true);
-        for (String provider : providers) {
-            if (provider.equalsIgnoreCase(LocationManager.GPS_PROVIDER)) {
-                mGPSOn = true;
-            }
-            if (provider.equalsIgnoreCase(LocationManager.NETWORK_PROVIDER)) {
-                mNetworkOn = true;
-            }
-        }
-    }
-
-    private void loadMapView() {
+    private void loadMapView(Bundle savedInstanceState) {
+        // Gets the MapView from the XML layout and creates it
         mMapView = (MapView)findViewById(R.id.mapview);
-        mMapController = mMapView.getController();
+        mMapView.onCreate(savedInstanceState);
 
-        mMapView.setBuiltInZoomControls(true);
-        mMapView.setSatellite(false);
-        mMapController.setZoom(16);
-        mLocationOverlay = new MyLocationOverlay(this, mMapView);
-        mMapView.getOverlays().add(mLocationOverlay);
-        if (inViewMode) {
-            Overlay mGeoPointOverlay = new Marker(mGeoPoint);
-            mMapView.getOverlays().add(mGeoPointOverlay);
-        }
+        // Gets to GoogleMap from the MapView and does initialization stuff
+        mMapView.getMapAsync(this);
     }
 
     private void setupButtons() {
@@ -130,11 +114,10 @@ public class GeoPointMapActivity extends Activity implements LocationListener {
             mShowLocation.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    mMapController.animateTo(mGeoPoint);
+                    animateToPoint(mGeoPoint.getLatitudeE6(), mGeoPoint.getLongitudeE6());
                 }
             });
         }
-
     }
 
     private void loadViewModeState() {
@@ -143,6 +126,18 @@ public class GeoPointMapActivity extends Activity implements LocationListener {
             double[] location = intent.getDoubleArrayExtra(GeoPointWidget.LOCATION);
             mGeoPoint = new GeoPoint((int)(location[0] * 1E6), (int)(location[1] * 1E6));
             inViewMode = true;
+        }
+    }
+
+    private void loadProviders() {
+        List<String> providers = mLocationManager.getProviders(true);
+        for (String provider : providers) {
+            if (provider.equalsIgnoreCase(LocationManager.GPS_PROVIDER)) {
+                mGPSOn = true;
+            }
+            if (provider.equalsIgnoreCase(LocationManager.NETWORK_PROVIDER)) {
+                mNetworkOn = true;
+            }
         }
     }
 
@@ -166,15 +161,14 @@ public class GeoPointMapActivity extends Activity implements LocationListener {
                 ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
             mLocationManager.removeUpdates(this);
         }
-        ((MyLocationOverlay)mLocationOverlay).disableMyLocation();
-
     }
 
     @Override
     protected void onResume() {
+        mMapView.onResume();
+
         super.onResume();
 
-        ((MyLocationOverlay)mLocationOverlay).enableMyLocation();
         if (mGPSOn && ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
             mLocationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
         }
@@ -195,7 +189,7 @@ public class GeoPointMapActivity extends Activity implements LocationListener {
                         new GeoPoint((int)(mLocation.getLatitude() * 1E6),
                                 (int)(mLocation.getLongitude() * 1E6));
 
-                mMapController.animateTo(mGeoPoint);
+                animateToPoint(mGeoPoint.getLatitudeE6(), mGeoPoint.getLongitudeE6());
 
                 if (mLocation.getAccuracy() <= GeoUtils.GOOD_ACCURACY) {
                     returnLocation();
@@ -216,22 +210,37 @@ public class GeoPointMapActivity extends Activity implements LocationListener {
     public void onStatusChanged(String provider, int status, Bundle extras) {
     }
 
-    class Marker extends Overlay {
-        GeoPoint gp = null;
+    @Override
+    public void onMapReady(GoogleMap map) {
+        this.map = map;
+        map.getUiSettings().setMyLocationButtonEnabled(false);
+        map.setMyLocationEnabled(true);
 
-        Marker(GeoPoint gp) {
-            this.gp = gp;
-        }
+        MapsInitializer.initialize(this);
 
-        @Override
-        public void draw(Canvas canvas, MapView mapView, boolean shadow) {
-            super.draw(canvas, mapView, shadow);
-            Point screenPoint = new Point();
-            mMapView.getProjection().toPixels(gp, screenPoint);
-            canvas.drawBitmap(BitmapFactory.decodeResource(getResources(),
-                    R.drawable.ic_maps_indicator_current_position), screenPoint.x, screenPoint.y - 8,
-                    null); // -8 as image is 16px high
+        if (inViewMode) {
+            map.addMarker(new MarkerOptions().position(new LatLng(mGeoPoint.getLatitudeE6(), mGeoPoint.getLongitudeE6())).title("Marker"));
+        } else {
+            map.addMarker(new MarkerOptions().position(new LatLng(0, 0)).title("Marker"));
         }
+    }
+
+    private void animateToPoint(long lat, long lng) {
+        // Updates the location and zoom of the MapView
+        CameraUpdate cameraUpdate = CameraUpdateFactory.newLatLngZoom(new LatLng(lat, lng), 10);
+        map.animateCamera(cameraUpdate);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mMapView.onDestroy();
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        mMapView.onLowMemory();
     }
 
 }

--- a/app/src/org/commcare/activities/GeoPointMapActivity.java
+++ b/app/src/org/commcare/activities/GeoPointMapActivity.java
@@ -110,9 +110,7 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
                     returnLocation();
                 }
             });
-
         } else {
-
             Overlay mGeoPointOverlay = new Marker(mGeoPoint);
             mMapView.getOverlays().add(mGeoPointOverlay);
 
@@ -121,16 +119,13 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
             Button mShowLocation = ((Button)findViewById(R.id.show_location));
             mShowLocation.setVisibility(View.VISIBLE);
             mShowLocation.setOnClickListener(new OnClickListener() {
-
                 @Override
                 public void onClick(View v) {
                     mMapController.animateTo(mGeoPoint);
                 }
             });
-
         }
     }
-
 
     private void returnLocation() {
         if (mLocation != null) {
@@ -141,11 +136,9 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
         finish();
     }
 
-
-    private String truncateFloat(float f) {
+    private static String truncateFloat(float f) {
         return new DecimalFormat("#.##").format(f);
     }
-
 
     @Override
     protected void onPause() {
@@ -157,7 +150,6 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
         ((MyLocationOverlay)mLocationOverlay).disableMyLocation();
 
     }
-
 
     @Override
     protected void onResume() {
@@ -173,12 +165,10 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
         // TODO PLM: warn user and ask for permissions if the user has disabled them
     }
 
-
     @Override
     protected boolean isRouteDisplayed() {
         return false;
     }
-
 
     @Override
     public void onLocationChanged(Location location) {
@@ -200,16 +190,13 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
         }
     }
 
-
     @Override
     public void onProviderDisabled(String provider) {
     }
 
-
     @Override
     public void onProviderEnabled(String provider) {
     }
-
 
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
@@ -218,12 +205,9 @@ public class GeoPointMapActivity extends MapActivity implements LocationListener
     class Marker extends Overlay {
         GeoPoint gp = null;
 
-
-        public Marker(GeoPoint gp) {
-            super();
+        Marker(GeoPoint gp) {
             this.gp = gp;
         }
-
 
         @Override
         public void draw(Canvas canvas, MapView mapView, boolean shadow) {

--- a/app/src/org/commcare/views/widgets/GeoPointWidget.java
+++ b/app/src/org/commcare/views/widgets/GeoPointWidget.java
@@ -1,17 +1,3 @@
-/*
- * Copyright (C) 2009 University of Washington
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.commcare.views.widgets;
 
 import android.app.Activity;
@@ -136,7 +122,6 @@ public class GeoPointWidget extends QuestionWidget {
                 Intent i = new Intent(getContext(), GeoPointMapActivity.class);
                 i.putExtra(LOCATION, gp);
                 getContext().startActivity(i);
-
             }
         });
 
@@ -147,7 +132,6 @@ public class GeoPointWidget extends QuestionWidget {
         addView(mAnswerDisplay);
     }
 
-
     @Override
     public void clearAnswer() {
         mStringAnswer.setText(null);
@@ -155,7 +139,6 @@ public class GeoPointWidget extends QuestionWidget {
         mGetLocationButton.setText(StringUtils.getStringSpannableRobust(getContext(), R.string.get_location));
 
     }
-
 
     @Override
     public IAnswerData getAnswer() {
@@ -179,12 +162,10 @@ public class GeoPointWidget extends QuestionWidget {
         }
     }
 
-
     private String truncateDouble(String s) {
         DecimalFormat df = new DecimalFormat("#.##");
         return df.format(Double.valueOf(s));
     }
-
 
     private String formatGps(double coordinates, String type) {
         String location = Double.toString(coordinates);
@@ -213,7 +194,6 @@ public class GeoPointWidget extends QuestionWidget {
         return degree;
     }
 
-
     @Override
     public void setFocus(Context context) {
         // Hide the soft keyboard if it's showing.
@@ -221,7 +201,6 @@ public class GeoPointWidget extends QuestionWidget {
                 (InputMethodManager)context.getSystemService(Context.INPUT_METHOD_SERVICE);
         inputManager.hideSoftInputFromWindow(this.getWindowToken(), 0);
     }
-
 
     @Override
     public void setBinaryData(Object answer) {
@@ -269,5 +248,4 @@ public class GeoPointWidget extends QuestionWidget {
         mStringAnswer.cancelLongPress();
         mAnswerDisplay.cancelLongPress();
     }
-
 }


### PR DESCRIPTION
If a GPS capture question has the appearance attribute `maps`, then you are shown a map where you can select a location independent of your current GPS location. This stopped working when we updated to Google's new map APIs.

Since this feature is not really used, I left some things rough:

 - If you tap a location, it selects a new location, but the accuracy is hard-coded to 10 meters. A more robust implementation would scale the accuracy by the current zoom level.
 - When your location updates or you tap a new location, the zoom level is scaled by the accuracy. This works but could use some finessing to scale better.

Behavioral changes:

 - The activity no longer finishes after a certain accuracy is obtained. From my understanding the whole point of the activity is to not pick your current location.

Had to rewrite a large chunk of the code, so might be useful to disregard the diff and just look at the new `GeoPointMapActivity` implementation.

![screen](https://cloud.githubusercontent.com/assets/94817/20493591/9beb300a-b000-11e6-85b2-d51f2c2d7972.png)

Fix for http://manage.dimagi.com/default.asp?237541