### PR TITLE
Show notification message for all update errors

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -489,6 +489,9 @@ notification.install.badreqs.title=Incompatible CommCare Version for Install
 notification.install.badreqs.detail=${0}
 notification.install.badreqs.action=${0}
 
+notification.update.failed.general.title=Update failed due to an error
+notification.update.failed.general.detail=${0}
+
 notification.install.badarchive.title=Archive must be in file system
 notification.install.badarchive.detail=Your .ccz archive file must be on your phone's file system
 notification.install.badarchive.action=Download this fule and place it on your phone's SD card and retry. 

--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -67,7 +67,8 @@ public class AndroidResourceManager extends ResourceManager {
      * @return UpdateStaged upon update download, UpToDate if no new update,
      * otherwise an error status.
      */
-    public AppInstallStatus checkAndPrepareUpgradeResources(String profileRef, int profileAuthority) {
+    public AppInstallStatus checkAndPrepareUpgradeResources(String profileRef, int profileAuthority)
+            throws UnfullfilledRequirementsException, UnresolvedResourceException {
         synchronized (updateLock) {
             this.profileRef = profileRef;
             try {
@@ -88,16 +89,6 @@ public class AndroidResourceManager extends ResourceManager {
                 // The user cancelled the upgrade check process. The calling task
                 // should have caught and handled the cancellation
                 return AppInstallStatus.UnknownFailure;
-            } catch (LocalStorageUnavailableException e) {
-                ResourceInstallUtils.logInstallError(e,
-                        "Couldn't install file to local storage|");
-                return AppInstallStatus.NoLocalStorage;
-            } catch (UnfullfilledRequirementsException e) {
-                ResourceInstallUtils.logInstallError(e,
-                        "App resources are incompatible with this device|");
-                return AppInstallStatus.IncompatibleReqs;
-            } catch (UnresolvedResourceException e) {
-                return ResourceInstallUtils.processUnresolvedResource(e);
             }
 
             return AppInstallStatus.UpdateStaged;

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -29,7 +29,12 @@ public enum AppInstallStatus implements MessageTag {
     UnknownFailure("notification.install.unknown"),
     NoLocalStorage("notification.install.nolocal"),
     NoConnection("notification.install.no.connection"),
-    BadCertificate("notification.install.badcert");
+    BadCertificate("notification.install.badcert"),
+
+    /**
+     * A catch-all MessageTag to use for reporting app update failures to the notifications bar
+     */
+    UpdateFailedGeneral("notification.update.failed.general");
 
     AppInstallStatus(String root) {
         this.root = root;

--- a/app/src/org/commcare/tasks/UpdateTask.java
+++ b/app/src/org/commcare/tasks/UpdateTask.java
@@ -12,7 +12,6 @@ import org.commcare.engine.resource.ResourceInstallUtils;
 import org.commcare.engine.resource.installers.LocalStorageUnavailableException;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.resources.model.InstallCancelled;
-import org.commcare.resources.model.InstallCancelledException;
 import org.commcare.resources.model.InvalidResourceException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;

--- a/app/src/org/commcare/tasks/UpdateTask.java
+++ b/app/src/org/commcare/tasks/UpdateTask.java
@@ -9,15 +9,19 @@ import org.commcare.dalvik.R;
 import org.commcare.engine.resource.AndroidResourceManager;
 import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.engine.resource.ResourceInstallUtils;
+import org.commcare.engine.resource.installers.LocalStorageUnavailableException;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.resources.model.InstallCancelled;
+import org.commcare.resources.model.InstallCancelledException;
 import org.commcare.resources.model.InvalidResourceException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
 import org.commcare.resources.model.TableStateListener;
+import org.commcare.resources.model.UnresolvedResourceException;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.views.dialogs.PinnedNotificationWithProgress;
 import org.javarosa.core.services.Logger;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
 
 import java.util.Vector;
 
@@ -109,6 +113,16 @@ public class UpdateTask
             ResourceInstallUtils.logInstallError(e,
                     "Structure error ocurred during install|");
             return new ResultAndError<>(AppInstallStatus.UnknownFailure, buildCombinedErrorMessage(e.resourceName, e.getMessage()));
+        } catch (LocalStorageUnavailableException e) {
+            ResourceInstallUtils.logInstallError(e,
+                    "Couldn't install file to local storage|");
+            return new ResultAndError<>(AppInstallStatus.NoLocalStorage, e.getMessage());
+        } catch (UnfullfilledRequirementsException e) {
+            ResourceInstallUtils.logInstallError(e,
+                    "App resources are incompatible with this device|");
+            return new ResultAndError<>(AppInstallStatus.IncompatibleReqs, e.getMessage());
+        } catch (UnresolvedResourceException e) {
+            return new ResultAndError<>(ResourceInstallUtils.processUnresolvedResource(e), e.getMessage());
         } catch (Exception e) {
             ResourceInstallUtils.logInstallError(e,
                     "Unknown error ocurred during install|");
@@ -129,7 +143,8 @@ public class UpdateTask
                 "Beginning install attempt for profile " + profileRef);
     }
 
-    private AppInstallStatus stageUpdate() {
+    private AppInstallStatus stageUpdate() throws UnfullfilledRequirementsException,
+            UnresolvedResourceException {
         Resource profile = resourceManager.getMasterProfile();
         boolean appInstalled = (profile != null &&
                 profile.getStatus() == Resource.RESOURCE_STATUS_INSTALLED);

--- a/app/unit-tests/src/org/commcare/android/tests/activities/UpdateActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/UpdateActivityTest.java
@@ -50,7 +50,8 @@ public class UpdateActivityTest {
      */
     @Test
     public void invalidUpdateTest() {
-        String invalidUpdateReference = "jr://resource/commcare-apps/update_tests/invalid_suite_update/profile.ccpr";
+        String invalidUpdateReference =
+                "jr://resource/commcare-apps/update_tests/invalid_suite_update/profile.ccpr";
 
         // start the update activity
         Intent updateActivityIntent =
@@ -64,27 +65,33 @@ public class UpdateActivityTest {
         ShadowActivity shadowActivity = Shadows.shadowOf(updateActivity);
         shadowActivity.clickMenuItem(UpdateActivity.MENU_UPDATE_FROM_CCZ);
 
-        // make sure there are no pinned notifications
+        // Make sure there are no pinned notifications before we start
         NotificationManager notificationManager =
-                (NotificationManager)RuntimeEnvironment.application.getSystemService(Context.NOTIFICATION_SERVICE);
-        Notification notification = Shadows.shadowOf(notificationManager).getNotification(CommCareNoficationManager.MESSAGE_NOTIFICATION);
+                (NotificationManager)RuntimeEnvironment.application
+                        .getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager.cancel(CommCareNoficationManager.MESSAGE_NOTIFICATION);
+        Notification notification = Shadows.shadowOf(notificationManager)
+                .getNotification(CommCareNoficationManager.MESSAGE_NOTIFICATION);
         assertNull(notification);
 
         // mock receiving the offline app reference and start the update
         Intent referenceIntent = new Intent();
         referenceIntent.putExtra(InstallArchiveActivity.ARCHIVE_JR_REFERENCE, invalidUpdateReference);
-        shadowActivity.receiveResult(shadowActivity.getNextStartedActivity(), Activity.RESULT_OK, referenceIntent);
+        shadowActivity.receiveResult(shadowActivity.getNextStartedActivity(), Activity.RESULT_OK,
+                referenceIntent);
 
         Robolectric.flushBackgroundThreadScheduler();
         Robolectric.flushForegroundThreadScheduler();
 
         // assert that we get the right error message
-        String errorMessage = (String)((TextView)updateActivity.findViewById(R.id.update_progress_text)).getText();
+        String errorMessage = (String)((TextView)updateActivity
+                .findViewById(R.id.update_progress_text)).getText();
         assertEquals(Localization.get("updates.check.failed"), errorMessage);
 
         // check that a pinned notification was created for invalid update
         // NOTE: it is way more work to assert the notification body is correct, so skip over that
-        notification = Shadows.shadowOf(notificationManager).getNotification(CommCareNoficationManager.MESSAGE_NOTIFICATION);
+        notification = Shadows.shadowOf(notificationManager)
+                .getNotification(CommCareNoficationManager.MESSAGE_NOTIFICATION);
         assertNotNull(notification);
     }
 }


### PR DESCRIPTION
Somehow the error handling for updates had gotten set up such that we were only creating a notification message for certain types of failures, even though the primary error message would always say "(See notification for details)". By moving the exception-handling up the chain from `AndroidResourceManager.checkAndPrepareUpgradeResources` to `UpdateTask.doInBackground`, we can retain access to the exception error messages in order to use them in a notification. 

(There's no ticket for this, Mike O just reported the behavior to me)