### PR TITLE
Try SMS install only when on 'install method chooser' menu

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -168,8 +168,12 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         if (!askingForPerms) {
             if (isSingleAppBuild()) {
                 SingleAppInstallation.installSingleApp(this, DIALOG_INSTALL_PROGRESS);
-            } else {
-                // With basic perms satisfied, ask user to allow SMS reading for sms app install code
+            } else if (uiState == UiState.CHOOSE_INSTALL_ENTRY_METHOD) {
+                // Don't perform SMS install if we aren't on base setup state
+                // (i.e. in the middle of an install)
+
+                // With basic perms satisfied, ask user to allow SMS reading
+                // for sms app install code
                 performSMSInstall(false);
             }
         }
@@ -409,14 +413,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         }
     }
 
-    private CommCareApp getCommCareApp() {
-        ApplicationRecord newRecord =
-                new ApplicationRecord(PropertyUtils.genUUID().replace("-", ""),
-                        ApplicationRecord.STATUS_UNINITIALIZED);
-
-        return new CommCareApp(newRecord);
-    }
-
     @Override
     public void startBlockingForTask(int id) {
         super.startBlockingForTask(id);
@@ -498,6 +494,14 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         } else {
             Log.i(TAG, "During install: blocked a resource install press since a task was already running");
         }
+    }
+
+    public static CommCareApp getCommCareApp() {
+        ApplicationRecord newRecord =
+                new ApplicationRecord(PropertyUtils.genUUID().replace("-", ""),
+                        ApplicationRecord.STATUS_UNINITIALIZED);
+
+        return new CommCareApp(newRecord);
     }
 
     @Override

--- a/app/src/org/commcare/android/database/global/models/ApplicationRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ApplicationRecord.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.android.database.global.models;
 
 import org.commcare.android.storage.framework.Persisted;
@@ -18,7 +15,6 @@ import org.javarosa.core.util.NoLocalizedTextException;
  * @author ctsims
  * @author amstone
  */
-
 @Table(ApplicationRecord.STORAGE_KEY)
 public class ApplicationRecord extends Persisted {
 

--- a/app/src/org/commcare/engine/resource/installers/SingleAppInstallation.java
+++ b/app/src/org/commcare/engine/resource/installers/SingleAppInstallation.java
@@ -3,9 +3,7 @@ package org.commcare.engine.resource.installers;
 import org.commcare.CommCareApp;
 import org.commcare.activities.CommCareSetupActivity;
 import org.commcare.engine.resource.AppInstallStatus;
-import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.tasks.ResourceEngineTask;
-import org.javarosa.core.util.PropertyUtils;
 
 /**
  * Install CC app from the APK's asset directory
@@ -22,11 +20,7 @@ public class SingleAppInstallation {
      * without prompting the user.
      */
     public static void installSingleApp(CommCareSetupActivity activity, int dialogId) {
-        ApplicationRecord newRecord =
-                new ApplicationRecord(PropertyUtils.genUUID().replace("-", ""),
-                        ApplicationRecord.STATUS_UNINITIALIZED);
-
-        CommCareApp app = new CommCareApp(newRecord);
+        CommCareApp app = CommCareSetupActivity.getCommCareApp();
 
         ResourceEngineTask<CommCareSetupActivity> task =
                 new ResourceEngineTask<CommCareSetupActivity>(app, dialogId, false) {


### PR DESCRIPTION
SMS install was running whenever you rotated the device, even if you were in the middle of another install. This was causing the install progress dialog to disappear.

Fix for http://manage.dimagi.com/default.asp?244434