### PR TITLE
Preserve params when deriving JavaHttpRoot

### DIFF
--- a/app/src/org/commcare/engine/references/JavaHttpRoot.java
+++ b/app/src/org/commcare/engine/references/JavaHttpRoot.java
@@ -19,8 +19,13 @@ public class JavaHttpRoot implements ReferenceFactory {
 
     @Override
     public Reference derive(String URI, String context) throws InvalidReferenceException {
-        context = context.substring(0, context.lastIndexOf('/') + 1);
-        return new JavaHttpReference(context + URI, generator);
+        String rootPath = context.substring(0, context.lastIndexOf('/') + 1);
+        String derivedPath = rootPath + URI;
+        if (context.contains("?")) {
+            String paramsPath = context.substring(context.lastIndexOf('?'));
+            derivedPath = derivedPath + paramsPath;
+        }
+        return new JavaHttpReference(derivedPath, generator);
     }
 
     @Override


### PR DESCRIPTION
fixes https://manage.dimagi.com/default.asp?254166

We were dropping all parameters when deriving a root from its parent since we were just taking the substring up to the file name. This checks for params in the context root and appends them to the derived path if they're present.

I think this change has enough potential side effects, and the affected feature internal enough, that we should wait until 2.37 instead of trying to get into 2.36, but open to discussion. 