### PR TITLE
Prevent hint text from getting cut off in conditionally-visible questions in a question list

### DIFF
--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -227,9 +227,19 @@ public class QuestionsView extends ScrollView
         int newHeight = MeasureSpec.getSize(heightMeasureSpec);
         int oldHeight = this.getMeasuredHeight();
         
-        if(oldHeight == 0 || Math.abs(((newHeight * 1.0 - oldHeight) / oldHeight)) > .2) {
-            for(QuestionWidget qw : this.widgets) { 
+        if (oldHeight == 0 || Math.abs(((newHeight * 1.0 - oldHeight) / oldHeight)) > .2) {
+            // Update the frame size and hint height based on the new height
+            for (QuestionWidget qw : this.widgets) {
                 qw.updateFrameSize(newHeight);
+                qw.updateHintHeight(newHeight/4);
+            }
+        } else {
+            // Check to see if any of our QuestionWidgets have a hint text that was initially
+            // displayed without proper height spec information
+            for (QuestionWidget qw : this.widgets) {
+                if (qw.hintTextNeedsHeightSpec) {
+                    qw.updateHintHeight(newHeight/4);
+                }
             }
         }
         

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -83,6 +83,8 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
     protected WidgetChangedListener widgetChangedListener;
     protected BlockingActionsManager blockingActionsManager;
 
+    public boolean hintTextNeedsHeightSpec = false;
+
     public QuestionWidget(Context context, FormEntryPrompt p) {
         super(context);
         mPrompt = p;
@@ -547,11 +549,14 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
     }
 
     public void updateFrameSize(int height) {
-        int maxHintHeight = height / 4;
-        if(mHintText != null) {
+        mFrameHeight = height;
+    }
+
+    public void updateHintHeight(int maxHintHeight) {
+        if (mHintText != null) {
             mHintText.updateMaxHeight(maxHintHeight);
         }
-        mFrameHeight = height;
+        hintTextNeedsHeightSpec = false;
     }
 
     /**
@@ -574,7 +579,12 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
     }
 
     private int getMaxHintHeight() {
-        return -1;
+        if (mFrameHeight != -1) {
+            return mFrameHeight / 4;
+        } else {
+            hintTextNeedsHeightSpec = true;
+            return -1;
+        }
     }
 
     /**


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?243134. The issue is a little convoluted and I'm still a little vague on some of the details, but boils down to:
-The hint text for questions is always shown as a `ShrinkingTextView`
-Normally, when hint text is added to a question, `updateMaxHeight()` for the `ShrinkingTextView` is called twice in quick succession: first by the `ShrinkingTextView` constructor with a parameter of `-1` which doesn't do anything meaningful/useful, and then again when the `QuestionsView.onMeasure()` method is called and triggers an update to the hint height for each QuestionWidget it contains, passing a fraction of the newly measured height as the maxHeight.
-The problem comes up _only_ when a question that contains hint text is in a question list _and_ has a display condition that means it may appear based on the answer to another question. In this case, when the new `QuestionWidget` is created for the conditionally-visible question, the second call to `updateMaxHeight()` never happens, because it doesn't deem there to be any old height to "update" from (since it's a new QuestionWidget for which `onMeasure() has never been called before).

**The solution I went with** is to keep track of when a hint text view is created before the proper maxHeight spec is available, and then add logic to `onMeasure()` for checking if this happened and updating the hint text height if so.

Notes:

- All of the changes in `ShrinkingTextView` are just variable renames, to try to make things a little clearer. The functional changes are in `QuestionsView` and `QuestionWidget`.
- There may be a cleaner way of fixing this by making the `ShrinkingTextView.updateMaxHeight()` method behave better with an input of `-1`, but I was having a lot of trouble understanding the details of that method, so I didn't feel comfortable trying to do that.