### PR TITLE
Normalize DB Transaction Formats

### DIFF
--- a/app/src/org/commcare/models/database/HybridFileBackedSqlStorage.java
+++ b/app/src/org/commcare/models/database/HybridFileBackedSqlStorage.java
@@ -296,7 +296,9 @@ public class HybridFileBackedSqlStorage<T extends Persistable> extends SqlStorag
             if (dataFilePath != null) {
                 HybridFileBackedSqlHelpers.unsetFileAsOrphan(db, dataFilePath);
             }
-            db.setTransactionSuccessful();
+            if(startedTransaction) {
+                db.setTransactionSuccessful();
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {
@@ -359,7 +361,8 @@ public class HybridFileBackedSqlStorage<T extends Persistable> extends SqlStorag
         SQLiteDatabase db = getDbOrThrow();
 
         ByteArrayOutputStream bos = null;
-        db.beginTransaction();
+        boolean startedTransaction = false;
+
         try {
             Pair<String, byte[]> filenameAndKey =
                     HybridFileBackedSqlHelpers.getEntryFilenameAndKey(helper, table, id);
@@ -369,16 +372,22 @@ public class HybridFileBackedSqlStorage<T extends Persistable> extends SqlStorag
 
             bos = writeExternalizableToStream(extObj);
             if (blobFitsInDb(bos)) {
+                db.beginTransaction();
+                startedTransaction = true;
                 updateEntryToStoreInDb(extObj, objectInDb, filename, bos, db, id);
             } else {
                 String newFilePath = HybridFileBackedSqlHelpers.newFileForEntry(dbDir).getAbsolutePath();
                 HybridFileBackedSqlHelpers.setFileAsOrphan(db, newFilePath);
 
+                db.beginTransaction();
+                startedTransaction = true;
                 updateEntryToStoreInFs(extObj, objectInDb, filename,
                         newFilePath, fileEncryptionKey, bos, db, id);
             }
 
-            db.setTransactionSuccessful();
+            if(startedTransaction) {
+                db.setTransactionSuccessful();
+            }
         } catch (IOException e) {
             throw new RuntimeException("Unable update db entry to store data in filesystem", e);
         } finally {
@@ -389,7 +398,9 @@ public class HybridFileBackedSqlStorage<T extends Persistable> extends SqlStorag
                     e.printStackTrace();
                 }
             }
-            db.endTransaction();
+            if(startedTransaction) {
+                db.endTransaction();
+            }
         }
     }
 

--- a/app/src/org/commcare/models/database/IndexedFixturePathUtils.java
+++ b/app/src/org/commcare/models/database/IndexedFixturePathUtils.java
@@ -67,9 +67,8 @@ public class IndexedFixturePathUtils {
         contentValues.put(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_CHILD, childName);
         contentValues.put(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_NAME, fixtureName);
 
+        db.beginTransaction();
         try {
-            db.beginTransaction();
-
             long ret = db.insertOrThrow(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_TABLE,
                     IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_BASE,
                     contentValues);
@@ -92,8 +91,8 @@ public class IndexedFixturePathUtils {
     public static void buildFixtureIndices(SQLiteDatabase database,
                                            String tableName,
                                            Set<String> indices) {
+        database.beginTransaction();
         try {
-            database.beginTransaction();
             for (String indexStmt : DatabaseIndexingUtils.getIndexStatements(tableName, indices)) {
                 database.execSQL(indexStmt);
             }

--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -242,8 +242,8 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         SQLiteDatabase db;
         db = helper.getHandle();
         int i = -1;
+        db.beginTransaction();
         try {
-            db.beginTransaction();
             long ret = db.insertOrThrow(table, DatabaseHelper.DATA_COL, helper.getContentValues(e));
 
             if (ret > Integer.MAX_VALUE) {
@@ -519,8 +519,8 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
             return;
         }
         SQLiteDatabase db = helper.getHandle();
+        db.beginTransaction();
         try {
-            db.beginTransaction();
             long ret = db.insertOrThrow(table, DatabaseHelper.DATA_COL, helper.getContentValues(p));
 
             if (ret > Integer.MAX_VALUE) {
@@ -543,10 +543,10 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
     public static <T extends Persistable> Map<Integer, Integer> cleanCopy(SqlStorage<T> from, SqlStorage<T> to, LegacyInstallUtils.CopyMapper<T> mapper) {
         to.removeAll();
         SQLiteDatabase toDb = to.helper.getHandle();
+        toDb.beginTransaction();
+
         try {
             Hashtable<Integer, Integer> idMapping = new Hashtable<>();
-            toDb.beginTransaction();
-
             for (T t : from) {
                 int key = t.getID();
                 //Clear the ID, we don't wanna guarantee it

--- a/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
+++ b/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
@@ -51,8 +51,8 @@ public class DatabaseAppOpenHelper extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase database) {
+        database.beginTransaction();
         try {
-            database.beginTransaction();
             TableBuilder builder = new TableBuilder("GLOBAL_RESOURCE_TABLE");
             builder.addData(new Resource());
             database.execSQL(builder.getTableCreateString());

--- a/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
+++ b/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
@@ -44,10 +44,8 @@ public class DatabaseGlobalOpenHelper extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase database) {
-
+        database.beginTransaction();
         try {
-            database.beginTransaction();
-            
             TableBuilder builder = new TableBuilder(ApplicationRecord.class);
             database.execSQL(builder.getTableCreateString());
             

--- a/app/src/org/commcare/models/database/migration/FixtureSerializationMigration.java
+++ b/app/src/org/commcare/models/database/migration/FixtureSerializationMigration.java
@@ -52,9 +52,11 @@ public class FixtureSerializationMigration {
         // wait longer to make sure this can finish.
         CommCareApplication.instance().setCustomServiceBindTimeout(60 * 5 * 1000);
         long start = System.currentTimeMillis();
-        db.beginTransaction();
+
         ConcreteAndroidDbHelper helper = new ConcreteAndroidDbHelper(c, db);
         DataInputStream fixtureByteStream = null;
+
+        db.beginTransaction();
         try {
             HybridFileBackedSqlStorage<Persistable> fixtureStorage;
             if (fileMigrationKeySeed != null) {
@@ -109,9 +111,9 @@ public class FixtureSerializationMigration {
 
     public static void stageFixtureTables(SQLiteDatabase db) {
         db.beginTransaction();
-        boolean resumingMigration = doesTempFixtureTableExist(db);
-
         try {
+            boolean resumingMigration = doesTempFixtureTableExist(db);
+
             DbUtil.createOrphanedFileTable(db);
             if (resumingMigration) {
                 db.execSQL("DROP TABLE IF EXISTS fixture;");

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -79,9 +79,8 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase database) {
+        database.beginTransaction();
         try {
-            database.beginTransaction();
-
             TableBuilder builder = new TableBuilder(ACase.STORAGE_KEY);
             builder.addData(new ACase());
             builder.setUnique(ACase.INDEX_CASE_ID);
@@ -194,9 +193,8 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
     public static void buildTable(SQLiteDatabase database,
                                   String tableName,
                                   Persistable dataObject) {
+        database.beginTransaction();
         try {
-            database.beginTransaction();
-
             TableBuilder builder = new TableBuilder(tableName);
             builder.addData(dataObject);
             database.execSQL(builder.getTableCreateString());
@@ -208,8 +206,8 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
 
     public static void dropTable(SQLiteDatabase database,
                                  String tableName) {
+        database.beginTransaction();
         try {
-            database.beginTransaction();
             database.execSQL("DROP TABLE IF EXISTS '" + tableName + "'");
             database.setTransactionSuccessful();
         } finally {

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -563,8 +563,8 @@ public abstract class DataPullTask<R>
 
         //this is _really_ coupled, but we'll tolerate it for now because of the absurd performance gains
         SQLiteDatabase db = CommCareApplication.instance().getUserDbHandle();
+        db.beginTransaction();
         try {
-            db.beginTransaction();
             parser = new DataModelPullParser(stream, factory, true, false, this);
             parser.parse();
             db.setTransactionSuccessful();

--- a/app/src/org/commcare/xml/AndroidBulkCaseXmlParser.java
+++ b/app/src/org/commcare/xml/AndroidBulkCaseXmlParser.java
@@ -96,8 +96,9 @@ public class AndroidBulkCaseXmlParser extends BulkProcessingCaseXmlParser {
     protected void performBulkWrite(LinkedHashMap<String, Case> writeLog) throws IOException {
         SQLiteDatabase db;
         db = getDbHandle();
-        db.beginTransaction();
         ArrayList<Integer> recordIdsToWipe = new ArrayList<>();
+
+        db.beginTransaction();
         try {
             for (String cid : writeLog.keySet()) {
                 Case c = writeLog.get(cid);


### PR DESCRIPTION
Many of our DB writes were not using safe transaction formatting.

Most of these are trivial changes, but the HybridFileBackedSqlStorage update should get a deeper look, as its transaction format was very dangerously configured.