### PR TITLE
Calendar Style Update

### DIFF
--- a/app/res/layout/entity_select_layout.xml
+++ b/app/res/layout/entity_select_layout.xml
@@ -81,7 +81,7 @@
             android:listSelector="@drawable/selector"
             android:drawSelectorOnTop="true"
             android:visibility="gone"
-            android:background="@color/black"
+            android:background="@color/cc_light_warm_accent_text"
             android:horizontalSpacing="1dp"
             android:verticalSpacing="1dp"
             android:padding="1dp"/>

--- a/app/res/layout/entity_select_layout.xml
+++ b/app/res/layout/entity_select_layout.xml
@@ -83,7 +83,8 @@
             android:visibility="gone"
             android:background="@color/black"
             android:horizontalSpacing="1dp"
-            android:verticalSpacing="1dp"/>
+            android:verticalSpacing="1dp"
+            android:padding="1dp"/>
 
         <include layout="@layout/component_drop_shadow"/>
     </FrameLayout>

--- a/app/src/org/commcare/utils/MarkupUtil.java
+++ b/app/src/org/commcare/utils/MarkupUtil.java
@@ -5,17 +5,36 @@ import android.os.Build;
 import android.text.Html;
 import android.text.Spannable;
 import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
+import android.text.style.UnderlineSpan;
 
 import net.nightwhistler.htmlspanner.HtmlSpanner;
+import net.nightwhistler.htmlspanner.SpanStack;
+import net.nightwhistler.htmlspanner.TagNodeHandler;
 
 import org.commcare.CommCareApplication;
 import org.commcare.preferences.DeveloperPreferences;
+import org.htmlcleaner.TagNode;
 import org.javarosa.core.services.locale.Localization;
 
 import in.uncod.android.bypass.Bypass;
 
 public class MarkupUtil {
-    private static final HtmlSpanner htmlspanner = new HtmlSpanner();
+
+    public static class UnderlineHandler extends TagNodeHandler {
+
+        @Override
+        public void handleTagNode(TagNode node, SpannableStringBuilder builder,
+                                  int start, int end, SpanStack spanStack) {
+            spanStack.pushSpan(new UnderlineSpan(), start, end);
+        }
+    }
+
+    private static final HtmlSpanner htmlspanner = new HtmlSpanner() {
+        {
+            this.registerHandler("u", new UnderlineHandler());
+        }
+    };
 
     public static Spannable styleSpannable(Context c, String message) {
         if (DeveloperPreferences.isMarkdownEnabled()) {


### PR DESCRIPTION
Minor tweak to make calendar (grid) entity views be fully framed by the border to improve aesthetics in portrait mode.

Also enabled underlined text, and shifted the background color to match the "Accent" color of text to minimize the number of potentially distracting colors on the screen.

Updated Styles:
![calenadr_border](https://cloud.githubusercontent.com/assets/155066/20633629/e11ebc14-b316-11e6-913a-3dabb054794b.png)
