### PR TITLE
Camera Widget Fix for Sdk 24+

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -118,6 +118,17 @@
             android:exported="true"
             android:readPermission="${applicationId}.provider.cases.read"/>
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.external.files.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
+
+
         <activity android:name="org.commcare.preferences.CommCarePreferences">
         </activity>
         <activity android:name="org.commcare.activities.DotsEntryActivity">

--- a/app/res/xml/provider_paths.xml
+++ b/app/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-files-path name="external_files" path="temp/external/"/>
+</paths>

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -629,6 +629,14 @@ public class CommCareApplication extends Application {
         if (!success) {
             Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Couldn't create temp folder");
         }
+
+        String externalRoot = this.getAndroidFsExternalTemp();
+        FileUtil.deleteFileOrDir(externalRoot);
+        success = FileUtil.createFolder(externalRoot);
+        if (!success) {
+            Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Couldn't create external file folder");
+        }
+
     }
 
     /**
@@ -884,6 +892,9 @@ public class CommCareApplication extends Application {
     public String getAndroidFsTemp() {
         return Environment.getExternalStorageDirectory().toString() + "/Android/data/" + getPackageName() + "/temp/";
     }
+    public String getAndroidFsExternalTemp() {
+        return getAndroidFsRoot() + "/temp/external/";
+    }
 
     /**
      * @return a path to a file location that can be used to store a file
@@ -892,6 +903,14 @@ public class CommCareApplication extends Application {
      */
     public String getTempFilePath() {
         return getAndroidFsTemp() + PropertyUtils.genUUID();
+    }
+
+    /**
+     * @param fileStem a relative file path to reference in the temp storage space
+     * @return A file that can be shared with external applications via URI
+     */
+    public String getExternalTempPath(String fileStem) {
+        return getAndroidFsExternalTemp() + fileStem;
     }
 
     public ArchiveFileRoot getArchiveFileRoot() {

--- a/app/src/org/commcare/activities/DrawActivity.java
+++ b/app/src/org/commcare/activities/DrawActivity.java
@@ -29,6 +29,8 @@ import org.commcare.utils.MediaUtil;
 import org.commcare.utils.StringUtils;
 import org.commcare.views.dialogs.DialogChoiceItem;
 import org.commcare.views.dialogs.PaneledChoiceDialog;
+import org.commcare.views.widgets.ImageWidget;
+import org.commcare.views.widgets.SignatureWidget;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -88,9 +90,9 @@ public class DrawActivity extends Activity {
         if (extras == null) {
             loadOption = OPTION_DRAW;
             refImage = null;
-            savepointImage = new File(ODKStorage.TMPDRAWFILE_PATH);
+            savepointImage = SignatureWidget.getTempFileForDrawingCapture();
             savepointImage.delete();
-            output = new File(ODKStorage.TMPFILE_PATH);
+            output = ImageWidget.getTempFileForImageCapture();
         } else {
             loadOption = extras.getString(OPTION);
             if (loadOption == null) {
@@ -114,7 +116,7 @@ public class DrawActivity extends Activity {
                     }
                 }
             } else {
-                savepointImage = new File(ODKStorage.TMPDRAWFILE_PATH);
+                savepointImage = SignatureWidget.getTempFileForDrawingCapture();
                 savepointImage.delete();
                 if (refImage != null && refImage.exists()) {
                     try {
@@ -130,7 +132,7 @@ public class DrawActivity extends Activity {
             if (uri != null) {
                 output = new File(uri.getPath());
             } else {
-                output = new File(ODKStorage.TMPFILE_PATH);
+                output = ImageWidget.getTempFileForImageCapture();
             }
         }
 
@@ -349,7 +351,7 @@ public class DrawActivity extends Activity {
             mBitmapPaint = new Paint(Paint.DITHER_FLAG);
             mCurrentPath = new Path();
             setBackgroundColor(0xFFFFFFFF);
-            mBackgroundBitmapFile = new File(ODKStorage.TMPDRAWFILE_PATH);
+            mBackgroundBitmapFile = SignatureWidget.getTempFileForDrawingCapture();
         }
 
         public DrawView(Context c, boolean isSignature, File f, Paint paint, Paint pointPaint) {

--- a/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
+++ b/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
@@ -93,7 +93,7 @@ public class ImageCaptureProcessing {
          */
 
         // The intent is empty, but we know we saved the image to the temp file
-        File originalImage = ImageWidget.TEMP_FILE_FOR_IMAGE_CAPTURE;
+        File originalImage = ImageWidget.getTempFileForImageCapture();
         try {
             File unscaledFinalImage = moveAndScaleImage(originalImage, isImage, instanceFolder, activity);
             activity.saveImageWidgetAnswer(buildImageFileContentValues(unscaledFinalImage));

--- a/app/src/org/commcare/models/ODKStorage.java
+++ b/app/src/org/commcare/models/ODKStorage.java
@@ -11,8 +11,6 @@ public class ODKStorage {
     public static final String INSTANCES_PATH = ODK_ROOT + "/instances";
     public static final String CACHE_PATH = ODK_ROOT + "/.cache";
     public static final String METADATA_PATH = ODK_ROOT + "/metadata";
-    public static final String TMPFILE_PATH = CACHE_PATH + "/tmp.jpg";
-    public static final String TMPDRAWFILE_PATH = CACHE_PATH + "/tmpDraw.jpg";
 
     public static final String DEFAULT_FONTSIZE = "21";
 

--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -697,6 +697,10 @@ public class FileUtil {
         return "com.google.android.apps.photos.content".equals(uri.getAuthority());
     }
 
+    /**
+     * @return A platform-dependent URI for the file at the provided URI. If using SDK24+ only files
+     * supported by a FileProvider are able to be shared externally by these URI's
+     */
     public static Uri getUriForExternalFile(Context context, File file) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ) {
             return FileProvider.getUriForFile(context,

--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
+import android.support.v4.content.FileProvider;
 import android.util.Log;
 import android.util.Pair;
 
@@ -695,4 +696,15 @@ public class FileUtil {
     private static boolean isGooglePhotosUri(Uri uri) {
         return "com.google.android.apps.photos.content".equals(uri.getAuthority());
     }
+
+    public static Uri getUriForExternalFile(Context context, File file) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ) {
+            return FileProvider.getUriForFile(context,
+                    context.getApplicationContext().getPackageName() + ".external.files.provider",
+                    file);
+        } else {
+            return Uri.fromFile(file);
+        }
+    }
+
 }

--- a/app/src/org/commcare/utils/GlobalConstants.java
+++ b/app/src/org/commcare/utils/GlobalConstants.java
@@ -14,6 +14,9 @@ public class GlobalConstants {
 
     public static final String FILE_CC_FORMS = "formdata/";
 
+    public static final String TEMP_FILE_STEM_IMAGE_HOLDER = "tmp.jpg";
+    public static final String TEMP_FILE_STEM_DRAW_HOLDER = "tmpDraw.jpg";
+
     /**
      * Root file directory for storing serialized objects for the file backed
      * sql storage layer (currently used for fixtures).

--- a/app/src/org/commcare/views/widgets/SignatureWidget.java
+++ b/app/src/org/commcare/views/widgets/SignatureWidget.java
@@ -32,12 +32,14 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.commcare.CommCareApplication;
 import org.commcare.activities.DrawActivity;
 import org.commcare.activities.components.FormEntryConstants;
 import org.commcare.activities.components.FormEntryInstanceState;
 import org.commcare.dalvik.R;
 import org.commcare.logic.PendingCalloutInterface;
 import org.commcare.models.ODKStorage;
+import org.commcare.utils.GlobalConstants;
 import org.commcare.utils.MediaUtil;
 import org.commcare.utils.StringUtils;
 import org.commcare.utils.UrlUtils;
@@ -63,6 +65,11 @@ public class SignatureWidget extends QuestionWidget {
     private final PendingCalloutInterface pendingCalloutInterface;
 
     private final TextView mErrorTextView;
+
+    public static File getTempFileForDrawingCapture() {
+        return new File(CommCareApplication.instance().
+                getExternalTempPath(GlobalConstants.TEMP_FILE_STEM_DRAW_HOLDER));
+    }
 
     public SignatureWidget(Context context, FormEntryPrompt prompt, PendingCalloutInterface pic) {
         super(context, prompt);
@@ -154,7 +161,7 @@ public class SignatureWidget extends QuestionWidget {
         }
 
         i.putExtra(DrawActivity.EXTRA_OUTPUT,
-                Uri.fromFile(new File(ODKStorage.TMPFILE_PATH)));
+                Uri.fromFile(ImageWidget.getTempFileForImageCapture()));
 
         try {
             ((Activity)getContext()).startActivityForResult(i, FormEntryConstants.SIGNATURE_CAPTURE);


### PR DESCRIPTION
Fix for: https://manage.dimagi.com/default.asp?248780

As of SDK 24 and beyond, you are no longer allowed to provide free access to your device's external files (FileUriExposedException).  The camera widget needs to be able to provide a "stub" file to the camera in order to receive correct access to its functionality, so this PR implements a "temporary external" file store location where we can place those files in the short term to allow them to be read.

Release Note:
- Fix for Camera image capture not working on Android 'N' Devices.