### PR TITLE
Stop audio button animation on question validation issue

### DIFF
--- a/app/src/org/commcare/views/media/AudioController.java
+++ b/app/src/org/commcare/views/media/AudioController.java
@@ -59,7 +59,7 @@ public enum AudioController {
         currentEntity.getPlayer().setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override
             public void onCompletion(MediaPlayer mediaPlayer) {
-                currentAudioButton.endPlaying();
+                releaseCurrentMediaEntity();
             }
         });
     }
@@ -80,6 +80,9 @@ public enum AudioController {
      * Release current media resources.
      */
     public void releaseCurrentMediaEntity() {
+        if (currentAudioButton != null) {
+            currentAudioButton.endPlaying();
+        }
         if (currentEntity != null) {
             MediaPlayer mp = currentEntity.getPlayer();
             mp.reset();

--- a/app/src/org/commcare/views/media/AudioPlaybackButtonBase.java
+++ b/app/src/org/commcare/views/media/AudioPlaybackButtonBase.java
@@ -109,8 +109,6 @@ public abstract class AudioPlaybackButtonBase extends LinearLayout {
     }
 
     public void endPlaying() {
-        AudioController.INSTANCE.releaseCurrentMediaEntity();
-
         currentState = MediaState.Ready;
         refreshAppearance();
     }


### PR DESCRIPTION
If you swipe forward while audio is playing, the animation continues but the audio stops. Then if you try to resume playback CC crashes.
This PR fixes these issues by stopping the playback and animation.

Fix for http://manage.dimagi.com/default.asp?244503