### PR TITLE
Enable submitting issue reports to a custom email address as an app preference

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -10,6 +10,7 @@
     <!-- string name="ota_restore_url">https://pact.dimagi.com/provider/caselist</string -->
     <string name="key_server">https://pact.dimagi.com/keys/getkey</string>
     <string name="your_comment">Your comment</string>
+    <string name="support_email_address_default">commcarehq-support@dimagi.com</string>
 
     <!-- region: All strings for multiple apps and app-agnostic properties -->
 

--- a/app/res/xml/server_preferences.xml
+++ b/app/res/xml/server_preferences.xml
@@ -37,4 +37,11 @@
         android:key="default_key_server"
         android:title="Key Server"/>
 
+
+    <EditTextPreference
+        android:defaultValue="@string/support_email_address_default"
+        android:enabled="true"
+        android:key="support-email-address"
+        android:title="Support Email Address"/>
+
 </PreferenceScreen>

--- a/app/src/org/commcare/activities/ReportProblemActivity.java
+++ b/app/src/org/commcare/activities/ReportProblemActivity.java
@@ -14,6 +14,7 @@ import org.commcare.CommCareApplication;
 import org.commcare.android.logging.ReportingUtils;
 import org.commcare.dalvik.R;
 import org.commcare.logging.AndroidLogger;
+import org.commcare.preferences.CommCareServerPreferences;
 import org.javarosa.core.services.Logger;
 
 public class ReportProblemActivity extends SessionAwareCommCareActivity<ReportProblemActivity> implements OnClickListener {
@@ -59,7 +60,7 @@ public class ReportProblemActivity extends SessionAwareCommCareActivity<ReportPr
     private void sendReportEmail(String report) {
         Intent i = new Intent(Intent.ACTION_SEND);
         i.setType("message/rfc822");
-        i.putExtra(Intent.EXTRA_EMAIL, new String[]{"commcarehq-support@dimagi.com"});
+        i.putExtra(Intent.EXTRA_EMAIL, new String[]{CommCareServerPreferences.getSupportEmailAddress()});
         i.putExtra(Intent.EXTRA_TEXT, ReportProblemActivity.buildMessage(report));
         i.putExtra(Intent.EXTRA_SUBJECT, "Mobile Error Report");
 

--- a/app/src/org/commcare/google/services/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/google/services/analytics/GoogleAnalyticsFields.java
@@ -128,6 +128,7 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_SUBMISSION_SERVER = "Submission Server";
     public static final String LABEL_KEY_SERVER = "Key Server";
     public static final String LABEL_FORM_RECORD_SERVER = "Form Record Server";
+    public static final String LABEL_SUPPORT_EMAIL = "Support Email Address";
     public static final String LABEL_AUTO_UPDATE = "Auto Update Frequency";
     public static final String LABEL_FUZZY_SEARCH = "Fuzzy Search Matches";
     public static final String LABEL_PRINT_TEMPLATE = "Set Print Template";

--- a/app/src/org/commcare/preferences/CommCareServerPreferences.java
+++ b/app/src/org/commcare/preferences/CommCareServerPreferences.java
@@ -1,11 +1,14 @@
 package org.commcare.preferences;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.view.MenuItem;
 
+import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.activities.SessionAwarePreferenceActivity;
+import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.commcare.google.services.analytics.GoogleAnalyticsFields;
 import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
@@ -28,6 +31,7 @@ public class CommCareServerPreferences
     public final static String PREFS_LOG_POST_URL_KEY = "log_receiver_url";
     private final static String PREFS_KEY_SERVER_KEY = "default_key_server";
     public final static String PREFS_FORM_RECORD_KEY = "form-record-url";
+    public final static String PREFS_SUPPORT_ADDRESS_KEY = "support-email-address";
 
     private static final Map<String, String> prefKeyToAnalyticsEvent = new HashMap<>();
 
@@ -37,6 +41,7 @@ public class CommCareServerPreferences
         prefKeyToAnalyticsEvent.put(PREFS_SUBMISSION_URL_KEY, GoogleAnalyticsFields.LABEL_SUBMISSION_SERVER);
         prefKeyToAnalyticsEvent.put(PREFS_KEY_SERVER_KEY, GoogleAnalyticsFields.LABEL_KEY_SERVER);
         prefKeyToAnalyticsEvent.put(PREFS_FORM_RECORD_KEY, GoogleAnalyticsFields.LABEL_FORM_RECORD_SERVER);
+        prefKeyToAnalyticsEvent.put(PREFS_SUPPORT_ADDRESS_KEY, GoogleAnalyticsFields.LABEL_SUPPORT_EMAIL);
     }
 
     @Override
@@ -66,4 +71,19 @@ public class CommCareServerPreferences
         }
         return super.onOptionsItemSelected(item);
     }
+
+    public static String getSupportEmailAddress() {
+        return getServerProperty(PREFS_SUPPORT_ADDRESS_KEY, CommCareApplication.instance().getString(R.string.support_email_address_default)) ;
+    }
+
+    private static String getServerProperty(String key, String defaultValue) {
+        CommCareApp app = CommCareApplication.instance().getCurrentApp();
+        if (app == null) {
+            return defaultValue;
+        }
+        SharedPreferences properties = app.getAppPreferences();
+        return properties.getString(key, defaultValue);
+    }
+
+
 }


### PR DESCRIPTION
Added an option to control the support email address on the report issue page

Needed by UATBC