### PR TITLE
Audio recorder widget filename fix: don't save files as mp40

### DIFF
--- a/app/src/org/commcare/CommCareApp.java
+++ b/app/src/org/commcare/CommCareApp.java
@@ -78,9 +78,6 @@ public class CommCareApp implements AppFilePathBuilder {
     }
 
     public String storageRoot() {
-        // This External Storage Directory will always destroy your data when you upgrade, which is stupid. Unfortunately
-        // it's also largely unavoidable until Froyo's fix for this problem makes it to the phones. For now we're going
-        // to rely on the fact that the phone knows how to fix missing/corrupt directories every time it upgrades.
         return CommCareApplication.instance().getAndroidFsRoot() + "app/" + record.getApplicationId() + "/";
     }
 

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -153,7 +153,6 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     public boolean upgrade(Resource r) {
         boolean fileUpgrade = super.upgrade(r);
         return fileUpgrade && updateFilePath();
-
     }
 
     /**

--- a/app/src/org/commcare/engine/references/JavaFileRoot.java
+++ b/app/src/org/commcare/engine/references/JavaFileRoot.java
@@ -1,13 +1,9 @@
-/**
- *
- */
 package org.commcare.engine.references;
 
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceFactory;
 import org.javarosa.core.reference.ReferenceManager;
-
 
 /**
  * @author ctsims

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -39,8 +39,9 @@ import java.io.IOException;
 public class RecordingFragment extends android.support.v4.app.DialogFragment {
 
     private String fileName;
-    private static final String FILE_EXT =
-            "/Android/data/org.commcare.dalvik/temp/Custom_Recording.mp4";
+    private static final String FILE_BASE =
+            "/Android/data/org.commcare.dalvik/temp/Custom_Recording";
+    private static final String FILE_EXT = ".mp4";
 
     private LinearLayout layout;
     private ImageButton toggleRecording;
@@ -63,7 +64,7 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
         prepareButtons();
         prepareText();
         setWindowSize();
-        fileName = Environment.getExternalStorageDirectory().getAbsolutePath() + FILE_EXT + listener.getFileExtension();
+        fileName = Environment.getExternalStorageDirectory().getAbsolutePath() + FILE_BASE + listener.getFileExtension() + FILE_EXT;
 
         File f = new File(fileName);
         if (f.exists()) {


### PR DESCRIPTION
Audio files captured using the built-in audio capture widget were getting saved as mp40, which meant they weren't getting uploaded to CommCare HQ.