### PR TITLE
Make "Install an App" button in app manager look nicer

### DIFF
--- a/app/res/layout/app_manager.xml
+++ b/app/res/layout/app_manager.xml
@@ -35,14 +35,17 @@
 
     <Button
         android:id="@+id/install_app_button"
-        android:layout_width="fill_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
         android:layout_below="@id/manager_instructions"
         android:layout_marginTop="@dimen/standard_spacer"
+        android:paddingLeft="@dimen/standard_spacer_double"
+        android:paddingRight="@dimen/standard_spacer_double"
         android:onClick="installAppClicked"
         android:text="@string/install_app"
-        android:textColor="@color/darkest_grey"
+        android:background="@color/cc_brand_color"
+        android:textColor="@color/cc_neutral_bg"
         android:textSize="@dimen/font_size_xlarger"/>
 
     <ListView


### PR DESCRIPTION
As @jjackson rightfully pointed out, I left the "Install An App" button in the app manager looking really shitty for some reason... It could probably be improved more than this but this was quick and 75% better.

Before:
![screenshot_20170209-114533](https://cloud.githubusercontent.com/assets/3723143/22793268/5c13d8f0-eebd-11e6-8ef3-194a34c54360.png)

After:
![screenshot_20170209-114408](https://cloud.githubusercontent.com/assets/3723143/22793199/22a73bca-eebd-11e6-815e-a0075bf4bd9e.png)
