### PR TITLE
Calendar on Last Question Fix

### DIFF
--- a/app/src/org/commcare/views/widgets/GregorianDateWidget.java
+++ b/app/src/org/commcare/views/widgets/GregorianDateWidget.java
@@ -40,6 +40,8 @@ public class GregorianDateWidget extends AbstractUniversalDateWidget
     private Calendar calendar;
     private LinearLayout gregorianView;
     private Spinner monthSpinner;
+    private long dateOfLastWidgetUpdateNotice = -1;
+
     private final ImageButton openCalButton;
     private static final int EMPTY_MONTH_ENTRY_INDEX = 12;
 
@@ -159,7 +161,15 @@ public class GregorianDateWidget extends AbstractUniversalDateWidget
         yearText.setText(String.format(YEARFORMAT, dateUniv.year));
         calendar.setTimeInMillis(millisFromJavaEpoch);
         dayOfWeek.setText(calendar.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG, Locale.getDefault()));
-        widgetEntryChanged();
+
+        //The setSelection response above is delayed in its execution, which means that on a given
+        //ui loop where the widget is created, we're guaranteed to get this execution path
+        //on the next loop. If something changes, we should fire the event, but otherwise
+        //this can end up supressing QuestionWidget state like validation messages
+        if(dateOfLastWidgetUpdateNotice != millisFromJavaEpoch) {
+            dateOfLastWidgetUpdateNotice = millisFromJavaEpoch;
+            widgetEntryChanged();
+        }
     }
 
     //Used to calculate new time when a button is pressed


### PR DESCRIPTION
The new calendar widget setting an array adapter selection in its creation. "Refreshing" that event gets put  onto the UIThread queue and executed on the _next_ polling cycle, which means that the gregorian widget is guaranteed a second update call.

Long story short that means that no behavior you applied to a GregorianWidget's QuestionView (like validation messages) that you created in one uithead poll would be capable of persisting, which is how we apply validation messages when you are on the final screen of a form.

Fixes: https://manage.dimagi.com/default.asp?252431