### PR TITLE
Query Planner

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     }
     compile 'org.apache.httpcomponents:httpclient-android:4.3.5.1'
     compile 'net.sourceforge.htmlcleaner:htmlcleaner:2.16'
+    compile 'com.carrotsearch:hppc:0.7.2'
 }
 
 ext {

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -100,6 +100,13 @@
         android:key="cc-use-root-menu-as-home-screen"
         android:title="Use root module menu as home screen"/>
     <ListPreference
+        android:defaultValue="no"
+        android:enabled="true"
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
+        android:key="cc-show-entity-trace-outputs"
+        android:title="Output Entity List Trace Data to ADB"/>
+    <ListPreference
         android:enabled="true"
         android:defaultValue="no"
         android:entries="@array/pref_enabled_labels"

--- a/app/src/org/commcare/engine/cases/AndroidCaseInstanceTreeElement.java
+++ b/app/src/org/commcare/engine/cases/AndroidCaseInstanceTreeElement.java
@@ -112,6 +112,7 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
         String[] valuesToMatch = new String[numKeys];
 
         String cacheKey = "";
+        String keyDescription ="";
 
         for (int i = numKeys - 1; i >= 0; i--) {
             namesToMatch[i] = profiles.elementAt(i).getKey();
@@ -119,6 +120,7 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
                     (((IndexedValueLookup)profiles.elementAt(i)).value);
 
             cacheKey += "|" + namesToMatch[i] + "=" + valuesToMatch[i];
+            keyDescription = namesToMatch[i] + "|";
         }
         mMostRecentBatchFetch = new String[2][];
         mMostRecentBatchFetch[0] = namesToMatch;
@@ -128,7 +130,13 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
         if(mPairedIndexCache.containsKey(cacheKey)) {
             ids = mPairedIndexCache.get(cacheKey);
         } else {
+            EvaluationTrace trace = new EvaluationTrace("Case Storage Lookup" + "["+keyDescription + "]");
             ids = sqlStorage.getIDsForValues(namesToMatch, valuesToMatch);
+
+            trace.setOutcome("Results: " + ids.size());
+            queryPlanner.reportTrace(trace);
+
+
             mPairedIndexCache.put(cacheKey, ids);
         }
 

--- a/app/src/org/commcare/engine/cases/AndroidLedgerInstanceTreeElement.java
+++ b/app/src/org/commcare/engine/cases/AndroidLedgerInstanceTreeElement.java
@@ -2,6 +2,10 @@ package org.commcare.engine.cases;
 
 import org.commcare.cases.ledger.Ledger;
 import org.commcare.cases.instance.LedgerInstanceTreeElement;
+import org.commcare.cases.util.IndexedValueLookup;
+import org.commcare.cases.util.PredicateProfile;
+import org.commcare.cases.util.QueryUtils;
+import org.commcare.cases.util.StaticLookupQueryHandler;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.SqlStorageIterator;
 import org.commcare.android.database.user.models.ACase;
@@ -22,15 +26,21 @@ public class AndroidLedgerInstanceTreeElement extends LedgerInstanceTreeElement 
     public AndroidLedgerInstanceTreeElement(AbstractTreeElement instanceRoot, SqlStorage<Ledger> storage) {
         super(instanceRoot, storage);
         primaryIdMapping = null;
+        addStaticQueryHandler();
     }
 
-    @Override
-    protected Hashtable<String, Integer> getKeyMapping(String keyId) {
-        if (keyId.equals(Ledger.INDEX_ENTITY_ID) && primaryIdMapping != null) {
-            return primaryIdMapping;
-        } else {
-            return null;
-        }
+    private void addStaticQueryHandler() {
+        this.getQueryPlanner().addQueryHandler(new StaticLookupQueryHandler() {
+            @Override
+            protected boolean canHandle(String attributeName) {
+                return attributeName.equals(Ledger.INDEX_ENTITY_ID) && primaryIdMapping != null;
+            }
+
+            @Override
+            protected Vector<Integer> getMatches(String attributeName, String valueToMatch) {
+                return QueryUtils.wrapSingleResult(primaryIdMapping.get(valueToMatch));
+            }
+        });
     }
 
     @Override

--- a/app/src/org/commcare/engine/cases/AndroidLedgerInstanceTreeElement.java
+++ b/app/src/org/commcare/engine/cases/AndroidLedgerInstanceTreeElement.java
@@ -2,10 +2,8 @@ package org.commcare.engine.cases;
 
 import org.commcare.cases.ledger.Ledger;
 import org.commcare.cases.instance.LedgerInstanceTreeElement;
-import org.commcare.cases.util.IndexedValueLookup;
-import org.commcare.cases.util.PredicateProfile;
 import org.commcare.cases.util.QueryUtils;
-import org.commcare.cases.util.StaticLookupQueryHandler;
+import org.commcare.cases.query.handlers.StaticLookupQueryHandler;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.SqlStorageIterator;
 import org.commcare.android.database.user.models.ACase;

--- a/app/src/org/commcare/engine/cases/CaseGroupResultCache.java
+++ b/app/src/org/commcare/engine/cases/CaseGroupResultCache.java
@@ -23,12 +23,12 @@ import java.util.Vector;
 
 public class CaseGroupResultCache implements QueryCacheEntry {
 
-    HashMap<String,IntSet> bulkFetchBodies = new HashMap<>();
+    HashMap<String,LinkedHashSet<Integer>> bulkFetchBodies = new HashMap<>();
 
-    IntObjectMap<Case> cachedCases = new IntObjectHashMap<>();
+    HashMap<Integer, Case> cachedCases = new HashMap<>();
 
 
-    public void reportBulkCaseBody(String key, IntSet ids) {
+    public void reportBulkCaseBody(String key, LinkedHashSet<Integer> ids) {
         if(bulkFetchBodies.containsKey(key)) {
             return;
         }
@@ -45,8 +45,8 @@ public class CaseGroupResultCache implements QueryCacheEntry {
         return false;
     }
 
-    public IntSet getTranche(int recordId) {
-        for(IntSet tranche: bulkFetchBodies.values()) {
+    public LinkedHashSet<Integer> getTranche(int recordId) {
+        for(LinkedHashSet<Integer> tranche: bulkFetchBodies.values()) {
             if(tranche.contains(recordId)){
                 return tranche;
             }
@@ -58,7 +58,7 @@ public class CaseGroupResultCache implements QueryCacheEntry {
         return cachedCases.containsKey(recordId);
     }
 
-    public IntObjectMap<Case> getLoadedCaseMap() {
+    public HashMap<Integer, Case> getLoadedCaseMap() {
         return cachedCases;
     }
 

--- a/app/src/org/commcare/engine/cases/CaseGroupResultCache.java
+++ b/app/src/org/commcare/engine/cases/CaseGroupResultCache.java
@@ -1,0 +1,68 @@
+package org.commcare.engine.cases;
+
+import android.util.SparseArray;
+
+import com.carrotsearch.hppc.IntHashSet;
+import com.carrotsearch.hppc.IntObjectHashMap;
+import com.carrotsearch.hppc.IntObjectMap;
+import com.carrotsearch.hppc.IntSet;
+
+import org.commcare.cases.model.Case;
+import org.commcare.cases.query.QueryCache;
+import org.commcare.cases.query.QueryCacheEntry;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Vector;
+
+/**
+ * Created by ctsims on 1/25/2017.
+ */
+
+public class CaseGroupResultCache implements QueryCacheEntry {
+
+    HashMap<String,IntSet> bulkFetchBodies = new HashMap<>();
+
+    IntObjectMap<Case> cachedCases = new IntObjectHashMap<>();
+
+
+    public void reportBulkCaseBody(String key, IntSet ids) {
+        if(bulkFetchBodies.containsKey(key)) {
+            return;
+        }
+        bulkFetchBodies.put(key, ids);
+    }
+
+    public boolean hasMatchingCaseSet(int recordId) {
+        if(isLoaded(recordId)) {
+            return true;
+        }
+        if(getTranche(recordId) != null) {
+            return true;
+        }
+        return false;
+    }
+
+    public IntSet getTranche(int recordId) {
+        for(IntSet tranche: bulkFetchBodies.values()) {
+            if(tranche.contains(recordId)){
+                return tranche;
+            }
+        }
+        return null;
+    }
+
+    public boolean isLoaded(int recordId) {
+        return cachedCases.containsKey(recordId);
+    }
+
+    public IntObjectMap<Case> getLoadedCaseMap() {
+        return cachedCases;
+    }
+
+    public Case getLoadedCase(int recordId) {
+        return cachedCases.get(recordId);
+    }
+}

--- a/app/src/org/commcare/engine/cases/CaseIndexPrefetchHandler.java
+++ b/app/src/org/commcare/engine/cases/CaseIndexPrefetchHandler.java
@@ -1,0 +1,75 @@
+package org.commcare.engine.cases;
+
+import org.commcare.cases.model.Case;
+import org.commcare.cases.query.IndexedValueLookup;
+import org.commcare.cases.query.PredicateProfile;
+import org.commcare.cases.query.QueryCacheEntry;
+import org.commcare.cases.query.QueryContext;
+import org.commcare.cases.query.QueryHandler;
+import org.commcare.cases.query.QueryPlanner;
+import org.commcare.cases.util.QueryUtils;
+import org.commcare.models.database.user.models.CaseIndexTable;
+import org.javarosa.core.model.trace.EvaluationTrace;
+
+import java.util.HashMap;
+import java.util.Vector;
+
+/**
+ * This handler detects contexts in which the query is likely to trip many index lookups and will
+ * strategically perform a cache of relevant indexes
+ *
+ * Created by ctsims on 1/25/2017.
+ */
+
+public class CaseIndexPrefetchHandler implements QueryHandler<IndexedValueLookup> {
+
+    private final CaseIndexTable mCaseIndexTable;
+
+    public static final class Cache implements QueryCacheEntry {
+        Vector<String> currentlyFetchedIndexKeys = new Vector<>();
+        private HashMap<String, Vector<Integer>> indexCache = new HashMap<>();
+    }
+
+    public CaseIndexPrefetchHandler(CaseIndexTable caseIndexTable) {
+        this.mCaseIndexTable = caseIndexTable;
+    }
+
+    @Override
+    public int getExpectedRuntime() {
+        return 1;
+    }
+
+    @Override
+    public IndexedValueLookup profileHandledQuerySet(Vector<PredicateProfile> profiles) {
+        IndexedValueLookup ret = QueryUtils.getFirstKeyIndexedValue(profiles);
+        if(ret != null){
+            if (ret.getKey().startsWith(Case.INDEX_CASE_INDEX_PRE)) {
+                return ret;
+            }
+        }
+        return null;
+
+    }
+
+    @Override
+    public Vector<Integer> loadProfileMatches(IndexedValueLookup querySet, QueryContext context) {
+        String indexName = querySet.getKey().substring(Case.INDEX_CASE_INDEX_PRE.length());
+        String value = (String)querySet.value;
+
+        Cache cache = context.getQueryCache(Cache.class);
+        if(!cache.currentlyFetchedIndexKeys.contains(indexName)) {
+            EvaluationTrace trace = new EvaluationTrace("Index Bulk Prefetch [" + indexName + "]");
+            mCaseIndexTable.loadIntoIndexTable(cache.indexCache, indexName);
+            trace.setOutcome("");
+            context.reportTrace(trace);
+            cache.currentlyFetchedIndexKeys.add(indexName);
+        }
+        String cacheKey = indexName + "|" + value;
+        return cache.indexCache.get(cacheKey);
+    }
+
+    @Override
+    public void updateProfiles(IndexedValueLookup querySet, Vector<PredicateProfile> profiles) {
+        profiles.remove(querySet);
+    }
+}

--- a/app/src/org/commcare/engine/cases/query/CaseIndexPrefetchHandler.java
+++ b/app/src/org/commcare/engine/cases/query/CaseIndexPrefetchHandler.java
@@ -11,6 +11,7 @@ import org.commcare.models.database.user.models.CaseIndexTable;
 import org.javarosa.core.model.trace.EvaluationTrace;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Vector;
 
 /**
@@ -57,7 +58,7 @@ public class CaseIndexPrefetchHandler implements QueryHandler<IndexedValueLookup
     }
 
     @Override
-    public Vector<Integer> loadProfileMatches(IndexedValueLookup querySet, QueryContext context) {
+    public List<Integer> loadProfileMatches(IndexedValueLookup querySet, QueryContext context) {
         String indexName = querySet.getKey().substring(Case.INDEX_CASE_INDEX_PRE.length());
         String value = (String)querySet.value;
 

--- a/app/src/org/commcare/engine/cases/query/CaseIndexPrefetchHandler.java
+++ b/app/src/org/commcare/engine/cases/query/CaseIndexPrefetchHandler.java
@@ -1,4 +1,4 @@
-package org.commcare.engine.cases;
+package org.commcare.engine.cases.query;
 
 import org.commcare.cases.model.Case;
 import org.commcare.cases.query.IndexedValueLookup;

--- a/app/src/org/commcare/engine/cases/query/CaseIndexPrefetchHandler.java
+++ b/app/src/org/commcare/engine/cases/query/CaseIndexPrefetchHandler.java
@@ -68,8 +68,8 @@ public class CaseIndexPrefetchHandler implements QueryHandler<IndexedValueLookup
             }
 
             EvaluationTrace trace = new EvaluationTrace("Index Bulk Prefetch [" + indexName + "]");
-            mCaseIndexTable.loadIntoIndexTable(cache.indexCache, indexName);
-            trace.setOutcome("");
+            int indexFetchSize = mCaseIndexTable.loadIntoIndexTable(cache.indexCache, indexName);
+            trace.setOutcome("Loaded: " + indexFetchSize);
             context.reportTrace(trace);
             cache.currentlyFetchedIndexKeys.add(indexName);
         }

--- a/app/src/org/commcare/models/database/AndroidTableBuilder.java
+++ b/app/src/org/commcare/models/database/AndroidTableBuilder.java
@@ -2,6 +2,9 @@ package org.commcare.models.database;
 
 import android.util.Pair;
 
+import com.carrotsearch.hppc.IntCollection;
+import com.carrotsearch.hppc.cursors.IntCursor;
+
 import org.commcare.models.framework.Table;
 import org.commcare.modern.database.TableBuilder;
 
@@ -68,4 +71,45 @@ public class AndroidTableBuilder extends TableBuilder {
         }
         return ops;
     }
+
+    public static List<Pair<String, String[]>> sqlList(IntCollection input) {
+        return sqlList(input, MAX_SQL_ARGS);
+    }
+
+    /**
+     * Given a list of integer params to insert and a maximum number of args, return the
+     * String containing (?, ?,...) to be used in the SQL query and the array of args
+     * to replace them with
+     */
+    private static List<Pair<String, String[]>> sqlList(IntCollection input, int maxArgs) {
+
+        List<Pair<String, String[]>> ops = new ArrayList<>();
+
+        //figure out how many iterations we'll need
+        int numIterations = (int)Math.ceil(((double)input.size()) / maxArgs);
+
+        Iterator<IntCursor> iterator = input.iterator();
+
+        for (int currentRound = 0; currentRound < numIterations; ++currentRound) {
+
+            int startPoint = currentRound * maxArgs;
+            int lastIndex = Math.min((currentRound + 1) * maxArgs, input.size());
+            StringBuilder stringBuilder = new StringBuilder("(");
+            for (int i = startPoint; i < lastIndex; ++i) {
+                stringBuilder.append("?,");
+            }
+
+            String[] array = new String[lastIndex - startPoint];
+            int count = 0;
+            for (int i = startPoint; i < lastIndex; ++i) {
+                array[count++] = String.valueOf(iterator.next().value);
+            }
+
+            ops.add(new Pair<>(stringBuilder.toString().substring(0,
+                    stringBuilder.toString().length() - 1) + ")", array));
+
+        }
+        return ops;
+    }
+
 }

--- a/app/src/org/commcare/models/database/AndroidTableBuilder.java
+++ b/app/src/org/commcare/models/database/AndroidTableBuilder.java
@@ -6,6 +6,8 @@ import org.commcare.models.framework.Table;
 import org.commcare.modern.database.TableBuilder;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -27,7 +29,7 @@ public class AndroidTableBuilder extends TableBuilder {
         super(name);
     }
 
-    public static List<Pair<String, String[]>> sqlList(List<Integer> input) {
+    public static List<Pair<String, String[]>> sqlList(Collection<Integer> input) {
         return sqlList(input, MAX_SQL_ARGS);
     }
 
@@ -36,12 +38,14 @@ public class AndroidTableBuilder extends TableBuilder {
      * String containing (?, ?,...) to be used in the SQL query and the array of args
      * to replace them with
      */
-    private static List<Pair<String, String[]>> sqlList(List<Integer> input, int maxArgs) {
+    private static List<Pair<String, String[]>> sqlList(Collection<Integer> input, int maxArgs) {
 
         List<Pair<String, String[]>> ops = new ArrayList<>();
 
         //figure out how many iterations we'll need
         int numIterations = (int)Math.ceil(((double)input.size()) / maxArgs);
+
+        Iterator<Integer> iterator = input.iterator();
 
         for (int currentRound = 0; currentRound < numIterations; ++currentRound) {
 
@@ -55,7 +59,7 @@ public class AndroidTableBuilder extends TableBuilder {
             String[] array = new String[lastIndex - startPoint];
             int count = 0;
             for (int i = startPoint; i < lastIndex; ++i) {
-                array[count++] = String.valueOf(input.get(i));
+                array[count++] = String.valueOf(iterator.next());
             }
 
             ops.add(new Pair<>(stringBuilder.toString().substring(0,

--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -605,26 +605,25 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
 
     public void bulkRead(IntSet cuedCases, IntObjectMap recordMap) {
         List<Pair<String, String[]>> whereParamList = AndroidTableBuilder.sqlList(cuedCases);
-        Pair<String, String[]> whereArgs = whereParamList.get(0);
-
-        Cursor c = helper.getHandle().query(table, new String[]{DatabaseHelper.ID_COL, DatabaseHelper.DATA_COL}, DatabaseHelper.ID_COL + " IN " + whereArgs.first, whereArgs.second, null, null, null);
-        try {
-            if (c.getCount() == 0) {
-                return;
-            } else {
-                c.moveToFirst();
-                int index = c.getColumnIndexOrThrow(DatabaseHelper.DATA_COL);
-                while (!c.isAfterLast()) {
-                    byte[] data = c.getBlob(index);
-                    recordMap.put(c.getInt(c.getColumnIndexOrThrow(DatabaseHelper.ID_COL)),
-                            newObject(data, c.getInt(c.getColumnIndexOrThrow(DatabaseHelper.ID_COL))));
-                    c.moveToNext();
+        for(Pair<String, String[]> querySet : whereParamList) {
+            Cursor c = helper.getHandle().query(table, new String[]{DatabaseHelper.ID_COL, DatabaseHelper.DATA_COL}, DatabaseHelper.ID_COL + " IN " + querySet.first, querySet.second, null, null, null);
+            try {
+                if (c.getCount() == 0) {
+                    return;
+                } else {
+                    c.moveToFirst();
+                    int index = c.getColumnIndexOrThrow(DatabaseHelper.DATA_COL);
+                    while (!c.isAfterLast()) {
+                        byte[] data = c.getBlob(index);
+                        recordMap.put(c.getInt(c.getColumnIndexOrThrow(DatabaseHelper.ID_COL)),
+                                newObject(data, c.getInt(c.getColumnIndexOrThrow(DatabaseHelper.ID_COL))));
+                        c.moveToNext();
+                    }
                 }
+            } finally {
+                c.close();
             }
-        } finally {
-            c.close();
         }
-
 
     }
 }

--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -286,9 +286,12 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
     @Override
     public int getNumRecords() {
         Cursor c = helper.getHandle().query(table, new String[]{DatabaseHelper.ID_COL}, null, null, null, null, null);
-        int records = c.getCount();
-        c.close();
-        return records;
+        try {
+            int records = c.getCount();
+            return records;
+        } finally {
+            c.close();
+        }
     }
 
     @Override

--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -2,9 +2,7 @@ package org.commcare.models.database;
 
 import android.database.Cursor;
 import android.util.Pair;
-import android.util.SparseArray;
 
-import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntObjectMap;
 import com.carrotsearch.hppc.IntSet;
 
@@ -18,7 +16,6 @@ import org.commcare.models.legacy.LegacyInstallUtils;
 import org.commcare.modern.database.DatabaseHelper;
 import org.commcare.modern.models.EncryptedModel;
 import org.commcare.utils.SessionUnavailableException;
-import org.commcare.utils.StringUtils;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.storage.EntityFilter;
 import org.javarosa.core.services.storage.IStorageIterator;
@@ -33,7 +30,6 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
@@ -96,7 +92,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return getIDsForValues(fieldNames, values, null);
     }
 
-    public Vector<Integer> getIDsForValues(String[] fieldNames, Object[] values, IntSet returnSet) {
+    public Vector<Integer> getIDsForValues(String[] fieldNames, Object[] values, LinkedHashSet<Integer> returnSet) {
         SQLiteDatabase db = helper.getHandle();
 
         Pair<String, String[]> whereClause = helper.createWhereAndroid(fieldNames, values, em, null);
@@ -114,7 +110,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return fillIdWindow(c, columnName, null);
     }
 
-    public static Vector<Integer> fillIdWindow(Cursor c, String columnName, IntSet newReturn) {
+    public static Vector<Integer> fillIdWindow(Cursor c, String columnName, LinkedHashSet<Integer> newReturn) {
         Vector<Integer> indices = new Vector<>();
         try {
             if (c.moveToFirst()) {
@@ -603,7 +599,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return new IndexSpanningIterator<>(c, this, minValue, maxValue, countValue);
     }
 
-    public void bulkRead(IntSet cuedCases, IntObjectMap recordMap) {
+    public void bulkRead(LinkedHashSet<Integer> cuedCases, HashMap recordMap) {
         List<Pair<String, String[]>> whereParamList = AndroidTableBuilder.sqlList(cuedCases);
         for(Pair<String, String[]> querySet : whereParamList) {
             Cursor c = helper.getHandle().query(table, new String[]{DatabaseHelper.ID_COL, DatabaseHelper.DATA_COL}, DatabaseHelper.ID_COL + " IN " + querySet.first, querySet.second, null, null, null);

--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -587,7 +587,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return new IndexSpanningIterator<>(c, this, minValue, maxValue, countValue);
     }
 
-    public void bulkRead(List<Integer> cuedCases, HashMap recordMap) {
+    public void bulkRead(Collection<Integer> cuedCases, HashMap recordMap) {
         List<Pair<String, String[]>> whereParamList = AndroidTableBuilder.sqlList(cuedCases);
         Pair<String, String[]> whereArgs = whereParamList.get(0);
 

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -50,9 +50,10 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
      * V.13 - Add tables for storing normal device logs and force close logs in user storage
      * V.14 - Change format of last modified date in form record to canonical SQLite form
      * V.15 - Add table to store path info about storage-backed fixture tables
+     * V.16 - Add type -> id index for case index storage
      */
 
-    private static final int USER_DB_VERSION = 15;
+    private static final int USER_DB_VERSION = 16;
 
     private static final String USER_DB_LOCATOR = "database_sandbox_";
 

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -134,6 +134,11 @@ class UserDatabaseUpgrader {
                 oldVersion = 15;
             }
         }
+        if (oldVersion == 15) {
+            if (upgradeFifteenSixteen(db)) {
+                oldVersion = 16;
+            }
+        }
     }
 
     private boolean upgradeOneTwo(final SQLiteDatabase db) {
@@ -427,6 +432,22 @@ class UserDatabaseUpgrader {
             db.endTransaction();
         }
     }
+
+    private boolean upgradeFifteenSixteen(SQLiteDatabase db) {
+        db.beginTransaction();
+        try {
+            String typeFirstIndexId = "NAME_TARGET_RECORD";
+            String typeFirstIndex = "name" + ", " + "case_rec_id" + ", " + "target";
+            db.execSQL(DatabaseIndexingUtils.indexOnTableCommand(typeFirstIndexId, "case_index_storage", typeFirstIndex));
+
+            db.setTransactionSuccessful();
+            return true;
+        } finally {
+            db.endTransaction();
+        }
+    }
+
+
 
     private void updateIndexes(SQLiteDatabase db) {
         db.execSQL(DatabaseIndexingUtils.indexOnTableCommand("case_id_index", "AndroidCase", "case_id"));

--- a/app/src/org/commcare/models/database/user/models/CaseIndexTable.java
+++ b/app/src/org/commcare/models/database/user/models/CaseIndexTable.java
@@ -52,8 +52,13 @@ public class CaseIndexTable {
     }
 
     public static void createIndexes(SQLiteDatabase db) {
-        String columns = COL_CASE_RECORD_ID + ", " + COL_INDEX_NAME + ", " + COL_INDEX_TARGET;
-        db.execSQL(DatabaseIndexingUtils.indexOnTableCommand("RECORD_NAME_ID_TARGET", TABLE_NAME, columns));
+        String recordFirstIndexId = "RECORD_NAME_ID_TARGET";
+        String recordFirstIndex = COL_CASE_RECORD_ID + ", " + COL_INDEX_NAME + ", " + COL_INDEX_TARGET;
+        db.execSQL(DatabaseIndexingUtils.indexOnTableCommand(recordFirstIndexId, TABLE_NAME, recordFirstIndex));
+
+        String typeFirstIndexId = "NAME_TARGET_RECORD";
+        String typeFirstIndex = COL_INDEX_NAME + ", " + COL_CASE_RECORD_ID + ", " + COL_INDEX_TARGET;
+        db.execSQL(DatabaseIndexingUtils.indexOnTableCommand(typeFirstIndexId, TABLE_NAME, typeFirstIndex));
     }
 
     /**
@@ -145,7 +150,7 @@ public class CaseIndexTable {
         int resultsReturned = 0;
         String[] args = new String[]{indexName};
         if (SqlStorage.STORAGE_OUTPUT_DEBUG) {
-            String query = String.format("SELECT %s,%s FROM %s where %s = %s", COL_CASE_RECORD_ID, COL_INDEX_NAME, COL_INDEX_TARGET, TABLE_NAME, COL_INDEX_NAME, indexName);
+            String query = String.format("SELECT %s,%s %s FROM %s where %s = '%s'", COL_CASE_RECORD_ID, COL_INDEX_NAME, COL_INDEX_TARGET, TABLE_NAME, COL_INDEX_NAME, indexName);
             DbUtil.explainSql(db, query, null);
         }
 

--- a/app/src/org/commcare/models/database/user/models/CaseIndexTable.java
+++ b/app/src/org/commcare/models/database/user/models/CaseIndexTable.java
@@ -141,7 +141,8 @@ public class CaseIndexTable {
         return SqlStorage.fillIdWindow(c, COL_CASE_RECORD_ID);
     }
 
-    public void loadIntoIndexTable(HashMap<String, Vector<Integer>> indexCache, String indexName) {
+    public int loadIntoIndexTable(HashMap<String, Vector<Integer>> indexCache, String indexName) {
+        int resultsReturned = 0;
         String[] args = new String[]{indexName};
         if (SqlStorage.STORAGE_OUTPUT_DEBUG) {
             String query = String.format("SELECT %s,%s FROM %s where %s = %s", COL_CASE_RECORD_ID, COL_INDEX_NAME, COL_INDEX_TARGET, TABLE_NAME, COL_INDEX_NAME, indexName);
@@ -153,6 +154,7 @@ public class CaseIndexTable {
         try {
             if (c.moveToFirst()) {
                 while (!c.isAfterLast()) {
+                    resultsReturned++;
                     int id = c.getInt(c.getColumnIndexOrThrow(COL_CASE_RECORD_ID));
                     String target = c.getString(c.getColumnIndexOrThrow(COL_INDEX_TARGET));
 
@@ -168,6 +170,8 @@ public class CaseIndexTable {
                     c.moveToNext();
                 }
             }
+
+            return resultsReturned;
         } finally {
             if (c != null) {
                 c.close();

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -31,6 +31,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static final String LOAD_FORM_PAYLOAD_AS = "cc-form-payload-status";
     public static final String DETAIL_TAB_SWIPE_ACTION_ENABLED = "cc-detail-final-swipe-enabled";
     public static final String USE_ROOT_MENU_AS_HOME_SCREEN = "cc-use-root-menu-as-home-screen";
+    public static final String SHOW_ADB_ENTITY_LIST_TRACES = "cc-show-entity-trace-outputs";
     public static final String UPDATE_TO_LATEST_SAVED_ENABLED = "cc-update-to-latest-saved";
     /**
      * Stores last used password and performs auto-login when that password is
@@ -295,6 +296,10 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
 
     public static boolean useRootModuleMenuAsHomeScreen() {
         return doesPropertyMatch(USE_ROOT_MENU_AS_HOME_SCREEN, CommCarePreferences.NO, CommCarePreferences.YES);
+    }
+
+    public static boolean collectAndDisplayEntityTrances() {
+        return doesPropertyMatch(SHOW_ADB_ENTITY_LIST_TRACES, CommCarePreferences.NO, CommCarePreferences.YES);
     }
 
     public static boolean updateToLatestSavedEnabled() {

--- a/app/src/org/commcare/tasks/EntityLoaderTask.java
+++ b/app/src/org/commcare/tasks/EntityLoaderTask.java
@@ -9,6 +9,7 @@ import org.commcare.cases.entity.NodeEntityFactory;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.logging.XPathErrorLogger;
 import org.commcare.models.AsyncNodeEntityFactory;
+import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.suite.model.Detail;
 import org.commcare.tasks.templates.ManagedAsyncTask;
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -39,6 +40,9 @@ public class EntityLoaderTask
             this.factory = new AsyncNodeEntityFactory(detail, evalCtx);
         } else {
             this.factory = new NodeEntityFactory(detail, evalCtx);
+            if(DeveloperPreferences.collectAndDisplayEntityTrances()) {
+                this.factory.activateDebugTraceOutput();
+            }
         }
     }
 
@@ -66,6 +70,7 @@ public class EntityLoaderTask
             }
 
             factory.prepareEntities();
+            factory.printAndClearTraces("build");
             return new Pair<>(full, references);
         } catch (XPathException xe) {
             XPathErrorLogger.INSTANCE.logErrorToCurrentApp(xe);


### PR DESCRIPTION
Very simply query planner which give us a place to migrate optimizations we've been using for predicate evaluation and make informed decisions about which to use/not use when evaluating complex queries.

Also provides a Query Profiler which makes it possible to understand how a query was executed, and profile the runtime of that evaluation.

cross-request: https://github.com/dimagi/commcare-core/pull/511