### PR TITLE
Hotfix for 412's not cleaning storage properly

### DIFF
--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -55,9 +55,10 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
      * V.16 - Add type -> id index for case index storage
      * V.17 - Add global counter metadata field to form records, for use in submission ordering
      * V.18 - Add index on @owner_id for cases
+     * V.19 - Rebuild case index table due to the possibility of previous 412 indexing issues
      */
 
-    private static final int USER_DB_VERSION = 18;
+    private static final int USER_DB_VERSION = 19;
 
     private static final String USER_DB_LOCATOR = "database_sandbox_";
 

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -150,6 +150,11 @@ class UserDatabaseUpgrader {
                 oldVersion = 18;
             }
         }
+        if (oldVersion == 18) {
+            if (upgradeEighteenNineteen(db)) {
+                oldVersion = 19;
+            }
+        }
     }
 
     private boolean upgradeOneTwo(final SQLiteDatabase db) {
@@ -506,6 +511,24 @@ class UserDatabaseUpgrader {
             db.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
                     "case_owner_id_index", "AndroidCase", "owner_id"));
             db.setTransactionSuccessful();
+            return true;
+        } finally {
+            db.endTransaction();
+        }
+    }
+
+
+    private boolean upgradeEighteenNineteen(SQLiteDatabase db) {
+        db.beginTransaction();
+        try {
+            SqlStorage<ACase> caseStorage = new SqlStorage<>(ACase.STORAGE_KEY, ACase.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            AndroidCaseIndexTable indexTable = new AndroidCaseIndexTable(db);
+            indexTable.reIndexAllCases(caseStorage);
+
+            db.setTransactionSuccessful();
+            db.endTransaction();
             return true;
         } finally {
             db.endTransaction();

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
@@ -126,6 +126,18 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
         }
     }
 
+    /**
+     * Removes all records from the case index table
+     */
+    public void wipeTable() {
+        db.beginTransaction();
+        try {
+            db.delete(TABLE_NAME, null, null);
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+    }
 
     /**
      * Get a list of Case Record id's for cases which index a provided value.
@@ -277,6 +289,19 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
         }
         sb.append(")");
         return sb.toString();
+    }
+
+    public void reIndexAllCases(SqlStorage<ACase> caseStorage) {
+        db.beginTransaction();
+        try {
+            wipeTable();
+            for(ACase c : caseStorage) {
+                indexCase(c);
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
     }
 
 }

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -11,12 +11,14 @@ import org.apache.http.conn.ConnectTimeoutException;
 import org.commcare.CommCareApplication;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.user.models.ACase;
+import org.commcare.cases.ledger.Ledger;
 import org.commcare.data.xml.DataModelPullParser;
 import org.commcare.engine.cases.CaseUtils;
 import org.commcare.interfaces.HttpRequestEndpoints;
 import org.commcare.logging.AndroidLogger;
 import org.commcare.google.services.analytics.GoogleAnalyticsFields;
 import org.commcare.models.database.SqlStorage;
+import org.commcare.models.database.user.models.AndroidCaseIndexTable;
 import org.commcare.models.encryption.ByteEncrypter;
 import org.commcare.core.encryption.CryptUtil;
 import org.commcare.modern.models.RecordTooLargeException;
@@ -504,7 +506,7 @@ public abstract class DataPullTask<R>
 
         //Wipe storage
         //TODO: move table instead. Should be straightforward with sandboxed db's
-        CommCareApplication.instance().getUserStorage(ACase.STORAGE_KEY, ACase.class).removeAll();
+        wipeStorageForFourTwelveSync();
 
         String failureReason = "";
         try {
@@ -531,6 +533,12 @@ public abstract class DataPullTask<R>
         //TODO: Roll back changes
         Logger.log(AndroidLogger.TYPE_USER, "Sync recovery failed|" + failureReason);
         return new Pair<>(PROGRESS_RECOVERY_FAIL_BAD, failureReason);
+    }
+
+    private void wipeStorageForFourTwelveSync() {
+        CommCareApplication.instance().getUserStorage(ACase.STORAGE_KEY, ACase.class).removeAll();
+        new AndroidCaseIndexTable().wipeTable();
+        CommCareApplication.instance().getUserStorage(Ledger.STORAGE_KEY, Ledger.class).removeAll();
     }
 
     private void updateCurrentUser(String password) {


### PR DESCRIPTION
Fixes issue where 412 syncs don't clear case index table, and rebuild existing index table to ensure any old stale state is corrected