### PR TITLE
Show forms sent on stopping the upload sync

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -93,7 +93,7 @@ menu.print.detail=Print Case Detail
 menu.enable.privileges=Mobile Privileges
 menu.privilege.claim.disable=Disable Privileges
 
-sync.success.sent.singular=Form sent to server!
+sync.success.sent.singular=${0} form sent to server!
 sync.success.sent=${0} forms sent to server!
 sync.fail.unsent=Having issues communicating with the server to send forms. Will try again later.
 sync.fail.timeout=CommCare didn't receive a response from the remote service in time, it may be busy! Please wait a while and try your request again later.
@@ -329,6 +329,7 @@ title.datum.wrapper=[${0}]
 activity.task.error.generic=Unexpected error! Please try again.
 activity.task.cancelling.title=Cancelling: ${0}
 activity.task.cancelling.message=Cancelling...
+activity.task.cancelled.message=Task Cancelled.
 
 connection.test.prompt=This will try to fix connection problems that you may be having.
 connection.test.run=Run Connection Test

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -93,7 +93,8 @@ menu.print.detail=Print Case Detail
 menu.enable.privileges=Mobile Privileges
 menu.privilege.claim.disable=Disable Privileges
 
-sync.success.sent.singular=${0} form sent to server!
+sync.success.sent.none=No forms sent to server!
+sync.success.sent.singular=1 form sent to server!
 sync.success.sent=${0} forms sent to server!
 sync.fail.unsent=Having issues communicating with the server to send forms. Will try again later.
 sync.fail.timeout=CommCare didn't receive a response from the remote service in time, it may be busy! Please wait a while and try your request again later.
@@ -329,7 +330,7 @@ title.datum.wrapper=[${0}]
 activity.task.error.generic=Unexpected error! Please try again.
 activity.task.cancelling.title=Cancelling: ${0}
 activity.task.cancelling.message=Cancelling...
-activity.task.cancelled.message=Task Cancelled.
+activity.task.cancelled.message=Form sending cancelled.
 
 connection.test.prompt=This will try to fix connection problems that you may be having.
 connection.test.run=Run Connection Test

--- a/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
+++ b/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
@@ -356,12 +356,14 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
                 title = Localization.get("sync.progress.submitting.title");
                 message = Localization.get("sync.progress.submitting");
                 dialog = CustomProgressDialog.newInstance(title, message, taskId);
+                dialog.addCancelButton();
                 break;
             case ProcessAndSendTask.PROCESSING_PHASE_ID:
                 title = Localization.get("form.entry.processing.title");
                 message = Localization.get("form.entry.processing");
                 dialog = CustomProgressDialog.newInstance(title, message, taskId);
                 dialog.addProgressBar();
+                dialog.addCancelButton();
                 break;
             case DataPullTask.DATA_PULL_TASK_ID:
                 title = Localization.get("sync.communicating.title");

--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -18,6 +18,7 @@ import org.commcare.views.notifications.NotificationMessageFactory;
 import org.commcare.views.notifications.ProcessIssues;
 import org.javarosa.core.model.User;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.locale.Localization;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.xmlpull.v1.XmlPullParserException;
@@ -465,6 +466,18 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
         }
         return successes;
     }
+
+    protected String getLabelForFormsSent() {
+        int successfulSends = getSuccessfulSends();
+        String label = Localization.get("sync.success.sent",
+                new String[]{String.valueOf(successfulSends)});
+        if (successfulSends == 1) {
+            label = Localization.get("sync.success.sent.singular",
+                    new String[]{String.valueOf(successfulSends)});
+        }
+        return label;
+    }
+
 
     //Wrappers for the internal stuff
     @Override

--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -469,11 +469,17 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
 
     protected String getLabelForFormsSent() {
         int successfulSends = getSuccessfulSends();
-        String label = Localization.get("sync.success.sent",
-                new String[]{String.valueOf(successfulSends)});
-        if (successfulSends == 1) {
-            label = Localization.get("sync.success.sent.singular",
-                    new String[]{String.valueOf(successfulSends)});
+        String label;
+        switch (successfulSends) {
+            case 0:
+                label = Localization.get("sync.success.sent.none");
+                break;
+            case 1:
+                label = Localization.get("sync.success.sent.singular");
+                break;
+            default:
+                label = Localization.get("sync.success.sent",
+                        new String[]{String.valueOf(successfulSends)});
         }
         return label;
     }

--- a/app/src/org/commcare/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/tasks/templates/CommCareTask.java
@@ -5,7 +5,9 @@ import android.util.Log;
 
 import org.commcare.logging.UserCausedRuntimeException;
 import org.commcare.utils.ACRAUtil;
+import org.commcare.utils.FormUploadResult;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.locale.Localization;
 
 /**
  * @author ctsims
@@ -69,6 +71,7 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
                 connector.startTaskTransition();
                 connector.stopBlockingForTask(getTaskId());
                 connector.taskCancelled();
+                handleCancellation(connector.getReceiver());
                 connector.stopTaskTransition();
             }
         }
@@ -99,6 +102,10 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
     protected abstract void deliverUpdate(Receiver receiver, Progress... update);
 
     protected abstract void deliverError(Receiver receiver, Exception e);
+
+    protected void handleCancellation(Receiver receiver){
+        // Do nothing by default
+    }
 
     @Override
     protected void onPreExecute() {


### PR DESCRIPTION
Case Url: https://manage.dimagi.com/default.asp?252457#1356296

- Feedback from https://github.com/dimagi/commcare-android/pull/1751
- Shows a toast indicating no of forms sent before user presses stop to cancel the task.