### PR TITLE
Set colors properly

### DIFF
--- a/app/src/org/commcare/graph/view/c3/DataConfiguration.java
+++ b/app/src/org/commcare/graph/view/c3/DataConfiguration.java
@@ -286,17 +286,19 @@ public class DataConfiguration extends Configuration {
         String barColorJSON = s.getConfiguration("bar-color");
         if (barColorJSON != null) {
             JSONArray requestedColors = new JSONArray(barColorJSON);
-            JSONArray colors = new JSONArray();
-            JSONArray opacities = new JSONArray();
-            for (int i = 0; i < requestedColors.length(); i++) {
-                String color = requestedColors.getString(i);
-                color = normalizeColor(color);
-                colors.put(i, "#" + color.substring(3));
-                opacities.put(getOpacity(color));
+            if (requestedColors.length() > 0) {
+                JSONArray colors = new JSONArray();
+                JSONArray opacities = new JSONArray();
+                for (int i = 0; i < requestedColors.length(); i++) {
+                    String color = requestedColors.getString(i);
+                    color = normalizeColor(color);
+                    colors.put(i, "#" + color.substring(3));
+                    opacities.put(getOpacity(color));
+                }
+                mBarColors.put(yID, colors);
+                mBarOpacities.put(yID, opacities);
+                return;
             }
-            mBarColors.put(yID, colors);
-            mBarOpacities.put(yID, opacities);
-            return;
         }
 
         String color = s.getConfiguration("line-color", "#ff000000");


### PR DESCRIPTION
Vaguely similar issue to https://github.com/dimagi/commcare-android/pull/1675 : https://github.com/dimagi/commcare-android/pull/1664 makes the default value of `bar-color` an empty array, rather than `null`. The code only checks for `null`, so the `bar-color` code in `setColor` runs, does nothing because the array is empty, but still returns early without ever looking at `line-color`, so graphs were getting D3's default color scheme.

`w=1`