### PR TITLE
Change rule for acceptance of previous value in ComboboxWidget

### DIFF
--- a/app/src/org/commcare/views/Combobox.java
+++ b/app/src/org/commcare/views/Combobox.java
@@ -88,7 +88,7 @@ public class Combobox extends AutoCompleteTextView {
             @Override
             public void afterTextChanged(Editable s) {
                 fixingInvalidEntry = false;
-                if (!customAdapter.isValidUserEntry(s.toString())) {
+                if (!isValidUserEntry(s.toString())) {
                     fixingInvalidEntry = true;
                     // Re-set the entered text to be what it was before this change was made
                     setText(lastAcceptableStringEntered);
@@ -99,6 +99,10 @@ public class Combobox extends AutoCompleteTextView {
                 }
             }
         };
+    }
+
+    public boolean isValidUserEntry(String enteredText) {
+        return customAdapter.isValidUserEntry(enteredText);
     }
 
     /**

--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -116,11 +116,8 @@ public class ComboboxWidget extends QuestionWidget {
     private void fillInPreviousAnswer(FormEntryPrompt prompt) {
         if (prompt.getAnswerValue() != null) {
             String previousAnswerValue = ((Selection)prompt.getAnswerValue().getValue()).getValue();
-            for (int i = 0; i < choices.size(); i++) {
-                if (choices.get(i).getValue().equals(previousAnswerValue)) {
-                    comboBox.setText(choiceTexts.get(i));
-                    break;
-                }
+            if (comboBox.isValidUserEntry(previousAnswerValue)) {
+                comboBox.setText(previousAnswerValue);
             }
         }
     }


### PR DESCRIPTION
Change the rule by which the ComboboxWidget accepts a previous answer value or default value to accept anything that is a "valid user entry" (i.e. anything for which at least 1 answer choice will be present in the dropdown), rather than only anything that is an exact answer choice.

This was a request from Nick Nestle to support the workflow in which they're using the ComboboxWidget for a large nutrition project, so I'd like to get into 2.34 for them since it's a small change and QA has barely started.