### PR TITLE
Don't show breadcrumb bar in app manager 

### DIFF
--- a/app/src/org/commcare/activities/AppManagerActivity.java
+++ b/app/src/org/commcare/activities/AppManagerActivity.java
@@ -18,7 +18,6 @@ import org.commcare.dalvik.R;
 import org.commcare.logging.analytics.GoogleAnalyticsFields;
 import org.commcare.logging.analytics.GoogleAnalyticsUtils;
 import org.commcare.services.CommCareSessionService;
-import org.commcare.utils.MultipleAppsUtil;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.services.locale.Localization;
@@ -189,5 +188,10 @@ public class AppManagerActivity extends CommCareActivity implements OnItemClickL
         d.setPositiveButton(getString(R.string.ok), listener);
         d.setNegativeButton(getString(R.string.cancel), listener);
         showAlertDialog(d);
+    }
+
+    @Override
+    protected boolean shouldShowBreadcrumbBar() {
+        return false;
     }
 }

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -133,7 +133,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
         persistManagedUiState(fm);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && shouldShowBreadcrumbBar()) {
             getActionBar().setDisplayShowCustomEnabled(true);
 
             // Add breadcrumb bar
@@ -817,9 +817,11 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public void refreshActionBar() {
-        FragmentManager fm = this.getSupportFragmentManager();
-        BreadcrumbBarFragment bar = (BreadcrumbBarFragment) fm.findFragmentByTag("breadcrumbs");
-        bar.refresh(this);
+        if (shouldShowBreadcrumbBar()) {
+            FragmentManager fm = this.getSupportFragmentManager();
+            BreadcrumbBarFragment bar = (BreadcrumbBarFragment) fm.findFragmentByTag("breadcrumbs");
+            bar.refresh(this);
+        }
     }
 
     /**
@@ -858,7 +860,11 @@ public abstract class CommCareActivity<R> extends FragmentActivity
         return lastQueryString;
     }
 
-    protected  void setLastQueryString(String lastQueryString) {
+    protected void setLastQueryString(String lastQueryString) {
         this.lastQueryString = lastQueryString;
+    }
+
+    protected boolean shouldShowBreadcrumbBar() {
+        return true;
     }
 }

--- a/app/src/org/commcare/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/activities/SingleAppManagerActivity.java
@@ -350,4 +350,9 @@ public class SingleAppManagerActivity extends CommCareActivity {
         d.setNegativeButton(getString(R.string.cancel), listener);
         showAlertDialog(d);
     }
+
+    @Override
+    protected boolean shouldShowBreadcrumbBar() {
+        return false;
+    }
 }


### PR DESCRIPTION
The breadcrumb bar is out of place / not useful in the app manager because it ends up just showing the title of 1 of the installed apps. Make it so CommCareActivities can request not to show it at all