### PR TITLE
Add option to update to latest saved state of an app

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -69,6 +69,10 @@ home.menu.pin.change=Change My PIN
 
 menu.update.from.ccz=Offline Update
 menu.update.from.hub=Update from Local Hub
+menu.update.options=Update Options
+update.option.starred=Latest starred build
+update.option.build=Latest build
+update.option.saved=Latest saved state (NEW!)
 
 home.developer.options.enabled=Developer Mode Enabled
 

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -142,6 +142,16 @@ Some images in CommCare are graciously used under Creative Commons Licensing fro
         <item>400</item>
         <item>480</item>
     </string-array>
+    <string-array name="update_target_labels">
+        <item>Latest starred build</item>
+        <item>Latest build</item>
+        <item>Latest saved state (NEW!)</item>
+    </string-array>
+    <string-array name="update_target_vals">
+        <item>release</item>
+        <item>build</item>
+        <item>save</item>
+    </string-array>
 
     <item name="detail_size_cutoff" format="integer" type="integer">500</item>
 

--- a/app/res/xml/commcare_preferences.xml
+++ b/app/res/xml/commcare_preferences.xml
@@ -29,11 +29,11 @@
         android:title="Fuzzy Search Matches"/>
     <ListPreference
         android:enabled="true"
-        android:defaultValue="no"
-        android:entries="@array/pref_enabled_labels"
-        android:entryValues="@array/pref_enabled_vals"
-        android:key="cc-update-to-unstarred-builds"
-        android:title="Enable Updating to Un-Starred Builds"/>
+        android:defaultValue="release"
+        android:entries="@array/update_target_labels"
+        android:entryValues="@array/update_target_vals"
+        android:key="cc-update-target"
+        android:title="Update Options"/>
     <ListPreference
         android:enabled="true"
         android:defaultValue="always_hidden"

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -99,11 +99,4 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-use-root-menu-as-home-screen"
         android:title="Use root module menu as home screen"/>
-    <ListPreference
-        android:enabled="true"
-        android:defaultValue="no"
-        android:entries="@array/pref_enabled_labels"
-        android:entryValues="@array/pref_enabled_vals"
-        android:key="cc-update-to-latest-saved"
-        android:title="Enable Updating to Latest Saved Version"/>
 </PreferenceScreen>

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -557,7 +557,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                     }
                 }
         );
-        // Purposefully don't persist this dialog accross rotation! Rotation
+        // Purposefully don't persist this dialog across rotation! Rotation
         // refreshes the view, which steps the form index back from the repeat
         // event. This can be fixed, but the dialog click listeners closures
         // capture refences to the old activity, so we need to redo our

--- a/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
+++ b/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
@@ -215,20 +215,13 @@ public class ResourceInstallUtils {
             return profileRef;
         }
 
-        if (DeveloperPreferences.updateToLatestSavedEnabled()) {
+        String targetParam = CommCarePreferences.getUpdateTargetParam();
+        if (!"".equals(targetParam)) {
             if (profileUrl.getQuery() != null) {
                 // url already has query strings, so add a new one to the end
-                return profileRef + "&target=save";
+                return profileRef + "&target=" + targetParam;
             } else {
-                return profileRef + "?target=save";
-            }
-        }
-        else if (CommCarePreferences.updateToUnstarredBuildsEnabled()) {
-            if (profileUrl.getQuery() != null) {
-                // url already has query strings, so add a new one to the end
-                return profileRef + "&target=build";
-            } else {
-                return profileRef + "?target=build";
+                return profileRef + "?target=" + targetParam;
             }
         }
 

--- a/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/logging/analytics/GoogleAnalyticsFields.java
@@ -125,7 +125,7 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_FUZZY_SEARCH = "Fuzzy Search Matches";
     public static final String LABEL_PRINT_TEMPLATE = "Set Print Template";
     public static final String LABEL_DEVELOPER_OPTIONS = "Developer Options";
-    public static final String LABEL_UPDATE_TO_UNSTARRED = "Update to Unstarred Builds";
+    public static final String LABEL_UPDATE_TARGET = "Change Update Target";
 
     // Labels for ACTION_VIEW_PREF and ACTION_EDIT_PREF in CATEGORY_FORM_PREFS
     public static final String LABEL_FONT_SIZE = "Font Size";
@@ -208,6 +208,11 @@ public final class GoogleAnalyticsFields {
     public static final int VALUE_NEVER = 0;
     public static final int VALUE_DAILY = 1;
     public static final int VALUE_WEEKLY = 2;
+
+    // Values for LABEL_UPDATE_TARGET
+    public static final int VALUE_STARRED = 0;
+    public static final int VALUE_BUILD = 1;
+    public static final int VALUE_SAVED = 2;
 
     // Values for all labels under ACTION_EDIT_PREF in CATEGORY_DEV_PREFS, and for LABEL_FUZZY_SEARCH
     public static final int VALUE_DISABLED = 0;

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -87,11 +87,10 @@ public class CommCarePreferences
     private final static String PREFS_FUZZY_SEARCH_KEY = "cc-fuzzy-search-enabled";
     public final static String GRID_MENUS_ENABLED = "cc-grid-menus";
 
-    /**
-     * Does the user want to download the latest app version deployed (built),
-     * not just the latest app version released (starred)?
-     */
-    public final static String UPDATE_TO_UNSTARRED_BUILDS = "cc-update-to-unstarred-builds";
+    public final static String UPDATE_TARGET = "cc-update-target";
+    public final static String UPDATE_TARGET_STARRED = "release";
+    public final static String UPDATE_TARGET_BUILD = "build";
+    public final static String UPDATE_TARGET_SAVED = "save";
 
     // Preferences that are set incidentally/automatically by CommCare, based upon a user's workflow
     public final static String HAS_DISMISSED_PIN_CREATION = "has-dismissed-pin-creation";
@@ -135,7 +134,7 @@ public class CommCarePreferences
         prefKeyToAnalyticsEvent.put(AUTO_UPDATE_FREQUENCY, GoogleAnalyticsFields.LABEL_AUTO_UPDATE);
         prefKeyToAnalyticsEvent.put(PREFS_FUZZY_SEARCH_KEY, GoogleAnalyticsFields.LABEL_FUZZY_SEARCH);
         prefKeyToAnalyticsEvent.put(GRID_MENUS_ENABLED, GoogleAnalyticsFields.LABEL_GRID_MENUS);
-        prefKeyToAnalyticsEvent.put(UPDATE_TO_UNSTARRED_BUILDS, GoogleAnalyticsFields.LABEL_UPDATE_TO_UNSTARRED);
+        prefKeyToAnalyticsEvent.put(UPDATE_TARGET, GoogleAnalyticsFields.LABEL_UPDATE_TARGET);
     }
 
     @Override
@@ -331,6 +330,16 @@ public class CommCarePreferences
                     editPrefValue = GoogleAnalyticsFields.VALUE_ENABLED;
                 } else {
                     editPrefValue = GoogleAnalyticsFields.VALUE_DISABLED;
+                }
+                break;
+            case UPDATE_TARGET:
+                String target = sharedPreferences.getString(key, UPDATE_TARGET_STARRED);
+                if (UPDATE_TARGET_BUILD.equals(target)) {
+                    editPrefValue = GoogleAnalyticsFields.VALUE_BUILD;
+                } else if (UPDATE_TARGET_SAVED.equals(target)) {
+                    editPrefValue = GoogleAnalyticsFields.VALUE_SAVED;
+                } else {
+                    editPrefValue = GoogleAnalyticsFields.VALUE_STARRED;
                 }
                 break;
         }
@@ -552,20 +561,38 @@ public class CommCarePreferences
         return CommCareApplication.instance().getCurrentApp().getAppPreferences().getString("key_server", null);
     }
 
-    /**
-     * @return true if developer option to download the latest app version
-     * deployed (built) is enabled.  Otherwise the latest released (starred)
-     * app version will be downloaded on upgrade.
-     */
-    public static boolean updateToUnstarredBuildsEnabled() {
-        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        return properties.getString(UPDATE_TO_UNSTARRED_BUILDS, CommCarePreferences.NO).equals(CommCarePreferences.YES);
+    public static String getUpdateTargetParam() {
+        String updateTarget = getUpdateTarget();
+        if (UPDATE_TARGET_BUILD.equals(updateTarget) || UPDATE_TARGET_SAVED.equals(updateTarget)) {
+            // We only need to add a query param to the update URL if the target is set to
+            // something other than the default
+            return updateTarget;
+        } else {
+            return "";
+        }
     }
 
-    public static void enableUpdateToUnstarredBuilds() {
-        CommCareApplication.instance().getCurrentApp().getAppPreferences()
-                .edit()
-                .putString(UPDATE_TO_UNSTARRED_BUILDS, CommCarePreferences.YES)
-                .apply();
+    /**
+     * @return the update target set by the user, or default to latest starred build if none set.
+     * The 3 options are:
+     * 1. Latest starred build (this is the default)
+     * 2. Latest build, starred or un-starred
+     * 3. Latest saved version (whether or not a build has been created it for it)
+     */
+    private static String getUpdateTarget() {
+        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        return properties.getString(UPDATE_TARGET, UPDATE_TARGET_STARRED);
+    }
+
+    public static void setUpdateTarget(String updateTargetValue) {
+        if (UPDATE_TARGET_BUILD.equals(updateTargetValue) ||
+                UPDATE_TARGET_SAVED.equals(updateTargetValue) ||
+                UPDATE_TARGET_STARRED.equals(updateTargetValue)) {
+            CommCareApplication.instance().getCurrentApp().getAppPreferences()
+                    .edit()
+                    .putString(UPDATE_TARGET, updateTargetValue)
+                    .apply();
+        }
+
     }
 }

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -31,7 +31,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static final String LOAD_FORM_PAYLOAD_AS = "cc-form-payload-status";
     public static final String DETAIL_TAB_SWIPE_ACTION_ENABLED = "cc-detail-final-swipe-enabled";
     public static final String USE_ROOT_MENU_AS_HOME_SCREEN = "cc-use-root-menu-as-home-screen";
-    public static final String UPDATE_TO_LATEST_SAVED_ENABLED = "cc-update-to-latest-saved";
     /**
      * Stores last used password and performs auto-login when that password is
      * present
@@ -297,15 +296,4 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
         return doesPropertyMatch(USE_ROOT_MENU_AS_HOME_SCREEN, CommCarePreferences.NO, CommCarePreferences.YES);
     }
 
-    public static boolean updateToLatestSavedEnabled() {
-        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        return properties.getString(UPDATE_TO_LATEST_SAVED_ENABLED, CommCarePreferences.NO).equals(CommCarePreferences.YES);
-    }
-
-    public static void enableUpdateToLatestSavedVersion() {
-        CommCareApplication.instance().getCurrentApp().getAppPreferences()
-                .edit()
-                .putString(UPDATE_TO_LATEST_SAVED_ENABLED, CommCarePreferences.YES)
-                .apply();
-    }
 }

--- a/app/src/org/commcare/provider/RefreshToLatestBuildReceiver.java
+++ b/app/src/org/commcare/provider/RefreshToLatestBuildReceiver.java
@@ -28,9 +28,9 @@ public class RefreshToLatestBuildReceiver extends BroadcastReceiver {
         DeveloperPreferences.enableSessionSaving();
 
         if (intent.getBooleanExtra("useLatestSaved", false)) {
-            DeveloperPreferences.enableUpdateToLatestSavedVersion();
+            CommCarePreferences.setUpdateTarget(CommCarePreferences.UPDATE_TARGET_SAVED);
         } else if (intent.getBooleanExtra("useLatestBuild", false)) {
-            CommCarePreferences.enableUpdateToUnstarredBuilds();
+            CommCarePreferences.setUpdateTarget(CommCarePreferences.UPDATE_TARGET_BUILD);
         }
 
         Intent i = new Intent(context, RefreshToLatestBuildActivity.class);


### PR DESCRIPTION
In follow-up to Cal's hackathon work https://github.com/dimagi/commcare-hq/pull/14737, add the option to update to the latest saved state of an app.

I chatted with @orangejenny for a bit today on the best way to do the UI for this, taking into account the fact that we didn't want to confuse existing workflows but also wanted it to be semi-discoverable. We settled on putting a menu item called "Update Options" in 2 places: one in the main "Settings" menu (as a replacement for the "Enable Updating to Un-Starred Builds" setting that is currently there) and one in the options menu of the Update Activity (since that is the most logical place that someone might look for it). Screenshots of both of these are below. The UIs of the 2 menus are slightly different because 1 is part of a native Android preference screen and 1 isn't, but I'm inclined not to worry about that.

UI from main settings screen:
![screenshot_20170206-152141](https://cloud.githubusercontent.com/assets/3723143/22665436/c1c85d3e-ec82-11e6-80a1-aee138fbb682.png)
![screenshot_20170206-152144](https://cloud.githubusercontent.com/assets/3723143/22665467/d966e28a-ec82-11e6-8fc8-c55f3238a4bc.png)

UI from update activity:
![screenshot_20170206-152041](https://cloud.githubusercontent.com/assets/3723143/22665475/dea5a8f8-ec82-11e6-9dee-895f3009577d.png)
![screenshot_20170206-152050](https://cloud.githubusercontent.com/assets/3723143/22665478/e1e5f4c8-ec82-11e6-8727-7a7c9ba17a3c.png)

@orangejenny What are your thoughts on the "NEW!" text I added next to the saved state option? I sort of like it but don't have any basis for whether that's a good practice or not. I wish we had a convenient way to link to documentation from mobile, but I can't think of anything.