### PR TITLE
Don't request focus when just getting answer

### DIFF
--- a/app/src/org/commcare/views/widgets/GregorianDateWidget.java
+++ b/app/src/org/commcare/views/widgets/GregorianDateWidget.java
@@ -287,8 +287,6 @@ public class GregorianDateWidget extends AbstractUniversalDateWidget
 
     @Override
     public IAnswerData getAnswer() {
-        setFocus(getContext());
-
         String month = (String)monthSpinner.getSelectedItem();
         String day = dayText.getText().toString();
         String year = yearText.getText().toString();


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?247868

getAnswer() shouldn't require getting focus (its frequently called when it should not have focus)