### PR TITLE
Prevent updateFormRelevancies() from calling itself downstream

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -75,6 +75,8 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
     private int indexOfLastChangedWidget = -1;
     private BlockingActionsManager blockingActionsManager;
 
+    private boolean formRelevanicesUpdateInProgress = false;
+
     private static final String KEY_LAST_CHANGED_WIDGET = "index-of-last-changed-widget";
 
     enum AnimationType {
@@ -694,7 +696,13 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         activity.findViewById(R.id.multiple_intent_dispatch_button).setVisibility(View.GONE);
     }
 
-    protected void updateFormRelevancies() {
+    protected synchronized void updateFormRelevancies() {
+        if (formRelevanicesUpdateInProgress) {
+            // Don't allow this method to call itself downstream accidentally
+            return;
+        }
+        formRelevanicesUpdateInProgress = true;
+
         ArrayList<QuestionWidget> oldWidgets = questionsView.getWidgets();
         // These 2 calls need to be made here, rather than in the for loop below, because at that
         // point the widgets will have already started being updated to the values for the new view
@@ -751,5 +759,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
             }
         }
         updateCompoundIntentButtonVisibility();
+
+        formRelevanicesUpdateInProgress = false;
     }
 }

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -695,7 +695,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         activity.findViewById(R.id.multiple_intent_dispatch_button).setVisibility(View.GONE);
     }
 
-    protected synchronized void updateFormRelevancies() {
+    protected void updateFormRelevancies() {
         if (formRelevanciesUpdateInProgress) {
             // Don't allow this method to call itself downstream accidentally
             return;

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -75,7 +75,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
     private int indexOfLastChangedWidget = -1;
     private BlockingActionsManager blockingActionsManager;
 
-    private boolean formRelevanicesUpdateInProgress = false;
+    private boolean formRelevanciesUpdateInProgress = false;
 
     private static final String KEY_LAST_CHANGED_WIDGET = "index-of-last-changed-widget";
 
@@ -697,11 +697,11 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
     }
 
     protected synchronized void updateFormRelevancies() {
-        if (formRelevanicesUpdateInProgress) {
+        if (formRelevanciesUpdateInProgress) {
             // Don't allow this method to call itself downstream accidentally
             return;
         }
-        formRelevanicesUpdateInProgress = true;
+        formRelevanciesUpdateInProgress = true;
 
         ArrayList<QuestionWidget> oldWidgets = questionsView.getWidgets();
         // These 2 calls need to be made here, rather than in the for loop below, because at that
@@ -760,6 +760,6 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         }
         updateCompoundIntentButtonVisibility();
 
-        formRelevanicesUpdateInProgress = false;
+        formRelevanciesUpdateInProgress = false;
     }
 }

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -149,7 +149,7 @@ public class QuestionsView extends ScrollView
         addView(mView);
     }
 
-    private void removeQuestionFromIndex(int i){
+    private void removeQuestionFromIndex(int i) {
         int dividerIndex = Math.max(i - 1, 0);
 
         if (dividerIndex < dividers.size()) {


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?247841. 

This was a fun one. The root of this ended up being the fact that `ComboboxWidget` calls `widgetEntryChanged()` when it loses focus: https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/views/widgets/ComboboxWidget.java#L95. `QuestionWidget.widgetEntryChanged()` triggers `FormEntryActivity.updateFormRelevancies()` downstream, which in turn calls `questionsView.removeQuestionsFromIndex()`. In this case, `removeQuestionsFromIndex()` rightfully removes the `ComboboxWidget` for district choice (it will then get added back later in the method), but removing the widget triggers its `onFocusChangedListener` and thus results in `updateFormRelevancies()` effectively recursing in the middle of its first execution. The method is definitely not designed to handle that, because when it returns from the recursion, the `promptsLeftInView` list that has been built up in the first call is now stale and inaccurate, but it proceeds with using it anyway. Thus, even though the 2 combobox widgets have already been added back to the view once by the recursive call, they get added a second time.

`ComboboxWidget` is the only widget we have which calls `widgetEntryChanged()` from a place like this, which is why this has never come up before. 

@czue I'm assuming this needs a hotfix, let me know if that's not necessarily true.