### PR TITLE
Small logging improvements

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -374,8 +374,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         if (mFormController != null) {
             FormIndex pendingIndex = mFormController.getPendingCalloutFormIndex();
             if (pendingIndex == null) {
-                Logger.log(AndroidLogger.SOFT_ASSERT,
-                        "getPendingWidget called when pending callout form index was null");
                 return null;
             }
             for (QuestionWidget q : uiController.questionsView.getWidgets()) {
@@ -384,7 +382,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 }
             }
             Logger.log(AndroidLogger.SOFT_ASSERT,
-                    "getPendingWidget couldn't find question widget with a form index that matches the pending callout.");
+                    "getPendingWidget couldn't find question widget with a form index that " +
+                            "matches the pending callout.");
         }
         return null;
     }

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
@@ -161,7 +162,7 @@ public class FormUploadUtil {
                     "Internal error reading form record during submission: " +
                             ioe.getWrapped().getMessage());
             return FormUploadResult.RECORD_FAILURE;
-        } catch (ClientProtocolException e) {
+        } catch (ClientProtocolException | UnknownHostException e) {
             e.printStackTrace();
             Logger.log(AndroidLogger.TYPE_WARNING_NETWORK,
                     "Client network issues during submission: " + e.getMessage());


### PR DESCRIPTION
2 very small improvements to logging:

1. Log UnknownHostException as a network issue -- Because `UnknownHostException` is a subclass of `IOException`, the previous state of exception handling here caused any instances of `UnknownHostException` to be logged as `TYPE_ERROR_STORAGE`, with the message "Error reading form during submission", even though it's just a result of the phone not having a connection. This PR changes that to log it as `TYPE_WARNING_NETWORK` instead.

2. Don't log every time `getPendingWidget()` is called when `getPendingCalloutFormIndex()` is null, because we now call this method speculatively every time `onResume()` is called (it _used to_ only get called when we would expect `getPendingCalloutFormIndex()` to be non-null)