### PR TITLE
Actually set chosen locale in app prefs

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -302,7 +302,9 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                 if (position >= localeCodes.length) {
                     Localization.setLocale("default");
                 } else {
-                    Localization.setLocale(localeCodes[position]);
+                    String selectedLocale = localeCodes[position];
+                    CommCarePreferences.setCurrentLocale(selectedLocale);
+                    Localization.setLocale(selectedLocale);
                 }
                 // rebuild home buttons in case language changed;
                 if (uiController != null) {

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -639,4 +639,9 @@ public class CommCarePreferences
             return path;
         }
     }
+
+    public static void setCurrentLocale(String locale) {
+        SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        prefs.edit().putString(PREFS_LOCALE_KEY, locale).commit();
+    }
 }


### PR DESCRIPTION
Fix for https://manage.dimagi.com/default.asp?256042. When the user selected a locale in the choice dialog on the home screen, we were never saving it in app prefs, meaning that even though we do attempt to pull the locale from app prefs on app startup [here](https://github.com/dimagi/commcare-android/blob/e695007b30796b7311295bb1b9ec47e75207c54c/app/src/org/commcare/CommCareApp.java#L218-L219), it was never doing anything except setting to the default.