### PR TITLE
Language Consistency for Preferences

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -417,7 +417,7 @@ refresh.build.up.to.date=Your app is already up to date, so no refresh occurred.
 refresh.build.update.error=An error occurred while attempting to update, so no refresh occurred.
 refresh.build.update.canceled=The update was canceled, so no refresh occurred.
 refresh.build.session.error=The refresh build utility cannot be used when you are not logged in, so no refresh occurred.
-refresh.build.settings.error=No refresh occurred. In order to use this utility, please turn on the "Enable Session Saving" setting in the Developer Preferences menu.
+refresh.build.settings.error=No refresh occurred. In order to use this utility, please turn on the "Enable Session Saving" setting in the Developer Options menu.
 
 login.attempt.fail.auth.title=Invalid Username or Password
 login.attempt.fail.auth.detail=Your username or password was not recognized, please type them again and retry.
@@ -711,7 +711,7 @@ fingerprints.scanned=Fingerprints scanned: ${0}
 settings.server.listing=Server Settings
 settings.server.title=CommCare > Server Settings
 settings.developer.options=Developer Options
-settings.main.title=CommCare > Application Preferences
+settings.main.title=CommCare > Settings
 settings.advanced.title=CommCare > Advanced
 clear.user.data=Clear User Data
 clear.user.data.warning.title=Clear User Data

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -93,7 +93,7 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
         prefMgr.setSharedPreferencesName((CommCareApplication.instance().getCurrentApp().getPreferencesFilename()));
 
         addPreferencesFromResource(R.xml.preferences_developer);
-        setTitle("Developer Preferences");
+        setTitle("Developer Options");
 
         populatePrefKeyToEventLabelMapping();
         GoogleAnalyticsUtils.createPreferenceOnClickListeners(


### PR DESCRIPTION
Ensure that the menu text and title text for preferences match up.