### PR TITLE
Percolate XPathException to UI in suite parsing

### DIFF
--- a/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
@@ -88,11 +88,10 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
 
             table.commitCompoundResource(r, upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED);
             return true;
-        } catch (InvalidStructureException e) {
+        } catch (InvalidStructureException | XPathException e) {
             // push up suite config issues so user can act on them
             throw new InvalidResourceException(r.getDescriptor(), e.getMessage());
-        } catch (XmlPullParserException  | InvalidReferenceException
-                | IOException | XPathException e) {
+        } catch (XmlPullParserException  | InvalidReferenceException | IOException e) {
             e.printStackTrace();
         }
 


### PR DESCRIPTION
In this [ticket](https://manage.dimagi.com/default.asp?257707) we were encountering mismatched parens in the suite file but were only displaying a misleading message about the resource being unable to be found:

![image](https://user-images.githubusercontent.com/2293064/27966812-9979d18e-630e-11e7-8a28-cb3d8244b4b2.png)

This change displays the core error at the UI level: 

![device-2017-07-07-122036](https://user-images.githubusercontent.com/2293064/27966836-b4dc2e2c-630e-11e7-9531-8f8c47b3d536.png)
