### PR TITLE
Generalize text for entity list exception

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -609,7 +609,7 @@ wifi.direct.base.folder=wifidirect
 wifi.direct.submit.missing=The folder ${0} you are trying to submit does not exist. Please verify that this file is where it should be.
 
 notification.case.predicate.title=List failed to load
-notification.case.predicate.action=Filtering your list failed with a bad filter expression. Please fix this and re-deploy your app. Error was ${0}.
+notification.case.predicate.action=Loading your list failed with a bad expression. Please fix this and re-deploy your app. Error: ${0}.
 
 archive.install.title=Unzipping your Application Resources
 archive.install.progress=Unzipped ${0} out of ${1} resources

--- a/app/src/org/commcare/tasks/EntityLoaderTask.java
+++ b/app/src/org/commcare/tasks/EntityLoaderTask.java
@@ -74,7 +74,7 @@ public class EntityLoaderTask
             return new Pair<>(full, references);
         } catch (XPathException xe) {
             XPathErrorLogger.INSTANCE.logErrorToCurrentApp(xe);
-            XPathException me = new XPathException("Encountered an xpath error while trying to load and filter the list.");
+            XPathException me = new XPathException("Encountered an xpath error while trying to load the list.");
             me.setSource(xe.getSource());
             xe.printStackTrace();
             Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, ForceCloseLogger.getStackTrace(me));


### PR DESCRIPTION
Case URL: https://manage.dimagi.com/default.asp?255119#1353059
cross-request: https://github.com/dimagi/commcare-core/pull/600

Since the exception can occur due to sort expression as well saying 'Filtering your list failed with a bad filter expression' is a bit misleading'.



