### PR TITLE
Fix for image file enlargement on Android 7

### DIFF
--- a/app/src/org/commcare/views/ResizingImageView.java
+++ b/app/src/org/commcare/views/ResizingImageView.java
@@ -17,6 +17,7 @@ import android.widget.ImageView;
 import android.widget.Toast;
 
 import org.commcare.dalvik.R;
+import org.commcare.utils.FileUtil;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
 
@@ -127,7 +128,10 @@ public class ResizingImageView extends ImageView {
             File bigImage = new File(imageFilename);
 
             Intent i = new Intent("android.intent.action.VIEW");
-            i.setDataAndType(Uri.fromFile(bigImage), "image/*");
+            Uri videoFileUri = FileUtil.getUriForExternalFile(getContext(), bigImage);
+            i.setDataAndType(videoFileUri, "image/*");
+            i.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
             getContext().startActivity(i);
         } catch (InvalidReferenceException e1) {
             e1.printStackTrace();

--- a/app/src/org/commcare/views/ResizingImageView.java
+++ b/app/src/org/commcare/views/ResizingImageView.java
@@ -128,8 +128,8 @@ public class ResizingImageView extends ImageView {
             File bigImage = new File(imageFilename);
 
             Intent i = new Intent("android.intent.action.VIEW");
-            Uri videoFileUri = FileUtil.getUriForExternalFile(getContext(), bigImage);
-            i.setDataAndType(videoFileUri, "image/*");
+            Uri imageFileUri = FileUtil.getUriForExternalFile(getContext(), bigImage);
+            i.setDataAndType(imageFileUri, "image/*");
             i.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
             getContext().startActivity(i);


### PR DESCRIPTION
Fix for: https://manage.dimagi.com/default.asp?253951

Images on Android 7 would crash when double clicked, due to lack of file system permissions

@amstone326 Copied your technique for this from the video work. 