### PR TITLE
Localize language codes in form entry dialog

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -177,7 +177,6 @@ Some images in CommCare are graciously used under Creative Commons Licensing fro
     <string name="capture_image" cc:translatable="true">Take Picture</string>
     <string name="capture_video" cc:translatable="true">Record Video</string>
     <string name="change_language" cc:translatable="true">Change Language</string>
-    <string name="choose_language" cc:translatable="true">Choose Language</string>
     <string name="clearanswer_confirm" cc:translatable="true">Remove the response to \"%s\"?</string>
     <string name="clear_answer" cc:translatable="true">Remove response</string>
     <string name="clear_answer_ask" cc:translatable="true">Remove This Response?</string>

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -41,6 +41,7 @@ import org.commcare.dalvik.R;
 import org.commcare.interfaces.CommCareActivityUIController;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.logic.AndroidFormController;
+import org.commcare.utils.ChangeLocaleUtil;
 import org.commcare.utils.CompoundIntentList;
 import org.commcare.views.media.MediaLayout;
 import org.commcare.android.javarosa.IntentCallout;
@@ -915,11 +916,12 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
      */
     private void createLanguageDialog() {
         final PaneledChoiceDialog dialog = new PaneledChoiceDialog(this,
-                StringUtils.getStringRobust(this, R.string.choose_language));
+                Localization.get("home.menu.locale.select"));
 
-        final String[] languages = mFormController.getLanguages();
-        DialogChoiceItem[] choiceItems = new DialogChoiceItem[languages.length];
-        for (int i = 0; i < languages.length; i++) {
+        final String[] languageCodes = mFormController.getLanguages();
+        final String[] localizedLanguages = ChangeLocaleUtil.translateLocales(languageCodes);
+        DialogChoiceItem[] choiceItems = new DialogChoiceItem[languageCodes.length];
+        for (int i = 0; i < languageCodes.length; i++) {
             final int index = i;
             View.OnClickListener listener = new View.OnClickListener() {
                 @Override
@@ -927,7 +929,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                     // Update the language in the content provider when selecting a new
                     // language
                     ContentValues values = new ContentValues();
-                    values.put(FormsColumns.LANGUAGE, languages[index]);
+                    values.put(FormsColumns.LANGUAGE, languageCodes[index]);
                     String selection = FormsColumns.FORM_FILE_PATH + "=?";
                     String selectArgs[] = {
                             mFormPath
@@ -935,10 +937,10 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                     int updated =
                             getContentResolver().update(formProviderContentURI, values,
                                     selection, selectArgs);
-                    Log.i(TAG, "Updated language to: " + languages[index] + " in "
+                    Log.i(TAG, "Updated language to: " + languageCodes[index] + " in "
                             + updated + " rows");
 
-                    mFormController.setLanguage(languages[index]);
+                    mFormController.setLanguage(languageCodes[index]);
                     dismissAlertDialog();
                     if (currentPromptIsQuestion()) {
                         saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
@@ -946,17 +948,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                     uiController.refreshView();
                 }
             };
-            choiceItems[i] = new DialogChoiceItem(languages[i], -1, listener);
+            choiceItems[i] = new DialogChoiceItem(localizedLanguages[i], -1, listener);
         }
-
-        dialog.addButton(StringUtils.getStringSpannableRobust(this, R.string.cancel).toString(),
-                new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        dismissAlertDialog();
-                    }
-                }
-        );
 
         dialog.setChoiceItems(choiceItems);
         showAlertDialog(dialog);

--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -5,7 +5,6 @@ import android.os.Build;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.StaggeredGridLayoutManager;
 import android.view.ViewTreeObserver;
-import android.widget.Toast;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;

--- a/app/src/org/commcare/utils/ChangeLocaleUtil.java
+++ b/app/src/org/commcare/utils/ChangeLocaleUtil.java
@@ -18,7 +18,7 @@ public class ChangeLocaleUtil {
         return output;
     }
 
-    private static String[] translateLocales(String[] raw) {
+    public static String[] translateLocales(String[] raw) {
         String[] translated = new String[raw.length];
         for (int i = 0; i < raw.length; i++) {
             try {


### PR DESCRIPTION
Make form entry language selection dialog expand the language name.
So that 
![image](https://cloud.githubusercontent.com/assets/94817/21467064/07e65228-c9c7-11e6-8472-a37d3c22ec04.png)
Now matches 
![image](https://cloud.githubusercontent.com/assets/94817/21467065/0d17b926-c9c7-11e6-82ae-a8eafa8cb29b.png)

Also removed the cancel button from form entry language selection dialog. I can add it people think it is good to keep.

Fix for http://manage.dimagi.com/default.asp?239764

