### PR TITLE
Change Arity Parse to be a Syntax Error

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -82,7 +82,6 @@ import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryController;
-import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathTypeMismatchException;
 
@@ -1251,7 +1250,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         try {
             uiController.recordLastChangedWidgetIndex(changedWidget);
             uiController.updateFormRelevancies();
-        } catch (XPathTypeMismatchException | XPathArityException e) {
+        } catch (XPathTypeMismatchException e) {
             UserfacingErrorHandling.logErrorAndShowDialog(this, e, FormEntryConstants.EXIT);
             return;
         }

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -46,7 +46,6 @@ import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathTypeMismatchException;
 import org.javarosa.xpath.XPathUnhandledException;
@@ -447,7 +446,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                             break;
                     }
                 } while (event != FormEntryController.EVENT_END_OF_FORM);
-            } catch (XPathTypeMismatchException | XPathArityException e) {
+            } catch (XPathTypeMismatchException e) {
                 UserfacingErrorHandling.logErrorAndShowDialog(activity, e, FormEntryConstants.EXIT);
             }
         }
@@ -464,7 +463,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         FormNavigationController.NavigationDetails details;
         try {
             details = FormNavigationController.calculateNavigationStatus(FormEntryActivity.mFormController, questionsView);
-        } catch (XPathTypeMismatchException | XPathArityException e) {
+        } catch (XPathTypeMismatchException e) {
             UserfacingErrorHandling.logErrorAndShowDialog(activity, e, FormEntryConstants.EXIT);
             return;
         }
@@ -517,7 +516,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                 dialog.dismiss();
                 try {
                     FormEntryActivity.mFormController.newRepeat();
-                } catch (XPathUnhandledException | XPathTypeMismatchException | XPathArityException e) {
+                } catch (XPathUnhandledException | XPathTypeMismatchException e) {
                     Logger.exception(e);
                     UserfacingErrorHandling.logErrorAndShowDialog(activity, e, FormEntryConstants.EXIT);
                     return;

--- a/app/src/org/commcare/activities/FormHierarchyActivity.java
+++ b/app/src/org/commcare/activities/FormHierarchyActivity.java
@@ -22,7 +22,6 @@ import org.commcare.utils.SessionActivityRegistration;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryController;
-import org.javarosa.xpath.XPathArityException;
 import org.javarosa.xpath.XPathTypeMismatchException;
 
 import java.util.ArrayList;
@@ -183,7 +182,7 @@ public class FormHierarchyActivity extends ListActivity {
         String hierarchyPath;
         try {
             hierarchyPath = FormHierarchyBuilder.populateHierarchyList(this, formList);
-        } catch (XPathTypeMismatchException | XPathArityException e) {
+        } catch (XPathTypeMismatchException e) {
             XPathErrorLogger.INSTANCE.logErrorToCurrentApp(e);
 
             final String errorMsg = "Encounted xpath error: " + e.getMessage();


### PR DESCRIPTION
Updates XPath Arity (incorrect signature) errors to be thrown properly during runtime.

In Android's code this just means handling errors at runtime based on the new behavior (which is identical to the old behavior, but with less code).

Release Note: Fixed issue where functions with the wrong number of arguments would produce a poor error message.

cross-request: https://github.com/dimagi/commcare-core/pull/523