### PR TITLE
Use username in last sync date key

### DIFF
--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -28,6 +28,7 @@ import org.commcare.services.CommCareSessionService;
 import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.utils.FormSaveUtil;
 import org.commcare.utils.SessionUnavailableException;
+import org.commcare.utils.SyncDetailCalculations;
 import org.commcare.utils.UnknownSyncError;
 import org.commcare.core.network.bitcache.BitCache;
 import org.commcare.xml.AndroidTransactionParserFactory;
@@ -460,7 +461,7 @@ public abstract class DataPullTask<R>
 
     private static void recordSuccessfulSyncTime() {
         CommCareApplication.instance().getCurrentApp().getAppPreferences().edit()
-                .putLong("last-succesful-sync", new Date().getTime()).commit();
+                .putLong(SyncDetailCalculations.getLastSyncKey(), new Date().getTime()).commit();
     }
 
     //TODO: This and the normal sync share a ton of code. It's hard to really... figure out the right way to 

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -26,7 +26,7 @@ import java.util.Date;
 public class SyncDetailCalculations {
     private final static String UNSENT_FORM_NUMBER_KEY = "unsent-number-limit";
     private final static String UNSENT_FORM_TIME_KEY = "unsent-time-limit";
-    public final static String LAST_SYNC_KEY_BASE = "last-succesful-sync-";
+    private final static String LAST_SYNC_KEY_BASE = "last-succesful-sync-";
 
     public static void updateSubText(final StandardHomeActivity activity,
                                      SquareButtonViewHolder squareButtonViewHolder,

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -26,6 +26,7 @@ import java.util.Date;
 public class SyncDetailCalculations {
     private final static String UNSENT_FORM_NUMBER_KEY = "unsent-number-limit";
     private final static String UNSENT_FORM_TIME_KEY = "unsent-time-limit";
+    public final static String LAST_SYNC_KEY_BASE = "last-succesful-sync-";
 
     public static void updateSubText(final StandardHomeActivity activity,
                                      SquareButtonViewHolder squareButtonViewHolder,
@@ -61,13 +62,17 @@ public class SyncDetailCalculations {
     public static Pair<Long, String> getLastSyncTimeAndMessage() {
         CharSequence syncTimeMessage;
         SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        long lastSyncTime = prefs.getLong("last-succesful-sync", 0);
+        long lastSyncTime = prefs.getLong(getLastSyncKey(), 0);
         if (lastSyncTime == 0) {
             syncTimeMessage = Localization.get("home.sync.message.last.never");
         } else {
             syncTimeMessage = DateUtils.formatSameDayTime(lastSyncTime, new Date().getTime(), DateFormat.DEFAULT, DateFormat.DEFAULT);
         }
         return new Pair<>(lastSyncTime, Localization.get("home.sync.message.last", new String[]{syncTimeMessage.toString()}));
+    }
+
+    public static String getLastSyncKey() {
+        return LAST_SYNC_KEY_BASE + CommCareApplication.instance().getCurrentUserId();
     }
 
     private static void setSyncSubtextColor(TextView subtext, int numUnsentForms, long lastSyncTime,


### PR DESCRIPTION
If you login with user `a`, sync, logout, login with user `b`, then the last sync time for user `a` is shown. This PR fixes that by adding the userid into the storage key for the last sync time.

Note, when this change is released, everyone's last sync time will be lost, defaulting to a "you've never synced" message. A simple sync should get things back to normal.