### PR TITLE
Allow users to specify an optional custom banner to display in Demo Mode

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -798,12 +798,22 @@ public class CommCareApplication extends Application {
      * be triggered.
      */
     private static boolean areAutomatedActionsInvalid() {
+        return isInDemoMode(true);
+    }
+
+    /**
+     * Whether the current login is a "demo" mode login.
+     *
+     * Returns a provided default value if there is no active user login
+     */
+    public static boolean isInDemoMode(boolean defaultValue) {
         try {
             return User.TYPE_DEMO.equals(CommCareApplication.instance().getSession().getLoggedInUser().getUserType());
         } catch (SessionUnavailableException sue) {
-            return true;
+            return defaultValue;
         }
     }
+
 
     private void unbindUserSessionService() {
         synchronized (serviceLock) {

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -104,6 +104,7 @@ public class CommCarePreferences
     public final static String PREFS_LOCALE_KEY = "cur_locale";
     public final static String BRAND_BANNER_LOGIN = "brand-banner-login";
     public final static String BRAND_BANNER_HOME = "brand-banner-home";
+    public final static String BRAND_BANNER_HOME_DEMO = "brand-banner-home-demo";
     public final static String LOGIN_DURATION = "cc-login-duration-seconds";
     public final static String GPS_AUTO_CAPTURE_ACCURACY = "cc-gps-auto-capture-accuracy";
     public final static String GPS_AUTO_CAPTURE_TIMEOUT_MINS = "cc-gps-auto-capture-timeout";

--- a/app/src/org/commcare/views/CustomBanner.java
+++ b/app/src/org/commcare/views/CustomBanner.java
@@ -27,12 +27,20 @@ public class CustomBanner {
                                           int screenHeight, int screenWidth,
                                           @NonNull ImageView topBannerImageView) {
         CommCareApp app = CommCareApplication.instance().getCurrentApp();
+
         if (app == null) {
             return false;
         }
 
         String customBannerURI =
                 app.getAppPreferences().getString(CommCarePreferences.BRAND_BANNER_HOME, "");
+
+        if (CommCareApplication.instance().isInDemoMode(false)) {
+            customBannerURI =
+                    app.getAppPreferences().getString(CommCarePreferences.BRAND_BANNER_HOME_DEMO,
+                            customBannerURI);
+        }
+
         if (!"".equals(customBannerURI)) {
             int maxBannerHeight = screenHeight / 4;
 


### PR DESCRIPTION
Allows user to specify a second custom banner for the home screen, which is displayed to the user when they log in as a "Demo" or practice user.

Needs to be tested (will do tomorrow), but can self-merge after approval