### PR TITLE
Migrate all instances of PreferenceActivity to use PrferenceFragmentCompat

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -129,7 +129,11 @@
         </provider>
 
 
-        <activity android:name="org.commcare.preferences.CommCarePreferences">
+        <activity android:name="org.commcare.activities.CommCarePreferenceActivity"
+            android:theme="@style/PreferenceTheme">
+        </activity>
+        <activity android:name="org.commcare.activities.SessionAwarePreferenceActivity"
+                  android:theme="@style/PreferenceTheme">
         </activity>
         <activity android:name="org.commcare.activities.DotsEntryActivity">
             <intent-filter>
@@ -257,10 +261,6 @@
             android:windowSoftInputMode="adjustResize">
         </activity>
         <activity
-            android:name="org.commcare.preferences.FormEntryPreferences"
-            android:windowSoftInputMode="adjustResize">
-        </activity>
-        <activity
             android:name="org.commcare.activities.InstallArchiveActivity"
             android:windowSoftInputMode="adjustResize">
         </activity>
@@ -272,8 +272,6 @@
         <activity android:name="org.commcare.activities.MultipleAppsLimitWarningActivity">
         </activity>
         <activity android:name="org.commcare.activities.GlobalPrivilegeClaimingActivity">
-        </activity>
-        <activity android:name="org.commcare.activities.AppManagerAdvancedSettings">
         </activity>
         <activity android:name="org.commcare.activities.InstallFromListActivity">
         </activity>
@@ -367,10 +365,6 @@
             android:windowSoftInputMode="adjustPan">
         </activity>
         <activity
-            android:name="org.commcare.activities.AdvancedActionsActivity"/>
-        <activity
-            android:name="org.commcare.preferences.CommCareServerPreferences"/>
-        <activity
             android:name="org.commcare.activities.ConnectionDiagnosticActivity"
             android:windowSoftInputMode="adjustResize">
         </activity>
@@ -379,8 +373,6 @@
             android:screenOrientation="portrait">
         </activity>
         <activity android:name="org.commcare.activities.RecoveryActivity">
-        </activity>
-        <activity android:name="org.commcare.preferences.DeveloperPreferences">
         </activity>
         <activity
             android:name="org.commcare.print.TemplatePrinterActivity"

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -724,6 +724,7 @@ fingerprints.scanned=Fingerprints scanned: ${0}
 settings.server.listing=Server Settings
 settings.server.title=CommCare > Server Settings
 settings.developer.options=Developer Options
+settings.developer.title=Developer Options
 settings.main.title=CommCare > Settings
 settings.advanced.title=CommCare > Advanced
 clear.user.data=Clear User Data

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     compile 'com.android.support:cardview-v7:25.0.1'
     compile 'com.android.support:recyclerview-v7:25.0.1'
     compile 'com.android.support:support-v4:25.0.1'
+    compile 'com.android.support:preference-v7:25.0.1'
     compile 'com.android.support:gridlayout-v7:25.0.1'
     compile 'com.madgag.spongycastle:core:1.54.0.0'
     compile 'com.madgag.spongycastle:prov:1.54.0.0'

--- a/app/res/values/themes.xml
+++ b/app/res/values/themes.xml
@@ -20,6 +20,11 @@
         <item name="android:windowContentOverlay">@null</item>
     </style>
 
+    <style name="PreferenceTheme" parent="AppBaseTheme">
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
+        <item name="alertDialogTheme">@style/Theme.AppCompat.Light.Dialog.Alert</item>
+    </style>
+
     <style name="fading_edge" parent="android:Widget.ListView">
         <item name="android:requiresFadingEdge">vertical</item>
         <item name="android:fadingEdgeLength">48dp</item>
@@ -59,5 +64,6 @@
     <style name="Theme.Dialog.NoTitle" parent="@android:style/Theme.Dialog">
         <item name="android:windowNoTitle">true</item>
     </style>
+
 
 </resources>

--- a/app/src/org/commcare/activities/AppManagerActivity.java
+++ b/app/src/org/commcare/activities/AppManagerActivity.java
@@ -69,7 +69,8 @@ public class AppManagerActivity extends CommCareActivity implements OnItemClickL
                 startActivity(i);
                 return true;
             case MENU_ADVANCED_SETTINGS:
-                i = new Intent(this, AppManagerAdvancedSettings.class);
+                i = new Intent(this, CommCarePreferenceActivity.class);
+                i.putExtra(CommCarePreferenceActivity.EXTRA_PREF_TYPE, CommCarePreferenceActivity.PREF_TYPE_APP_MANAGER_ADVANCED);
                 startActivity(i);
                 return true;
         }
@@ -138,12 +139,12 @@ public class AppManagerActivity extends CommCareActivity implements OnItemClickL
                             StandardAlertDialog.getBasicAlertDialog(
                                     this, title, msg, new DialogInterface.OnClickListener() {
 
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            dismissAlertDialog();
-                        }
+                                        @Override
+                                        public void onClick(DialogInterface dialog, int which) {
+                                            dismissAlertDialog();
+                                        }
 
-                    }));
+                                    }));
                 } else if (resultCode == RESULT_OK) {
                     Toast.makeText(this, R.string.media_verified, Toast.LENGTH_LONG).show();
                 }

--- a/app/src/org/commcare/activities/AppManagerAdvancedPreferences.java
+++ b/app/src/org/commcare/activities/AppManagerAdvancedPreferences.java
@@ -52,7 +52,7 @@ public class AppManagerAdvancedPreferences extends CommCarePreferenceFragment {
 
     @NonNull
     @Override
-    protected int getPreferenceXmlFile() {
+    protected int getPreferencesResource() {
         return R.xml.app_manager_preferences;
     }
 

--- a/app/src/org/commcare/activities/AppManagerAdvancedPreferences.java
+++ b/app/src/org/commcare/activities/AppManagerAdvancedPreferences.java
@@ -38,6 +38,12 @@ public class AppManagerAdvancedPreferences extends CommCarePreferenceFragment {
         return Localization.get("app.manager.advanced.settings.title");
     }
 
+    @NonNull
+    @Override
+    protected String getAnalyticsCategory() {
+        return GoogleAnalyticsFields.CATEGORY_APP_MANAGER;
+    }
+
     @Nullable
     @Override
     protected Map<String, String> getPrefKeyAnalyticsEventMap() {
@@ -50,7 +56,6 @@ public class AppManagerAdvancedPreferences extends CommCarePreferenceFragment {
         return keyToTitleMap;
     }
 
-    @NonNull
     @Override
     protected int getPreferencesResource() {
         return R.xml.app_manager_preferences;
@@ -58,6 +63,7 @@ public class AppManagerAdvancedPreferences extends CommCarePreferenceFragment {
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        // No listeners
     }
 
     @Override

--- a/app/src/org/commcare/activities/AppManagerAdvancedPreferences.java
+++ b/app/src/org/commcare/activities/AppManagerAdvancedPreferences.java
@@ -1,16 +1,17 @@
 package org.commcare.activities;
 
 import android.content.Intent;
-import android.os.Bundle;
-import android.preference.Preference;
-import android.preference.PreferenceActivity;
-import android.view.MenuItem;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.preference.Preference;
 
 import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
+import org.commcare.fragments.CommCarePreferenceFragment;
 import org.commcare.google.services.analytics.GoogleAnalyticsFields;
 import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
-import org.commcare.preferences.CommCarePreferences;
+import org.commcare.preferences.AdvancedActionsPreferences;
 import org.javarosa.core.services.locale.Localization;
 
 import java.util.HashMap;
@@ -19,7 +20,7 @@ import java.util.Map;
 /**
  * @author Aliza Stone (astone@dimagi.com), created 6/9/16.
  */
-public class AppManagerAdvancedSettings extends PreferenceActivity {
+public class AppManagerAdvancedPreferences extends CommCarePreferenceFragment {
 
     private final static String ENABLE_PRIVILEGE = "enable-mobile-privilege";
     private final static String CLEAR_USER_DATA = "clear-user-data";
@@ -31,22 +32,36 @@ public class AppManagerAdvancedSettings extends PreferenceActivity {
         keyToTitleMap.put(CLEAR_USER_DATA, "clear.user.data");
     }
 
+    @NonNull
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.app_manager_preferences);
-        GoogleAnalyticsUtils.reportPrefActivityEntry(GoogleAnalyticsFields.CATEGORY_APP_MANAGER);
-        setupUI();
+    protected String getTitle() {
+        return Localization.get("app.manager.advanced.settings.title");
     }
 
-    private void setupUI() {
-        setTitle(Localization.get("app.manager.advanced.settings.title"));
-        CommCarePreferences.addBackButtonToActionBar(this);
-        CommCarePreferences.setupLocalizedText(this, keyToTitleMap);
-        setupButtons();
+    @Nullable
+    @Override
+    protected Map<String, String> getPrefKeyAnalyticsEventMap() {
+        return null;
     }
 
-    private void setupButtons() {
+    @Nullable
+    @Override
+    protected Map<String, String> getPrefKeyTitleMap() {
+        return keyToTitleMap;
+    }
+
+    @NonNull
+    @Override
+    protected int getPreferenceXmlFile() {
+        return R.xml.app_manager_preferences;
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+    }
+
+    @Override
+    protected void setupPrefClickListeners() {
         Preference enablePrivilegesButton = findPreference(ENABLE_PRIVILEGE);
         enablePrivilegesButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
@@ -63,25 +78,14 @@ public class AppManagerAdvancedSettings extends PreferenceActivity {
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 GoogleAnalyticsUtils.reportAdvancedActionItemClick(GoogleAnalyticsFields.ACTION_CLEAR_USER_DATA);
-                AdvancedActionsActivity.clearUserData(AppManagerAdvancedSettings.this);
+                AdvancedActionsPreferences.clearUserData(getActivity());
                 return true;
             }
         });
     }
 
     private void launchPrivilegeClaimActivity() {
-        Intent i = new Intent(this, GlobalPrivilegeClaimingActivity.class);
+        Intent i = new Intent(getActivity(), GlobalPrivilegeClaimingActivity.class);
         startActivity(i);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            // Respond to the action bar's Up/Home button
-            case android.R.id.home:
-                finish();
-                return true;
-        }
-        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/org/commcare/activities/CommCareFormDumpActivity.java
+++ b/app/src/org/commcare/activities/CommCareFormDumpActivity.java
@@ -16,6 +16,7 @@ import org.commcare.dalvik.R;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
+import org.commcare.preferences.AdvancedActionsPreferences;
 import org.commcare.preferences.CommCarePreferences;
 import org.commcare.preferences.CommCareServerPreferences;
 import org.commcare.tasks.DumpTask;
@@ -96,7 +97,7 @@ public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommC
                         if (result == Boolean.TRUE) {
                             CommCareApplication.notificationManager().clearNotifications(AIRPLANE_MODE_CATEGORY);
                             Intent i = new Intent(getIntent());
-                            i.putExtra(AdvancedActionsActivity.KEY_NUMBER_DUMPED, formsOnSD);
+                            i.putExtra(AdvancedActionsPreferences.KEY_NUMBER_DUMPED, formsOnSD);
                             receiver.setResult(BULK_SEND_ID, i);
                             Logger.log(AndroidLogger.TYPE_FORM_DUMP, "Successfully submitted " + formsOnSD + " forms.");
                             receiver.finish();
@@ -142,7 +143,7 @@ public class CommCareFormDumpActivity extends SessionAwareCommCareActivity<CommC
                     protected void deliverResult(CommCareFormDumpActivity receiver, Boolean result) {
                         if (result == Boolean.TRUE) {
                             Intent i = new Intent(getIntent());
-                            i.putExtra(AdvancedActionsActivity.KEY_NUMBER_DUMPED, formsOnPhone);
+                            i.putExtra(AdvancedActionsPreferences.KEY_NUMBER_DUMPED, formsOnPhone);
                             receiver.setResult(BULK_DUMP_ID, i);
                             Logger.log(AndroidLogger.TYPE_FORM_DUMP, "Successfully dumped " + formsOnPhone + " forms.");
                             receiver.finish();

--- a/app/src/org/commcare/activities/CommCarePreferenceActivity.java
+++ b/app/src/org/commcare/activities/CommCarePreferenceActivity.java
@@ -17,9 +17,6 @@ import org.commcare.preferences.CommCareServerPreferences;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.preferences.FormEntryPreferences;
 
-/**
- * Created by dimagi on 26/06/17.
- */
 
 public class CommCarePreferenceActivity extends FragmentActivity {
 
@@ -65,8 +62,6 @@ public class CommCarePreferenceActivity extends FragmentActivity {
                 default:
                     throw new IllegalStateException("Invalid prefType : " + prefType);
             }
-
-            assert commCarePreferenceFragment != null;
 
             getSupportFragmentManager().beginTransaction()
                     .replace(android.R.id.content, commCarePreferenceFragment)

--- a/app/src/org/commcare/activities/CommCarePreferenceActivity.java
+++ b/app/src/org/commcare/activities/CommCarePreferenceActivity.java
@@ -1,0 +1,97 @@
+package org.commcare.activities;
+
+import android.app.ActionBar;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentActivity;
+import android.view.MenuItem;
+
+import org.commcare.fragments.CommCarePreferenceFragment;
+import org.commcare.preferences.AdvancedActionsPreferences;
+import org.commcare.preferences.CommCarePreferences;
+import org.commcare.preferences.CommCareServerPreferences;
+import org.commcare.preferences.DeveloperPreferences;
+import org.commcare.preferences.FormEntryPreferences;
+
+/**
+ * Created by dimagi on 26/06/17.
+ */
+
+public class CommCarePreferenceActivity extends FragmentActivity {
+
+
+    public static final String EXTRA_PREF_TYPE = "extra_pref_type";
+
+    //List of Pref Types
+    public static final String PREF_TYPE_COMMCARE = "pref_type_commcare";
+    public static final String PREF_TYPE_SERVER = "pref_type_server";
+    public static final String PREF_TYPE_DEVELOPER = "pref_type_developer";
+    public static final String PREF_TYPE_ADVANCED_ACTIONS = "pref_type_advanced_actions";
+    public static final String PREF_TYPE_FORM_ENTRY = "pref_type_form_entry";
+    public static final String PREF_TYPE_APP_MANAGER_ADVANCED = "pref_type_app_manager_advanced";
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addBackButtonToActionBar();
+
+        Intent intent = getIntent();
+        if (intent != null && intent.hasExtra(EXTRA_PREF_TYPE)) {
+            String prefType = intent.getStringExtra(EXTRA_PREF_TYPE);
+            CommCarePreferenceFragment commCarePreferenceFragment;
+            switch (prefType) {
+                case PREF_TYPE_COMMCARE:
+                    commCarePreferenceFragment = new CommCarePreferences();
+                    break;
+                case PREF_TYPE_SERVER:
+                    commCarePreferenceFragment = new CommCareServerPreferences();
+                    break;
+                case PREF_TYPE_DEVELOPER:
+                    commCarePreferenceFragment = new DeveloperPreferences();
+                    break;
+                case PREF_TYPE_ADVANCED_ACTIONS:
+                    commCarePreferenceFragment = new AdvancedActionsPreferences();
+                    break;
+                case PREF_TYPE_FORM_ENTRY:
+                    commCarePreferenceFragment = new FormEntryPreferences();
+                    break;
+                case PREF_TYPE_APP_MANAGER_ADVANCED:
+                    commCarePreferenceFragment = new AppManagerAdvancedPreferences();
+                    break;
+                default:
+                    throw new IllegalStateException("Invalid prefType : " + prefType);
+            }
+
+            assert commCarePreferenceFragment != null;
+
+            getSupportFragmentManager().beginTransaction()
+                    .replace(android.R.id.content, commCarePreferenceFragment)
+                    .commit();
+        } else {
+            throw new IllegalStateException("Must pass an intent with key extra_pref_type to " + CommCarePreferenceActivity.class.getSimpleName());
+        }
+    }
+
+    private void addBackButtonToActionBar() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            ActionBar actionBar = getActionBar();
+            if (actionBar != null) {
+                actionBar.setDisplayShowHomeEnabled(true);
+                actionBar.setDisplayHomeAsUpEnabled(true);
+            }
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            // Respond to the action bar's Up/Home button
+            case android.R.id.home:
+                finish();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/app/src/org/commcare/activities/CommCarePreferenceActivity.java
+++ b/app/src/org/commcare/activities/CommCarePreferenceActivity.java
@@ -1,9 +1,11 @@
 package org.commcare.activities;
 
 import android.app.ActionBar;
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentActivity;
 import android.view.MenuItem;
@@ -35,7 +37,7 @@ public class CommCarePreferenceActivity extends FragmentActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        addBackButtonToActionBar();
+        addBackButtonToActionBar(this);
 
         Intent intent = getIntent();
         if (intent != null && intent.hasExtra(EXTRA_PREF_TYPE)) {
@@ -74,9 +76,9 @@ public class CommCarePreferenceActivity extends FragmentActivity {
         }
     }
 
-    private void addBackButtonToActionBar() {
+    public static void addBackButtonToActionBar(@NonNull Activity activity) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            ActionBar actionBar = getActionBar();
+            ActionBar actionBar = activity.getActionBar();
             if (actionBar != null) {
                 actionBar.setDisplayShowHomeEnabled(true);
                 actionBar.setDisplayHomeAsUpEnabled(true);

--- a/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
@@ -37,6 +37,7 @@ import org.commcare.interfaces.WithUIController;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
+import org.commcare.preferences.AdvancedActionsPreferences;
 import org.commcare.preferences.CommCareServerPreferences;
 import org.commcare.services.WiFiDirectBroadcastReceiver;
 import org.commcare.tasks.FormRecordToFileTask;
@@ -416,7 +417,7 @@ public class CommCareWiFiDirectActivity
             protected void deliverResult(CommCareWiFiDirectActivity receiver, Boolean result) {
                 if (result == Boolean.TRUE) {
                     Intent i = new Intent(getIntent());
-                    i.putExtra(AdvancedActionsActivity.KEY_NUMBER_DUMPED, formsOnSD);
+                    i.putExtra(AdvancedActionsPreferences.KEY_NUMBER_DUMPED, formsOnSD);
                     receiver.setResult(BULK_SEND_ID, i);
                     Logger.log(TAG, "Sucessfully dumped " + formsOnSD);
                     receiver.finish();

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -490,7 +490,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 startActivityForResult(i, FormEntryConstants.HIERARCHY_ACTIVITY);
                 return true;
             case FormEntryConstants.MENU_PREFERENCES:
-                Intent pref = new Intent(this, FormEntryPreferences.class);
+                Intent pref = new Intent(this, SessionAwarePreferenceActivity.class);
+                pref.putExtra(CommCarePreferenceActivity.EXTRA_PREF_TYPE,CommCarePreferenceActivity.PREF_TYPE_FORM_ENTRY);
                 startActivityForResult(pref, FormEntryConstants.FORM_PREFERENCES_KEY);
                 return true;
             case android.R.id.home:

--- a/app/src/org/commcare/activities/GlobalPrivilegeClaimingActivity.java
+++ b/app/src/org/commcare/activities/GlobalPrivilegeClaimingActivity.java
@@ -54,7 +54,7 @@ public class GlobalPrivilegeClaimingActivity extends Activity {
             }
         });
 
-        CommCarePreferences.addBackButtonToActionBar(this);
+//        CommCarePreferences.addBackButtonToActionBar(this);
     }
 
     @Override

--- a/app/src/org/commcare/activities/GlobalPrivilegeClaimingActivity.java
+++ b/app/src/org/commcare/activities/GlobalPrivilegeClaimingActivity.java
@@ -54,7 +54,7 @@ public class GlobalPrivilegeClaimingActivity extends Activity {
             }
         });
 
-//        CommCarePreferences.addBackButtonToActionBar(this);
+        CommCarePreferenceActivity.addBackButtonToActionBar(this);
     }
 
     @Override

--- a/app/src/org/commcare/activities/HomeNavDrawerController.java
+++ b/app/src/org/commcare/activities/HomeNavDrawerController.java
@@ -147,7 +147,7 @@ public class HomeNavDrawerController {
                         HomeScreenBaseActivity.createPreferencesMenu(activity);
                         break;
                     case ADVANCED_DRAWER_ITEM_ID:
-                        activity.startAdvancedActionsActivity();
+                        activity.showAdvancedActionsPreferences();
                         break;
                     case CHANGE_LANGUAGE_DRAWER_ITEM_ID:
                         activity.showLocaleChangeMenu(null);

--- a/app/src/org/commcare/activities/SessionAwarePreferenceActivity.java
+++ b/app/src/org/commcare/activities/SessionAwarePreferenceActivity.java
@@ -9,7 +9,7 @@ import org.commcare.utils.SessionActivityRegistration;
  *
  * @author Phillip Mates (pmates@dimagi.com)
  */
-public abstract class SessionAwarePreferenceActivity extends PreferenceActivity {
+public class SessionAwarePreferenceActivity extends CommCarePreferenceActivity {
 
     @Override
     protected void onResume() {

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -185,7 +185,7 @@ public class StandardHomeActivity
                 createPreferencesMenu(this);
                 return true;
             case MENU_ADVANCED:
-                startAdvancedActionsActivity();
+                showAdvancedActionsPreferences();
                 return true;
             case MENU_ABOUT:
                 showAboutCommCareDialog();

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -28,15 +28,15 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
-        GoogleAnalyticsUtils.reportPrefActivityEntry(GoogleAnalyticsFields.CATEGORY_CC_PREFS);
-        setupUI();
-        initPrefs();
+        GoogleAnalyticsUtils.reportPrefActivityEntry(getAnalyticsCategory());
+        setTitle();
+        initPrefsFile();
         loadPrefs();
     }
 
     @CallSuper
-    protected void initPrefs() {
-        if(isAppLevelPreference()) {
+    protected void initPrefsFile() {
+        if (isPersistentAppPreference()) {
             PreferenceManager prefMgr = getPreferenceManager();
             prefMgr.setSharedPreferencesName((CommCareApplication.instance().getCurrentApp().getPreferencesFilename()));
         }
@@ -54,7 +54,7 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
     }
 
     @CallSuper
-    protected void setupUI() {
+    protected void setTitle() {
         if (getActivity() != null) {
             getActivity().setTitle(getTitle());
         }
@@ -78,17 +78,19 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
         }
     }
 
+
+
     @Override
-    public void onStart() {
-        super.onStart();
+    public void onResume() {
+        super.onResume();
         // register the preference change listener
         getPreferenceScreen().getSharedPreferences()
                 .registerOnSharedPreferenceChangeListener(this);
     }
 
     @Override
-    public void onStop() {
-        super.onStop();
+    public void onPause() {
+        super.onPause();
         // unregister the preference change listener
         getPreferenceScreen().getSharedPreferences()
                 .unregisterOnSharedPreferenceChangeListener(this);
@@ -104,16 +106,18 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
     }
 
     /**
-     *
      * @return whether the preference should be stored in app specific preference file.
      */
-    protected boolean isAppLevelPreference() {
+    protected boolean isPersistentAppPreference() {
         return false;
     }
 
 
     @NonNull
     protected abstract String getTitle();
+
+    @NonNull
+    protected abstract String getAnalyticsCategory();
 
     @Nullable
     protected abstract Map<String, String> getPrefKeyAnalyticsEventMap();
@@ -123,7 +127,6 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
     @Nullable
     protected abstract Map<String, String> getPrefKeyTitleMap();
 
-    @NonNull
     protected abstract int getPreferencesResource();
 
     @Override

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -1,0 +1,118 @@
+package org.commcare.fragments;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.support.annotation.CallSuper;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.preference.PreferenceFragmentCompat;
+import android.support.v7.preference.PreferenceManager;
+import android.support.v7.preference.PreferenceScreen;
+import android.util.Log;
+
+import org.commcare.CommCareApplication;
+import org.commcare.google.services.analytics.GoogleAnalyticsFields;
+import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.NoLocalizedTextException;
+
+import java.util.Map;
+
+public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompat
+        implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private static final String TAG = CommCarePreferenceFragment.class.getSimpleName();
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        GoogleAnalyticsUtils.reportPrefActivityEntry(GoogleAnalyticsFields.CATEGORY_CC_PREFS);
+        setupUI();
+        initPrefs();
+        loadPrefs();
+    }
+
+    @CallSuper
+    protected void initPrefs() {
+        PreferenceManager prefMgr = getPreferenceManager();
+        prefMgr.setSharedPreferencesName((CommCareApplication.instance().getCurrentApp().getPreferencesFilename()));
+    }
+
+    @CallSuper
+    protected void loadPrefs() {
+        // Add 'general' preferences, defined in the XML file
+        addPreferencesFromResource(getPreferenceXmlFile());
+
+        GoogleAnalyticsUtils.createPreferenceOnClickListeners(getPreferenceManager(), getPrefKeyAnalyticsEventMap(),
+                GoogleAnalyticsFields.CATEGORY_CC_PREFS);
+        setupPrefClickListeners();
+        setupLocalizedText();
+    }
+
+    @CallSuper
+    protected void setupUI() {
+        if (getActivity() != null) {
+            getActivity().setTitle(getTitle());
+        }
+    }
+
+    private void setupLocalizedText() {
+        Map<String, String> prefToTitleMap = getPrefKeyTitleMap();
+        if (prefToTitleMap != null) {
+            PreferenceScreen screen = getPreferenceScreen();
+            for (int i = 0; i < screen.getPreferenceCount(); i++) {
+                String key = screen.getPreference(i).getKey();
+                if (prefToTitleMap.containsKey(key)) {
+                    try {
+                        String localizedString = Localization.get(prefToTitleMap.get(key));
+                        screen.getPreference(i).setTitle(localizedString);
+                    } catch (NoLocalizedTextException nle) {
+                        Log.w(TAG, "Unable to localize: " + prefToTitleMap.get(key));
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        // register the preference change listener
+        getPreferenceScreen().getSharedPreferences()
+                .registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        // unregister the preference change listener
+        getPreferenceScreen().getSharedPreferences()
+                .unregisterOnSharedPreferenceChangeListener(this);
+    }
+
+    /**
+     * Use this to reload prefs screen
+     */
+    @CallSuper
+    protected void reset() {
+        getPreferenceScreen().removeAll();
+        loadPrefs();
+    }
+
+
+    @NonNull
+    protected abstract String getTitle();
+
+    @Nullable
+    protected abstract Map<String, String> getPrefKeyAnalyticsEventMap();
+
+    protected abstract void setupPrefClickListeners();
+
+    @Nullable
+    protected abstract Map<String, String> getPrefKeyTitleMap();
+
+    @NonNull
+    protected abstract int getPreferenceXmlFile();
+
+    @Override
+    public abstract void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key);
+}

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -18,6 +18,9 @@ import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.util.Map;
 
+/**
+ * Common PreferenceFragment class from which all other preferences extend.
+ */
 public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompat
         implements SharedPreferences.OnSharedPreferenceChangeListener {
 
@@ -37,14 +40,6 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
             PreferenceManager prefMgr = getPreferenceManager();
             prefMgr.setSharedPreferencesName((CommCareApplication.instance().getCurrentApp().getPreferencesFilename()));
         }
-    }
-
-    /**
-     *
-     * @return whether the preference should be stored in app specific preference file.
-     */
-    protected boolean isAppLevelPreference() {
-        return false;
     }
 
     @CallSuper
@@ -106,6 +101,14 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
     protected void reset() {
         getPreferenceScreen().removeAll();
         loadPrefs();
+    }
+
+    /**
+     *
+     * @return whether the preference should be stored in app specific preference file.
+     */
+    protected boolean isAppLevelPreference() {
+        return false;
     }
 
 

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -33,14 +33,24 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
 
     @CallSuper
     protected void initPrefs() {
-        PreferenceManager prefMgr = getPreferenceManager();
-        prefMgr.setSharedPreferencesName((CommCareApplication.instance().getCurrentApp().getPreferencesFilename()));
+        if(isAppLevelPreference()) {
+            PreferenceManager prefMgr = getPreferenceManager();
+            prefMgr.setSharedPreferencesName((CommCareApplication.instance().getCurrentApp().getPreferencesFilename()));
+        }
+    }
+
+    /**
+     *
+     * @return whether the preference should be stored in app specific preference file.
+     */
+    protected boolean isAppLevelPreference() {
+        return false;
     }
 
     @CallSuper
     protected void loadPrefs() {
         // Add 'general' preferences, defined in the XML file
-        addPreferencesFromResource(getPreferenceXmlFile());
+        addPreferencesFromResource(getPreferencesResource());
 
         GoogleAnalyticsUtils.createPreferenceOnClickListeners(getPreferenceManager(), getPrefKeyAnalyticsEventMap(),
                 GoogleAnalyticsFields.CATEGORY_CC_PREFS);
@@ -111,7 +121,7 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
     protected abstract Map<String, String> getPrefKeyTitleMap();
 
     @NonNull
-    protected abstract int getPreferenceXmlFile();
+    protected abstract int getPreferencesResource();
 
     @Override
     public abstract void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key);

--- a/app/src/org/commcare/google/services/analytics/GoogleAnalyticsUtils.java
+++ b/app/src/org/commcare/google/services/analytics/GoogleAnalyticsUtils.java
@@ -1,8 +1,8 @@
 package org.commcare.google.services.analytics;
 
 import android.os.Build;
-import android.preference.Preference;
-import android.preference.PreferenceManager;
+import android.support.v7.preference.Preference;
+import android.support.v7.preference.PreferenceManager;
 
 import com.google.android.gms.analytics.HitBuilders;
 import com.google.android.gms.analytics.Tracker;
@@ -375,9 +375,11 @@ public class GoogleAnalyticsUtils {
     public static void createPreferenceOnClickListeners(PreferenceManager prefManager,
                                                         Map<String, String> menuIdToAnalyticsEvent, String category) {
 
-        for (String prefKey : menuIdToAnalyticsEvent.keySet()) {
-            createPreferenceOnClickListener(prefManager, prefKey, category,
-                    menuIdToAnalyticsEvent.get(prefKey));
+        if (menuIdToAnalyticsEvent != null) {
+            for (String prefKey : menuIdToAnalyticsEvent.keySet()) {
+                createPreferenceOnClickListener(prefManager, prefKey, category,
+                        menuIdToAnalyticsEvent.get(prefKey));
+            }
         }
     }
 

--- a/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
+++ b/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
@@ -109,7 +109,7 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-
+        // No listeners
     }
 
 

--- a/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
+++ b/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
@@ -98,7 +98,7 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
 
     @NonNull
     @Override
-    protected int getPreferenceXmlFile() {
+    protected int getPreferencesResource() {
         return R.xml.advanced_actions;
     }
 

--- a/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
+++ b/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
@@ -1,22 +1,29 @@
-package org.commcare.activities;
+package org.commcare.preferences;
 
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.os.Bundle;
-import android.preference.Preference;
-import android.view.MenuItem;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.preference.Preference;
 
 import org.commcare.AppUtils;
 import org.commcare.CommCareApplication;
+import org.commcare.activities.CommCareFormDumpActivity;
+import org.commcare.activities.CommCareVerificationActivity;
+import org.commcare.activities.CommCareWiFiDirectActivity;
+import org.commcare.activities.ConnectionDiagnosticActivity;
+import org.commcare.activities.HomeScreenBaseActivity;
+import org.commcare.activities.RecoveryActivity;
+import org.commcare.activities.ReportProblemActivity;
 import org.commcare.dalvik.R;
+import org.commcare.fragments.CommCarePreferenceFragment;
 import org.commcare.google.services.analytics.GoogleAnalyticsFields;
 import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
-import org.commcare.preferences.CommCarePreferences;
-import org.commcare.preferences.DevSessionRestorer;
 import org.commcare.tasks.DumpTask;
 import org.commcare.tasks.SendTask;
 import org.commcare.tasks.WipeTask;
@@ -33,7 +40,7 @@ import java.util.Map;
  *
  * @author Phillip Mates (pmates@dimagi.com)
  */
-public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
+public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
 
     private final static String WIFI_DIRECT = "wifi-direct";
     private final static String DUMP_FORMS = "manage-sd-card";
@@ -55,7 +62,7 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
 
     public final static String FORM_PROCESS_COUNT_KEY = "forms-processed-count";
     public final static String FORM_PROCESS_MESSAGE_KEY = "forms-processed-message";
-    static final String KEY_NUMBER_DUMPED = "num_dumped";
+    public final static String KEY_NUMBER_DUMPED = "num_dumped";
 
     private final static Map<String, String> keyToTitleMap = new HashMap<>();
 
@@ -71,26 +78,38 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
         keyToTitleMap.put(CLEAR_SAVED_SESSION, "menu.clear.saved.session");
     }
 
+    @NonNull
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        addPreferencesFromResource(R.xml.advanced_actions);
-
-        GoogleAnalyticsUtils.reportPrefActivityEntry(GoogleAnalyticsFields.CATEGORY_ADVANCED_ACTIONS);
-
-        setupUI();
+    protected String getTitle() {
+        return Localization.get("settings.advanced.title");
     }
 
-    private void setupUI() {
-        setTitle(Localization.get("settings.advanced.title"));
-        CommCarePreferences.addBackButtonToActionBar(this);
-
-        CommCarePreferences.setupLocalizedText(this, keyToTitleMap);
-        setupButtons();
+    @Nullable
+    @Override
+    protected Map<String, String> getPrefKeyAnalyticsEventMap() {
+        return null;
     }
 
-    private void setupButtons() {
+    @Nullable
+    @Override
+    protected Map<String, String> getPrefKeyTitleMap() {
+        return keyToTitleMap;
+    }
+
+    @NonNull
+    @Override
+    protected int getPreferenceXmlFile() {
+        return R.xml.advanced_actions;
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+
+    }
+
+
+    @Override
+    protected void setupPrefClickListeners() {
         Preference serverSettingsButton = findPreference(REPORT_PROBLEM);
         serverSettingsButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
@@ -150,7 +169,7 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 GoogleAnalyticsUtils.reportAdvancedActionItemClick(GoogleAnalyticsFields.ACTION_CLEAR_USER_DATA);
-                clearUserData(AdvancedActionsActivity.this);
+                clearUserData(getActivity());
                 return true;
             }
         });
@@ -175,7 +194,7 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 GoogleAnalyticsUtils.reportAdvancedActionItemClick(GoogleAnalyticsFields.ACTION_FORCE_LOG_SUBMISSION);
-                CommCareUtil.triggerLogSubmission(AdvancedActionsActivity.this);
+                CommCareUtil.triggerLogSubmission(getActivity());
                 return true;
             }
         });
@@ -192,39 +211,39 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
     }
 
     private void startReportActivity() {
-        Intent i = new Intent(this, ReportProblemActivity.class);
+        Intent i = new Intent(getActivity(), ReportProblemActivity.class);
         startActivityForResult(i, REPORT_PROBLEM_ACTIVITY);
     }
 
     private void startValidationActivity() {
-        Intent i = new Intent(this, CommCareVerificationActivity.class);
+        Intent i = new Intent(getActivity(), CommCareVerificationActivity.class);
         i.putExtra(CommCareVerificationActivity.KEY_LAUNCH_FROM_SETTINGS, true);
         startActivityForResult(i, VALIDATE_MEDIA_ACTIVITY);
     }
 
     private void startWifiDirect() {
-        Intent i = new Intent(this, CommCareWiFiDirectActivity.class);
+        Intent i = new Intent(getActivity(), CommCareWiFiDirectActivity.class);
         startActivityForResult(i, WIFI_DIRECT_ACTIVITY);
     }
 
     private void startFormDump() {
-        Intent i = new Intent(this, CommCareFormDumpActivity.class);
+        Intent i = new Intent(getActivity(), CommCareFormDumpActivity.class);
         i.putExtra(CommCareFormDumpActivity.EXTRA_FILE_DESTINATION, CommCareApplication.instance().getCurrentApp().storageRoot());
         startActivityForResult(i, DUMP_FORMS_ACTIVITY);
     }
 
     private void startRecoveryMode() {
-        Intent i = new Intent(this, RecoveryActivity.class);
+        Intent i = new Intent(getActivity(), RecoveryActivity.class);
         this.startActivity(i);
     }
 
     private boolean hasP2p() {
         return Build.VERSION.SDK_INT > Build.VERSION_CODES.ICE_CREAM_SANDWICH
-                && getPackageManager().hasSystemFeature(PackageManager.FEATURE_WIFI_DIRECT);
+                && getActivity().getPackageManager().hasSystemFeature(PackageManager.FEATURE_WIFI_DIRECT);
     }
 
     private void startConnectionTest() {
-        Intent i = new Intent(this, ConnectionDiagnosticActivity.class);
+        Intent i = new Intent(getActivity(), ConnectionDiagnosticActivity.class);
         startActivity(i);
     }
 
@@ -251,9 +270,9 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
+    public void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if (requestCode == REPORT_PROBLEM_ACTIVITY || requestCode == VALIDATE_MEDIA_ACTIVITY) {
-            finish();
+            getActivity().finish();
         } else if (requestCode == WIFI_DIRECT_ACTIVITY || requestCode == DUMP_FORMS_ACTIVITY) {
             String messageKey = getBulkFormMessageKey(resultCode);
             if (messageKey == null) {
@@ -264,8 +283,8 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
             Intent returnIntent = new Intent();
             returnIntent.putExtra(FORM_PROCESS_COUNT_KEY, dumpedCount);
             returnIntent.putExtra(FORM_PROCESS_MESSAGE_KEY, messageKey);
-            setResult(RESULT_FORMS_PROCESSED, returnIntent);
-            finish();
+            getActivity().setResult(RESULT_FORMS_PROCESSED, returnIntent);
+            getActivity().finish();
         }
     }
 
@@ -279,17 +298,6 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
         } else {
             return null;
         }
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            // Respond to the action bar's Up/Home button
-            case android.R.id.home:
-                finish();
-                return true;
-        }
-        return super.onOptionsItemSelected(item);
     }
 }
 

--- a/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
+++ b/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
@@ -84,6 +84,12 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
         return Localization.get("settings.advanced.title");
     }
 
+    @NonNull
+    @Override
+    protected String getAnalyticsCategory() {
+        return GoogleAnalyticsFields.CATEGORY_ADVANCED_ACTIONS;
+    }
+
     @Nullable
     @Override
     protected Map<String, String> getPrefKeyAnalyticsEventMap() {
@@ -96,7 +102,6 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
         return keyToTitleMap;
     }
 
-    @NonNull
     @Override
     protected int getPreferencesResource() {
         return R.xml.advanced_actions;

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -167,8 +167,13 @@ public class CommCarePreferences
     }
 
     @Override
-    protected int getPreferenceXmlFile() {
+    protected int getPreferencesResource() {
         return R.xml.commcare_preferences;
+    }
+
+    @Override
+    protected boolean isAppLevelPreference() {
+        return true;
     }
 
     @Override

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.net.Uri;
+import android.support.annotation.NonNull;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceScreen;
 import android.util.DisplayMetrics;
@@ -151,9 +152,16 @@ public class CommCarePreferences
         }
     }
 
+    @NonNull
     @Override
     protected String getTitle() {
         return Localization.get("settings.main.title");
+    }
+
+    @NonNull
+    @Override
+    protected String getAnalyticsCategory() {
+        return GoogleAnalyticsFields.CATEGORY_CC_PREFS;
     }
 
     @Override
@@ -172,7 +180,7 @@ public class CommCarePreferences
     }
 
     @Override
-    protected boolean isAppLevelPreference() {
+    protected boolean isPersistentAppPreference() {
         return true;
     }
 

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -1,30 +1,24 @@
 package org.commcare.preferences;
 
-import android.app.ActionBar;
-import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.net.Uri;
-import android.os.Build;
-import android.os.Bundle;
-import android.preference.Preference;
-import android.preference.PreferenceActivity;
-import android.preference.PreferenceManager;
-import android.preference.PreferenceScreen;
+import android.support.v7.preference.Preference;
+import android.support.v7.preference.PreferenceScreen;
 import android.util.DisplayMetrics;
-import android.util.Log;
-import android.view.MenuItem;
 import android.widget.Toast;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
+import org.commcare.activities.CommCarePreferenceActivity;
 import org.commcare.activities.GeoPointActivity;
 import org.commcare.activities.SessionAwarePreferenceActivity;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
+import org.commcare.fragments.CommCarePreferenceFragment;
 import org.commcare.google.services.analytics.GoogleAnalyticsFields;
 import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
 import org.commcare.utils.FileUtil;
@@ -34,14 +28,15 @@ import org.commcare.utils.UriToFilePath;
 import org.commcare.views.PasswordShow;
 import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.services.locale.Localization;
-import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static android.app.Activity.RESULT_OK;
+
 public class CommCarePreferences
-        extends SessionAwarePreferenceActivity
+        extends CommCarePreferenceFragment
         implements OnSharedPreferenceChangeListener {
 
     private final static String TAG = CommCarePreferences.class.getSimpleName();
@@ -141,19 +136,8 @@ public class CommCarePreferences
     }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        PreferenceManager prefMgr = getPreferenceManager();
-        prefMgr.setSharedPreferencesName((CommCareApplication.instance().getCurrentApp().getPreferencesFilename()));
-        addPreferencesFromResource(R.xml.commcare_preferences);
-
-        GoogleAnalyticsUtils.reportPrefActivityEntry(GoogleAnalyticsFields.CATEGORY_CC_PREFS);
-
-        setupUI();
-
-        GoogleAnalyticsUtils.createPreferenceOnClickListeners(prefMgr, prefKeyToAnalyticsEvent,
-                GoogleAnalyticsFields.CATEGORY_CC_PREFS);
+    protected void loadPrefs() {
+        super.loadPrefs();
         hideServerPrefsIfNeeded();
     }
 
@@ -167,40 +151,34 @@ public class CommCarePreferences
         }
     }
 
-    private void setupUI() {
-        setTitle(Localization.get("settings.main.title"));
-        addBackButtonToActionBar(this);
-        setupLocalizedText(this, keyToTitleMap);
-        setupButtons();
+    @Override
+    protected String getTitle() {
+        return Localization.get("settings.main.title");
     }
 
-    public static void setupLocalizedText(PreferenceActivity activity,
-                                          Map<String, String> prefToTitleMap) {
-        PreferenceScreen screen = activity.getPreferenceScreen();
-        for (int i = 0; i < screen.getPreferenceCount(); i++) {
-            String key = screen.getPreference(i).getKey();
-            if (prefToTitleMap.containsKey(key)) {
-                try {
-                    String localizedString = Localization.get(prefToTitleMap.get(key));
-                    screen.getPreference(i).setTitle(localizedString);
-                } catch (NoLocalizedTextException nle) {
-                    Log.w(TAG, "Unable to localize: " + prefToTitleMap.get(key));
-                }
-            }
-        }
+    @Override
+    protected Map<String, String> getPrefKeyAnalyticsEventMap() {
+        return prefKeyToAnalyticsEvent;
     }
 
-    public static void addBackButtonToActionBar(Activity activity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            ActionBar actionBar = activity.getActionBar();
-            if (actionBar != null) {
-                actionBar.setDisplayShowHomeEnabled(true);
-                actionBar.setDisplayHomeAsUpEnabled(true);
-            }
-        }
+    @Override
+    protected Map<String, String> getPrefKeyTitleMap() {
+        return keyToTitleMap;
     }
 
-    private void setupButtons() {
+    @Override
+    protected int getPreferenceXmlFile() {
+        return R.xml.commcare_preferences;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        setVisibilityOfUpdateOptionsPref();
+    }
+
+    @Override
+    protected void setupPrefClickListeners() {
         Preference serverSettingsButton = findPreference(SERVER_SETTINGS);
         serverSettingsButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
@@ -252,17 +230,6 @@ public class CommCarePreferences
         });
     }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-
-        setVisibilityOfUpdateOptionsPref();
-
-        // Set up a listener whenever a key changes
-        getPreferenceScreen().getSharedPreferences()
-                .registerOnSharedPreferenceChangeListener(this);
-    }
-
     private void setVisibilityOfUpdateOptionsPref() {
         Preference updateOptionsPref = getPreferenceManager().findPreference(UPDATE_TARGET);
         if (!DeveloperPreferences.shouldShowUpdateOptionsSetting() && updateOptionsPref != null) {
@@ -272,15 +239,12 @@ public class CommCarePreferences
         } else if (DeveloperPreferences.shouldShowUpdateOptionsSetting() &&
                 updateOptionsPref == null) {
             // If the pref isn't showing and it should be
-            getPreferenceScreen().removeAll();
-            addPreferencesFromResource(R.xml.commcare_preferences);
-            setupLocalizedText(this, keyToTitleMap);
-            setupButtons();
+            reset();
         }
     }
 
     private void showAnalyticsOptOutDialog() {
-        StandardAlertDialog f = new StandardAlertDialog(this,
+        StandardAlertDialog f = new StandardAlertDialog(getActivity(),
                 Localization.get("analytics.opt.out.title"),
                 Localization.get("analytics.opt.out.message"));
 
@@ -307,7 +271,7 @@ public class CommCarePreferences
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == REQUEST_TEMPLATE) {
             if (resultCode == RESULT_OK && data != null) {
                 Uri uri = data.getData();
@@ -318,32 +282,23 @@ public class CommCarePreferences
                             getAppPreferences().edit();
                     editor.putString(PREFS_PRINT_DOC_LOCATION, filePath);
                     editor.commit();
-                    Toast.makeText(this, Localization.get("template.success"), Toast.LENGTH_SHORT).show();
+                    Toast.makeText(getActivity(), Localization.get("template.success"), Toast.LENGTH_SHORT).show();
                 } else {
-                    TemplatePrinterUtils.showAlertDialog(this, Localization.get("template.not.set"),
+                    TemplatePrinterUtils.showAlertDialog(getActivity(), Localization.get("template.not.set"),
                             Localization.get("template.warning"), false);
                 }
             } else {
                 //No file selected
-                Toast.makeText(this, Localization.get("template.not.set"), Toast.LENGTH_SHORT).show();
+                Toast.makeText(getActivity(), Localization.get("template.not.set"), Toast.LENGTH_SHORT).show();
             }
         }
         if (requestCode == REQUEST_DEVELOPER_PREFERENCES) {
             if (resultCode == DeveloperPreferences.RESULT_SYNC_CUSTOM && data != null) {
-                this.setResult(DeveloperPreferences.RESULT_SYNC_CUSTOM, data);
-                this.finish();
+                getActivity().setResult(DeveloperPreferences.RESULT_SYNC_CUSTOM, data);
+                getActivity().finish();
             }
         }
 
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-
-        // Unregister the listener whenever a key changes
-        getPreferenceScreen().getSharedPreferences()
-                .unregisterOnSharedPreferenceChangeListener(this);
     }
 
     @Override
@@ -383,16 +338,6 @@ public class CommCarePreferences
                 prefKeyToAnalyticsEvent.get(key), editPrefValue);
     }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            // Respond to the action bar's Up/Home button
-            case android.R.id.home:
-                finish();
-                return true;
-        }
-        return super.onOptionsItemSelected(item);
-    }
 
     public static boolean isIncompleteFormsEnabled() {
         if (CommCareApplication.instance().isConsumerApp()) {
@@ -577,18 +522,20 @@ public class CommCarePreferences
             startActivityForResult(chooseTemplateIntent, REQUEST_TEMPLATE);
         } catch (ActivityNotFoundException e) {
             // Means that there is no file browser installed on the device
-            TemplatePrinterUtils.showAlertDialog(this, Localization.get("cannot.set.template"),
+            TemplatePrinterUtils.showAlertDialog(getActivity(), Localization.get("cannot.set.template"),
                     Localization.get("no.file.browser"), false);
         }
     }
 
     private void startServerSettings() {
-        Intent i = new Intent(this, CommCareServerPreferences.class);
+        Intent i = new Intent(getActivity(), SessionAwarePreferenceActivity.class);
+        i.putExtra(CommCarePreferenceActivity.EXTRA_PREF_TYPE,CommCarePreferenceActivity.PREF_TYPE_SERVER);
         startActivity(i);
     }
 
     private void startDeveloperOptions() {
-        Intent intent = new Intent(this, DeveloperPreferences.class);
+        Intent intent = new Intent(getActivity(), SessionAwarePreferenceActivity.class);
+        intent.putExtra(CommCarePreferenceActivity.EXTRA_PREF_TYPE,CommCarePreferenceActivity.PREF_TYPE_DEVELOPER);
         startActivityForResult(intent, REQUEST_DEVELOPER_PREFERENCES);
     }
 

--- a/app/src/org/commcare/preferences/CommCareServerPreferences.java
+++ b/app/src/org/commcare/preferences/CommCareServerPreferences.java
@@ -3,6 +3,8 @@ package org.commcare.preferences;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.MenuItem;
 
 import org.commcare.CommCareApp;
@@ -10,6 +12,7 @@ import org.commcare.CommCareApplication;
 import org.commcare.activities.SessionAwarePreferenceActivity;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
+import org.commcare.fragments.CommCarePreferenceFragment;
 import org.commcare.google.services.analytics.GoogleAnalyticsFields;
 import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
 import org.javarosa.core.services.locale.Localization;
@@ -23,7 +26,7 @@ import java.util.Map;
  * @author Phillip Mates (pmates@dimagi.com)
  */
 public class CommCareServerPreferences
-        extends SessionAwarePreferenceActivity {
+        extends CommCarePreferenceFragment {
 
     public final static String PREFS_APP_SERVER_KEY = "default_app_server";
     public final static String PREFS_DATA_SERVER_KEY = "ota-restore-url";
@@ -45,32 +48,38 @@ public class CommCareServerPreferences
         prefKeyToAnalyticsEvent.put(PREFS_SUPPORT_ADDRESS_KEY, GoogleAnalyticsFields.LABEL_SUPPORT_EMAIL);
     }
 
+    @NonNull
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected String getTitle() {
+        return Localization.get("settings.server.title");
+    }
 
-        PreferenceManager prefMgr = getPreferenceManager();
-        prefMgr.setSharedPreferencesName(CommCareApplication.instance().getCurrentApp().getPreferencesFilename());
-        addPreferencesFromResource(R.xml.server_preferences);
+    @Nullable
+    @Override
+    protected Map<String, String> getPrefKeyAnalyticsEventMap() {
+        return prefKeyToAnalyticsEvent;
+    }
 
-        GoogleAnalyticsUtils.reportPrefActivityEntry(GoogleAnalyticsFields.CATEGORY_SERVER_PREFS);
+    @Nullable
+    @Override
+    protected Map<String, String> getPrefKeyTitleMap() {
+        return null;
+    }
 
-        setTitle(Localization.get("settings.server.title"));
-        CommCarePreferences.addBackButtonToActionBar(this);
-
-        GoogleAnalyticsUtils.createPreferenceOnClickListeners(prefMgr, prefKeyToAnalyticsEvent,
-                GoogleAnalyticsFields.CATEGORY_SERVER_PREFS);
+    @NonNull
+    @Override
+    protected int getPreferenceXmlFile() {
+        return R.xml.server_preferences;
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            // Respond to the action bar's Up/Home button
-            case android.R.id.home:
-                finish();
-                return true;
-        }
-        return super.onOptionsItemSelected(item);
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        // No listeners
+    }
+
+    @Override
+    protected void setupPrefClickListeners() {
+        // No listeners
     }
 
     public static String getSupportEmailAddress() {
@@ -85,6 +94,5 @@ public class CommCareServerPreferences
         SharedPreferences properties = app.getAppPreferences();
         return properties.getString(key, defaultValue);
     }
-
 
 }

--- a/app/src/org/commcare/preferences/CommCareServerPreferences.java
+++ b/app/src/org/commcare/preferences/CommCareServerPreferences.java
@@ -68,7 +68,7 @@ public class CommCareServerPreferences
 
     @NonNull
     @Override
-    protected int getPreferenceXmlFile() {
+    protected int getPreferencesResource() {
         return R.xml.server_preferences;
     }
 
@@ -80,6 +80,11 @@ public class CommCareServerPreferences
     @Override
     protected void setupPrefClickListeners() {
         // No listeners
+    }
+
+    @Override
+    protected boolean isAppLevelPreference() {
+        return true;
     }
 
     public static String getSupportEmailAddress() {

--- a/app/src/org/commcare/preferences/CommCareServerPreferences.java
+++ b/app/src/org/commcare/preferences/CommCareServerPreferences.java
@@ -54,6 +54,12 @@ public class CommCareServerPreferences
         return Localization.get("settings.server.title");
     }
 
+    @NonNull
+    @Override
+    protected String getAnalyticsCategory() {
+        return GoogleAnalyticsFields.CATEGORY_SERVER_PREFS;
+    }
+
     @Nullable
     @Override
     protected Map<String, String> getPrefKeyAnalyticsEventMap() {
@@ -66,7 +72,6 @@ public class CommCareServerPreferences
         return null;
     }
 
-    @NonNull
     @Override
     protected int getPreferencesResource() {
         return R.xml.server_preferences;
@@ -83,7 +88,7 @@ public class CommCareServerPreferences
     }
 
     @Override
-    protected boolean isAppLevelPreference() {
+    protected boolean isPersistentAppPreference() {
         return true;
     }
 

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -132,7 +132,7 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
 
     @NonNull
     @Override
-    protected int getPreferenceXmlFile() {
+    protected int getPreferencesResource() {
         return R.xml.preferences_developer;
     }
 
@@ -140,6 +140,11 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         super.onCreatePreferences(savedInstanceState, rootKey);
         savedSessionEditTextPreference = findPreference(EDIT_SAVE_SESSION);
+    }
+
+    @Override
+    protected boolean isAppLevelPreference() {
+        return true;
     }
 
     @Override

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -110,7 +110,13 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     @NonNull
     @Override
     protected String getTitle() {
-        return "Developer Options";
+        return Localization.get("settings.developer.title");
+    }
+
+    @NonNull
+    @Override
+    protected String getAnalyticsCategory() {
+        return GoogleAnalyticsFields.CATEGORY_DEV_PREFS;
     }
 
     @Nullable
@@ -130,7 +136,6 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
         return null;
     }
 
-    @NonNull
     @Override
     protected int getPreferencesResource() {
         return R.xml.preferences_developer;
@@ -143,7 +148,7 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     }
 
     @Override
-    protected boolean isAppLevelPreference() {
+    protected boolean isPersistentAppPreference() {
         return true;
     }
 

--- a/app/src/org/commcare/preferences/FormEntryPreferences.java
+++ b/app/src/org/commcare/preferences/FormEntryPreferences.java
@@ -50,7 +50,7 @@ public class FormEntryPreferences extends CommCarePreferenceFragment
     }
 
     @Override
-    protected int getPreferenceXmlFile() {
+    protected int getPreferencesResource() {
         return R.xml.preferences;
     }
 

--- a/app/src/org/commcare/preferences/FormEntryPreferences.java
+++ b/app/src/org/commcare/preferences/FormEntryPreferences.java
@@ -2,6 +2,7 @@ package org.commcare.preferences;
 
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.support.annotation.NonNull;
 import android.support.v7.preference.ListPreference;
 
 import org.commcare.dalvik.R;
@@ -29,9 +30,16 @@ public class FormEntryPreferences extends CommCarePreferenceFragment
         prefKeyToAnalyticsEvent.put(KEY_HELP_MODE_TRAY, GoogleAnalyticsFields.LABEL_INLINE_HELP);
     }
 
+    @NonNull
     @Override
     protected String getTitle() {
         return getString(R.string.application_name) + " > " + getString(R.string.form_entry_settings);
+    }
+
+    @NonNull
+    @Override
+    protected String getAnalyticsCategory() {
+        return GoogleAnalyticsFields.CATEGORY_FORM_ENTRY;
     }
 
     @Override

--- a/app/src/org/commcare/preferences/FormEntryPreferences.java
+++ b/app/src/org/commcare/preferences/FormEntryPreferences.java
@@ -2,55 +2,61 @@ package org.commcare.preferences;
 
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
-import android.os.Bundle;
-import android.preference.ListPreference;
-import android.preference.PreferenceManager;
+import android.support.v7.preference.ListPreference;
 
-import org.commcare.activities.SessionAwarePreferenceActivity;
 import org.commcare.dalvik.R;
+import org.commcare.fragments.CommCarePreferenceFragment;
 import org.commcare.google.services.analytics.GoogleAnalyticsFields;
 import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author yanokwa
  */
-public class FormEntryPreferences extends SessionAwarePreferenceActivity
+
+public class FormEntryPreferences extends CommCarePreferenceFragment
         implements OnSharedPreferenceChangeListener {
 
     public static final String KEY_FONT_SIZE = "font_size";
     public static final String KEY_HELP_MODE_TRAY = "help_mode_tray";
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.preferences);
-        GoogleAnalyticsUtils.reportPrefActivityEntry(GoogleAnalyticsFields.CATEGORY_FORM_PREFS);
-        setTitle(getString(R.string.application_name) + " > " + getString(R.string.form_entry_settings));
-        updateFontSize();
-        createPreferenceOnClickListeners();
-    }
+    private final static Map<String, String> prefKeyToAnalyticsEvent = new HashMap<>();
 
-    private void createPreferenceOnClickListeners() {
-        PreferenceManager prefMgr = getPreferenceManager();
-        GoogleAnalyticsUtils.createPreferenceOnClickListener(prefMgr, KEY_FONT_SIZE,
-                GoogleAnalyticsFields.CATEGORY_FORM_PREFS,
-                GoogleAnalyticsFields.LABEL_FONT_SIZE);
-        GoogleAnalyticsUtils.createPreferenceOnClickListener(prefMgr, KEY_HELP_MODE_TRAY,
-                GoogleAnalyticsFields.CATEGORY_FORM_PREFS,
-                GoogleAnalyticsFields.LABEL_INLINE_HELP);
+    static {
+        prefKeyToAnalyticsEvent.put(KEY_FONT_SIZE, GoogleAnalyticsFields.LABEL_FONT_SIZE);
+        prefKeyToAnalyticsEvent.put(KEY_HELP_MODE_TRAY, GoogleAnalyticsFields.LABEL_INLINE_HELP);
     }
 
     @Override
-    protected void onPause() {
-        super.onPause();
-        getPreferenceScreen().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(
-                this);
+    protected String getTitle() {
+        return getString(R.string.application_name) + " > " + getString(R.string.form_entry_settings);
     }
 
     @Override
-    protected void onResume() {
-        super.onResume();
-        getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+    protected Map<String, String> getPrefKeyAnalyticsEventMap() {
+        return prefKeyToAnalyticsEvent;
+    }
+
+    @Override
+    protected void setupPrefClickListeners() {
+        // Nothing to do here
+    }
+
+    @Override
+    protected Map<String, String> getPrefKeyTitleMap() {
+        return null;
+    }
+
+    @Override
+    protected int getPreferenceXmlFile() {
+        return R.xml.preferences;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
         updateFontSize();
     }
 


### PR DESCRIPTION
Case Url: https://manage.dimagi.com/default.asp?253212#1354692

- All preferences now use the common CommCarePreferenceFragment which serves as a super class and handles the common functionalities.
- We have a single activity called CommCarePreferenceActivity which initialises the respective preference fragment type depending on the intent extra 'extra_pref_type'.
- SessionAwarePreferenceActivity just adds the session listeners on top of CommCarePreferenceActivity and should be used if the preference screen is accessible after login. 