### PR TITLE
Remove last vestiges of server-tether setting in Android code

### DIFF
--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -103,7 +103,6 @@ public class SyncDetailCalculations {
         int secs_ago = (int)((lastSyncTime - now) / 1000);
         int days_ago = secs_ago / 86400;
 
-        return ((-days_ago) > unsentFormTimeLimit) &&
-                prefs.getString("server-tether", "push-only").equals("sync");
+        return (-days_ago) > unsentFormTimeLimit;
     }
 }


### PR DESCRIPTION
tl;dr version: Before this is merged, can either @wpride or @ctsims confirm that the Sync Mode setting on HQ (the actual preference key for which is "server-tether") is only intended to be used on java phones?

Full explanation: I recently asked HQ interrupt to move the Auto-Sync Frequency and Unsynced Time Limit settings from Java Phone General Settings into just General Settings, since they are used in Android code. However, those 2 settings are currently coupled with the Sync Mode setting, the actual preference key for which is "server-tether". My understanding from both looking at our code and prior conversations is that the server-tether setting, unlike the other 2, _is_ only intended to be used on java phones. The only place it is referenced in the Android codebase is the line I deleted in this PR, which I believe is just a holdover that got left in by mistake. Assuming this is correct, I will have HQ decouple this setting from the other 2 so that Sync Mode can stay in the java-only settings menu, but the other 2 can move to the general settings menu.

(Also worth noting that the only thing the "server-tether" setting is controlling here is whether or not we turn the sync button subtext red).

cc @orangejenny 