### PR TITLE
Don't show save option in read only mode

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -118,6 +118,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     private static final String KEY_FORM_LOAD_FAILED = "form-failed";
     private static final String KEY_LOC_ERROR = "location-not-enabled";
     private static final String KEY_LOC_ERROR_PATH = "location-based-xpath-error";
+    private static final String KEY_IS_READ_ONLY = "instance-is-read-only";
 
     private FormEntryInstanceState instanceState;
     private FormEntrySessionWrapper formEntryRestoreSession = new FormEntrySessionWrapper();
@@ -258,6 +259,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         outState.putBoolean(KEY_INCOMPLETE_ENABLED, mIncompleteEnabled);
         outState.putBoolean(KEY_HAS_SAVED, hasSaved);
         outState.putString(KEY_RESIZING_ENABLED, ResizingImageView.resizeMethod);
+        outState.putBoolean(KEY_IS_READ_ONLY, instanceIsReadOnly);
         formEntryRestoreSession.saveFormEntrySession(outState);
 
         if (indexOfWidgetWithVideoPlaying != -1) {
@@ -1316,6 +1318,11 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 indexOfWidgetWithVideoPlaying = savedInstanceState.getInt(KEY_WIDGET_WITH_VIDEO_PLAYING);
                 positionOfVideoProgress = savedInstanceState.getInt(KEY_POSITION_OF_VIDEO_PLAYING);
             }
+
+            if (savedInstanceState.containsKey(KEY_IS_READ_ONLY)) {
+                this.instanceIsReadOnly = savedInstanceState.getBoolean(KEY_IS_READ_ONLY);
+            }
+
             uiController.restoreSavedState(savedInstanceState);
         }
     }


### PR DESCRIPTION
Fixes an issue that made it possible for already-sent/saved forms to get into an "Unsent" state and thus be re-submittable: http://manage.dimagi.com/default.asp?232353

Also, Clayton and I both tested and confirmed that if you resubmit a form that is set to "Unsent" in this way, it's form submission ordering # is set to -1, which explains the troubling logs we were seeing