### PR TITLE
Remove Update to latest saved from Developer Preferences

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -106,13 +106,6 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-show-entity-trace-outputs"
         android:title="Output Entity List Trace Data to ADB"/>
-    <ListPreference
-        android:enabled="true"
-        android:defaultValue="no"
-        android:entries="@array/pref_enabled_labels"
-        android:entryValues="@array/pref_enabled_vals"
-        android:key="cc-update-to-latest-saved"
-        android:title="Enable Updating to Latest Saved Version"/>
     <Preference
         android:title="Restore a custom user XML data file"
         android:key="cc-custom-restore-doc-location"/>

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -47,7 +47,6 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static final String DETAIL_TAB_SWIPE_ACTION_ENABLED = "cc-detail-final-swipe-enabled";
     public static final String USE_ROOT_MENU_AS_HOME_SCREEN = "cc-use-root-menu-as-home-screen";
     public static final String SHOW_ADB_ENTITY_LIST_TRACES = "cc-show-entity-trace-outputs";
-    public static final String UPDATE_TO_LATEST_SAVED_ENABLED = "cc-update-to-latest-saved";
     public static final String ENABLE_BULK_PERFORMANCE = "cc-enable-bulk-performance";
 
     /**
@@ -368,5 +367,5 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static boolean isBulkPerformanceEnabled() {
         return doesPropertyMatch(ENABLE_BULK_PERFORMANCE, CommCarePreferences.NO, CommCarePreferences.YES);
     }
-    
+
 }

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -368,16 +368,5 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static boolean isBulkPerformanceEnabled() {
         return doesPropertyMatch(ENABLE_BULK_PERFORMANCE, CommCarePreferences.NO, CommCarePreferences.YES);
     }
-
-    public static boolean updateToLatestSavedEnabled() {
-        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        return properties.getString(UPDATE_TO_LATEST_SAVED_ENABLED, CommCarePreferences.NO).equals(CommCarePreferences.YES);
-    }
-
-    public static void enableUpdateToLatestSavedVersion() {
-        CommCareApplication.instance().getCurrentApp().getAppPreferences()
-                .edit()
-                .putString(UPDATE_TO_LATEST_SAVED_ENABLED, CommCarePreferences.YES)
-                .apply();
-    }
+    
 }


### PR DESCRIPTION
Remove update to latest saved from developer preferences, since it is now available in the core app.