### PR TITLE
Remove 'fire triggers on save' feature flag

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -61,13 +61,6 @@
         android:key="cc-alternate-question-text-format"
         android:title="Image Above Question Text Enabled"/>
     <ListPreference
-        android:defaultValue="no"
-        android:enabled="true"
-        android:entries="@array/pref_enabled_labels"
-        android:entryValues="@array/pref_enabled_vals"
-        android:key="cc-fire-triggers-on-save"
-        android:title="Fire triggers on form save"/>
-    <ListPreference
         android:enabled="true"
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -47,14 +47,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
      * Spacer to distinguish between the saved navigation session and form entry session
      */
     private static final String NAV_AND_FORM_SESSION_SPACER = "@@@@@";
-    /**
-     * The current default for constraint checking during form saving (as of
-     * CommCare 2.24) is to re-answer all the questions, causing a lot of
-     * triggers to fire. We probably don't need to do this, but it is hard to
-     * know, so allow the adventurous to use form saving that doesn't re-fire
-     * triggers.
-     */
-    public final static String FIRE_TRIGGERS_ON_SAVE = "cc-fire-triggers-on-save";
     public final static String ALTERNATE_QUESTION_LAYOUT_ENABLED = "cc-alternate-question-text-format";
 
     public final static String OFFER_PIN_FOR_LOGIN = "cc-offer-pin-for-login";
@@ -94,7 +86,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
         prefKeyToAnalyticsEvent.put(CSS_ENABLED, GoogleAnalyticsFields.LABEL_CSS);
         prefKeyToAnalyticsEvent.put(MARKDOWN_ENABLED, GoogleAnalyticsFields.LABEL_MARKDOWN);
         prefKeyToAnalyticsEvent.put(ALTERNATE_QUESTION_LAYOUT_ENABLED, GoogleAnalyticsFields.LABEL_IMAGE_ABOVE_TEXT);
-        prefKeyToAnalyticsEvent.put(FIRE_TRIGGERS_ON_SAVE, GoogleAnalyticsFields.LABEL_TRIGGERS_ON_SAVE);
         prefKeyToAnalyticsEvent.put(HOME_REPORT_ENABLED, GoogleAnalyticsFields.LABEL_REPORT_BUTTON_ENABLED);
         prefKeyToAnalyticsEvent.put(AUTO_PURGE_ENABLED, GoogleAnalyticsFields.LABEL_AUTO_PURGE);
         prefKeyToAnalyticsEvent.put(LOAD_FORM_PAYLOAD_AS, GoogleAnalyticsFields.LABEL_LOAD_FORM_PAYLOAD_AS);
@@ -240,11 +231,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static boolean isListRefreshEnabled() {
         SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
         return properties.getString(LIST_REFRESH_ENABLED, CommCarePreferences.NO).equals(CommCarePreferences.YES);
-    }
-
-    public static boolean shouldFireTriggersOnSave() {
-        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        return properties.getString(FIRE_TRIGGERS_ON_SAVE, CommCarePreferences.NO).equals(CommCarePreferences.YES);
     }
 
     public static boolean isAutoLoginEnabled() {

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -96,7 +96,7 @@ public class SaveToDiskTask extends
     @Override
     protected ResultAndError<SaveStatus> doTaskBackground(Void... nothing) {
         try{
-            if (hasInvalidAnswers(mMarkCompleted, DeveloperPreferences.shouldFireTriggersOnSave())) {
+            if (hasInvalidAnswers(mMarkCompleted)) {
                 return new ResultAndError<>(SaveStatus.INVALID_ANSWER);
             }
         } catch(XPathException xpe) {
@@ -365,30 +365,17 @@ public class SaveToDiskTask extends
      * with their constraints.  Constraints are ignored on 'jump to', so
      * answers can be outside of constraints. We don't allow saving to disk,
      * though, until all answers conform to their constraints/requirements.
-     * @param fireTriggerables re-fire the triggers associated with the
-     *                         question when checking its constraints?
      */
-    private boolean hasInvalidAnswers(boolean markCompleted, boolean fireTriggerables) {
+    private boolean hasInvalidAnswers(boolean markCompleted) {
         FormIndex i = FormEntryActivity.mFormController.getFormIndex();
         FormEntryActivity.mFormController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
 
         int event;
-        if (!fireTriggerables) {
-            Logger.log(AndroidLogger.TYPE_FORM_ENTRY, "Saving form without firing triggers.");
-        }
         while ((event =
             FormEntryActivity.mFormController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP)) != FormEntryController.EVENT_END_OF_FORM) {
             if (event == FormEntryController.EVENT_QUESTION) {
-                int saveStatus;
-                if (fireTriggerables) {
-                    saveStatus =
-                            FormEntryActivity.mFormController
-                                    .answerQuestion(FormEntryActivity.mFormController.getQuestionPrompt()
-                                            .getAnswerValue());
-                } else {
-                    saveStatus =
+                int saveStatus =
                             FormEntryActivity.mFormController.checkCurrentQuestionConstraint();
-                }
                 if (markCompleted &&
                         (saveStatus == FormEntryController.ANSWER_REQUIRED_BUT_EMPTY ||
                                 saveStatus == FormEntryController.ANSWER_CONSTRAINT_VIOLATED)) {


### PR DESCRIPTION
We've gone 3 releases without a save issue related to form save optimization, so I'm removing the feature flag that toggles it. Details in https://github.com/dimagi/commcare-android/pull/1207