### PR TITLE
Grid menu density fix

### DIFF
--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -33,6 +33,7 @@
     <dimen name="list_content_with_space_for_badge">58dp</dimen>
     <dimen name="list_icon_size">48dp</dimen>
     <dimen name="list_icon_bounding_dimen">60dp</dimen>
+    <dimen name="list_grid_bounding_dimension">180dp</dimen>
 
     <dimen name="numeric_badge_width_for_list">20dp</dimen>
     <dimen name="numeric_badge_font_size_list">10dp</dimen>

--- a/app/src/org/commcare/adapters/GridMenuAdapter.java
+++ b/app/src/org/commcare/adapters/GridMenuAdapter.java
@@ -44,7 +44,7 @@ public class GridMenuAdapter extends MenuAdapter {
 
         // set up the image, if available
         ImageView mIconView = (ImageView)menuListItem.findViewById(R.id.row_img);
-        setupImageView(mIconView, menuDisplayable);
+        setupImageView(mIconView, menuDisplayable, (int)context.getResources().getDimension(R.dimen.list_grid_bounding_dimension));
 
         setupBadgeView(menuListItem, menuDisplayable);
 

--- a/app/src/org/commcare/adapters/MenuAdapter.java
+++ b/app/src/org/commcare/adapters/MenuAdapter.java
@@ -189,8 +189,13 @@ public class MenuAdapter extends BaseAdapter {
     }
 
     public void setupImageView(ImageView mIconView, MenuDisplayable menuDisplayable) {
+        setupImageView(mIconView, menuDisplayable, (int)context.getResources().getDimension(R.dimen.list_icon_bounding_dimen));
+    }
+
+
+    public void setupImageView(ImageView mIconView, MenuDisplayable menuDisplayable, int defaultBoundingBox) {
         if (mIconView != null) {
-            int iconDimension = (int)context.getResources().getDimension(R.dimen.list_icon_bounding_dimen);
+            int iconDimension = defaultBoundingBox;
             Bitmap image = MediaUtil.inflateDisplayImage(context, menuDisplayable.getImageURI(),
                     iconDimension, iconDimension);
             if (image != null) {


### PR DESCRIPTION
Fix issue where on grid menus the initial scaledown that gets applied to images is the same as for non-grid icons. Made images look terrible.

Before:
![scale_before](https://cloud.githubusercontent.com/assets/155066/25411883/677c8118-29ed-11e7-8539-c998a5afad38.png)

After
![scale_after](https://cloud.githubusercontent.com/assets/155066/25411885/68b56694-29ed-11e7-9f40-d89db397691d.png)


