### PR TITLE
Debug Tool: End-User Offline Data Restore 

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -113,5 +113,9 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-update-to-latest-saved"
         android:title="Enable Updating to Latest Saved Version"/>
+    <Preference
+        android:title="Restore a custom user XML data file"
+        android:key="cc-custom-restore-doc-location"/>
+
 
 </PreferenceScreen>

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -11,7 +11,7 @@ import org.commcare.engine.resource.installers.SingleAppInstallation;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.network.DataPullRequester;
-import org.commcare.network.LocalDataPullResponseFactory;
+import org.commcare.network.LocalReferencePullResponseFactory;
 import org.commcare.network.mocks.LocalFilePullResponseFactory;
 import org.commcare.preferences.CommCareServerPreferences;
 import org.commcare.suite.model.OfflineUserRestore;
@@ -184,9 +184,9 @@ public class FormAndDataSyncer {
             throw new RuntimeException("Local restore file missing");
         }
 
-        LocalDataPullResponseFactory.setRequestPayloads(new String[]{SingleAppInstallation.LOCAL_RESTORE_REFERENCE});
+        LocalReferencePullResponseFactory.setRequestPayloads(new String[]{SingleAppInstallation.LOCAL_RESTORE_REFERENCE});
         syncData(context, false, false, "fake-server-that-is-never-used", username, password,
-                LocalDataPullResponseFactory.INSTANCE, true);
+                LocalReferencePullResponseFactory.INSTANCE, true);
     }
 
 
@@ -194,10 +194,10 @@ public class FormAndDataSyncer {
             I context,
             OfflineUserRestore offlineUserRestore) {
         String[] demoUserRestore = new String[]{offlineUserRestore.getReference()};
-        LocalDataPullResponseFactory.setRequestPayloads(demoUserRestore);
+        LocalReferencePullResponseFactory.setRequestPayloads(demoUserRestore);
         syncData(context, false, false, "fake-server-that-is-never-used",
                 offlineUserRestore.getUsername(), OfflineUserRestore.DEMO_USER_PASSWORD,
-                LocalDataPullResponseFactory.INSTANCE, true);
+                LocalReferencePullResponseFactory.INSTANCE, true);
     }
 
     public <I extends CommCareActivity & PullTaskResultReceiver> void syncData(

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -12,6 +12,7 @@ import org.commcare.interfaces.WithUIController;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.network.DataPullRequester;
 import org.commcare.network.LocalDataPullResponseFactory;
+import org.commcare.network.mocks.LocalFilePullResponseFactory;
 import org.commcare.preferences.CommCareServerPreferences;
 import org.commcare.suite.model.OfflineUserRestore;
 import org.commcare.tasks.DataPullTask;
@@ -26,6 +27,7 @@ import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.locale.Localization;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -158,6 +160,18 @@ public class FormAndDataSyncer {
                 password);
     }
 
+    public <I extends CommCareActivity & PullTaskResultReceiver> void performCustomRestoreFromFile(
+            I context,
+            File incomingRestoreFile) {
+        User u = CommCareApplication.instance().getSession().getLoggedInUser();
+        String username = u.getUsername();
+
+        LocalFilePullResponseFactory.setRequestPayloads(new File[]{incomingRestoreFile});
+        syncData(context, false, false, "fake-server-that-is-never-used", username, null,
+                LocalFilePullResponseFactory.INSTANCE, true);
+    }
+
+
     public <I extends CommCareActivity & PullTaskResultReceiver> void performLocalRestore(
             I context,
             String username,
@@ -174,6 +188,7 @@ public class FormAndDataSyncer {
         syncData(context, false, false, "fake-server-that-is-never-used", username, password,
                 LocalDataPullResponseFactory.INSTANCE, true);
     }
+
 
     public <I extends CommCareActivity & PullTaskResultReceiver> void performDemoUserRestore(
             I context,

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -56,6 +56,7 @@ import org.commcare.utils.ChangeLocaleUtil;
 import org.commcare.utils.EntityDetailUtils;
 import org.commcare.utils.GlobalConstants;
 import org.commcare.utils.SessionUnavailableException;
+import org.commcare.utils.UriToFilePath;
 import org.commcare.views.UserfacingErrorHandling;
 import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.DialogChoiceItem;
@@ -70,6 +71,7 @@ import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.xpath.XPathTypeMismatchException;
 
+import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Vector;
@@ -359,6 +361,20 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                 case PREFERENCES_ACTIVITY:
                     if (resultCode == AdvancedActionsActivity.RESULT_DATA_RESET) {
                         finish();
+                    } else if (resultCode == DeveloperPreferences.RESULT_SYNC_CUSTOM) {
+                        try {
+                            Uri uri = intent.getData();
+                            String filePath = UriToFilePath.getPathFromUri(CommCareApplication.instance(), uri);
+                            if(filePath != null) {
+                                File f = new File(filePath);
+                                if (f != null && f.exists()) {
+                                    formAndDataSyncer.performCustomRestoreFromFile(this, f);
+                                }
+                            }
+                        } catch(Exception e) {
+                            Toast.makeText(this, "Error loading custom sync...",
+                                    Toast.LENGTH_LONG).show();
+                        }
                     }
                     return;
                 case ADVANCED_ACTIONS_ACTIVITY:

--- a/app/src/org/commcare/google/services/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/google/services/analytics/GoogleAnalyticsFields.java
@@ -149,6 +149,7 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_LOAD_FORM_PAYLOAD_AS = "Load form payload as";
     public static final String LABEL_DETAIL_TAB_SWIPE_ACTION = "Detail tab final swipe action enabled";
     public static final String LABEL_OFFLINE_UPDATE = "Offline Updates enabled";
+    public static final String LABEL_CUSTOM_RESTORE = "Custom Restore Requested";
 
     // Labels for ACTION_OPTIONS_MENU_ITEM in CATEGORY_HOME_SCREEN
     public static final String LABEL_SETTINGS = "Settings";

--- a/app/src/org/commcare/network/LocalReferencePullResponse.java
+++ b/app/src/org/commcare/network/LocalReferencePullResponse.java
@@ -12,11 +12,11 @@ import java.io.InputStream;
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */
-public class LocalDataPullResponse extends RemoteDataPullResponse {
+public class LocalReferencePullResponse extends RemoteDataPullResponse {
     private InputStream debugStream = null;
 
-    public LocalDataPullResponse(String xmlPayloadReference,
-                                 HttpResponse response) throws IOException {
+    public LocalReferencePullResponse(String xmlPayloadReference,
+                                      HttpResponse response) throws IOException {
         super(null, response);
 
         try {

--- a/app/src/org/commcare/network/LocalReferencePullResponse.java
+++ b/app/src/org/commcare/network/LocalReferencePullResponse.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Data pulling requester that gets data from a local reference.
+ * Data pulling requester that gets data from a local CommCare reference.
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */

--- a/app/src/org/commcare/network/LocalReferencePullResponseFactory.java
+++ b/app/src/org/commcare/network/LocalReferencePullResponseFactory.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Builds data pull requester that gets data from a local reference.
+ * Builds data pull requester that gets data from a local CommCare reference.
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */

--- a/app/src/org/commcare/network/LocalReferencePullResponseFactory.java
+++ b/app/src/org/commcare/network/LocalReferencePullResponseFactory.java
@@ -14,7 +14,7 @@ import java.util.List;
  *
  * @author Phillip Mates (pmates@dimagi.com).
  */
-public enum LocalDataPullResponseFactory implements DataPullRequester {
+public enum LocalReferencePullResponseFactory implements DataPullRequester {
     INSTANCE;
 
     // data pull requests will pop off and use the top reference in this list
@@ -38,7 +38,7 @@ public enum LocalDataPullResponseFactory implements DataPullRequester {
                                                       boolean includeSyncToken) throws IOException {
         numTries++;
         HttpResponse response = requestor.makeCaseFetchRequest(server, includeSyncToken);
-        return new LocalDataPullResponse(xmlPayloadReferences.remove(0), response);
+        return new LocalReferencePullResponse(xmlPayloadReferences.remove(0), response);
     }
 
     @Override

--- a/app/src/org/commcare/network/mocks/LocalFilePullResponse.java
+++ b/app/src/org/commcare/network/mocks/LocalFilePullResponse.java
@@ -1,0 +1,49 @@
+package org.commcare.network.mocks;
+
+import org.apache.http.HttpResponse;
+import org.commcare.network.RemoteDataPullResponse;
+import org.javarosa.core.reference.InvalidReferenceException;
+import org.javarosa.core.reference.ReferenceManager;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Data pulling requester that gets data from a local file on the android filesystem.
+ *
+ * @author Clayton Sims (csims@dimagi.com).
+ */
+public class LocalFilePullResponse extends RemoteDataPullResponse {
+    private InputStream debugStream = null;
+
+    public LocalFilePullResponse(File xmlPayload,
+                                 HttpResponse response) throws IOException {
+        super(null, response);
+
+        try {
+            debugStream =
+                    new FileInputStream(xmlPayload);
+        } catch (IOException ire) {
+            throw new IOException("No payload available at " + xmlPayload.toString(), ire);
+        }
+    }
+
+    @Override
+    protected InputStream getInputStream() throws IOException {
+        return debugStream;
+    }
+
+    @Override
+    protected long guessDataSize() {
+        try {
+            //Note: this is really stupid, but apparently you can't 
+            //retrieve the size of Assets due to some bullshit, so
+            //this is the closest you get.
+            return debugStream.available();
+        } catch (IOException e) {
+            return -1;
+        }
+    }
+}

--- a/app/src/org/commcare/network/mocks/LocalFilePullResponseFactory.java
+++ b/app/src/org/commcare/network/mocks/LocalFilePullResponseFactory.java
@@ -1,0 +1,52 @@
+package org.commcare.network.mocks;
+
+import org.apache.http.HttpResponse;
+import org.commcare.interfaces.HttpRequestEndpoints;
+import org.commcare.network.DataPullRequester;
+import org.commcare.network.HttpRequestEndpointsMock;
+import org.commcare.network.RemoteDataPullResponse;
+import org.commcare.tasks.DataPullTask;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Builds data pull requester that gets data from a local file on the android filesystem.
+ *
+ * @author Clayton Sims (csims@dimagi.com)
+ */
+public enum LocalFilePullResponseFactory implements DataPullRequester {
+    INSTANCE;
+
+    // data pull requests will pop off and use the top reference in this list
+    private final List<File> xmlPayloadReferences = new ArrayList<>();
+    public int numTries = 0;
+
+    public static void setRequestPayloads(File[] payloadReferences) {
+        INSTANCE.xmlPayloadReferences.clear();
+        Collections.addAll(INSTANCE.xmlPayloadReferences, payloadReferences);
+    }
+
+    public static int getNumRequestsMade() {
+        return INSTANCE.numTries;
+    }
+
+    // this is what DataPullTask will call when it's being run in a test
+    @Override
+    public RemoteDataPullResponse makeDataPullRequest(DataPullTask task,
+                                                      HttpRequestEndpoints requestor,
+                                                      String server,
+                                                      boolean includeSyncToken) throws IOException {
+        numTries++;
+        HttpResponse response = requestor.makeCaseFetchRequest(server, includeSyncToken);
+        return new LocalFilePullResponse(xmlPayloadReferences.remove(0), response);
+    }
+
+    @Override
+    public HttpRequestEndpoints getHttpGenerator(String username, String password) {
+        return new HttpRequestEndpointsMock();
+    }
+}

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -122,6 +122,7 @@ public class CommCarePreferences
     public final static String FALSE = "False";
 
     private static final int REQUEST_TEMPLATE = 0;
+    private static final int REQUEST_DEVELOPER_PREFERENCES = 1;
 
     private final static Map<String, String> prefKeyToAnalyticsEvent = new HashMap<>();
     private final static Map<String, String> keyToTitleMap = new HashMap<>();
@@ -291,6 +292,13 @@ public class CommCarePreferences
                 Toast.makeText(this, Localization.get("template.not.set"), Toast.LENGTH_SHORT).show();
             }
         }
+        if (requestCode == REQUEST_DEVELOPER_PREFERENCES) {
+            if (resultCode == DeveloperPreferences.RESULT_SYNC_CUSTOM && data != null) {
+                this.setResult(DeveloperPreferences.RESULT_SYNC_CUSTOM, data);
+                this.finish();
+            }
+        }
+
     }
 
     @Override
@@ -554,7 +562,7 @@ public class CommCarePreferences
 
     private void startDeveloperOptions() {
         Intent intent = new Intent(this, DeveloperPreferences.class);
-        startActivity(intent);
+        startActivityForResult(intent, REQUEST_DEVELOPER_PREFERENCES);
     }
 
     public static String getKeyServer() {

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -1,10 +1,15 @@
 package org.commcare.preferences;
 
+import android.app.Activity;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Bundle;
 import android.preference.EditTextPreference;
 import android.preference.Preference;
 import android.preference.PreferenceManager;
+import android.widget.Toast;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
@@ -14,12 +19,22 @@ import org.commcare.dalvik.R;
 import org.commcare.google.services.analytics.GoogleAnalyticsFields;
 import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
 import org.commcare.android.database.user.models.FormRecord;
+import org.commcare.utils.FileUtil;
+import org.commcare.utils.TemplatePrinterUtils;
+import org.commcare.utils.UriToFilePath;
+import org.javarosa.core.services.locale.Localization;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class DeveloperPreferences extends SessionAwarePreferenceActivity
         implements SharedPreferences.OnSharedPreferenceChangeListener {
+    public static final int RESULT_SYNC_CUSTOM = Activity.RESULT_FIRST_USER + 1;
+    public static final int REQUEST_SYNC_FILE = 1;
+
+    public final static String PREFS_CUSTOM_RESTORE_DOC_LOCATION = "cc-custom-restore-doc-location";
+
+
     public static final String SUPERUSER_ENABLED = "cc-superuser-enabled";
     public static final String NAV_UI_ENABLED = "cc-nav-ui-enabled";
     public static final String CSS_ENABLED = "cc-css-enabled";
@@ -75,7 +90,51 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
 
         savedSessionEditTextPreference = findPreference(EDIT_SAVE_SESSION);
         setSessionEditText();
+        createOnCustomRestoreOption(prefMgr);
     }
+
+    private void createOnCustomRestoreOption(PreferenceManager prefMgr) {
+        Preference pref = prefMgr.findPreference(PREFS_CUSTOM_RESTORE_DOC_LOCATION);
+        pref.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                GoogleAnalyticsUtils.reportPrefItemClick(
+                        GoogleAnalyticsFields.CATEGORY_DEV_PREFS,
+                        GoogleAnalyticsFields.LABEL_CUSTOM_RESTORE);
+                startFileBrowser();
+                return true;
+            }
+        });
+    }
+
+    private void startFileBrowser() {
+        Intent chooseTemplateIntent = new Intent()
+                .setAction(Intent.ACTION_GET_CONTENT)
+                .setType("file/*")
+                .addCategory(Intent.CATEGORY_OPENABLE);
+        try {
+            startActivityForResult(chooseTemplateIntent, REQUEST_SYNC_FILE);
+        } catch (ActivityNotFoundException e) {
+            // Means that there is no file browser installed on the device
+            TemplatePrinterUtils.showAlertDialog(this, "Can't restore custom XML File",
+                    Localization.get("no.file.browser"), false);
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == REQUEST_SYNC_FILE) {
+            if (resultCode == RESULT_OK && data != null) {
+                this.setResult(DeveloperPreferences.RESULT_SYNC_CUSTOM, data);
+                this.finish();
+            } else {
+                //No file selected
+                Toast.makeText(this, "No file requested...", Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+
+
 
     private static void populatePrefKeyToEventLabelMapping() {
         prefKeyToAnalyticsEvent.put(SUPERUSER_ENABLED, GoogleAnalyticsFields.LABEL_DEV_MODE);
@@ -92,6 +151,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
         prefKeyToAnalyticsEvent.put(AUTO_PURGE_ENABLED, GoogleAnalyticsFields.LABEL_AUTO_PURGE);
         prefKeyToAnalyticsEvent.put(LOAD_FORM_PAYLOAD_AS, GoogleAnalyticsFields.LABEL_LOAD_FORM_PAYLOAD_AS);
         prefKeyToAnalyticsEvent.put(DETAIL_TAB_SWIPE_ACTION_ENABLED, GoogleAnalyticsFields.LABEL_DETAIL_TAB_SWIPE_ACTION);
+        prefKeyToAnalyticsEvent.put(PREFS_CUSTOM_RESTORE_DOC_LOCATION, GoogleAnalyticsFields.LABEL_CUSTOM_RESTORE);
     }
 
     private void setSessionEditText() {

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -18,7 +18,7 @@ import org.commcare.models.database.HybridFileBackedSqlStorageMock;
 import org.commcare.models.encryption.ByteEncrypter;
 import org.commcare.network.DataPullRequester;
 import org.commcare.network.HttpUtils;
-import org.commcare.network.LocalDataPullResponseFactory;
+import org.commcare.network.LocalReferencePullResponseFactory;
 import org.commcare.services.CommCareSessionService;
 import org.commcare.utils.AndroidCacheDirSetup;
 import org.javarosa.core.model.User;
@@ -219,7 +219,7 @@ public class CommCareTestApplication extends CommCareApplication implements Test
 
     @Override
     public DataPullRequester getDataPullRequester() {
-        return LocalDataPullResponseFactory.INSTANCE;
+        return LocalReferencePullResponseFactory.INSTANCE;
     }
 
     @Override

--- a/app/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
@@ -6,7 +6,7 @@ import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.network.HttpRequestEndpointsMock;
 import org.commcare.android.util.TestAppInstaller;
-import org.commcare.network.LocalDataPullResponseFactory;
+import org.commcare.network.LocalReferencePullResponseFactory;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.ResultAndError;
 import org.junit.Assert;
@@ -125,7 +125,7 @@ public class DataPullTaskTest {
         
         // Indicates that the task executed all of the retries we indicated, and then successfully
         // parsed the final success response
-        Assert.assertEquals(4, LocalDataPullResponseFactory.getNumRequestsMade());
+        Assert.assertEquals(4, LocalReferencePullResponseFactory.getNumRequestsMade());
 
         // Indicates that the mock retry result was parsed correctly
         Assert.assertTrue(pullTask.getAsyncRestoreHelper().serverProgressCompletedSoFar == 55);
@@ -142,10 +142,10 @@ public class DataPullTaskTest {
 
     private static void runDataPull(Integer[] resultCodes, String[] payloadResources) {
         HttpRequestEndpointsMock.setCaseFetchResponseCodes(resultCodes);
-        LocalDataPullResponseFactory.setRequestPayloads(payloadResources);
+        LocalReferencePullResponseFactory.setRequestPayloads(payloadResources);
 
         DataPullTask<Object> task =
-                new DataPullTask<Object>("test", "123", "fake.server.com", RuntimeEnvironment.application, LocalDataPullResponseFactory.INSTANCE, false) {
+                new DataPullTask<Object>("test", "123", "fake.server.com", RuntimeEnvironment.application, LocalReferencePullResponseFactory.INSTANCE, false) {
                     @Override
                     protected void deliverResult(Object o, ResultAndError<PullTaskResult> pullTaskResultResultAndError) {
                         dataPullResult = pullTaskResultResultAndError;

--- a/app/unit-tests/src/org/commcare/android/tests/activities/PostRequestActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/PostRequestActivityTest.java
@@ -17,7 +17,7 @@ import org.commcare.dalvik.R;
 import org.commcare.models.AndroidSessionWrapper;
 import org.commcare.modern.util.Pair;
 import org.commcare.network.HttpRequestEndpointsMock;
-import org.commcare.network.LocalDataPullResponseFactory;
+import org.commcare.network.LocalReferencePullResponseFactory;
 import org.commcare.session.CommCareSession;
 import org.commcare.session.RemoteQuerySessionManager;
 import org.javarosa.core.model.instance.ExternalDataInstance;
@@ -152,7 +152,7 @@ public class PostRequestActivityTest {
     public void retryClaimTest() {
         ModernHttpRequesterMock.setResponseCodes(new Integer[]{500, 200});
         HttpRequestEndpointsMock.setCaseFetchResponseCodes(new Integer[]{200});
-        LocalDataPullResponseFactory.setRequestPayloads(new String[]{"jr://resource/commcare-apps/case_search_and_claim/empty_restore.xml"});
+        LocalReferencePullResponseFactory.setRequestPayloads(new String[]{"jr://resource/commcare-apps/case_search_and_claim/empty_restore.xml"});
 
         PostRequestActivity postRequestActivity = buildPostActivity("https://www.fake.com");
 
@@ -172,7 +172,7 @@ public class PostRequestActivityTest {
     public void makeSuccessfulPostRequestTest() {
         ModernHttpRequesterMock.setResponseCodes(new Integer[]{200});
         HttpRequestEndpointsMock.setCaseFetchResponseCodes(new Integer[]{200});
-        LocalDataPullResponseFactory.setRequestPayloads(new String[]{"jr://resource/commcare-apps/case_search_and_claim/empty_restore.xml"});
+        LocalReferencePullResponseFactory.setRequestPayloads(new String[]{"jr://resource/commcare-apps/case_search_and_claim/empty_restore.xml"});
 
         AndroidSessionWrapper sessionWrapper =
                 CommCareApplication.instance().getCurrentSessionWrapper();


### PR DESCRIPTION
Created a developer option to allow restoring a custom XML file to make it easier to debug/demonstrate certain issues on device without munging files at the APK level.

Adds an option to Developer Options that lets you pick an XML file from the file system and then runs that restore as if it had come from the server.