### PR TITLE
Tests for empty ledger queries

### DIFF
--- a/app/unit-tests/src/org/commcare/android/tests/queries/LedgerDbQueryTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/queries/LedgerDbQueryTest.java
@@ -52,5 +52,12 @@ public class LedgerDbQueryTest {
                 CaseTestUtils.xpathEvalAndCompare(evalContext,
                         "instance('ledger')/ledgerdb/ledger[@entity-id='ocean_state_job_lot']/section[@section-id='cleaning_stock']/entry[@id='soap']",
                         9.0));
+
+        // checking a non-existent entity
+        assertTrue(
+                CaseTestUtils.xpathEvalAndCompare(evalContext,
+                        "count(instance('ledger')/ledgerdb/ledger[@entity-id='doesnt_exist']/section[@section-id='cleaning_stock']/entry[@id='soap'])",
+                        0.0));
+
     }
 }


### PR DESCRIPTION
Tests for https://manage.dimagi.com/default.asp?251635

cross-request: https://github.com/dimagi/commcare-core/pull/546