### PR TITLE
Enable detail nodeset sorting

### DIFF
--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -790,14 +790,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
                                   NodeEntityFactory factory, int focusTargetIndex) {
         loader = null;
 
-        int[] order = shortSelect.getSortOrder();
-        for (int i = 0; i < shortSelect.getFields().length; ++i) {
-            String header = shortSelect.getFields()[i].getHeader().evaluate();
-            if (order.length == 0 && !"".equals(header)) {
-                order = new int[]{i};
-            }
-        }
-
         AdapterView visibleView;
         if (shortSelect.shouldBeLaidOutInGrid()) {
             visibleView = ((GridView)this.findViewById(R.id.screen_entity_select_grid));
@@ -807,9 +799,8 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             visibleView = listView;
         }
 
-        adapter = new EntityListAdapter(this, shortSelect, references, entities,
-                order, factory, hideActionsFromEntityList,
-                shortSelect.getCustomActions(evalContext()), inAwesomeMode);
+        adapter = new EntityListAdapter(this, shortSelect, references, entities, factory,
+                hideActionsFromEntityList, shortSelect.getCustomActions(evalContext()), inAwesomeMode);
         visibleView.setAdapter(adapter);
         adapter.registerDataSetObserver(this.mListStateObserver);
         containerFragment.setData(adapter);

--- a/app/src/org/commcare/adapters/EntitySubnodeDetailAdapter.java
+++ b/app/src/org/commcare/adapters/EntitySubnodeDetailAdapter.java
@@ -7,7 +7,9 @@ import android.view.ViewGroup;
 import android.widget.ListAdapter;
 
 import org.commcare.cases.entity.Entity;
+import org.commcare.cases.entity.NodeEntityFactory;
 import org.commcare.interfaces.ModifiableEntityDetailAdapter;
+import org.commcare.interfaces.SortableEntityAdapter;
 import org.commcare.suite.model.Detail;
 import org.commcare.views.EntityView;
 import org.javarosa.core.model.instance.TreeReference;
@@ -21,7 +23,8 @@ import java.util.List;
  * Adapter for taking a nodeset, contextualizing it against an entity,
  * and then displaying one item for each node in the resulting set.
  */
-public class EntitySubnodeDetailAdapter implements ListAdapter, ModifiableEntityDetailAdapter {
+public class EntitySubnodeDetailAdapter extends SortableEntityAdapter
+        implements ListAdapter, ModifiableEntityDetailAdapter {
 
     private final Context context;
     private final Detail detail;
@@ -29,10 +32,10 @@ public class EntitySubnodeDetailAdapter implements ListAdapter, ModifiableEntity
     private List<Entity<TreeReference>> entities;
     private ListItemViewModifier modifier;
 
-    public EntitySubnodeDetailAdapter(Context context, Detail detail,
-                                      List<TreeReference> references,
+    public EntitySubnodeDetailAdapter(Context context, Detail detail, List<TreeReference> references,
                                       List<Entity<TreeReference>> entities,
-                                      ListItemViewModifier modifier) {
+                                      ListItemViewModifier modifier, NodeEntityFactory factory) {
+        super(entities, detail, factory);
         this.context = context;
         this.detail = detail;
         this.modifier = modifier;
@@ -132,4 +135,5 @@ public class EntitySubnodeDetailAdapter implements ListAdapter, ModifiableEntity
     public void setModifier(ListItemViewModifier modifier) {
         this.modifier = modifier;
     }
+
 }

--- a/app/src/org/commcare/fragments/EntitySubnodeDetailFragment.java
+++ b/app/src/org/commcare/fragments/EntitySubnodeDetailFragment.java
@@ -88,7 +88,8 @@ public class EntitySubnodeDetailFragment extends EntityDetailFragment implements
         }
 
         this.loader = null;
-        this.adapter = new EntitySubnodeDetailAdapter(getActivity(), childDetail, references, entities, modifier);
+        this.adapter = new EntitySubnodeDetailAdapter(getActivity(), childDetail, references,
+                entities, modifier, factory);
         this.listView.setAdapter((ListAdapter)this.adapter);
         if (focusTargetIndex != -1) {
             listView.setSelection(focusTargetIndex);

--- a/app/src/org/commcare/interfaces/SortableEntityAdapter.java
+++ b/app/src/org/commcare/interfaces/SortableEntityAdapter.java
@@ -1,0 +1,80 @@
+package org.commcare.interfaces;
+
+import org.commcare.CommCareApplication;
+import org.commcare.cases.entity.Entity;
+import org.commcare.cases.entity.EntitySortNotificationInterface;
+import org.commcare.cases.entity.EntitySorter;
+import org.commcare.cases.entity.NodeEntityFactory;
+import org.commcare.models.AsyncNodeEntityFactory;
+import org.commcare.suite.model.Detail;
+import org.commcare.views.notifications.NotificationMessageFactory;
+import org.javarosa.core.model.instance.TreeReference;
+
+import java.util.List;
+
+/**
+ * Created by amstone326 on 5/24/17.
+ */
+
+public abstract class SortableEntityAdapter implements EntitySortNotificationInterface {
+
+    private List<Entity<TreeReference>> entities;
+    private Detail detail;
+    private int[] currentSort = {};
+    private boolean reverseSort = false;
+    protected boolean mAsyncMode = false;
+
+    public SortableEntityAdapter(List<Entity<TreeReference>> entityList, Detail detail,
+                                 NodeEntityFactory factory) {
+        this.entities = entityList;
+        this.detail = detail;
+        this.mAsyncMode = factory instanceof AsyncNodeEntityFactory;
+
+        int[] orderedFieldsForSorting = determineFieldsForSortingInOrder();
+        if (!mAsyncMode && orderedFieldsForSorting.length != 0) {
+            sort(orderedFieldsForSorting);
+        }
+    }
+
+    private int[] determineFieldsForSortingInOrder() {
+        int[] fieldsForSorting = detail.getOrderedFieldIndicesForSorting();
+        if (fieldsForSorting.length == 0) {
+            for (int i = 0; i < detail.getFields().length; ++i) {
+                String header = detail.getFields()[i].getHeader().evaluate();
+                if (!"".equals(header)) {
+                    fieldsForSorting = new int[]{i};
+                    break;
+                }
+            }
+        }
+        return fieldsForSorting;
+    }
+
+    protected void sort(int[] fields) {
+        //The reversing here is only relevant if there's only one sort field and we're on it
+        sort(fields, (currentSort.length == 1 && currentSort[0] == fields[0]) && !reverseSort);
+    }
+
+    private void sort(int[] fields, boolean reverse) {
+        this.reverseSort = reverse;
+        currentSort = fields;
+
+        java.util.Collections.sort(this.entities,
+                new EntitySorter(detail.getFields(), reverseSort, currentSort, this));
+    }
+
+    public int[] getCurrentSort() {
+        return currentSort;
+    }
+
+    public boolean isCurrentSortReversed() {
+        return reverseSort;
+    }
+
+    @Override
+    public void notifyBadFilter(String[] args) {
+        CommCareApplication.notificationManager().reportNotificationMessage(
+                NotificationMessageFactory.message(
+                        NotificationMessageFactory.StockMessages.Bad_Case_Filter, args));
+    }
+}


### PR DESCRIPTION
cross-request: https://github.com/dimagi/commcare-core/pull/566

I've tested/confirmed that this ensures: 
a) Proper sorting behavior in `EntitySelectActivity` is preserved
b) If a `<sort>` element is added to a `<field>` within a sub-detail that uses a nodeset, the elements of the nodeset get sorted by that field 

~~Holding off on merge until the HQ side has been implemented and I can test with that.~~
Since the timeline and person responsible for the HQ side of this is currently unclear, Jenny and I decided it makes sense to consider this ready and have it merged now. I've tested that it works as long as HQ provides the correct suite formatting, which has been specified to them.