### PR TITLE
Make back button collapse an expanded persistent case tile

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -745,8 +745,8 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     @Override
     public void onBackPressed() {
         FragmentManager fm = this.getSupportFragmentManager();
-        BreadcrumbBarFragment bar = (BreadcrumbBarFragment) fm.findFragmentByTag("breadcrumbs");
-        if (bar.persistentCaseTileIsExpanded) {
+        BreadcrumbBarFragment bar = (BreadcrumbBarFragment)fm.findFragmentByTag("breadcrumbs");
+        if (bar != null && bar.persistentCaseTileIsExpanded) {
             bar.collapsePersistentCaseTile(this);
         } else {
             super.onBackPressed();

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -143,6 +143,10 @@ public abstract class CommCareActivity<R> extends FragmentActivity
             if (bar == null) {
                 bar = new BreadcrumbBarFragment();
                 fm.beginTransaction().add(bar, "breadcrumbs").commit();
+            } else {
+                // If we rotated while the persistent tile was expanded, it will not have gotten
+                // re-expanded, so reset the tracking variable to reflect that
+                bar.persistentCaseTileIsExpanded = false;
             }
         }
 
@@ -740,9 +744,14 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     @Override
     public void onBackPressed() {
-        super.onBackPressed();
-
-        AudioController.INSTANCE.releaseCurrentMediaEntity();
+        FragmentManager fm = this.getSupportFragmentManager();
+        BreadcrumbBarFragment bar = (BreadcrumbBarFragment) fm.findFragmentByTag("breadcrumbs");
+        if (bar.persistentCaseTileIsExpanded) {
+            bar.collapsePersistentCaseTile(this);
+        } else {
+            super.onBackPressed();
+            AudioController.INSTANCE.releaseCurrentMediaEntity();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fix for https://manage.dimagi.com/default.asp?256304

This overrides `onBackPressed` in `CommCareActivity` to first check whether the persistent case tile is currently expanded. If it is, we will collapse the tile instead of moving back a screen.

fyi @sheelio 