### PR TITLE
Prefer app localized arrays when available

### DIFF
--- a/app/src/org/commcare/utils/AndroidArrayDataSource.java
+++ b/app/src/org/commcare/utils/AndroidArrayDataSource.java
@@ -3,6 +3,8 @@ package org.commcare.utils;
 import android.content.Context;
 
 import org.commcare.util.ArrayDataSource;
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.NoLocalizedTextException;
 
 /**
  * ArrayDataSource that uses the Android 'values' resources
@@ -18,12 +20,15 @@ public class AndroidArrayDataSource implements ArrayDataSource {
 
     @Override
     public String[] getArray(String key) {
+        try {
+            return Localization.getArray(key);
+        } catch (NoLocalizedTextException e){
+            //default to Android resources
+        }
         int resourceId = context.getResources().getIdentifier(key, "array", context.getPackageName());
-
         if (resourceId == 0) {
             throw new RuntimeException("Localized array data for '" + key + "' not found");
         }
-
         return context.getResources().getStringArray(resourceId);
     }
 }


### PR DESCRIPTION
Addresses https://manage.dimagi.com/default.asp?252049

This will cause CommCare to use strings from the localization files when they are available. Functionally, this enables the calendar widgets to respect the app language rather than just the phone language. 