### PR TITLE
Use Developer Preferences to control visibility of Update Options setting item

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -6,6 +6,13 @@
         android:key="cc-superuser-enabled"
         android:title="Developer Mode Enabled"/>
     <ListPreference
+        android:enabled="true"
+        android:defaultValue="no"
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
+        android:key="cc-show-update-target-options"
+        android:title="Show Update Options Item"/>
+    <ListPreference
         android:defaultValue="yes"
         android:enabled="true"
         android:entries="@array/pref_enabled_labels"
@@ -123,6 +130,5 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-enable-bulk-performance"
         android:title="Enable cutting-edge performance improvements"/>
-
 
 </PreferenceScreen>

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -23,6 +23,7 @@ import org.commcare.interfaces.CommCareActivityUIController;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.preferences.CommCarePreferences;
+import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.tasks.InstallStagedUpdateTask;
 import org.commcare.tasks.ResultAndError;
 import org.commcare.tasks.TaskListener;
@@ -478,6 +479,8 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
+        menu.findItem(MENU_UPDATE_TARGET_OPTIONS).setVisible(
+                DeveloperPreferences.shouldShowUpdateOptionsSetting());
         menu.findItem(MENU_UPDATE_FROM_CCZ).setVisible(BuildConfig.DEBUG ||
                 !getIntent().getBooleanExtra(AppManagerActivity.KEY_LAUNCH_FROM_MANAGER, false));
         menu.findItem(MENU_UPDATE_FROM_HUB).setVisible(hubAppRecord != null);

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -48,6 +48,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static final String SHOW_ADB_ENTITY_LIST_TRACES = "cc-show-entity-trace-outputs";
     public static final String USE_OBFUSCATED_PW = "cc-use-pw-obfuscation";
     public static final String ENABLE_BULK_PERFORMANCE = "cc-enable-bulk-performance";
+    public static final String SHOW_UPDATE_OPTIONS_SETTING = "cc-show-update-target-options";
 
     /**
      * Stores last used password and performs auto-login when that password is
@@ -370,6 +371,10 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
 
     public static boolean isBulkPerformanceEnabled() {
         return doesPropertyMatch(ENABLE_BULK_PERFORMANCE, CommCarePreferences.NO, CommCarePreferences.YES);
+    }
+
+    public static boolean shouldShowUpdateOptionsSetting() {
+        return doesPropertyMatch(SHOW_UPDATE_OPTIONS_SETTING, CommCarePreferences.NO, CommCarePreferences.YES);
     }
 
 }

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -374,7 +374,8 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     }
 
     public static boolean shouldShowUpdateOptionsSetting() {
-        return doesPropertyMatch(SHOW_UPDATE_OPTIONS_SETTING, CommCarePreferences.NO, CommCarePreferences.YES);
+        return doesPropertyMatch(SHOW_UPDATE_OPTIONS_SETTING, CommCarePreferences.NO,
+                CommCarePreferences.YES) || BuildConfig.DEBUG;
     }
 
 }


### PR DESCRIPTION
Addresses https://manage.dimagi.com/default.asp?251402

Updated documentation in https://confluence.dimagi.com/display/commcarepublic/Update+Target+Options to instruction users that they will need to enable this Developer Option in CommCare 2.36 and above.

NOTE: This change means that we are explicitly deciding to make the Developer Options something that is public to non-Dimagi users (I plan to clean up [this page](https://confluence.dimagi.com/display/internal/CommCare+Android+Developer+Options) and then move it to the public wiki, as well as link to it from the public wiki page above). @ctsims and I briefly discussed that we may want to start using the mobile privileges framework to allow us to hide certain more-dangerous settings within the Developer Options.