### PR TITLE
Corrects Error reporting for Case list load failure

### DIFF
--- a/app/src/org/commcare/tasks/EntityLoaderTask.java
+++ b/app/src/org/commcare/tasks/EntityLoaderTask.java
@@ -74,11 +74,9 @@ public class EntityLoaderTask
             return new Pair<>(full, references);
         } catch (XPathException xe) {
             XPathErrorLogger.INSTANCE.logErrorToCurrentApp(xe);
-            XPathException me = new XPathException("Encountered an xpath error while trying to load the list.");
-            me.setSource(xe.getSource());
             xe.printStackTrace();
-            Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, ForceCloseLogger.getStackTrace(me));
-            mException = me;
+            Logger.log(AndroidLogger.TYPE_ERROR_DESIGN, ForceCloseLogger.getStackTrace(xe));
+            mException = xe;
             return null;
         }
     }


### PR DESCRIPTION
Case: http://manage.dimagi.com/default.asp?258799
- In the list load failure dialogue source was getting duplicated and the actual message was never getting shown. 

cross-request: https://github.com/dimagi/commcare-core/pull/617

