### PR TITLE
Bugfix: Make initial restore set the last sync time

### DIFF
--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -419,7 +419,7 @@ public abstract class DataPullTask<R>
     }
 
     private void onSuccessfulSync() {
-        recordSuccessfulSyncTime();
+        recordSuccessfulSyncTime(username);
 
         Intent i = new Intent("org.commcare.dalvik.api.action.data.update");
         this.context.sendBroadcast(i);
@@ -458,9 +458,9 @@ public abstract class DataPullTask<R>
                 .putLong("last-ota-restore", new Date().getTime()).commit();
     }
 
-    private static void recordSuccessfulSyncTime() {
+    private static void recordSuccessfulSyncTime(String username) {
         CommCareApplication.instance().getCurrentApp().getAppPreferences().edit()
-                .putLong(SyncDetailCalculations.getLastSyncKey(), new Date().getTime()).commit();
+                .putLong(SyncDetailCalculations.getLastSyncKey(username), new Date().getTime()).commit();
     }
 
     //TODO: This and the normal sync share a ton of code. It's hard to really... figure out the right way to 

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -9,6 +9,7 @@ import org.commcare.CommCareApplication;
 import org.commcare.activities.StandardHomeActivity;
 import org.commcare.adapters.HomeCardDisplayData;
 import org.commcare.adapters.SquareButtonViewHolder;
+import org.commcare.android.logging.ReportingUtils;
 import org.commcare.dalvik.R;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
@@ -72,11 +73,11 @@ public class SyncDetailCalculations {
 
     public static long getLastSyncTime() {
         SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        return prefs.getLong(getLastSyncKey(), 0);
+        return prefs.getLong(getLastSyncKey(ReportingUtils.getUser()), 0);
     }
 
-    public static String getLastSyncKey() {
-        return LAST_SYNC_KEY_BASE + CommCareApplication.instance().getCurrentUserId();
+    public static String getLastSyncKey(String username) {
+        return LAST_SYNC_KEY_BASE + username;
     }
 
     private static void setSyncSubtextColor(TextView subtext, int numUnsentForms, long lastSyncTime,


### PR DESCRIPTION
Fogbugz link - http://manage.dimagi.com/default.asp?251931

Using username instead of userid for lastSyncKey to set the last sync time indicator correctly on Initial login. Userid is only getting populated in the session after we set the last sync time causing getLastSyncKey() function to return an invalid last sync key. 