### PR TITLE
Accuracy string fix

### DIFF
--- a/app/src/org/commcare/activities/GeoPointActivity.java
+++ b/app/src/org/commcare/activities/GeoPointActivity.java
@@ -25,6 +25,7 @@ import org.commcare.utils.StringUtils;
 import org.commcare.views.dialogs.GeoProgressDialog;
 
 import java.text.DecimalFormat;
+import java.util.Arrays;
 import java.util.Set;
 
 /**
@@ -169,9 +170,9 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
     public void onLocationChanged(Location location) {
         this.location = location;
         if (this.location != null) {
-            String[] args = {this.location.getProvider(), truncateDouble(this.location.getAccuracy())};
+            String accuracy = truncateDouble(this.location.getAccuracy());
             locationDialog.setMessage(StringUtils.getStringRobust(this,
-                    R.string.location_provider_accuracy, args));
+                    R.string.location_provider_accuracy, accuracy));
 
             // If location is accurate, we're done
             if (this.location.getAccuracy() <= CommCarePreferences.getGpsWidgetGoodAccuracy()) {

--- a/app/src/org/commcare/activities/GeoPointActivity.java
+++ b/app/src/org/commcare/activities/GeoPointActivity.java
@@ -20,12 +20,11 @@ import org.commcare.dalvik.R;
 import org.commcare.interfaces.TimerListener;
 import org.commcare.preferences.CommCarePreferences;
 import org.commcare.utils.GeoUtils;
-import org.commcare.utils.TimeoutTimer;
 import org.commcare.utils.StringUtils;
+import org.commcare.utils.TimeoutTimer;
 import org.commcare.views.dialogs.GeoProgressDialog;
 
 import java.text.DecimalFormat;
-import java.util.Arrays;
 import java.util.Set;
 
 /**


### PR DESCRIPTION
Fixes http://manage.dimagi.com/default.asp?246312

We were including the location provider in the args even though this wasn't expected in the translation string

I'm not clear from git blame where this got introduced - as far as I can tell neither the translation string nor this line have changed since 2.32. Very odd. 