### PR TITLE
Add ledger parsing logic and tests to Android code

### DIFF
--- a/unit-tests/src/org/commcare/android/tests/queries/CaseDbQueryTest.java
+++ b/unit-tests/src/org/commcare/android/tests/queries/CaseDbQueryTest.java
@@ -34,7 +34,7 @@ public class CaseDbQueryTest {
     public void testBasicCaseQueries() {
         TestUtils.processResourceTransaction("/inputs/case_create.xml");
 
-        EvaluationContext ec = TestUtils.getInstanceBackedEvaluationContext();
+        EvaluationContext ec = TestUtils.getEvaluationContextWithoutSession();
 
         evaluate("count(instance('casedb')/casedb/case[@case_id = 'test_case_id'])", "1", ec);
         evaluate("instance('casedb')/casedb/case[@case_id = 'test_case_id']/case_name", "Test Case", ec);
@@ -51,7 +51,7 @@ public class CaseDbQueryTest {
         TestUtils.processResourceTransaction("/inputs/case_create.xml");
         TestUtils.processResourceTransaction("/inputs/case_create_and_index.xml");
 
-        EvaluationContext ec = TestUtils.getInstanceBackedEvaluationContext();
+        EvaluationContext ec = TestUtils.getEvaluationContextWithoutSession();
 
         evaluate("instance('casedb')/casedb/case[@case_id = 'test_case_id_child']/index/parent", "test_case_id", ec);
         evaluate("instance('casedb')/casedb/case[@case_id = 'test_case_id']/index/missing", "", ec);
@@ -67,7 +67,7 @@ public class CaseDbQueryTest {
     @Test
     public void testCaseOptimizationTriggers() {
         TestUtils.processResourceTransaction("/inputs/case_test_db_optimizations.xml");
-        EvaluationContext ec = TestUtils.getInstanceBackedEvaluationContext();
+        EvaluationContext ec = TestUtils.getEvaluationContextWithoutSession();
 
         evaluate("join(',',instance('casedb')/casedb/case[index/parent = 'test_case_parent']/@case_id)", "child_one,child_two,child_three", ec);
         evaluate("join(',',instance('casedb')/casedb/case[index/parent = 'test_case_parent'][@case_id = 'child_two']/@case_id)", "child_two", ec);

--- a/unit-tests/src/org/commcare/android/tests/queries/LedgerDbQueryTest.java
+++ b/unit-tests/src/org/commcare/android/tests/queries/LedgerDbQueryTest.java
@@ -1,0 +1,56 @@
+package org.commcare.android.tests.queries;
+
+import org.commcare.CommCareApplication;
+import org.commcare.android.CommCareTestRunner;
+import org.commcare.android.util.TestUtils;
+import org.commcare.test.utilities.CaseTestUtils;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Ledger queries at the Android level. Pretty much identical to
+ * 'LedgerAndCaseQueryTest' in commcare-core; duplicated here to
+ * up code coverage of Android specific logic.
+ *
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+@Config(application = CommCareApplication.class)
+@RunWith(CommCareTestRunner.class)
+public class LedgerDbQueryTest {
+
+    @Before
+    public void setUp() throws Exception {
+        TestUtils.initializeStaticTestStorage();
+
+        TestUtils.processResourceTransaction("/create_case_for_ledger.xml");
+        TestUtils.processResourceTransaction("/ledger_create_basic.xml");
+    }
+
+    @Test
+    public void ledgerQueriesWithLedgerData() throws XPathSyntaxException {
+        EvaluationContext evalContext = TestUtils.getEvaluationContextWithoutSession();
+
+        // case id 'market_basket' exists, and ledger data has been attached it
+        assertTrue(
+                CaseTestUtils.xpathEvalAndCompare(evalContext,
+                        "instance('ledger')/ledgerdb/ledger[@entity-id='market_basket']/section[@section-id='edible_stock']/entry[@id='rice']",
+                        10.0));
+        // Reference valid case but invalid section id
+        assertTrue(
+                CaseTestUtils.xpathEvalAndCompare(evalContext,
+                        "instance('ledger')/ledgerdb/ledger[@entity-id='market_basket']/section[@section-id='non-existent-section']",
+                        ""));
+        // case id 'ocean_state_job_lot' doesn't exists, but the ledger data
+        // corresponding to it does
+        assertTrue(
+                CaseTestUtils.xpathEvalAndCompare(evalContext,
+                        "instance('ledger')/ledgerdb/ledger[@entity-id='ocean_state_job_lot']/section[@section-id='cleaning_stock']/entry[@id='soap']",
+                        9.0));
+    }
+}

--- a/unit-tests/src/org/commcare/android/util/TestUtils.java
+++ b/unit-tests/src/org/commcare/android/util/TestUtils.java
@@ -4,10 +4,12 @@ import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.CommCareApplication;
 import org.commcare.CommCareTestApplication;
+import org.commcare.cases.ledger.Ledger;
 import org.commcare.data.xml.DataModelPullParser;
 import org.commcare.data.xml.TransactionParser;
 import org.commcare.data.xml.TransactionParserFactory;
 import org.commcare.engine.cases.AndroidCaseInstanceTreeElement;
+import org.commcare.engine.cases.AndroidLedgerInstanceTreeElement;
 import org.commcare.models.AndroidClassHasher;
 import org.commcare.models.database.ConcreteAndroidDbHelper;
 import org.commcare.models.database.AndroidPrototypeFactorySetup;
@@ -16,6 +18,7 @@ import org.commcare.models.database.user.DatabaseUserOpenHelper;
 import org.commcare.android.database.user.models.ACase;
 import org.commcare.models.database.user.models.CaseIndexTable;
 import org.commcare.models.database.user.models.EntityStorageCache;
+import org.commcare.test.utilities.CaseTestUtils;
 import org.commcare.utils.AndroidInstanceInitializer;
 import org.commcare.utils.FormSaveUtil;
 import org.commcare.utils.GlobalConstants;
@@ -23,6 +26,7 @@ import org.commcare.xml.AndroidCaseXmlParser;
 import org.commcare.xml.AndroidTransactionParserFactory;
 import org.commcare.xml.CaseXmlParser;
 import org.commcare.xml.FormInstanceXmlParser;
+import org.commcare.xml.LedgerXmlParsers;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
@@ -90,12 +94,12 @@ public class TestUtils {
                             return db;
                         }
                     };
-                } 
+                }  else if (LedgerXmlParsers.STOCK_XML_NAMESPACE.equals(namespace)) {
+                    return new LedgerXmlParsers(parser, getLedgerStorage(db));
+                }
                 return null;
             }
-            
         };
-        
     }
 
     /**
@@ -177,22 +181,29 @@ public class TestUtils {
      * @return The case storage object for the provided db
      */
     private static SqlStorage<ACase> getCaseStorage(SQLiteDatabase db) {
-
             return new SqlStorage<>(ACase.STORAGE_KEY, ACase.class, new ConcreteAndroidDbHelper(RuntimeEnvironment.application, db) {
                 @Override
                 public PrototypeFactory getPrototypeFactory() {
                     return getStaticPrototypeFactory();
                 }
-
             });
     }
-    
+
+    private static SqlStorage<Ledger> getLedgerStorage(SQLiteDatabase db) {
+        return new SqlStorage<>(Ledger.STORAGE_KEY, Ledger.class, new ConcreteAndroidDbHelper(RuntimeEnvironment.application, db) {
+            @Override
+            public PrototypeFactory getPrototypeFactory() {
+                return getStaticPrototypeFactory();
+            }
+        });
+    }
+
     //TODO: Make this work natively with the CommCare Android IIF
     /**
      * @return An evaluation context which is capable of evaluating against
      * the connected storage instances: casedb is the only one supported for now
      */
-    public static EvaluationContext getInstanceBackedEvaluationContext() {
+    public static EvaluationContext getEvaluationContextWithoutSession() {
         final SQLiteDatabase db = getTestDb();
         
         AndroidInstanceInitializer iif = new AndroidInstanceInitializer() {
@@ -203,25 +214,32 @@ public class TestUtils {
                 instance.setCacheHost(casebase);
                 return casebase;
             }
+
+            @Override
+            protected AbstractTreeElement setupLedgerData(ExternalDataInstance instance) {
+                SqlStorage<Ledger> storage = getLedgerStorage(db);
+                return new AndroidLedgerInstanceTreeElement(instance.getBase(), storage);
+            }
         };
 
-        ExternalDataInstance edi = new ExternalDataInstance("jr://instance/casedb", "casedb");
-        DataInstance specializedDataInstance = edi.initialize(iif, "casedb");
-        
-        Hashtable<String, DataInstance> formInstances = new Hashtable<>();
-        formInstances.put("casedb", specializedDataInstance);
-        
-        TreeReference dummy = TreeReference.rootRef().extendRef("a", TreeReference.DEFAULT_MUTLIPLICITY);
-        return new EvaluationContext(new EvaluationContext(null), formInstances, dummy);
+        return buildEvaluationContext(iif);
     }
 
     public static EvaluationContext getEvaluationContextWithAndroidIIF() {
         AndroidInstanceInitializer iif = new AndroidInstanceInitializer(CommCareApplication.instance().getCurrentSession());
-        ExternalDataInstance edi = new ExternalDataInstance("jr://instance/casedb", "casedb");
+        return buildEvaluationContext(iif);
+    }
+
+    private static EvaluationContext buildEvaluationContext(AndroidInstanceInitializer iif) {
+        ExternalDataInstance edi = new ExternalDataInstance(CaseTestUtils.CASE_INSTANCE, "casedb");
         DataInstance specializedDataInstance = edi.initialize(iif, "casedb");
+
+        ExternalDataInstance ledgerDataInstanceRaw = new ExternalDataInstance(CaseTestUtils.LEDGER_INSTANCE, "ledgerdb");
+        DataInstance ledgerDataInstance = ledgerDataInstanceRaw.initialize(iif, "ledger");
 
         Hashtable<String, DataInstance> formInstances = new Hashtable<>();
         formInstances.put("casedb", specializedDataInstance);
+        formInstances.put("ledger", ledgerDataInstance);
 
         TreeReference dummy = TreeReference.rootRef().extendRef("a", TreeReference.DEFAULT_MUTLIPLICITY);
         return new EvaluationContext(new EvaluationContext(null), formInstances, dummy);


### PR DESCRIPTION
Allow for Android-specific ledger code to be tested. Bumps code coverage of `StorageBackedTreeRoot.tryBatchChildFetch`