### PR TITLE
Order form submissions by global counter

### DIFF
--- a/app/src/org/commcare/activities/CommCareFormDumpActivity.java
+++ b/app/src/org/commcare/activities/CommCareFormDumpActivity.java
@@ -250,7 +250,7 @@ public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommC
 
     private Vector<Integer> getUnsyncedForms() {
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormsForCurrentApp(storage);
+        Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormIdsForCurrentApp(storage);
         Logger.log(AndroidLogger.TYPE_FORM_DUMP, "Found " + ids.size() + " unsynced forms.");
         return ids;
     }

--- a/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
@@ -790,7 +790,7 @@ public class CommCareWiFiDirectActivity
 
     private void updateStatusText() {
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormsForCurrentApp(storage);
+        Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormIdsForCurrentApp(storage);
 
         int numUnsyncedForms = ids.size();
         int numUnsubmittedForms;

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -45,7 +45,7 @@ public class FormAndDataSyncer {
                                                 final boolean syncAfterwards,
                                                 boolean userTriggered) {
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        FormRecord[] records = StorageUtils.getUnsentRecords(storage);
+        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage);
 
         if (records.length > 0) {
             processAndSendForms(activity, records, syncAfterwards, userTriggered);

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -45,7 +45,7 @@ public class FormAndDataSyncer {
                                                 final boolean syncAfterwards,
                                                 boolean userTriggered) {
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage, true);
+        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage);
 
         if (records.length > 0) {
             processAndSendForms(activity, records, syncAfterwards, userTriggered);

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -45,7 +45,7 @@ public class FormAndDataSyncer {
                                                 final boolean syncAfterwards,
                                                 boolean userTriggered) {
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage);
+        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage, true);
 
         if (records.length > 0) {
             processAndSendForms(activity, records, syncAfterwards, userTriggered);

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -655,10 +655,8 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
             // The form is either ready for processing, or not, depending on how it was saved
             if (complete) {
-                // We're honoring in order submissions, now, so trigger a full
-                // submission cycle
+                current.setFormNumberForSubmissionOrdering();
                 checkAndStartUnsentFormsTask(false, false);
-
                 refreshUI();
 
                 if (wasExternal) {
@@ -667,8 +665,8 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                     return false;
                 }
 
-                // Before we can terminate the session, we need to know that the form has been processed
-                // in case there is state that depends on it.
+                // Before we can terminate the session, we need to know that the form has been
+                // processed in case there is state that depends on it.
                 boolean terminateSuccessful;
                 try {
                     terminateSuccessful = currentState.terminateSession();

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -656,6 +656,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             // The form is either ready for processing, or not, depending on how it was saved
             if (complete) {
                 current.setFormNumberForSubmissionOrdering();
+                CommCareApplication.instance().getUserStorage(FormRecord.class).write(current);
                 checkAndStartUnsentFormsTask(false, false);
                 refreshUI();
 

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -56,6 +56,7 @@ import org.commcare.utils.ChangeLocaleUtil;
 import org.commcare.utils.EntityDetailUtils;
 import org.commcare.utils.GlobalConstants;
 import org.commcare.utils.SessionUnavailableException;
+import org.commcare.utils.StorageUtils;
 import org.commcare.utils.UriToFilePath;
 import org.commcare.views.UserfacingErrorHandling;
 import org.commcare.views.dialogs.CommCareAlertDialog;
@@ -657,7 +658,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             if (complete) {
                 // Now that we know this form is completed, we can give it the next available
                 // submission ordering number
-                current.setFormNumberForSubmissionOrdering();
+                current.setFormNumberForSubmissionOrdering(StorageUtils.getNextFormSubmissionNumber());
                 CommCareApplication.instance().getUserStorage(FormRecord.class).write(current);
                 checkAndStartUnsentFormsTask(false, false);
                 refreshUI();

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -655,6 +655,8 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
             // The form is either ready for processing, or not, depending on how it was saved
             if (complete) {
+                // Now that we know this form is completed, we can give it the next available
+                // submission ordering number
                 current.setFormNumberForSubmissionOrdering();
                 CommCareApplication.instance().getUserStorage(FormRecord.class).write(current);
                 checkAndStartUnsentFormsTask(false, false);

--- a/app/src/org/commcare/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/activities/RecoveryActivity.java
@@ -60,7 +60,7 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
             @Override
             public void onClick(View v) {
                 FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(
-                        CommCareApplication.instance().getUserStorage(FormRecord.class), true);
+                        CommCareApplication.instance().getUserStorage(FormRecord.class));
                 SharedPreferences settings = CommCareApplication.instance().getCurrentApp().getAppPreferences();
 
                 ProcessAndSendTask<RecoveryActivity> mProcess =
@@ -174,7 +174,7 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
 
         SqlStorage<FormRecord> recordStorage = CommCareApplication.instance().getUserStorage(FormRecord.class);
         try {
-            FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(recordStorage, false);
+            FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(recordStorage);
             if (records.length == 0) {
                 txtUnsentForms.setText("This device has no unsent forms");
             } else {

--- a/app/src/org/commcare/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/activities/RecoveryActivity.java
@@ -59,7 +59,7 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
             @SuppressLint("NewApi")
             @Override
             public void onClick(View v) {
-                FormRecord[] records = StorageUtils.getUnsentRecords(CommCareApplication.instance().getUserStorage(FormRecord.class));
+                FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(CommCareApplication.instance().getUserStorage(FormRecord.class));
                 SharedPreferences settings = CommCareApplication.instance().getCurrentApp().getAppPreferences();
 
                 ProcessAndSendTask<RecoveryActivity> mProcess =
@@ -173,7 +173,7 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
 
         SqlStorage<FormRecord> recordStorage = CommCareApplication.instance().getUserStorage(FormRecord.class);
         try {
-            FormRecord[] records = StorageUtils.getUnsentRecords(recordStorage);
+            FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(recordStorage);
             if (records.length == 0) {
                 txtUnsentForms.setText("This device has no unsent forms");
             } else {

--- a/app/src/org/commcare/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/activities/RecoveryActivity.java
@@ -59,7 +59,8 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
             @SuppressLint("NewApi")
             @Override
             public void onClick(View v) {
-                FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(CommCareApplication.instance().getUserStorage(FormRecord.class));
+                FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(
+                        CommCareApplication.instance().getUserStorage(FormRecord.class), true);
                 SharedPreferences settings = CommCareApplication.instance().getCurrentApp().getAppPreferences();
 
                 ProcessAndSendTask<RecoveryActivity> mProcess =
@@ -173,7 +174,7 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
 
         SqlStorage<FormRecord> recordStorage = CommCareApplication.instance().getUserStorage(FormRecord.class);
         try {
-            FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(recordStorage);
+            FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(recordStorage, false);
             if (records.length == 0) {
                 txtUnsentForms.setText("This device has no unsent forms");
             } else {

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -1,14 +1,17 @@
 package org.commcare.android.database.user.models;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.net.Uri;
 
+import org.commcare.CommCareApplication;
 import org.commcare.android.storage.framework.Persisted;
 import org.commcare.models.framework.Persisting;
 import org.commcare.models.framework.Table;
 import org.commcare.modern.models.EncryptedModel;
 import org.commcare.modern.models.MetaField;
+import org.commcare.preferences.CommCarePreferences;
 import org.commcare.provider.InstanceProviderAPI.InstanceColumns;
 
 import java.io.FileNotFoundException;
@@ -28,6 +31,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
     public static final String META_XMLNS = "XMLNS";
     public static final String META_LAST_MODIFIED = "DATE_MODIFIED";
     public static final String META_APP_ID = "APP_ID";
+    public static final String META_FORM_NUMBER = "FORM_NUMBER";
 
     /**
      * This form record is a stub that hasn't actually had data saved for it yet
@@ -67,23 +71,33 @@ public class FormRecord extends Persisted implements EncryptedModel {
     @Persisting(1)
     @MetaField(META_XMLNS)
     private String xmlns;
+
     @Persisting(2)
     @MetaField(META_INSTANCE_URI)
     private String instanceURI;
+
     @Persisting(3)
     @MetaField(META_STATUS)
     private String status;
+
     @Persisting(4)
     private byte[] aesKey;
+
     @Persisting(value = 5, nullable = true)
     @MetaField(META_UUID)
     private String uuid;
+
     @Persisting(6)
     @MetaField(META_LAST_MODIFIED)
     private Date lastModified;
+
     @Persisting(7)
     @MetaField(META_APP_ID)
     private String appId;
+
+    @Persisting(8)
+    @MetaField(META_FORM_NUMBER)
+    private String formNumberInOrder;
 
     public FormRecord() {
     }
@@ -190,5 +204,17 @@ public class FormRecord extends Persisted implements EncryptedModel {
     @Override
     public String toString() {
         return String.format("Form Record[%s][Status: %s]\n[Form: %s]\n[Last Modified: %s]", this.recordId, this.status, this.xmlns, this.lastModified.toString());
+    }
+
+    public void setFormNumberForSubmissionOrdering() {
+        this.formNumberInOrder = ""+getNextFormNumberInOrder();
+    }
+
+    private static int getNextFormNumberInOrder() {
+        SharedPreferences appPrefs =
+                CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        int lastFormNum = appPrefs.getInt(CommCarePreferences.GLOBAL_APP_FORM_COUNTER, -1);
+        appPrefs.edit().putInt(CommCarePreferences.GLOBAL_APP_FORM_COUNTER, lastFormNum + 1);
+        return lastFormNum + 1;
     }
 }

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -174,8 +174,8 @@ public class FormRecord extends Persisted implements EncryptedModel {
         return uuid;
     }
 
-    public String getSubmissionOrderingNumber() {
-        return submissionOrderingNumber;
+    public int getSubmissionOrderingNumber() {
+        return Integer.parseInt(submissionOrderingNumber);
     }
 
     /**

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -95,7 +95,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
     @MetaField(META_APP_ID)
     private String appId;
 
-    @Persisting(8)
+    @Persisting(value = 8, nullable = true)
     @MetaField(META_FORM_NUMBER)
     private String formNumberInOrder;
 

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -31,7 +31,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
     public static final String META_XMLNS = "XMLNS";
     public static final String META_LAST_MODIFIED = "DATE_MODIFIED";
     public static final String META_APP_ID = "APP_ID";
-    public static final String META_FORM_NUMBER = "FORM_NUMBER";
+    public static final String META_FORM_ORDERING_NUMBER = "FORM_ORDERING_NUMBER";
 
     /**
      * This form record is a stub that hasn't actually had data saved for it yet
@@ -96,8 +96,8 @@ public class FormRecord extends Persisted implements EncryptedModel {
     private String appId;
 
     @Persisting(value = 8, nullable = true)
-    @MetaField(META_FORM_NUMBER)
-    private String formNumberInOrder;
+    @MetaField(META_FORM_ORDERING_NUMBER)
+    private String formOrderingNumber;
 
     public FormRecord() {
     }
@@ -173,6 +173,10 @@ public class FormRecord extends Persisted implements EncryptedModel {
         return uuid;
     }
 
+    public String getFormOrderingNumber() {
+        return formOrderingNumber;
+    }
+
     /**
      * Get the file system path to the encrypted XML submission file.
      *
@@ -207,14 +211,15 @@ public class FormRecord extends Persisted implements EncryptedModel {
     }
 
     public void setFormNumberForSubmissionOrdering() {
-        this.formNumberInOrder = ""+getNextFormNumberInOrder();
+        this.formOrderingNumber = ""+getNextFormNumberInOrder();
     }
 
-    private static int getNextFormNumberInOrder() {
-        SharedPreferences appPrefs =
-                CommCareApplication.instance().getCurrentApp().getAppPreferences();
+    private int getNextFormNumberInOrder() {
+        SharedPreferences appPrefs = CommCareApplication.instance()
+                .getSharedPreferences(this.appId, Context.MODE_PRIVATE);
         int lastFormNum = appPrefs.getInt(CommCarePreferences.GLOBAL_APP_FORM_COUNTER, -1);
         appPrefs.edit().putInt(CommCarePreferences.GLOBAL_APP_FORM_COUNTER, lastFormNum + 1).commit();
         return lastFormNum + 1;
     }
+
 }

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -176,6 +176,9 @@ public class FormRecord extends Persisted implements EncryptedModel {
     }
 
     public int getSubmissionOrderingNumber() {
+        if (submissionOrderingNumber == null) {
+            return -1;
+        }
         return Integer.parseInt(submissionOrderingNumber);
     }
 

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -176,9 +176,6 @@ public class FormRecord extends Persisted implements EncryptedModel {
     }
 
     public int getSubmissionOrderingNumber() {
-        if (submissionOrderingNumber == null) {
-            return -1;
-        }
         return Integer.parseInt(submissionOrderingNumber);
     }
 
@@ -215,22 +212,8 @@ public class FormRecord extends Persisted implements EncryptedModel {
         return String.format("Form Record[%s][Status: %s]\n[Form: %s]\n[Last Modified: %s]", this.recordId, this.status, this.xmlns, this.lastModified.toString());
     }
 
-    public void setFormNumberForSubmissionOrdering() {
-        this.submissionOrderingNumber = ""+getNextSubmissionNumber();
-    }
-
-    private int getNextSubmissionNumber() {
-        SqlStorage<FormRecord> storage =
-                CommCareApplication.instance().getUserStorage(FormRecord.class);
-        Vector<FormRecord> records =
-                StorageUtils.getUnsentOrUnprocessedFormRecordsForCurrentApp(storage);
-        int maxSubmissionNumber = -1;
-        for (FormRecord record : records) {
-            if (record.getSubmissionOrderingNumber() > maxSubmissionNumber) {
-                maxSubmissionNumber = record.getSubmissionOrderingNumber();
-            }
-        }
-        return maxSubmissionNumber + 1;
+    public void setFormNumberForSubmissionOrdering(int num) {
+        this.submissionOrderingNumber = ""+num;
     }
 
 }

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -24,6 +24,7 @@ import java.util.Date;
 public class FormRecord extends Persisted implements EncryptedModel {
 
     public static final String STORAGE_KEY = "FORMRECORDS";
+    private final static String GLOBAL_APP_FORM_COUNTER = "global-app-form-counter";
 
     public static final String META_INSTANCE_URI = "INSTANCE_URI";
     public static final String META_STATUS = "STATUS";
@@ -218,8 +219,8 @@ public class FormRecord extends Persisted implements EncryptedModel {
     private int getNextFormNumberInOrder() {
         SharedPreferences appPrefs = CommCareApplication.instance()
                 .getSharedPreferences(this.appId, Context.MODE_PRIVATE);
-        int lastFormNum = appPrefs.getInt(CommCarePreferences.GLOBAL_APP_FORM_COUNTER, -1);
-        appPrefs.edit().putInt(CommCarePreferences.GLOBAL_APP_FORM_COUNTER, lastFormNum + 1).commit();
+        int lastFormNum = appPrefs.getInt(GLOBAL_APP_FORM_COUNTER, -1);
+        appPrefs.edit().putInt(GLOBAL_APP_FORM_COUNTER, lastFormNum + 1).commit();
         return lastFormNum + 1;
     }
 

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -214,7 +214,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
         SharedPreferences appPrefs =
                 CommCareApplication.instance().getCurrentApp().getAppPreferences();
         int lastFormNum = appPrefs.getInt(CommCarePreferences.GLOBAL_APP_FORM_COUNTER, -1);
-        appPrefs.edit().putInt(CommCarePreferences.GLOBAL_APP_FORM_COUNTER, lastFormNum + 1);
+        appPrefs.edit().putInt(CommCarePreferences.GLOBAL_APP_FORM_COUNTER, lastFormNum + 1).commit();
         return lastFormNum + 1;
     }
 }

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -129,6 +129,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
         FormRecord fr = new FormRecord(instanceURI, newStatus, xmlns, aesKey, uuid,
                 lastModified, appId);
         fr.recordId = this.recordId;
+        fr.formOrderingNumber = this.formOrderingNumber;
         return fr;
     }
 

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -11,7 +11,6 @@ import org.commcare.models.framework.Persisting;
 import org.commcare.models.framework.Table;
 import org.commcare.modern.models.EncryptedModel;
 import org.commcare.modern.models.MetaField;
-import org.commcare.preferences.CommCarePreferences;
 import org.commcare.provider.InstanceProviderAPI.InstanceColumns;
 
 import java.io.FileNotFoundException;
@@ -24,7 +23,7 @@ import java.util.Date;
 public class FormRecord extends Persisted implements EncryptedModel {
 
     public static final String STORAGE_KEY = "FORMRECORDS";
-    private final static String GLOBAL_APP_FORM_COUNTER = "global-app-form-counter";
+    private final static String APP_FORM_SUBMISSION_COUNTER = "app-form-submission-counter";
 
     public static final String META_INSTANCE_URI = "INSTANCE_URI";
     public static final String META_STATUS = "STATUS";
@@ -32,7 +31,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
     public static final String META_XMLNS = "XMLNS";
     public static final String META_LAST_MODIFIED = "DATE_MODIFIED";
     public static final String META_APP_ID = "APP_ID";
-    public static final String META_FORM_ORDERING_NUMBER = "FORM_ORDERING_NUMBER";
+    public static final String META_SUBMISSION_ORDERING_NUMBER = "SUBMISSION_ORDERING_NUMBER";
 
     /**
      * This form record is a stub that hasn't actually had data saved for it yet
@@ -97,8 +96,8 @@ public class FormRecord extends Persisted implements EncryptedModel {
     private String appId;
 
     @Persisting(value = 8, nullable = true)
-    @MetaField(META_FORM_ORDERING_NUMBER)
-    private String formOrderingNumber;
+    @MetaField(META_SUBMISSION_ORDERING_NUMBER)
+    private String submissionOrderingNumber;
 
     public FormRecord() {
     }
@@ -130,7 +129,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
         FormRecord fr = new FormRecord(instanceURI, newStatus, xmlns, aesKey, uuid,
                 lastModified, appId);
         fr.recordId = this.recordId;
-        fr.formOrderingNumber = this.formOrderingNumber;
+        fr.submissionOrderingNumber = this.submissionOrderingNumber;
         return fr;
     }
 
@@ -175,8 +174,8 @@ public class FormRecord extends Persisted implements EncryptedModel {
         return uuid;
     }
 
-    public String getFormOrderingNumber() {
-        return formOrderingNumber;
+    public String getSubmissionOrderingNumber() {
+        return submissionOrderingNumber;
     }
 
     /**
@@ -213,14 +212,14 @@ public class FormRecord extends Persisted implements EncryptedModel {
     }
 
     public void setFormNumberForSubmissionOrdering() {
-        this.formOrderingNumber = ""+getNextFormNumberInOrder();
+        this.submissionOrderingNumber = ""+ getNextSubmissionNumber();
     }
 
-    private int getNextFormNumberInOrder() {
+    private int getNextSubmissionNumber() {
         SharedPreferences appPrefs = CommCareApplication.instance()
                 .getSharedPreferences(this.appId, Context.MODE_PRIVATE);
-        int lastFormNum = appPrefs.getInt(GLOBAL_APP_FORM_COUNTER, -1);
-        appPrefs.edit().putInt(GLOBAL_APP_FORM_COUNTER, lastFormNum + 1).commit();
+        int lastFormNum = appPrefs.getInt(APP_FORM_SUBMISSION_COUNTER, -1);
+        appPrefs.edit().putInt(APP_FORM_SUBMISSION_COUNTER, lastFormNum + 1).commit();
         return lastFormNum + 1;
     }
 

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -176,6 +176,9 @@ public class FormRecord extends Persisted implements EncryptedModel {
     }
 
     public int getSubmissionOrderingNumber() {
+        if (submissionOrderingNumber == null) {
+            return -1;
+        }
         return Integer.parseInt(submissionOrderingNumber);
     }
 
@@ -213,7 +216,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
     }
 
     public void setFormNumberForSubmissionOrdering() {
-        this.submissionOrderingNumber = ""+ getNextSubmissionNumber();
+        this.submissionOrderingNumber = ""+getNextSubmissionNumber();
     }
 
     private int getNextSubmissionNumber() {

--- a/app/src/org/commcare/android/database/user/models/FormRecordV2.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecordV2.java
@@ -1,0 +1,90 @@
+package org.commcare.android.database.user.models;
+
+import org.commcare.android.storage.framework.Persisted;
+import org.commcare.models.framework.Persisting;
+import org.commcare.models.framework.Table;
+import org.commcare.modern.models.MetaField;
+
+import java.util.Date;
+
+/**
+ * This class represents the version of a FormRecord that exists on any devices running versions
+ * 2.26 though 2.34 of CommCare, which was deprecated in user db version 17. This class is used
+ * to read a FormRecord that exists in such a database, in order to run a db upgrade.
+ *
+ * @author Aliza Stone
+ */
+@Table("FORMRECORDS")
+public class FormRecordV2 extends Persisted {
+
+    @Persisting(1)
+    @MetaField(FormRecord.META_XMLNS)
+    private String xmlns;
+    @Persisting(2)
+    @MetaField(FormRecord.META_INSTANCE_URI)
+    private String instanceURI;
+    @Persisting(3)
+    @MetaField(FormRecord.META_STATUS)
+    private String status;
+    @Persisting(4)
+    private byte[] aesKey;
+    @Persisting(value = 5, nullable = true)
+    @MetaField(FormRecord.META_UUID)
+    private String uuid;
+    @Persisting(6)
+    @MetaField(FormRecord.META_LAST_MODIFIED)
+    private Date lastModified;
+    @Persisting(7)
+    @MetaField(FormRecord.META_APP_ID)
+    private String appId;
+
+    /*
+     * Deserialization only
+     */
+    public FormRecordV2() {
+    }
+
+    public FormRecordV2(String instanceURI, String status, String xmlns, byte[] aesKey, String uuid,
+                      Date lastModified, String appId) {
+        this.instanceURI = instanceURI;
+        this.status = status;
+        this.xmlns = xmlns;
+        this.aesKey = aesKey;
+
+        this.uuid = uuid;
+        this.lastModified = lastModified;
+        if (lastModified == null) {
+            this.lastModified = new Date();
+        }
+        this.appId = appId;
+    }
+
+    public String getInstanceURIString() {
+        return instanceURI;
+    }
+
+    public byte[] getAesKey() {
+        return aesKey;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getInstanceID() {
+        return uuid;
+    }
+
+    public Date lastModified() {
+        return lastModified;
+    }
+
+    public String getFormNamespace() {
+        return xmlns;
+    }
+
+    public String getAppId() {
+        return this.appId;
+    }
+
+}

--- a/app/src/org/commcare/android/database/user/models/FormRecordV2.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecordV2.java
@@ -10,7 +10,7 @@ import java.util.Date;
 /**
  * This class represents the version of a FormRecord that exists on any devices running versions
  * 2.26 though 2.34 of CommCare, which was deprecated in user db version 17. This class is used
- * to read a FormRecord that exists in such a database, in order to run a db upgrade.
+ * to read a form record that exists in such a database, in order to run a db upgrade.
  *
  * @author Aliza Stone
  */

--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -103,16 +103,6 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return fillIdWindow(c, DatabaseHelper.ID_COL, returnSet);
     }
 
-    public Vector<Integer> getIDsForAllRecords() {
-        SQLiteDatabase db = helper.getHandle();
-        Cursor c = db.query(table, new String[]{DatabaseHelper.ID_COL}, null, null, null, null, null);
-        return fillIdWindow(c, DatabaseHelper.ID_COL, null);
-    }
-
-    public static Vector<Integer> fillIdWindow(Cursor c, String columnName) {
-        return fillIdWindow(c, columnName, null);
-    }
-
     public static Vector<Integer> fillIdWindow(Cursor c, String columnName, LinkedHashSet<Integer> newReturn) {
         Vector<Integer> indices = new Vector<>();
         try {

--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -3,9 +3,6 @@ package org.commcare.models.database;
 import android.database.Cursor;
 import android.util.Pair;
 
-import com.carrotsearch.hppc.IntObjectMap;
-import com.carrotsearch.hppc.IntSet;
-
 import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteQueryBuilder;
 import net.sqlcipher.database.SQLiteStatement;
@@ -106,6 +103,12 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return fillIdWindow(c, DatabaseHelper.ID_COL, returnSet);
     }
 
+    public Vector<Integer> getIDsForAllRecords() {
+        SQLiteDatabase db = helper.getHandle();
+        Cursor c = db.query(table, new String[]{DatabaseHelper.ID_COL}, null, null, null, null, null);
+        return fillIdWindow(c, DatabaseHelper.ID_COL, null);
+    }
+
     public static Vector<Integer> fillIdWindow(Cursor c, String columnName) {
         return fillIdWindow(c, columnName, null);
     }
@@ -117,7 +120,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
                 int index = c.getColumnIndexOrThrow(columnName);
                 while (!c.isAfterLast()) {
                     int id = c.getInt(index);
-                    if(newReturn != null) {
+                    if (newReturn != null) {
                         newReturn.add(id);
                     }
                     indices.add(id);

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -51,9 +51,10 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
      * V.14 - Change format of last modified date in form record to canonical SQLite form
      * V.15 - Add table to store path info about storage-backed fixture tables
      * V.16 - Add type -> id index for case index storage
+     * V.17 - Add global counter metadata field to form records, for use in submission ordering
      */
 
-    private static final int USER_DB_VERSION = 16;
+    private static final int USER_DB_VERSION = 17;
 
     private static final String USER_DB_LOCATOR = "database_sandbox_";
 

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -507,6 +507,7 @@ class UserDatabaseUpgrader {
                 // sure that we are setting this form numbers in the most accurate order we can
                 newRecord.setFormNumberForSubmissionOrdering();
             }
+            newRecord.setID(oldRecord.getID());
             upgradedRecords.add(newRecord);
         }
     }

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -471,9 +471,13 @@ class UserDatabaseUpgrader {
                         oldRecord.getInstanceID(),
                         oldRecord.lastModified(),
                         oldRecord.getAppId());
-                // By processing the old records in order of their last modified date, we make sure
-                // that we are setting this form numbers in the most accurate order we can
-                newRecord.setFormNumberForSubmissionOrdering();
+                String statusOfOldRecord = oldRecord.getStatus();
+                if (FormRecord.STATUS_COMPLETE.equals(statusOfOldRecord) ||
+                        FormRecord.STATUS_UNSENT.equals(statusOfOldRecord)) {
+                    // By processing the old records in order of their last modified date, we make
+                    // sure that we are setting this form numbers in the most accurate order we can
+                    newRecord.setFormNumberForSubmissionOrdering();
+                }
                 upgradedRecords.add(newRecord);
             }
 

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -6,8 +6,8 @@ import android.util.Log;
 import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.user.models.FormRecordV2;
 import org.commcare.android.logging.ForceCloseLogEntry;
-import org.commcare.cases.ledger.Ledger;
 import org.commcare.android.javarosa.AndroidLogEntry;
 import org.commcare.logging.XPathErrorEntry;
 import org.commcare.models.database.AndroidTableBuilder;
@@ -16,7 +16,6 @@ import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.IndexedFixturePathUtils;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.SqlStorageIterator;
-import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.models.database.migration.FixtureSerializationMigration;
 import org.commcare.android.database.user.models.ACase;
 import org.commcare.android.database.user.models.ACasePreV6Model;
@@ -26,7 +25,6 @@ import org.commcare.models.database.user.models.EntityStorageCache;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.database.user.models.FormRecordV1;
 import org.commcare.android.database.user.models.GeocodeCacheModel;
-import org.commcare.android.database.user.models.SessionStateDescriptor;
 import org.commcare.modern.database.DatabaseIndexingUtils;
 import org.javarosa.core.model.User;
 import org.javarosa.core.services.storage.Persistable;
@@ -139,6 +137,11 @@ class UserDatabaseUpgrader {
                 oldVersion = 16;
             }
         }
+        if (oldVersion == 16) {
+            if (upgradeSixteenSeventeen(db)) {
+                oldVersion = 17;
+            }
+        }
     }
 
     private boolean upgradeOneTwo(final SQLiteDatabase db) {
@@ -166,8 +169,8 @@ class UserDatabaseUpgrader {
     private boolean upgradeThreeFour(SQLiteDatabase db) {
         db.beginTransaction();
         try {
-            addStockTable(db);
-            updateIndexes(db);
+            UserDbUpgradeUtils.addStockTable(db);
+            UserDbUpgradeUtils.updateIndexes(db);
             db.setTransactionSuccessful();
             return true;
         } finally {
@@ -291,12 +294,12 @@ class UserDatabaseUpgrader {
         db.beginTransaction();
         try {
 
-            if (multipleInstalledAppRecords()) {
+            if (UserDbUpgradeUtils.multipleInstalledAppRecords()) {
                 // Cannot migrate FormRecords once this device has already started installing
                 // multiple applications, because there is no way to know which of those apps the
                 // existing FormRecords belong to
-                deleteExistingFormRecordsAndWarnUser(c, db);
-                addAppIdColumnToTable(db);
+                UserDbUpgradeUtils.deleteExistingFormRecordsAndWarnUser(c, db);
+                UserDbUpgradeUtils.addAppIdColumnToTable(db);
                 db.setTransactionSuccessful();
                 return true;
             }
@@ -306,11 +309,11 @@ class UserDatabaseUpgrader {
                     FormRecordV1.class,
                     new ConcreteAndroidDbHelper(c, db));
 
-            String appId = getInstalledAppRecord().getApplicationId();
-            Vector<FormRecord> upgradedRecords = new Vector<>();
+            String appId = UserDbUpgradeUtils.getInstalledAppRecord().getApplicationId();
+            Vector<FormRecordV2> upgradedRecords = new Vector<>();
             // Create all of the updated records, based upon the existing ones
             for (FormRecordV1 oldRecord : oldStorage) {
-                FormRecord newRecord = new FormRecord(
+                FormRecordV2 newRecord = new FormRecordV2(
                         oldRecord.getInstanceURIString(),
                         oldRecord.getStatus(),
                         oldRecord.getFormNamespace(),
@@ -322,14 +325,14 @@ class UserDatabaseUpgrader {
                 upgradedRecords.add(newRecord);
             }
 
-            addAppIdColumnToTable(db);
+            UserDbUpgradeUtils.addAppIdColumnToTable(db);
 
             // Write all of the new records to the updated table
-            SqlStorage<FormRecord> newStorage = new SqlStorage<>(
+            SqlStorage<FormRecordV2> newStorage = new SqlStorage<>(
                     FormRecord.STORAGE_KEY,
-                    FormRecord.class,
+                    FormRecordV2.class,
                     new ConcreteAndroidDbHelper(c, db));
-            for (FormRecord r : upgradedRecords) {
+            for (FormRecordV2 r : upgradedRecords) {
                 newStorage.write(r);
             }
 
@@ -338,14 +341,6 @@ class UserDatabaseUpgrader {
         } finally {
             db.endTransaction();
         }
-    }
-
-    private static void addAppIdColumnToTable(SQLiteDatabase db) {
-        // Alter the FormRecord table to include an app id column
-        db.execSQL(DbUtil.addColumnToTable(
-                FormRecord.STORAGE_KEY,
-                FormRecord.META_APP_ID,
-                "TEXT"));
     }
 
     private boolean upgradeTenEleven(SQLiteDatabase db) {
@@ -447,19 +442,56 @@ class UserDatabaseUpgrader {
         }
     }
 
+    /**
+     * Add a metadata field to all form records for "form number" that will be used for ordering
+     * submissions. Since submissions were previously ordered by the last modified property,
+     * set the new form numbers in this order.
+     */
+    private boolean upgradeSixteenSeventeen(SQLiteDatabase db) {
+        db.beginTransaction();
+        try {
+            SqlStorage<FormRecordV2> oldStorage = new SqlStorage<>(
+                    FormRecord.STORAGE_KEY,
+                    FormRecordV2.class,
+                    new ConcreteAndroidDbHelper(c, db));
 
+            // Sort the old record ids by their last modified date, which is how form submission
+            // ordering was previously done
+            Vector<Integer> recordIds = oldStorage.getIDsForAllRecords();
+            UserDbUpgradeUtils.sortRecordsByDate(recordIds, oldStorage);
 
-    private void updateIndexes(SQLiteDatabase db) {
-        db.execSQL(DatabaseIndexingUtils.indexOnTableCommand("case_id_index", "AndroidCase", "case_id"));
-        db.execSQL(DatabaseIndexingUtils.indexOnTableCommand("case_type_index", "AndroidCase", "case_type"));
-        db.execSQL(DatabaseIndexingUtils.indexOnTableCommand("case_status_index", "AndroidCase", "case_status"));
-    }
+            Vector<FormRecord> upgradedRecords = new Vector<>();
+            for (int i = 0; i < recordIds.size(); i++) {
+                FormRecordV2 oldRecord = oldStorage.read(recordIds.elementAt(i));
+                FormRecord newRecord = new FormRecord(
+                        oldRecord.getInstanceURIString(),
+                        oldRecord.getStatus(),
+                        oldRecord.getFormNamespace(),
+                        oldRecord.getAesKey(),
+                        oldRecord.getInstanceID(),
+                        oldRecord.lastModified(),
+                        oldRecord.getAppId());
+                // By processing the old records in order of their last modified date, we make sure
+                // that we are setting this form numbers in the most accurate order we can
+                newRecord.setFormNumberForSubmissionOrdering();
+                upgradedRecords.add(newRecord);
+            }
 
-    private void addStockTable(SQLiteDatabase db) {
-        AndroidTableBuilder builder = new AndroidTableBuilder(Ledger.STORAGE_KEY);
-        builder.addData(new Ledger());
-        builder.setUnique(Ledger.INDEX_ENTITY_ID);
-        db.execSQL(builder.getTableCreateString());
+            // Add new column to db and then write all of the new records
+            UserDbUpgradeUtils.addFormNumberColumnToTable(db);
+            SqlStorage<FormRecord> newStorage = new SqlStorage<>(
+                    FormRecord.STORAGE_KEY,
+                    FormRecord.class,
+                    new ConcreteAndroidDbHelper(c, db));
+            for (FormRecord r : upgradedRecords) {
+                newStorage.write(r);
+            }
+
+            db.setTransactionSuccessful();
+            return true;
+        } finally {
+            db.endTransaction();
+        }
     }
 
     private void markSenseIncompleteUnsent(final SQLiteDatabase db) {
@@ -489,48 +521,4 @@ class UserDatabaseUpgrader {
         }
     }
 
-    private static boolean multipleInstalledAppRecords() {
-        SqlStorage<ApplicationRecord> storage =
-                CommCareApplication.instance().getGlobalStorage(ApplicationRecord.class);
-        int count = 0;
-        for (ApplicationRecord r : storage) {
-            if (r.getStatus() == ApplicationRecord.STATUS_INSTALLED && r.resourcesValidated()) {
-                count++;
-            }
-        }
-        return (count > 1);
-    }
-
-    private static ApplicationRecord getInstalledAppRecord() {
-        SqlStorage<ApplicationRecord> storage =
-                CommCareApplication.instance().getGlobalStorage(ApplicationRecord.class);
-        for (Persistable p : storage) {
-            ApplicationRecord r = (ApplicationRecord)p;
-            if (r.getStatus() == ApplicationRecord.STATUS_INSTALLED && r.resourcesValidated()) {
-                return r;
-            }
-        }
-        return null;
-    }
-
-    private static void deleteExistingFormRecordsAndWarnUser(Context c, SQLiteDatabase db) {
-        SqlStorage<FormRecordV1> formRecordStorage = new SqlStorage<>(
-                FormRecord.STORAGE_KEY,
-                FormRecordV1.class,
-                new ConcreteAndroidDbHelper(c, db));
-
-        SqlStorage<SessionStateDescriptor> ssdStorage = new SqlStorage<>(
-                SessionStateDescriptor.STORAGE_KEY,
-                SessionStateDescriptor.class,
-                new ConcreteAndroidDbHelper(c, db));
-
-        formRecordStorage.removeAll();
-        ssdStorage.removeAll();
-
-        String warningTitle = "Minor data loss during upgrade";
-        String warningMessage = "Due to the experimental state of" +
-                " multiple application seating, we were not able to migrate all of your app data" +
-                " during upgrade. Any saved, incomplete, and unsent forms on the device were deleted.";
-        CommCareApplication.instance().storeMessageForUserOnDispatch(warningTitle, warningMessage);
-    }
 }

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -490,6 +490,7 @@ class UserDatabaseUpgrader {
         // ordering was previously done
         UserDbUpgradeUtils.sortRecordsByDate(recordIds, oldStorage);
 
+        int submissionNumber = 0;
         for (int i = 0; i < recordIds.size(); i++) {
             FormRecordV2 oldRecord = oldStorage.read(recordIds.elementAt(i));
             FormRecord newRecord = new FormRecord(
@@ -505,7 +506,7 @@ class UserDatabaseUpgrader {
                     FormRecord.STATUS_UNSENT.equals(statusOfOldRecord)) {
                 // By processing the old records in order of their last modified date, we make
                 // sure that we are setting this form numbers in the most accurate order we can
-                newRecord.setFormNumberForSubmissionOrdering();
+                newRecord.setFormNumberForSubmissionOrdering(submissionNumber++);
             }
             newRecord.setID(oldRecord.getID());
             upgradedRecords.add(newRecord);

--- a/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
+++ b/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
@@ -23,6 +23,8 @@ import org.javarosa.core.services.storage.Persistable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.Vector;
 
 /**
@@ -103,6 +105,14 @@ public class UserDbUpgradeUtils {
         builder.addData(new Ledger());
         builder.setUnique(Ledger.INDEX_ENTITY_ID);
         db.execSQL(builder.getTableCreateString());
+    }
+
+    protected static Set<String> getAppIdsForRecords(SqlStorage<FormRecordV2> oldFormRecords) {
+        Set<String> appIds = new HashSet<>();
+        for (FormRecordV2 formRecord : oldFormRecords) {
+            appIds.add(formRecord.getAppId());
+        }
+        return appIds;
     }
 
     protected static void sortRecordsByDate(Vector<Integer> ids,

--- a/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
+++ b/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
@@ -44,7 +44,7 @@ public class UserDbUpgradeUtils {
         // Alter the FormRecord table to include an app id column
         db.execSQL(DbUtil.addColumnToTable(
                 FormRecord.STORAGE_KEY,
-                FormRecord.META_FORM_ORDERING_NUMBER,
+                FormRecord.META_SUBMISSION_ORDERING_NUMBER,
                 "TEXT"));
     }
 

--- a/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
+++ b/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
@@ -45,7 +45,7 @@ public class UserDbUpgradeUtils {
         // Alter the FormRecord table to include an app id column
         db.execSQL(DbUtil.addColumnToTable(
                 FormRecord.STORAGE_KEY,
-                FormRecord.META_FORM_NUMBER,
+                FormRecord.META_FORM_ORDERING_NUMBER,
                 "TEXT"));
     }
 

--- a/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
+++ b/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
@@ -30,7 +30,6 @@ import java.util.Vector;
 /**
  * Created by amstone326 on 3/8/17.
  */
-
 public class UserDbUpgradeUtils {
 
     protected static void addAppIdColumnToTable(SQLiteDatabase db) {

--- a/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
+++ b/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
@@ -1,0 +1,152 @@
+package org.commcare.models.database.user;
+
+import android.content.Context;
+
+import net.sqlcipher.database.SQLiteDatabase;
+
+import org.commcare.CommCareApplication;
+import org.commcare.android.database.global.models.ApplicationRecord;
+import org.commcare.android.database.user.models.FormRecord;
+import org.commcare.android.database.user.models.FormRecordV1;
+import org.commcare.android.database.user.models.FormRecordV2;
+import org.commcare.android.database.user.models.SessionStateDescriptor;
+import org.commcare.cases.ledger.Ledger;
+import org.commcare.logging.AndroidLogger;
+import org.commcare.models.database.AndroidTableBuilder;
+import org.commcare.models.database.ConcreteAndroidDbHelper;
+import org.commcare.models.database.DbUtil;
+import org.commcare.models.database.SqlStorage;
+import org.commcare.modern.database.DatabaseIndexingUtils;
+import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.storage.Persistable;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Vector;
+
+/**
+ * Created by amstone326 on 3/8/17.
+ */
+
+public class UserDbUpgradeUtils {
+
+    protected static void addAppIdColumnToTable(SQLiteDatabase db) {
+        // Alter the FormRecord table to include an app id column
+        db.execSQL(DbUtil.addColumnToTable(
+                FormRecord.STORAGE_KEY,
+                FormRecord.META_APP_ID,
+                "TEXT"));
+    }
+
+    protected static void addFormNumberColumnToTable(SQLiteDatabase db) {
+        // Alter the FormRecord table to include an app id column
+        db.execSQL(DbUtil.addColumnToTable(
+                FormRecord.STORAGE_KEY,
+                FormRecord.META_FORM_NUMBER,
+                "TEXT"));
+    }
+
+    protected static boolean multipleInstalledAppRecords() {
+        SqlStorage<ApplicationRecord> storage =
+                CommCareApplication.instance().getGlobalStorage(ApplicationRecord.class);
+        int count = 0;
+        for (ApplicationRecord r : storage) {
+            if (r.getStatus() == ApplicationRecord.STATUS_INSTALLED && r.resourcesValidated()) {
+                count++;
+            }
+        }
+        return (count > 1);
+    }
+
+    protected static ApplicationRecord getInstalledAppRecord() {
+        SqlStorage<ApplicationRecord> storage =
+                CommCareApplication.instance().getGlobalStorage(ApplicationRecord.class);
+        for (Persistable p : storage) {
+            ApplicationRecord r = (ApplicationRecord)p;
+            if (r.getStatus() == ApplicationRecord.STATUS_INSTALLED && r.resourcesValidated()) {
+                return r;
+            }
+        }
+        return null;
+    }
+
+    protected static void deleteExistingFormRecordsAndWarnUser(Context c, SQLiteDatabase db) {
+        SqlStorage<FormRecordV1> formRecordStorage = new SqlStorage<>(
+                FormRecord.STORAGE_KEY,
+                FormRecordV1.class,
+                new ConcreteAndroidDbHelper(c, db));
+
+        SqlStorage<SessionStateDescriptor> ssdStorage = new SqlStorage<>(
+                SessionStateDescriptor.STORAGE_KEY,
+                SessionStateDescriptor.class,
+                new ConcreteAndroidDbHelper(c, db));
+
+        formRecordStorage.removeAll();
+        ssdStorage.removeAll();
+
+        String warningTitle = "Minor data loss during upgrade";
+        String warningMessage = "Due to the experimental state of" +
+                " multiple application seating, we were not able to migrate all of your app data" +
+                " during upgrade. Any saved, incomplete, and unsent forms on the device were deleted.";
+        CommCareApplication.instance().storeMessageForUserOnDispatch(warningTitle, warningMessage);
+    }
+
+    protected static void updateIndexes(SQLiteDatabase db) {
+        db.execSQL(DatabaseIndexingUtils.indexOnTableCommand("case_id_index", "AndroidCase", "case_id"));
+        db.execSQL(DatabaseIndexingUtils.indexOnTableCommand("case_type_index", "AndroidCase", "case_type"));
+        db.execSQL(DatabaseIndexingUtils.indexOnTableCommand("case_status_index", "AndroidCase", "case_status"));
+    }
+
+    protected static void addStockTable(SQLiteDatabase db) {
+        AndroidTableBuilder builder = new AndroidTableBuilder(Ledger.STORAGE_KEY);
+        builder.addData(new Ledger());
+        builder.setUnique(Ledger.INDEX_ENTITY_ID);
+        db.execSQL(builder.getTableCreateString());
+    }
+
+    protected static void sortRecordsByDate(Vector<Integer> ids,
+                                         SqlStorage<FormRecordV2> storage) {
+        final HashMap<Integer, Long> idToDateIndex =
+                getIdToDateMap(ids, storage);
+
+        Collections.sort(ids, new Comparator<Integer>() {
+            @Override
+            public int compare(Integer lhs, Integer rhs) {
+                Long lhd = idToDateIndex.get(lhs);
+                Long rhd = idToDateIndex.get(rhs);
+                if (lhd < rhd) {
+                    return -1;
+                }
+                if (lhd > rhd) {
+                    return 1;
+                }
+                return 0;
+            }
+        });
+    }
+
+    private static HashMap<Integer, Long> getIdToDateMap(Vector<Integer> ids,
+                                                         SqlStorage<FormRecordV2> storage) {
+        HashMap<Integer, Long> idToDateIndex = new HashMap<>();
+        for (int id : ids) {
+            // Last modified for a unsent and complete forms is the formEnd
+            // date that was captured and locked when form entry, so it's a
+            // safe cannonical ordering
+            String dateAsString =
+                    storage.getMetaDataFieldForRecord(id, FormRecord.META_LAST_MODIFIED);
+            long dateAsSeconds;
+            try {
+                dateAsSeconds = Long.valueOf(dateAsString);
+            } catch (NumberFormatException e) {
+                // Go with the next best ordering for now
+                Logger.log(AndroidLogger.TYPE_ERROR_ASSERTION,
+                        "Invalid date in last modified value: " + dateAsString);
+                idToDateIndex.put(id, (long)id);
+                continue;
+            }
+            idToDateIndex.put(id, dateAsSeconds);
+        }
+        return idToDateIndex;
+    }
+}

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -98,6 +98,7 @@ public class CommCarePreferences
     public final static String LAST_PASSWORD = "last_password";
     public final static String CURRENT_SESSION = "current_user_session";
     public final static String CURRENT_FORM_ENTRY_SESSION = "current_form_entry_session";
+    public final static String GLOBAL_APP_FORM_COUNTER = "global-app-form-counter";
 
     // Preferences that are sent down by HQ
     public final static String PREFS_LOCALE_KEY = "cur_locale";
@@ -601,6 +602,5 @@ public class CommCarePreferences
                     .putString(UPDATE_TARGET, updateTargetValue)
                     .apply();
         }
-
     }
 }

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -98,7 +98,6 @@ public class CommCarePreferences
     public final static String LAST_PASSWORD = "last_password";
     public final static String CURRENT_SESSION = "current_user_session";
     public final static String CURRENT_FORM_ENTRY_SESSION = "current_form_entry_session";
-    public final static String GLOBAL_APP_FORM_COUNTER = "global-app-form-counter";
 
     // Preferences that are sent down by HQ
     public final static String PREFS_LOCALE_KEY = "cur_locale";

--- a/app/src/org/commcare/provider/ExternalApiReceiver.java
+++ b/app/src/org/commcare/provider/ExternalApiReceiver.java
@@ -118,7 +118,7 @@ public class ExternalApiReceiver extends BroadcastReceiver {
 
     private boolean checkAndStartUnsentTask(final Context context) {
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormsForCurrentApp(storage);
+        Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormIdsForCurrentApp(storage);
 
         if (ids.size() > 0) {
             FormRecord[] records = new FormRecord[ids.size()];

--- a/app/src/org/commcare/tasks/DumpTask.java
+++ b/app/src/org/commcare/tasks/DumpTask.java
@@ -198,7 +198,7 @@ public abstract class DumpTask extends CommCareTask<String, String, Boolean, Com
         dumpDirectory.mkdirs();
 
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormsForCurrentApp(storage);
+        Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormIdsForCurrentApp(storage);
 
         if(ids.size() > 0) {
             FormRecord[] records = new FormRecord[ids.size()];

--- a/app/src/org/commcare/tasks/FormRecordToFileTask.java
+++ b/app/src/org/commcare/tasks/FormRecordToFileTask.java
@@ -166,7 +166,7 @@ public abstract class FormRecordToFileTask extends CommCareTask<String, String, 
         storedFormDirectory.mkdirs();
 
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormsForCurrentApp(storage);
+        Vector<Integer> ids = StorageUtils.getUnsentOrUnprocessedFormIdsForCurrentApp(storage);
 
         if (ids.size() > 0) {
             FormRecord[] records = new FormRecord[ids.size()];

--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -273,9 +273,9 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                             results[i] = FormUploadUtil.sendInstance(i, folder, new SecretKeySpec(record.getAesKey(), "AES"), url, this, mUser);
                             if (results[i] == FormUploadResult.FULL_SUCCESS) {
                                 String submitLogMessage = String.format(
-                                        "Successfully submitted form with id %1$s and form ordering number %2$s",
+                                        "Successfully submitted form with id %1$s and submission ordering number %2$s",
                                         record.getInstanceID(),
-                                        record.getFormOrderingNumber());
+                                        record.getSubmissionOrderingNumber());
                                 Logger.log(AndroidLogger.TYPE_FORM_SUBMISSION, submitLogMessage);
                                 break;
                             } else {

--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -272,8 +272,11 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                             }
                             results[i] = FormUploadUtil.sendInstance(i, folder, new SecretKeySpec(record.getAesKey(), "AES"), url, this, mUser);
                             if (results[i] == FormUploadResult.FULL_SUCCESS) {
-                                Logger.log(AndroidLogger.TYPE_FORM_SUBMISSION,
-                                        String.format("Successfully submitted form with id %s", record.getInstanceID()));
+                                String submitLogMessage = String.format(
+                                        "Successfully submitted form with id %1$s and form ordering number %2$s",
+                                        record.getInstanceID(),
+                                        record.getFormOrderingNumber());
+                                Logger.log(AndroidLogger.TYPE_FORM_SUBMISSION, submitLogMessage);
                                 break;
                             } else {
                                 attemptsMade++;

--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -264,19 +264,15 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                     //Time to Send!
                     try {
                         User mUser = CommCareApplication.instance().getSession().getLoggedInUser();
-
                         int attemptsMade = 0;
+                        logSubmissionAttempt(record);
                         while (attemptsMade < SUBMISSION_ATTEMPTS) {
                             if (attemptsMade > 0) {
                                 Logger.log(AndroidLogger.TYPE_WARNING_NETWORK, "Retrying submission. " + (SUBMISSION_ATTEMPTS - attemptsMade) + " attempts remain");
                             }
                             results[i] = FormUploadUtil.sendInstance(i, folder, new SecretKeySpec(record.getAesKey(), "AES"), url, this, mUser);
                             if (results[i] == FormUploadResult.FULL_SUCCESS) {
-                                String submitLogMessage = String.format(
-                                        "Successfully submitted form with id %1$s and submission ordering number %2$s",
-                                        record.getInstanceID(),
-                                        record.getSubmissionOrderingNumber());
-                                Logger.log(AndroidLogger.TYPE_FORM_SUBMISSION, submitLogMessage);
+                                logSubmissionSuccess(record);
                                 break;
                             } else {
                                 attemptsMade++;
@@ -333,6 +329,22 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                 Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, "Totally Unexpected Error during form submission" + getExceptionText(e));
             }
         }
+    }
+
+    private static void logSubmissionAttempt(FormRecord record) {
+        String attemptMesssage = String.format(
+                "Attempting to submit form with id %1$s and submission ordering number %2$s",
+                record.getInstanceID(),
+                record.getSubmissionOrderingNumber());
+        Logger.log(AndroidLogger.TYPE_FORM_SUBMISSION, attemptMesssage);
+    }
+
+    private static void logSubmissionSuccess(FormRecord record) {
+        String successMessage = String.format(
+                "Successfully submitted form with id %1$s and submission ordering number %2$s",
+                record.getInstanceID(),
+                record.getSubmissionOrderingNumber());
+        Logger.log(AndroidLogger.TYPE_FORM_SUBMISSION, successMessage);
     }
 
     public static int pending() {

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -244,7 +244,7 @@ public class SaveToDiskTask extends
         // update the mUri. We've saved the reloadable instance, so update status...
         updateInstanceDatabase(true, true);
 
-        if ( markCompleted ) {
+        if (markCompleted) {
             // now see if it is to be finalized and perhaps update everything...
             boolean canEditAfterCompleted = FormEntryActivity.mFormController.isSubmissionEntireForm();
             boolean isEncrypted = false;
@@ -285,7 +285,7 @@ public class SaveToDiskTask extends
             //    and remove the plaintext attachments if encrypting
             updateInstanceDatabase(false, canEditAfterCompleted);
 
-            if (  !canEditAfterCompleted ) {
+            if (!canEditAfterCompleted) {
                 // AT THIS POINT, there is no going back.  We are committed
                 // to returning "success" (true) whether or not we can 
                 // rename "submission.xml" to instanceXml and whether or 
@@ -303,15 +303,15 @@ public class SaveToDiskTask extends
                 }
 
                 // rename the submission.xml to be the instanceXml
-                if ( !submissionXml.renameTo(instanceXml) ) {
+                if (!submissionXml.renameTo(instanceXml)) {
                     Log.e(TAG, "Error renaming submission.xml to " + instanceXml.getAbsolutePath());
                     return;
                 }
 
                 // if encrypted, delete all plaintext files
                 // (anything not named instanceXml or anything not ending in .enc)
-                if ( isEncrypted ) {
-                    if ( !EncryptionUtils.deletePlaintextFiles(instanceXml) ) {
+                if (isEncrypted) {
+                    if (!EncryptionUtils.deletePlaintextFiles(instanceXml)) {
                         Log.e(TAG, "Error deleting plaintext files for " + instanceXml.getAbsolutePath());
                     }
                 }

--- a/app/src/org/commcare/utils/StorageUtils.java
+++ b/app/src/org/commcare/utils/StorageUtils.java
@@ -63,8 +63,7 @@ public class StorageUtils {
                 new String[]{FormRecord.STATUS_INCOMPLETE, currentAppId}).size();
     }
 
-    public static FormRecord[] getUnsentRecordsForCurrentApp(SqlStorage<FormRecord> storage,
-                                                             boolean sortRequired) {
+    public static FormRecord[] getUnsentRecordsForCurrentApp(SqlStorage<FormRecord> storage) {
         // TODO: This could all be one big sql query instead of doing it in code
         Vector<FormRecord> records;
         try {
@@ -77,10 +76,8 @@ public class StorageUtils {
             return new FormRecord[0];
         }
 
-        if (sortRequired) {
-            // Order ids so they're submitted to and processed by the server in the correct order.
-            sortRecordsBySubmissionOrderingNumber(records);
-        }
+        // Order ids so they're submitted to and processed by the server in the correct order.
+        sortRecordsBySubmissionOrderingNumber(records);
 
         FormRecord[] recordArray = new FormRecord[records.size()];
         for (int i = 0; i < records.size(); ++i) {

--- a/app/src/org/commcare/utils/StorageUtils.java
+++ b/app/src/org/commcare/utils/StorageUtils.java
@@ -103,4 +103,18 @@ public class StorageUtils {
         });
     }
 
+    public static int getNextFormSubmissionNumber() {
+        SqlStorage<FormRecord> storage =
+                CommCareApplication.instance().getUserStorage(FormRecord.class);
+        Vector<FormRecord> records =
+                StorageUtils.getUnsentOrUnprocessedFormRecordsForCurrentApp(storage);
+        int maxSubmissionNumber = -1;
+        for (FormRecord record : records) {
+            if (record.getSubmissionOrderingNumber() > maxSubmissionNumber) {
+                maxSubmissionNumber = record.getSubmissionOrderingNumber();
+            }
+        }
+        return maxSubmissionNumber + 1;
+    }
+
 }

--- a/app/src/org/commcare/utils/StorageUtils.java
+++ b/app/src/org/commcare/utils/StorageUtils.java
@@ -47,7 +47,8 @@ public class StorageUtils {
                 new String[]{FormRecord.STATUS_INCOMPLETE, currentAppId}).size();
     }
 
-    public static FormRecord[] getUnsentRecordsForCurrentApp(SqlStorage<FormRecord> storage) {
+    public static FormRecord[] getUnsentRecordsForCurrentApp(SqlStorage<FormRecord> storage,
+                                                             boolean sortRequired) {
         // TODO: This could all be one big sql query instead of doing it in code
 
         Vector<Integer> ids;
@@ -61,8 +62,10 @@ public class StorageUtils {
             return new FormRecord[0];
         }
 
-        // Order ids so they're submitted to and processed by the server in the correct order.
-        sortRecordsByGlobalCounter(ids, storage);
+        if (sortRequired) {
+            // Order ids so they're submitted to and processed by the server in the correct order.
+            sortRecordsByGlobalCounter(ids, storage);
+        }
 
         // The records should now be in order and we can pass to the next phase
         FormRecord[] records = new FormRecord[ids.size()];

--- a/app/src/org/commcare/utils/StorageUtils.java
+++ b/app/src/org/commcare/utils/StorageUtils.java
@@ -97,7 +97,7 @@ public class StorageUtils {
         HashMap<Integer, Integer> idToFormNumberMapping = new HashMap<>();
         for (int id : ids) {
             String formNumberAsString =
-                    storage.getMetaDataFieldForRecord(id, FormRecord.META_FORM_NUMBER);
+                    storage.getMetaDataFieldForRecord(id, FormRecord.META_FORM_ORDERING_NUMBER);
             idToFormNumberMapping.put(id, Integer.parseInt(formNumberAsString));
         }
         return idToFormNumberMapping;

--- a/app/src/org/commcare/utils/StorageUtils.java
+++ b/app/src/org/commcare/utils/StorageUtils.java
@@ -47,7 +47,7 @@ public class StorageUtils {
                 new String[]{FormRecord.STATUS_INCOMPLETE, currentAppId}).size();
     }
 
-    public static FormRecord[] getUnsentRecords(SqlStorage<FormRecord> storage) {
+    public static FormRecord[] getUnsentRecordsForCurrentApp(SqlStorage<FormRecord> storage) {
         // TODO: This could all be one big sql query instead of doing it in code
 
         Vector<Integer> ids;

--- a/app/src/org/commcare/utils/StorageUtils.java
+++ b/app/src/org/commcare/utils/StorageUtils.java
@@ -100,7 +100,7 @@ public class StorageUtils {
         HashMap<Integer, Integer> idToFormNumberMapping = new HashMap<>();
         for (int id : ids) {
             String formNumberAsString =
-                    storage.getMetaDataFieldForRecord(id, FormRecord.META_FORM_ORDERING_NUMBER);
+                    storage.getMetaDataFieldForRecord(id, FormRecord.META_SUBMISSION_ORDERING_NUMBER);
             idToFormNumberMapping.put(id, Integer.parseInt(formNumberAsString));
         }
         return idToFormNumberMapping;

--- a/app/src/org/commcare/utils/StorageUtils.java
+++ b/app/src/org/commcare/utils/StorageUtils.java
@@ -64,7 +64,7 @@ public class StorageUtils {
 
         if (sortRequired) {
             // Order ids so they're submitted to and processed by the server in the correct order.
-            sortRecordsByGlobalCounter(ids, storage);
+            sortRecordsBySubmissionOrderingNumber(ids, storage);
         }
 
         // The records should now be in order and we can pass to the next phase
@@ -75,8 +75,8 @@ public class StorageUtils {
         return records;
     }
 
-    private static void sortRecordsByGlobalCounter(Vector<Integer> ids,
-                                                   SqlStorage<FormRecord> storage) {
+    private static void sortRecordsBySubmissionOrderingNumber(Vector<Integer> ids,
+                                                              SqlStorage<FormRecord> storage) {
         final HashMap<Integer, Integer> idToFormNumberMapping = getIdToFormNumberMap(ids, storage);
 
         Collections.sort(ids, new Comparator<Integer>() {

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -51,7 +51,7 @@ public class SyncDetailCalculations {
     public static int getNumUnsentForms() {
         SqlStorage<FormRecord> formsStorage = CommCareApplication.instance().getUserStorage(FormRecord.class);
         try {
-            return StorageUtils.getUnsentRecordsForCurrentApp(formsStorage).length;
+            return StorageUtils.getUnsentRecordsForCurrentApp(formsStorage, false).length;
         } catch (SessionUnavailableException e) {
             // Addresses unexpected issue where this db lookup occurs after session ends.
             // If possible, replace this with fix that addresses root issue

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -51,7 +51,7 @@ public class SyncDetailCalculations {
     public static int getNumUnsentForms() {
         SqlStorage<FormRecord> formsStorage = CommCareApplication.instance().getUserStorage(FormRecord.class);
         try {
-            return StorageUtils.getUnsentRecordsForCurrentApp(formsStorage, false).length;
+            return StorageUtils.getUnsentRecordsForCurrentApp(formsStorage).length;
         } catch (SessionUnavailableException e) {
             // Addresses unexpected issue where this db lookup occurs after session ends.
             // If possible, replace this with fix that addresses root issue

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -51,7 +51,7 @@ public class SyncDetailCalculations {
     public static int getNumUnsentForms() {
         SqlStorage<FormRecord> formsStorage = CommCareApplication.instance().getUserStorage(FormRecord.class);
         try {
-            return formsStorage.getIDsForValue(FormRecord.META_STATUS, FormRecord.STATUS_UNSENT).size();
+            return StorageUtils.getUnsentRecordsForCurrentApp(formsStorage).length;
         } catch (SessionUnavailableException e) {
             // Addresses unexpected issue where this db lookup occurs after session ends.
             // If possible, replace this with fix that addresses root issue

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -58,6 +58,7 @@ public class FormStorageTest {
             , "org.commcare.android.database.user.models.AUser"
             , "org.commcare.android.database.user.models.FormRecord"
             , "org.commcare.android.database.user.models.FormRecordV1"
+            , "org.commcare.android.database.user.models.FormRecordV2"
             , "org.commcare.android.database.user.models.GeocodeCacheModel"
             , "org.commcare.android.database.user.models.SessionStateDescriptor"
             , "org.commcare.android.javarosa.AndroidLogEntry"

--- a/app/unit-tests/src/org/commcare/android/tests/processing/UnsentFormsTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/UnsentFormsTest.java
@@ -56,7 +56,7 @@ public class UnsentFormsTest {
             storage.write(record);
         }
 
-        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage, true);
+        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage);
         int count = 0;
         for (FormRecord record : records) {
             assertEquals(instanceOrder[count], record.getInstanceID());

--- a/app/unit-tests/src/org/commcare/android/tests/processing/UnsentFormsTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/UnsentFormsTest.java
@@ -49,7 +49,7 @@ public class UnsentFormsTest {
                 "3dd1031e-ee5a-4423-93b3-ad45c3ced47c",
                 "4dd0031e-ee5a-4423-93b3-ad45c3ced47d"};
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage);
+        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage, true);
 
         int count = 0;
         for (FormRecord record : records) {

--- a/app/unit-tests/src/org/commcare/android/tests/processing/UnsentFormsTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/UnsentFormsTest.java
@@ -49,7 +49,7 @@ public class UnsentFormsTest {
                 "3dd1031e-ee5a-4423-93b3-ad45c3ced47c",
                 "4dd0031e-ee5a-4423-93b3-ad45c3ced47d"};
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        FormRecord[] records = StorageUtils.getUnsentRecords(storage);
+        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage);
 
         int count = 0;
         for (FormRecord record : records) {

--- a/app/unit-tests/src/org/commcare/android/tests/processing/UnsentFormsTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/UnsentFormsTest.java
@@ -52,7 +52,7 @@ public class UnsentFormsTest {
         SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
         for (int i = 0; i < instanceOrder.length; i++) {
             FormRecord record = storage.getRecordForValue(FormRecord.META_UUID, instanceOrder[i]);
-            record.setFormNumberForSubmissionOrdering();
+            record.setFormNumberForSubmissionOrdering(i);
             storage.write(record);
         }
 

--- a/app/unit-tests/src/org/commcare/android/tests/processing/UnsentFormsTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/UnsentFormsTest.java
@@ -48,9 +48,15 @@ public class UnsentFormsTest {
                 "2dd2031e-ee5a-4423-93b3-ad45c3ced47b",
                 "3dd1031e-ee5a-4423-93b3-ad45c3ced47c",
                 "4dd0031e-ee5a-4423-93b3-ad45c3ced47d"};
-        SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage, true);
 
+        SqlStorage<FormRecord> storage = CommCareApplication.instance().getUserStorage(FormRecord.class);
+        for (int i = 0; i < instanceOrder.length; i++) {
+            FormRecord record = storage.getRecordForValue(FormRecord.META_UUID, instanceOrder[i]);
+            record.setFormNumberForSubmissionOrdering();
+            storage.write(record);
+        }
+
+        FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(storage, true);
         int count = 0;
         for (FormRecord record : records) {
             assertEquals(instanceOrder[count], record.getInstanceID());


### PR DESCRIPTION
Changes our form submission ordering strategy to use a simple per-app counter. A `FormRecord` is marked with the next sequential `submissionOrderingNumber` only after it has been marked as completed, thus ensuring that forms are submitted in the order that they were completed by the user in. 

The ordering number for a record is also now included in a device log message for both attempting to submit the form and successfully submitting the form, which should make it easy to tell when a form has gone missing (since the submission numbers will always be sequential with no missing numbers).

I haven't yet been able to verify the results of this in the device logs or submitted forms report on HQ due to the current reporting issues, but I did verify that CommCare attempted to submit forms in the proper order after these changes.

Background here: http://manage.dimagi.com/default.asp?247383

FYI @snopoke