### PR TITLE
2.36 fix -- Revert "add auditing params to modern http get requests"

### DIFF
--- a/app/src/org/commcare/network/AndroidModernHttpRequester.java
+++ b/app/src/org/commcare/network/AndroidModernHttpRequester.java
@@ -2,7 +2,6 @@ package org.commcare.network;
 
 import android.net.Uri;
 
-import org.commcare.CommCareApplication;
 import org.commcare.core.network.ModernHttpRequester;
 import org.commcare.core.network.bitcache.BitCacheFactory;
 import org.commcare.modern.util.Pair;
@@ -42,11 +41,6 @@ public class AndroidModernHttpRequester extends ModernHttpRequester {
         for (Map.Entry<String, String> param : params.entrySet()) {
             b.appendQueryParameter(param.getKey(), param.getValue());
         }
-
-        // include IMEI and user id in request for general auditing purposes, if available
-        b.appendQueryParameter("device_id", CommCareApplication.instance().getPhoneId());
-        b.appendQueryParameter("user_id", CommCareApplication.instance().getCurrentUserId());
-
         return new URL(b.build().toString());
     }
 }


### PR DESCRIPTION
Fix for https://manage.dimagi.com/default.asp?254153. This reverts commit bc5f30d99d9ee604b83c366e48c95ded00457a5d, which apparently broke ModernHttpRequester's ability to make requests to HQ successfully. I'm electing to just revert this instead of digging into why right now, because I don't have much time and it wasn't an essential addition (just a nice-to-have for LTS that we can add back later when I figure out the right way to do it). 

