### PR TITLE
Change misleading method name

### DIFF
--- a/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
+++ b/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
@@ -146,7 +146,7 @@ public class CommCareAudioWidget extends AudioWidget
     }
 
     @Override
-    public String getFileExtension() {
+    public String getFileUniqueIdentifier() {
         return questionIndexText;
     }
 

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -63,7 +63,7 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
         prepareButtons();
         prepareText();
         setWindowSize();
-        fileName = Environment.getExternalStorageDirectory().getAbsolutePath() + FILE_EXT + listener.getFileExtension();
+        fileName = Environment.getExternalStorageDirectory().getAbsolutePath() + FILE_EXT + listener.getFileUniqueIdentifier();
 
         File f = new File(fileName);
         if (f.exists()) {
@@ -235,7 +235,7 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
     public interface RecordingCompletionListener {
         void onRecordingCompletion();
 
-        String getFileExtension();
+        String getFileUniqueIdentifier();
     }
 
     public void setListener(RecordingCompletionListener listener) {


### PR DESCRIPTION
As far as I can tell, the only implementation of `getFileExtension()` does not return a file extension, just a unique identifier of sorts, so I'm renaming it to reflect that