### PR TITLE
Fix Case tiles in 2.37 Release

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -143,10 +143,6 @@ public abstract class CommCareActivity<R> extends FragmentActivity
             if (bar == null) {
                 bar = new BreadcrumbBarFragment();
                 fm.beginTransaction().add(bar, "breadcrumbs").commit();
-            } else {
-                // If we rotated while the persistent tile was expanded, it will not have gotten
-                // re-expanded, so reset the tracking variable to reflect that
-                bar.persistentCaseTileIsExpanded = false;
             }
         }
 
@@ -746,12 +742,13 @@ public abstract class CommCareActivity<R> extends FragmentActivity
     public void onBackPressed() {
         FragmentManager fm = this.getSupportFragmentManager();
         BreadcrumbBarFragment bar = (BreadcrumbBarFragment)fm.findFragmentByTag("breadcrumbs");
-        if (bar != null && bar.persistentCaseTileIsExpanded) {
-            bar.collapsePersistentCaseTile(this);
-        } else {
-            super.onBackPressed();
-            AudioController.INSTANCE.releaseCurrentMediaEntity();
+        if (bar != null) {
+            if(bar.collapseTileIfExpanded(this)) {
+                return;
+            }
         }
+        super.onBackPressed();
+        AudioController.INSTANCE.releaseCurrentMediaEntity();
     }
 
     @Override


### PR DESCRIPTION
Fixes bugs introduced in:
https://github.com/dimagi/commcare-android/pull/1738

where all case tiles (regardless of inline/persistent/etc) wouldn't attach correctly and come out empty:

pre (all tiles look like this):
![image](https://user-images.githubusercontent.com/155066/28231103-c3b7d44c-68b7-11e7-81db-6d5ea281bd93.png)

post:
![image](https://user-images.githubusercontent.com/155066/28231183-2636c9e8-68b8-11e7-8b71-e541083ef6fc.png)

post:
![image](https://user-images.githubusercontent.com/155066/28231223-5637ac84-68b8-11e7-8919-cd90c4c5b5a4.png)
