### PR TITLE
Catch XPathExceptions and fail gracefully in next()

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -467,7 +467,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                             break;
                     }
                 } while (event != FormEntryController.EVENT_END_OF_FORM);
-            } catch (XPathTypeMismatchException e) {
+            } catch (XPathException e) {
                 UserfacingErrorHandling.logErrorAndShowDialog(activity, e, FormEntryConstants.EXIT);
             }
         }


### PR DESCRIPTION
Fixes: https://manage.dimagi.com/default.asp?255786#1349788

I can't think of any reason we wouldn't want to catch all XPathExceptions here? 