### PR TITLE
Actually use the display text in fillInPreviousAnswer

### DIFF
--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -18,6 +18,7 @@ import org.javarosa.core.model.data.InvalidData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.javarosa.xpath.XPathTypeMismatchException;
 
 import java.util.Vector;
 
@@ -115,9 +116,17 @@ public class ComboboxWidget extends QuestionWidget {
 
     private void fillInPreviousAnswer(FormEntryPrompt prompt) {
         if (prompt.getAnswerValue() != null) {
-            String previousAnswerValue = ((Selection)prompt.getAnswerValue().getValue()).getValue();
-            if (comboBox.isValidUserEntry(previousAnswerValue)) {
-                comboBox.setText(previousAnswerValue);
+            Selection priorSelection = (Selection)prompt.getAnswerValue().getValue();
+            String previousEnteredText;
+            try {
+                previousEnteredText = prompt.getSelectItemText(priorSelection);
+            } catch (XPathTypeMismatchException e) {
+                // Means that a default value was provided that is not a precise answer choice,
+                // but we can still grab the entered text this way and check if it's a valid entry
+                previousEnteredText = priorSelection.xmlValue;
+            }
+            if (previousEnteredText != null && comboBox.isValidUserEntry(previousEnteredText)) {
+                comboBox.setText(previousEnteredText);
             }
         }
     }


### PR DESCRIPTION
Addresses https://manage.dimagi.com/default.asp?248507, which was caused by https://github.com/dimagi/commcare-android/pull/1647. I had been using the select choice's _value_ when I meant to be using its display text; I clearly did not test this sufficiently, I'm sorry about that. Also going to give Nick a heads up because the change I made for him won't work properly at all until this is merged.