### PR TITLE
Fix buttons being cut off on dialogs

### DIFF
--- a/app/res/layout/custom_alert_dialog.xml
+++ b/app/res/layout/custom_alert_dialog.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <include
         android:id="@+id/dialog_title"
@@ -13,12 +13,12 @@
         android:orientation="vertical"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_weight="9">
+        android:weightSum="9">
 
         <ScrollView
             android:id="@+id/dialog_message_scroll_view"
             android:layout_width="wrap_content"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:layout_weight="7"
             android:layout_marginLeft="@dimen/standard_spacer_large"
             android:layout_marginRight="@dimen/standard_spacer_large"
@@ -27,7 +27,7 @@
             <RelativeLayout
                 android:orientation="vertical"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="wrap_content">
 
                 <TextView
                     android:id="@+id/dialog_message"
@@ -41,7 +41,7 @@
 
         <RelativeLayout
             android:layout_width="wrap_content"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:layout_weight="2"
             android:layout_marginBottom="@dimen/standard_spacer">
 


### PR DESCRIPTION
Confirmed that this makes our dialogs look 👍 on all of the following devices/versions:

-Android 7 Moto G
-Android 6 Huawei
-Android 4 Samsung tab
-Android 4 Samsung phone

Feel pretty comfortable that this gives us a good variety of confirmation on this. Thanks @ctsims for the fix!