### PR TITLE
Memory Tuning for Optimizations

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -234,7 +234,7 @@ public class CommCareApplication extends Application {
         // md5 hasher. Major speed improvements.
         AndroidClassHasher.registerAndroidClassHashStrategy();
 
-        ActivityManager am = (ActivityManager) getSystemService(ACTIVITY_SERVICE);
+        ActivityManager am = (ActivityManager)getSystemService(ACTIVITY_SERVICE);
         int memoryClass = am.getMemoryClass();
 
         PerformanceTuningUtil.updateMaxPrefetchCaseBlock(

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -238,7 +238,7 @@ public class CommCareApplication extends Application {
         int memoryClass = am.getMemoryClass();
 
         PerformanceTuningUtil.updateMaxPrefetchCaseBlock(
-                PerformanceTuningUtil.identifyDefaultPrefetchBlockSize(memoryClass * 1024 * 1024));
+                PerformanceTuningUtil.guessLargestSupportedBulkCaseFetchSizeFromHeap(memoryClass * 1024 * 1024));
     }
 
     public void startUserSession(byte[] symmetricKey, UserKeyRecord record, boolean restoreSession) {

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -2,6 +2,7 @@ package org.commcare;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
+import android.app.ActivityManager;
 import android.app.Application;
 import android.content.ComponentName;
 import android.content.Context;
@@ -63,6 +64,7 @@ import org.commcare.models.database.user.DatabaseUserOpenHelper;
 import org.commcare.modern.database.Table;
 import org.commcare.models.legacy.LegacyInstallUtils;
 import org.commcare.modern.util.Pair;
+import org.commcare.modern.util.PerformanceTuningUtil;
 import org.commcare.network.AndroidModernHttpRequester;
 import org.commcare.network.DataPullRequester;
 import org.commcare.network.DataPullResponseFactory;
@@ -168,9 +170,7 @@ public class CommCareApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
-        // Sets the static strategy for the deserialization code to be based on an optimized
-        // md5 hasher. Major speed improvements.
-        AndroidClassHasher.registerAndroidClassHashStrategy();
+        configureCommCareEngineConstantsAndStaticRegistrations();
 
         CommCareApplication.app = this;
         noficationManager = new CommCareNoficationManager(this);
@@ -223,6 +223,22 @@ public class CommCareApplication extends Application {
             analyticsInstance = GoogleAnalytics.getInstance(this);
             GoogleAnalyticsUtils.reportAndroidApiLevelAtStartup();
         }
+    }
+
+    /**
+     * configure internal constants required (or available) for static behaviors in the CommCare
+     * library to reflect the current platform capabilities
+     */
+    private void configureCommCareEngineConstantsAndStaticRegistrations() {
+        // Sets the static strategy for the deserialization code to be based on an optimized
+        // md5 hasher. Major speed improvements.
+        AndroidClassHasher.registerAndroidClassHashStrategy();
+
+        ActivityManager am = (ActivityManager) getSystemService(ACTIVITY_SERVICE);
+        int memoryClass = am.getMemoryClass();
+
+        PerformanceTuningUtil.updateMaxPrefetchCaseBlock(
+                PerformanceTuningUtil.identifyDefaultPrefetchBlockSize(memoryClass * 1024 * 1024));
     }
 
     public void startUserSession(byte[] symmetricKey, UserKeyRecord record, boolean restoreSession) {

--- a/app/src/org/commcare/engine/cases/AndroidCaseInstanceTreeElement.java
+++ b/app/src/org/commcare/engine/cases/AndroidCaseInstanceTreeElement.java
@@ -18,6 +18,7 @@ import org.commcare.modern.engine.cases.CaseGroupResultCache;
 import org.commcare.modern.engine.cases.CaseIndexQuerySetTransform;
 import org.commcare.modern.engine.cases.CaseObjectCache;
 import org.commcare.modern.engine.cases.query.CaseIndexPrefetchHandler;
+import org.commcare.modern.util.Pair;
 import org.commcare.modern.util.PerformanceTuningUtil;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.TreeReference;
@@ -291,10 +292,12 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
                 (caseObjectCache.isLoaded(recordId) || canLoadCaseFromGroup(caseGroupCache, recordId))) {
 
             if(!caseObjectCache.isLoaded(recordId)) {
-                EvaluationTrace loadTrace = new EvaluationTrace("Bulk Case Load");
+                Pair<String, LinkedHashSet<Integer>> tranche = caseGroupCache.getTranche(recordId);
+                EvaluationTrace loadTrace =
+                        new EvaluationTrace(String.format("Bulk Case Load [%s]", tranche.first));
                 SqlStorage<ACase> sqlStorage = ((SqlStorage<ACase>)storage);
-                LinkedHashSet<Integer>  body = caseGroupCache.getTranche(recordId);
 
+                LinkedHashSet<Integer>  body = tranche.second;
                 sqlStorage.bulkRead(body, caseObjectCache.getLoadedCaseMap());
                 loadTrace.setOutcome("Loaded: " + body.size());
                 context.reportTrace(loadTrace);

--- a/app/src/org/commcare/engine/cases/AndroidCaseInstanceTreeElement.java
+++ b/app/src/org/commcare/engine/cases/AndroidCaseInstanceTreeElement.java
@@ -14,7 +14,7 @@ import org.commcare.cases.query.handlers.ModelQueryLookupHandler;
 import org.commcare.cases.query.queryset.CaseModelQuerySetMatcher;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.user.models.AndroidCaseIndexTable;
-import org.commcare.modern.engine.cases.CaseGroupResultCache;
+import org.commcare.modern.engine.cases.CaseSetResultCache;
 import org.commcare.modern.engine.cases.CaseIndexQuerySetTransform;
 import org.commcare.modern.engine.cases.CaseObjectCache;
 import org.commcare.modern.engine.cases.query.CaseIndexPrefetchHandler;
@@ -152,8 +152,8 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
         }
 
         if(ids.size() > 50 && ids.size() < PerformanceTuningUtil.getMaxPrefetchCaseBlock()) {
-            CaseGroupResultCache cue = currentQueryContext.getQueryCache(CaseGroupResultCache.class);
-            cue.reportBulkCaseBody(cacheKey, ids);
+            CaseSetResultCache cue = currentQueryContext.getQueryCache(CaseSetResultCache.class);
+            cue.reportBulkCaseSet(cacheKey, ids);
         }
 
         //Ok, we matched! Remove all of the keys that we matched
@@ -284,7 +284,7 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
         if (context == null) {
             return super.getElement(recordId, context);
         }
-        CaseGroupResultCache caseGroupCache = context.getQueryCacheOrNull(CaseGroupResultCache.class);
+        CaseSetResultCache caseGroupCache = context.getQueryCacheOrNull(CaseSetResultCache.class);
 
         CaseObjectCache caseObjectCache = getCaseObjectCacheIfRelevant(context);
 
@@ -292,7 +292,7 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
                 (caseObjectCache.isLoaded(recordId) || canLoadCaseFromGroup(caseGroupCache, recordId))) {
 
             if (!caseObjectCache.isLoaded(recordId)) {
-                Pair<String, LinkedHashSet<Integer>> tranche = caseGroupCache.getTranche(recordId);
+                Pair<String, LinkedHashSet<Integer>> tranche = caseGroupCache.getCaseSetForRecord(recordId);
                 EvaluationTrace loadTrace =
                         new EvaluationTrace(String.format("Bulk Case Load [%s]", tranche.first));
                 SqlStorage<ACase> sqlStorage = ((SqlStorage<ACase>)storage);
@@ -307,7 +307,7 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
         return super.getElement(recordId, context);
     }
 
-    private boolean canLoadCaseFromGroup(CaseGroupResultCache caseGroupCache, int recordId) {
+    private boolean canLoadCaseFromGroup(CaseSetResultCache caseGroupCache, int recordId) {
         return caseGroupCache != null && caseGroupCache.hasMatchingCaseSet(recordId);
     }
 

--- a/app/src/org/commcare/engine/cases/AndroidCaseInstanceTreeElement.java
+++ b/app/src/org/commcare/engine/cases/AndroidCaseInstanceTreeElement.java
@@ -288,10 +288,10 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
 
         CaseObjectCache caseObjectCache = getCaseObjectCacheIfRelevant(context);
 
-        if(caseObjectCache != null &&
+        if (caseObjectCache != null &&
                 (caseObjectCache.isLoaded(recordId) || canLoadCaseFromGroup(caseGroupCache, recordId))) {
 
-            if(!caseObjectCache.isLoaded(recordId)) {
+            if (!caseObjectCache.isLoaded(recordId)) {
                 Pair<String, LinkedHashSet<Integer>> tranche = caseGroupCache.getTranche(recordId);
                 EvaluationTrace loadTrace =
                         new EvaluationTrace(String.format("Bulk Case Load [%s]", tranche.first));
@@ -315,8 +315,8 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
      * Get a case object cache if it's appropriate in the current context.
      */
     private CaseObjectCache getCaseObjectCacheIfRelevant(QueryContext context) {
-        //If the query isn't currently in a bulk mode, don't force an object cache to exist unless
-        //it already does
+        // If the query isn't currently in a bulk mode, don't force an object cache to exist unless
+        // it already does
         if (context.getScope() < QueryContext.BULK_QUERY_THRESHOLD) {
             return context.getQueryCacheOrNull(CaseObjectCache.class);
         } else {

--- a/app/src/org/commcare/engine/cases/AndroidCaseInstanceTreeElement.java
+++ b/app/src/org/commcare/engine/cases/AndroidCaseInstanceTreeElement.java
@@ -17,6 +17,7 @@ import org.commcare.models.database.user.models.AndroidCaseIndexTable;
 import org.commcare.modern.engine.cases.CaseGroupResultCache;
 import org.commcare.modern.engine.cases.CaseIndexQuerySetTransform;
 import org.commcare.modern.engine.cases.query.CaseIndexPrefetchHandler;
+import org.commcare.modern.util.PerformanceTuningUtil;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.EvaluationTrace;
@@ -148,7 +149,7 @@ public class AndroidCaseInstanceTreeElement extends CaseInstanceTreeElement impl
             mPairedIndexCache.put(cacheKey, ids);
         }
 
-        if(ids.size() > 50 && ids.size() < CaseGroupResultCache.MAX_PREFETCH_CASE_BLOCK) {
+        if(ids.size() > 50 && ids.size() < PerformanceTuningUtil.getMaxPrefetchCaseBlock()) {
             CaseGroupResultCache cue = currentQueryContext.getQueryCache(CaseGroupResultCache.class);
             cue.reportBulkCaseBody(cacheKey, ids);
         }

--- a/app/src/org/commcare/models/AsyncNodeEntityFactory.java
+++ b/app/src/org/commcare/models/AsyncNodeEntityFactory.java
@@ -8,6 +8,8 @@ import net.sqlcipher.database.SQLiteDatabase;
 import org.commcare.CommCareApplication;
 import org.commcare.cases.entity.Entity;
 import org.commcare.cases.entity.NodeEntityFactory;
+import org.commcare.cases.query.QueryContext;
+import org.commcare.cases.query.queryset.CurrentModelQuerySet;
 import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.user.models.EntityStorageCache;
@@ -21,6 +23,7 @@ import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.xpath.expr.XPathExpression;
 
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Vector;
 
 /**
@@ -73,6 +76,16 @@ public class AsyncNodeEntityFactory extends NodeEntityFactory {
         }
         return entity;
     }
+
+    @Override
+    protected void setEvaluationContextDefaultQuerySet(EvaluationContext ec,
+                                                       List<TreeReference> result) {
+
+        //Don't do anything for asynchronous lists. In theory the query set could help expand the
+        //first cache more quickly, but otherwise it's just keeping around tons of cases in memory
+        //that don't even need to be loaded.
+    }
+
 
     /**
      * Bulk loads search field cache from db.


### PR DESCRIPTION
See cross requested PR: Implements hooks which switch async entity list loads to _not_ use bulk optimizations inside of the entity load (since they load one by one no matter what), and allow different amounts of heap memory to be used based on device.

cross-request: https://github.com/dimagi/commcare-core/pull/596