### PR TITLE
Don't allow form entry to proceed if uncommitted combobox change is present

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -119,6 +119,8 @@ form.entry.save.error=Sorry, form save failed. Please contact technical support 
 form.entry.save.invalid.unicode=Could not save '${0}' text in form.
 form.entry.finish.button=FINISH
 
+combobox.value.invalid=The text entered is not a valid answer choice
+
 login.attempt.badcred=Username or password are incorrect. Please try again.
 
 login.username=Username

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -542,6 +542,11 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         // group
         boolean success = true;
         if (isEventQuestionOrListGroup()) {
+
+            if (evaluateConstraints) {
+                uiController.questionsView.lockComboboxAnswers();
+            }
+
             HashMap<FormIndex, IAnswerData> answers =
                     uiController.questionsView.getAnswers();
 

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -580,6 +580,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             }
         }
         if (uncommittedChangesWerePresent) {
+            // Lock in the uncommitted changes
             uiController.updateFormRelevancies();
         }
         return success && !uncommittedChangesWerePresent;

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -707,10 +707,10 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             }
             return;
         }
-        // save current answer; if headless, don't evaluate the constraints
-        // before doing so.
+        // Save current answer; if headless, don't evaluate the constraints before doing so.
+        boolean evaluateConstraints = !headless;
         boolean wasScreenSaved =
-                saveAnswersForCurrentScreen(FormEntryConstants.DO_NOT_EVALUATE_CONSTRAINTS, complete, headless);
+                saveAnswersForCurrentScreen(evaluateConstraints, complete, headless);
         if (!wasScreenSaved) {
             return;
         }

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -538,14 +538,11 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     private boolean saveAnswersForCurrentScreen(boolean evaluateConstraints,
                                                 boolean failOnRequired,
                                                 boolean headless) {
-        // only try to save if the current event is a question or a field-list
-        // group
+        // only try to save if the current event is a question or a field-list group
         boolean success = true;
+        boolean uncommittedChangesWerePresent = false;
         if (isEventQuestionOrListGroup()) {
-
-            if (evaluateConstraints) {
-                uiController.questionsView.lockComboboxAnswers();
-            }
+            uncommittedChangesWerePresent = uiController.questionsView.uncommittedChangesPresent();
 
             HashMap<FormIndex, IAnswerData> answers =
                     uiController.questionsView.getAnswers();
@@ -582,7 +579,10 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 }
             }
         }
-        return success;
+        if (uncommittedChangesWerePresent) {
+            uiController.updateFormRelevancies();
+        }
+        return success && !uncommittedChangesWerePresent;
     }
 
     private boolean isEventQuestionOrListGroup() {

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -531,6 +531,12 @@ public class QuestionsView extends ScrollView
         return compoundedCallout;
     }
 
+    /**
+     *
+     * @return true if any QuestionWidget in this view contains a change at the UI level that has
+     * not yet been "locked into" the underlying data model (currently only relevant for Combobox
+     * Widgets, but could be applied to others if necessary)
+     */
     public boolean uncommittedChangesPresent() {
         for (QuestionWidget widget : this.widgets) {
             if (widget instanceof ComboboxWidget &&

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -24,6 +24,7 @@ import org.commcare.models.ODKStorage;
 import org.commcare.preferences.FormEntryPreferences;
 import org.commcare.utils.CompoundIntentList;
 import org.commcare.utils.MarkupUtil;
+import org.commcare.views.widgets.ComboboxWidget;
 import org.commcare.views.widgets.DateTimeWidget;
 import org.commcare.views.widgets.IntentWidget;
 import org.commcare.views.widgets.QuestionWidget;
@@ -516,7 +517,7 @@ public class QuestionsView extends ScrollView
     public CompoundIntentList getAggregateIntentCallout() {
         CompoundIntentList compoundedCallout = null;
         for (QuestionWidget widget : this.getWidgets()) {
-            if(widget instanceof IntentWidget) {
+            if (widget instanceof IntentWidget) {
                 boolean expectResult = compoundedCallout != null;
                 compoundedCallout = ((IntentWidget)widget).addToCompoundIntent(compoundedCallout);
                 if(compoundedCallout == null && expectResult) {
@@ -524,9 +525,17 @@ public class QuestionsView extends ScrollView
                 }
             }
         }
-        if(compoundedCallout == null || compoundedCallout.getNumberOfCallouts() <= 1) {
+        if (compoundedCallout == null || compoundedCallout.getNumberOfCallouts() <= 1) {
             return null;
         }
         return compoundedCallout;
+    }
+
+    public void lockComboboxAnswers() {
+        for (QuestionWidget widget : this.widgets) {
+            if (widget instanceof ComboboxWidget) {
+                ((ComboboxWidget)widget).checkForUncommittedChange();
+            }
+        }
     }
 }

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -531,11 +531,13 @@ public class QuestionsView extends ScrollView
         return compoundedCallout;
     }
 
-    public void lockComboboxAnswers() {
+    public boolean uncommittedChangesPresent() {
         for (QuestionWidget widget : this.widgets) {
-            if (widget instanceof ComboboxWidget) {
-                ((ComboboxWidget)widget).checkForUncommittedChange();
+            if (widget instanceof ComboboxWidget &&
+                    ((ComboboxWidget)widget).checkForUncommittedChange()) {
+                return true;
             }
         }
+        return false;
     }
 }

--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -160,12 +160,15 @@ public class ComboboxWidget extends QuestionWidget {
     public void setOnLongClickListener(OnLongClickListener l) {
     }
 
-    public void checkForUncommittedChange() {
-        String currentEnteredText = comboBox.getText().toString();
-        String currentRegisteredAnswerText = mPrompt.getAnswerValue().getDisplayText();
-        if (!currentEnteredText.equals(currentRegisteredAnswerText)) {
-            widgetEntryChanged();
+    public boolean checkForUncommittedChange() {
+        if (mPrompt.getAnswerValue() != null) {
+            String currentRegisteredAnswerText = mPrompt.getAnswerValue().getDisplayText();
+            String currentEnteredText = comboBox.getText().toString();
+            if (!currentEnteredText.equals(currentRegisteredAnswerText)) {
+                return true;
+            }
         }
+        return false;
     }
 
 }

--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -160,6 +160,11 @@ public class ComboboxWidget extends QuestionWidget {
     public void setOnLongClickListener(OnLongClickListener l) {
     }
 
+    /**
+     *
+     * @return true if the saved value for this widget is out of sync with the text the user
+     * currently has entered (which means that we have not yet "locked in" their change)
+     */
     public boolean checkForUncommittedChange() {
         if (mPrompt.getAnswerValue() != null) {
             String currentRegisteredAnswerText = mPrompt.getAnswerValue().getDisplayText();

--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -17,6 +17,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.InvalidData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
+import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryPrompt;
 
 import java.util.Vector;
@@ -138,7 +139,7 @@ public class ComboboxWidget extends QuestionWidget {
         } else if ("".equals(enteredText)) {
             return null;
         } else {
-            return new InvalidData("The text entered is not a valid answer choice",
+            return new InvalidData(Localization.get("combobox.value.invalid"),
                     new SelectOneData(new Selection(enteredText)));
         }
     }

--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -160,4 +160,12 @@ public class ComboboxWidget extends QuestionWidget {
     public void setOnLongClickListener(OnLongClickListener l) {
     }
 
+    public void checkForUncommittedChange() {
+        String currentEnteredText = comboBox.getText().toString();
+        String currentRegisteredAnswerText = mPrompt.getAnswerValue().getDisplayText();
+        if (!currentEnteredText.equals(currentRegisteredAnswerText)) {
+            widgetEntryChanged();
+        }
+    }
+
 }


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?249276. Because `widgetEntryChanged()` for the `ComboboxWidget` is NOT called on every keystroke (which would overload the app with constant changes), but instead is only called when focus to the widget changes or the user touches a selection in the dropdown, Kriti was encountering a strange but valid edge case where:

-There were 2 combobox widgets on 1 screen, with the answer choices provided for the 2nd depending on the answer to the 1st
-If you selected answer choices for both, and then changed the answer to the first by pressing backspace but NOT clicking away, AND that change resulted in _another_ valid answer to that question (rather than an invalid one), and then navigated forward, CommCare would allow you to proceed, but the 2nd answer would now have become invalid (since the valid answer choices have changed), but the user would never see that, and would think they had answered the 2nd question, when in fact it will now be blank when the form is submitted.

It may be a little hard to understand what was going on here just from reading that, so I'd recommend following Kriti's repro steps in the ticket (which are really quick) if you want to better understand the situation I was trying to address.

The resolution to this feels a bit hacky, but was the best I could come up with without having to call `widgetEntryChanged()` more frequently. Instead, when saving the answers for the current screen, CommCare checks if there were "uncommitted changes" to any combobox widgets before doing so, and if there were, it calls `updateFormRelevances()` at the end of that method (to "commit" the previously uncommitted change), and also prevents the screen from advancing (so that the user will be able to see that the 2nd combobox widget has now become empty). 
