### PR TITLE
Dev Feature: Load forms from a local file

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -379,6 +379,8 @@ missing.template.file=No template file has been set for your print job. Please a
 template.malformed.mustache=The template file set for your print job has improperly-formed content. There is a mis-matched usage of '{'/'}' characters near the section: ${0}
 template.malformed.chevron=The template file set for your print job has improperly-formed content. There is a mis-matched usage of '<'/'>' characters near the section: ${0}
 cannot.set.template=Could not set your print template
+cannot.restore.xml=Could not restore custom XML File
+cannot.set.payload=Could not set payload file
 no.file.browser=Your device does not have a file browser installed. Please download one from the playstore and then try again.
 template.error=Your template is not correctly formatted
 

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -176,6 +176,7 @@ app.workflow.saved.heading=Saved Forms
 app.workflow.forms.open=Open
 app.workflow.forms.delete=Delete Record
 app.workflow.forms.fetch=Fetch Forms from Server
+app.workflow.forms.fetch.file=Fetch Forms from File
 app.workflow.forms.restore=Add Record Back to Unsent Queue
 app.workflow.forms.scan=Scan Record Integrity
 app.workflow.forms.scan.title.valid=Integrity Scan: PASS

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -760,3 +760,7 @@ calendar.low.year=Year value below min value of
 calendar.high.year=Year value above max value of ${0}
 calendar.low.day=Day value below min value of 1
 calendar.high.day=Day value above max value of ${0}
+
+file.not.exist=File does not exist
+file.not.selected=No file selected
+file.wrong.type=Wrong file type. Please select file of type ${0}

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -384,6 +384,15 @@ cannot.set.payload=Could not set payload file
 no.file.browser=Your device does not have a file browser installed. Please download one from the playstore and then try again.
 template.error=Your template is not correctly formatted
 
+file.not.exist=File does not exist
+file.not.selected=No file selected
+file.wrong.type=Wrong file type. Please select file of type ${0}
+payload.file.not.exist=Payload file does not exist
+payload.file.not.set=Payload file path is not set in preferences
+custom.restore.file.not.exist=Custom restore file does not exist
+custom.restore.file.not.set=Custom restore file path is not set in preferences
+custom.restore.error=Error loading custom sync
+
 start.recording=Start Recording
 stop.recording=Stop Recording
 recording.header=Record a sound
@@ -760,7 +769,3 @@ calendar.low.year=Year value below min value of
 calendar.high.year=Year value above max value of ${0}
 calendar.low.day=Day value below min value of 1
 calendar.high.day=Day value above max value of ${0}
-
-file.not.exist=File does not exist
-file.not.selected=No file selected
-file.wrong.type=Wrong file type. Please select file of type ${0}

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -379,8 +379,7 @@ missing.template.file=No template file has been set for your print job. Please a
 template.malformed.mustache=The template file set for your print job has improperly-formed content. There is a mis-matched usage of '{'/'}' characters near the section: ${0}
 template.malformed.chevron=The template file set for your print job has improperly-formed content. There is a mis-matched usage of '<'/'>' characters near the section: ${0}
 cannot.set.template=Could not set your print template
-cannot.restore.xml=Could not restore custom XML File
-cannot.set.payload=Could not set payload file
+no.file.browser.title=No File Browser Available
 no.file.browser=Your device does not have a file browser installed. Please download one from the playstore and then try again.
 template.error=Your template is not correctly formatted
 

--- a/app/res/layout/file_pref_dialog.xml
+++ b/app/res/layout/file_pref_dialog.xml
@@ -2,22 +2,22 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginBottom="48dp"
-            android:layout_marginTop="48dp"
+            android:layout_marginBottom="@dimen/pref_dialog_margin_bottom"
+            android:layout_marginTop="@dimen/pref_dialog_margin_top"
             android:overScrollMode="ifContentScrolls">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="5dip">
+        android:padding="@dimen/pref_dialog_content_padding">
 
         <TextView
             android:id="@android:id/message"
             style="?android:attr/textAppearanceSmall"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="48dp"
+            android:layout_marginBottom="@dimen/pref_dialog_message_margin_bottom"
             android:textColor="?android:attr/textColorSecondary"/>
 
         <LinearLayout

--- a/app/res/layout/file_pref_dialog.xml
+++ b/app/res/layout/file_pref_dialog.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginBottom="48dp"
+            android:layout_marginTop="48dp"
+            android:overScrollMode="ifContentScrolls">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="5dip">
+
+        <TextView
+            android:id="@android:id/message"
+            style="?android:attr/textAppearanceSmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="48dp"
+            android:textColor="?android:attr/textColorSecondary"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="horizontal">
+
+            <EditText
+                android:id="@android:id/edit"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"/>
+
+            <ImageButton
+                android:id="@+id/filefetch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_menu_archive"/>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -51,6 +51,7 @@
 
     <declare-styleable name="FilePreference">
         <attr name="file_type" format="string"/>
+        <attr name="error_dialog_title" format="string"/>
     </declare-styleable>
 
 </resources>

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -49,4 +49,8 @@
         <attr name="clip_height" format="reference|float"/>
     </declare-styleable>
 
+    <declare-styleable name="FilePreference">
+        <attr name="file_type" format="string"/>
+    </declare-styleable>
+
 </resources>

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -51,7 +51,6 @@
 
     <declare-styleable name="FilePreference">
         <attr name="file_type" format="string"/>
-        <attr name="error_dialog_title" format="string"/>
     </declare-styleable>
 
 </resources>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -115,4 +115,10 @@
     <!-- audio playback -->
     <dimen name="expanded_audio_playback_margin_bottom">24dp</dimen>
     <dimen name="expanded_audio_playback_margin">21dp</dimen>
+
+    <!--Custom Preferences Dialog-->
+    <dimen name="pref_dialog_margin_top">48dp</dimen>
+    <dimen name="pref_dialog_margin_bottom">48dp</dimen>
+    <dimen name="pref_dialog_content_padding">5dp</dimen>
+    <dimen name="pref_dialog_message_margin_bottom">48dp</dimen>
 </resources>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="expirenotification">CommCare Login Expired</string>
     <string name="submission_notification_title">Submitting Data</string>
     <string name="submission_logs_title">Submitting CommCare Logs</string>
-    <string name="form_record_url"/>
+    <string name="remote_form_payload_url"/>
 
     <item name="login_screen_hide_all_cuttoff" type="integer">200</item>
     <item name="login_screen_hide_banner_cuttoff" type="integer">250</item>

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -88,8 +88,8 @@
     <EditTextPreference
         android:defaultValue=""
         android:enabled="true"
-        android:key="cc-form-record-file-path"
-        android:title="Form Record File"/>
+        android:key="cc-local-form-payload-file-path"
+        android:title="Local Form Payload File"/>
     <ListPreference
         android:defaultValue="saved"
         android:enabled="true"

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -90,6 +90,11 @@
         android:enabled="true"
         android:key="cc-local-form-payload-file-path"
         android:title="Local Form Payload File"/>
+    <EditTextPreference
+        android:defaultValue="@string/remote_form_payload_url"
+        android:enabled="true"
+        android:key="remote-form-payload-url"
+        android:title="Form Payload Server"/>
     <ListPreference
         android:defaultValue="saved"
         android:enabled="true"

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -98,6 +98,7 @@
         android:enabled="true"
         android:key="cc-local-form-payload-file-path"
         android:title="Local Form Payload File"
+        app:error_dialog_title="cannot.set.payload"
         app:file_type="xml"/>
     <EditTextPreference
         android:defaultValue="@string/remote_form_payload_url"
@@ -132,9 +133,13 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-use-pw-obfuscation"
         android:title="Use Password Obfuscation"/>
-    <Preference
+    <org.commcare.preferences.FilePreference
+        android:defaultValue=""
+        android:enabled="true"
         android:key="cc-custom-restore-doc-location"
-        android:title="Restore a custom user XML data file"/>
+        android:title="Restore a custom user XML data file"
+        app:error_dialog_title="cannot.restore.xml"
+        app:file_type="xml"/>
     <ListPreference
         android:defaultValue="no"
         android:enabled="true"

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -98,7 +98,6 @@
         android:enabled="true"
         android:key="cc-local-form-payload-file-path"
         android:title="Local Form Payload File"
-        app:error_dialog_title="cannot.set.payload"
         app:file_type="xml"/>
     <EditTextPreference
         android:defaultValue="@string/remote_form_payload_url"
@@ -138,7 +137,6 @@
         android:enabled="true"
         android:key="cc-custom-restore-doc-location"
         android:title="Restore a custom user XML data file"
-        app:error_dialog_title="cannot.restore.xml"
         app:file_type="xml"/>
     <ListPreference
         android:defaultValue="no"

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -6,8 +6,8 @@
         android:key="cc-superuser-enabled"
         android:title="Developer Mode Enabled"/>
     <ListPreference
-        android:enabled="true"
         android:defaultValue="no"
+        android:enabled="true"
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-show-update-target-options"
@@ -85,7 +85,14 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-auto-purge"
         android:title="Detect and Trigger Purge on Form Save"/>
-    <EditTextPreference
+    <ListPreference
+        android:defaultValue="saved"
+        android:enabled="true"
+        android:entries="@array/pref_load_form_payload_as_labels"
+        android:entryValues="@array/pref_load_form_payload_as_vals"
+        android:key="cc-form-payload-status"
+        android:title="Load form payload status"/>
+    <org.commcare.preferences.FilePreference
         android:defaultValue=""
         android:enabled="true"
         android:key="cc-local-form-payload-file-path"
@@ -95,13 +102,6 @@
         android:enabled="true"
         android:key="remote-form-payload-url"
         android:title="Form Payload Server"/>
-    <ListPreference
-        android:defaultValue="saved"
-        android:enabled="true"
-        android:entries="@array/pref_load_form_payload_as_labels"
-        android:entryValues="@array/pref_load_form_payload_as_vals"
-        android:key="cc-form-payload-status"
-        android:title="Load form payload status"/>
     <ListPreference
         android:defaultValue="yes"
         android:enabled="true"
@@ -124,18 +124,18 @@
         android:key="cc-show-entity-trace-outputs"
         android:title="Output Entity List Trace Data to ADB"/>
     <ListPreference
-        android:enabled="true"
         android:defaultValue="no"
+        android:enabled="true"
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-use-pw-obfuscation"
         android:title="Use Password Obfuscation"/>
     <Preference
-        android:title="Restore a custom user XML data file"
-        android:key="cc-custom-restore-doc-location"/>
+        android:key="cc-custom-restore-doc-location"
+        android:title="Restore a custom user XML data file"/>
     <ListPreference
-        android:enabled="true"
         android:defaultValue="no"
+        android:enabled="true"
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-enable-bulk-performance"

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -1,4 +1,5 @@
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+                  xmlns:app="http://schemas.android.com/apk/res-auto">
     <ListPreference
         android:enabled="true"
         android:entries="@array/pref_enabled_labels"
@@ -96,7 +97,8 @@
         android:defaultValue=""
         android:enabled="true"
         android:key="cc-local-form-payload-file-path"
-        android:title="Local Form Payload File"/>
+        android:title="Local Form Payload File"
+        app:file_type="xml"/>
     <EditTextPreference
         android:defaultValue="@string/remote_form_payload_url"
         android:enabled="true"

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -85,6 +85,11 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-auto-purge"
         android:title="Detect and Trigger Purge on Form Save"/>
+    <EditTextPreference
+        android:defaultValue=""
+        android:enabled="true"
+        android:key="cc-form-record-file-path"
+        android:title="Form Record File"/>
     <ListPreference
         android:defaultValue="saved"
         android:enabled="true"

--- a/app/res/xml/server_preferences.xml
+++ b/app/res/xml/server_preferences.xml
@@ -26,17 +26,10 @@
         android:title="Data Server"/>
 
     <EditTextPreference
-        android:defaultValue="@string/remote_form_payload_url"
-        android:enabled="true"
-        android:key="remote-form-payload-url"
-        android:title="Form Payload Server"/>
-
-    <EditTextPreference
         android:defaultValue="@string/key_server"
         android:enabled="true"
         android:key="default_key_server"
         android:title="Key Server"/>
-
 
     <EditTextPreference
         android:defaultValue="@string/support_email_address_default"

--- a/app/res/xml/server_preferences.xml
+++ b/app/res/xml/server_preferences.xml
@@ -26,10 +26,10 @@
         android:title="Data Server"/>
 
     <EditTextPreference
-        android:defaultValue="@string/form_record_url"
+        android:defaultValue="@string/remote_form_payload_url"
         android:enabled="true"
-        android:key="form-record-url"
-        android:title="Form Record Server"/>
+        android:key="remote-form-payload-url"
+        android:title="Form Payload Server"/>
 
     <EditTextPreference
         android:defaultValue="@string/key_server"

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -4,7 +4,6 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
@@ -55,7 +54,6 @@ import org.commcare.utils.SessionUnavailableException;
 import org.commcare.views.IncompleteFormRecordView;
 import org.commcare.views.dialogs.StandardAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
-import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 
@@ -501,7 +499,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
             }
         });
         if (!FormRecordFilter.Incomplete.equals(adapter.getFilter())) {
-            String source = CommCareServerPreferences.getFormRecordKey();
+            String source = CommCareServerPreferences.getRemoteFormPayloadUrl();
 
             //If there's nowhere to fetch forms from, we can't really go fetch them
             if (!source.equals("")) {
@@ -509,7 +507,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
             }
             menu.add(0, MENU_SUBMIT_QUARANTINE_REPORT, MENU_SUBMIT_QUARANTINE_REPORT, Localization.get("app.workflow.forms.quarantine.report"));
 
-            String fileSource = DeveloperPreferences.getFormRecordFilePath();
+            String fileSource = DeveloperPreferences.getLocalFormPayloadFilePath();
             if(!fileSource.isEmpty()){
                 menu.add(0, DOWNLOAD_FORMS_FROM_FILE, 0, Localization.get("app.workflow.forms.fetch.file"));
             }
@@ -536,11 +534,11 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case DOWNLOAD_FORMS_FROM_SERVER:
-                String source = CommCareServerPreferences.getFormRecordKey();
+                String source = CommCareServerPreferences.getRemoteFormPayloadUrl();
                 ArchivedFormRemoteRestore.pullArchivedFormsFromServer(source, this, platform);
                 return true;
             case DOWNLOAD_FORMS_FROM_FILE:
-                String sourceFile = DeveloperPreferences.getFormRecordFilePath();
+                String sourceFile = DeveloperPreferences.getLocalFormPayloadFilePath();
                 ArchivedFormRemoteRestore.pullArchivedFormsFromFile(sourceFile, this, platform);
             case MENU_SUBMIT_QUARANTINE_REPORT:
                 generateQuarantineReport();

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -499,7 +499,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
             }
         });
         if (!FormRecordFilter.Incomplete.equals(adapter.getFilter())) {
-            String source = CommCareServerPreferences.getRemoteFormPayloadUrl();
+            String source = DeveloperPreferences.getRemoteFormPayloadUrl();
 
             //If there's nowhere to fetch forms from, we can't really go fetch them
             if (!source.equals("")) {
@@ -534,7 +534,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case DOWNLOAD_FORMS_FROM_SERVER:
-                String source = CommCareServerPreferences.getRemoteFormPayloadUrl();
+                String source = DeveloperPreferences.getRemoteFormPayloadUrl();
                 ArchivedFormRemoteRestore.pullArchivedFormsFromServer(source, this, platform);
                 return true;
             case DOWNLOAD_FORMS_FROM_FILE:

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -41,6 +41,7 @@ import org.commcare.models.FormRecordProcessor;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.database.user.models.SessionStateDescriptor;
 import org.commcare.preferences.CommCareServerPreferences;
+import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.FormRecordCleanupTask;
 import org.commcare.tasks.FormRecordLoadListener;
@@ -54,6 +55,7 @@ import org.commcare.utils.SessionUnavailableException;
 import org.commcare.views.IncompleteFormRecordView;
 import org.commcare.views.dialogs.StandardAlertDialog;
 import org.commcare.views.dialogs.CustomProgressDialog;
+import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 
@@ -62,15 +64,14 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         implements TextWatcher, FormRecordLoadListener, OnItemClickListener, TaskListener<Void, Void> {
     private static final String TAG = FormRecordListActivity.class.getSimpleName();
 
-    private static final String FORM_RECORD_URL = CommCareServerPreferences.PREFS_FORM_RECORD_KEY;
-
     private static final int OPEN_RECORD = Menu.FIRST;
     private static final int DELETE_RECORD = Menu.FIRST + 1;
     private static final int RESTORE_RECORD = Menu.FIRST + 2;
     private static final int SCAN_RECORD = Menu.FIRST + 3;
 
-    private static final int DOWNLOAD_FORMS = Menu.FIRST;
+    private static final int DOWNLOAD_FORMS_FROM_SERVER = Menu.FIRST;
     private static final int MENU_SUBMIT_QUARANTINE_REPORT = Menu.FIRST + 1;
+    private static final int DOWNLOAD_FORMS_FROM_FILE = Menu.FIRST + 2;
 
     private static final int BARCODE_FETCH = 1;
 
@@ -500,14 +501,18 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
             }
         });
         if (!FormRecordFilter.Incomplete.equals(adapter.getFilter())) {
-            SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-            String source = prefs.getString(FORM_RECORD_URL, this.getString(R.string.form_record_url));
+            String source = CommCareServerPreferences.getFormRecordKey();
 
             //If there's nowhere to fetch forms from, we can't really go fetch them
             if (!source.equals("")) {
-                menu.add(0, DOWNLOAD_FORMS, 0, Localization.get("app.workflow.forms.fetch")).setIcon(android.R.drawable.ic_menu_rotate);
+                menu.add(0, DOWNLOAD_FORMS_FROM_SERVER, 0, Localization.get("app.workflow.forms.fetch")).setIcon(android.R.drawable.ic_menu_rotate);
             }
             menu.add(0, MENU_SUBMIT_QUARANTINE_REPORT, MENU_SUBMIT_QUARANTINE_REPORT, Localization.get("app.workflow.forms.quarantine.report"));
+
+            String fileSource = DeveloperPreferences.getFormRecordFilePath();
+            if(!fileSource.isEmpty()){
+                menu.add(0, DOWNLOAD_FORMS_FROM_FILE, 0, Localization.get("app.workflow.forms.fetch.file"));
+            }
             return true;
         }
         return parent;
@@ -530,11 +535,13 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
-            case DOWNLOAD_FORMS:
-                SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-                String source = prefs.getString(FORM_RECORD_URL, this.getString(R.string.form_record_url));
+            case DOWNLOAD_FORMS_FROM_SERVER:
+                String source = CommCareServerPreferences.getFormRecordKey();
                 ArchivedFormRemoteRestore.pullArchivedFormsFromServer(source, this, platform);
                 return true;
+            case DOWNLOAD_FORMS_FROM_FILE:
+                String sourceFile = DeveloperPreferences.getFormRecordFilePath();
+                ArchivedFormRemoteRestore.pullArchivedFormsFromFile(sourceFile, this, platform);
             case MENU_SUBMIT_QUARANTINE_REPORT:
                 generateQuarantineReport();
                 return true;

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -373,26 +373,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                     if (resultCode == AdvancedActionsPreferences.RESULT_DATA_RESET) {
                         finish();
                     } else if (resultCode == DeveloperPreferences.RESULT_SYNC_CUSTOM) {
-                        try {
-                            String filePath = DeveloperPreferences.getCustomRestoreDocLocation();
-                            if (filePath != null && !filePath.isEmpty()) {
-                                if(FilenameUtils.getExtension(filePath).contentEquals("xml")) {
-                                    File f = new File(filePath);
-                                    if (f.exists()) {
-                                        formAndDataSyncer.performCustomRestoreFromFile(this, f);
-                                    } else {
-                                        Toast.makeText(this, Localization.get("custom.restore.file.not.exist"), Toast.LENGTH_LONG).show();
-                                    }
-                                }else {
-                                    Toast.makeText(this, Localization.get("file.wrong.type", "xml"), Toast.LENGTH_LONG).show();
-                                }
-                            } else {
-                                Toast.makeText(this, Localization.get("custom.restore.file.not.set"), Toast.LENGTH_LONG).show();
-                            }
-                        } catch (Exception e) {
-                            Toast.makeText(this, Localization.get("custom.restore.error"),
-                                    Toast.LENGTH_LONG).show();
-                        }
+                        performCustomRestore();
                     }
                     return;
                 case ADVANCED_ACTIONS_ACTIVITY:
@@ -478,6 +459,25 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             startNextSessionStepSafe();
         }
         super.onActivityResult(requestCode, resultCode, intent);
+    }
+
+    private void performCustomRestore() {
+        try {
+            String filePath = DeveloperPreferences.getCustomRestoreDocLocation();
+            if (filePath != null && !filePath.isEmpty()) {
+                File f = new File(filePath);
+                if (f.exists()) {
+                    formAndDataSyncer.performCustomRestoreFromFile(this, f);
+                } else {
+                    Toast.makeText(this, Localization.get("custom.restore.file.not.exist"), Toast.LENGTH_LONG).show();
+                }
+            } else {
+                Toast.makeText(this, Localization.get("custom.restore.file.not.set"), Toast.LENGTH_LONG).show();
+            }
+        } catch (Exception e) {
+            Toast.makeText(this, Localization.get("custom.restore.error"),
+                    Toast.LENGTH_LONG).show();
+        }
     }
 
     private boolean processReturnFromGetCase(int resultCode, Intent intent) {

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -15,8 +15,8 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.Toast;
 
+import org.apache.commons.io.FilenameUtils;
 import org.commcare.CommCareApplication;
-import org.commcare.heartbeat.UpdatePromptHelper;
 import org.commcare.activities.components.FormEntryConstants;
 import org.commcare.activities.components.FormEntryInstanceState;
 import org.commcare.activities.components.FormEntrySessionWrapper;
@@ -27,10 +27,11 @@ import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.commcare.google.services.ads.AdMobManager;
-import org.commcare.interfaces.CommCareActivityUIController;
-import org.commcare.logging.AndroidLogger;
 import org.commcare.google.services.analytics.GoogleAnalyticsFields;
 import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
+import org.commcare.heartbeat.UpdatePromptHelper;
+import org.commcare.interfaces.CommCareActivityUIController;
+import org.commcare.logging.AndroidLogger;
 import org.commcare.models.AndroidSessionWrapper;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.preferences.AdvancedActionsPreferences;
@@ -59,7 +60,6 @@ import org.commcare.utils.EntityDetailUtils;
 import org.commcare.utils.GlobalConstants;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.utils.StorageUtils;
-import org.commcare.utils.UriToFilePath;
 import org.commcare.views.UserfacingErrorHandling;
 import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.DialogChoiceItem;
@@ -374,16 +374,23 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                         finish();
                     } else if (resultCode == DeveloperPreferences.RESULT_SYNC_CUSTOM) {
                         try {
-                            Uri uri = intent.getData();
-                            String filePath = UriToFilePath.getPathFromUri(CommCareApplication.instance(), uri);
-                            if (filePath != null) {
-                                File f = new File(filePath);
-                                if (f != null && f.exists()) {
-                                    formAndDataSyncer.performCustomRestoreFromFile(this, f);
+                            String filePath = DeveloperPreferences.getCustomRestoreDocLocation();
+                            if (filePath != null && !filePath.isEmpty()) {
+                                if(FilenameUtils.getExtension(filePath).contentEquals("xml")) {
+                                    File f = new File(filePath);
+                                    if (f.exists()) {
+                                        formAndDataSyncer.performCustomRestoreFromFile(this, f);
+                                    } else {
+                                        Toast.makeText(this, Localization.get("custom.restore.file.not.exist"), Toast.LENGTH_LONG).show();
+                                    }
+                                }else {
+                                    Toast.makeText(this, Localization.get("file.wrong.type", "xml"), Toast.LENGTH_LONG).show();
                                 }
+                            } else {
+                                Toast.makeText(this, Localization.get("custom.restore.file.not.set"), Toast.LENGTH_LONG).show();
                             }
                         } catch (Exception e) {
-                            Toast.makeText(this, "Error loading custom sync...",
+                            Toast.makeText(this, Localization.get("custom.restore.error"),
                                     Toast.LENGTH_LONG).show();
                         }
                     }

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -1,8 +1,6 @@
 package org.commcare.fragments;
 
-import android.app.Activity;
 import android.content.ActivityNotFoundException;
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -127,9 +125,9 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
 
     /**
      * Utility function to request a file using a file browser
-     * @param fragment
-     * @param requestCode
-     * @param errorTitle
+     * @param fragment Fragment implementing onActivityResult for this file request
+     * @param requestCode Request code to fire the file fetch intent with
+     * @param errorTitle Title of the error dialogue that appears if no file browser is installed
      */
     public static void startFileBrowser(Fragment fragment, int requestCode, String errorTitle) {
         Intent chooseTemplateIntent = new Intent()

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -125,8 +125,9 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
                 .unregisterOnSharedPreferenceChangeListener(this);
     }
 
-    /***
+    /**
      * Utility function to request a file using a file browser
+     * @param fragment
      * @param requestCode
      * @param errorTitle
      */

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -37,7 +37,6 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
     private static final String DIALOG_FRAGMENT_TAG =
             "android.support.v7.preference.PreferenceFragment.DIALOG";
 
-
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         GoogleAnalyticsUtils.reportPrefActivityEntry(getAnalyticsCategory());

--- a/app/src/org/commcare/google/services/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/google/services/analytics/GoogleAnalyticsFields.java
@@ -128,7 +128,6 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_DATA_SERVER = "Data Server";
     public static final String LABEL_SUBMISSION_SERVER = "Submission Server";
     public static final String LABEL_KEY_SERVER = "Key Server";
-    public static final String LABEL_REMOTE_FORM_PAYLOAD_SERVER = "Form Record Server";
     public static final String LABEL_SUPPORT_EMAIL = "Support Email Address";
     public static final String LABEL_AUTO_UPDATE = "Auto Update Frequency";
     public static final String LABEL_FUZZY_SEARCH = "Fuzzy Search Matches";
@@ -159,7 +158,8 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_DETAIL_TAB_SWIPE_ACTION = "Detail tab final swipe action enabled";
     public static final String LABEL_OFFLINE_UPDATE = "Offline Updates enabled";
     public static final String LABEL_CUSTOM_RESTORE = "Custom Restore Requested";
-    public static final String LABEL_FORM_RECORD_FILE_PATH = "Form Record File";
+    public static final String LABEL_LOCAL_FORM_PAYLOAD_FILE_PATH = "Form Payload File";
+    public static final String LABEL_REMOTE_FORM_PAYLOAD_URL = "Form Payload Server";
 
     // Labels for ACTION_OPTIONS_MENU_ITEM in CATEGORY_HOME_SCREEN
     public static final String LABEL_SETTINGS = "Settings";

--- a/app/src/org/commcare/google/services/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/google/services/analytics/GoogleAnalyticsFields.java
@@ -128,7 +128,7 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_DATA_SERVER = "Data Server";
     public static final String LABEL_SUBMISSION_SERVER = "Submission Server";
     public static final String LABEL_KEY_SERVER = "Key Server";
-    public static final String LABEL_FORM_RECORD_SERVER = "Form Record Server";
+    public static final String LABEL_REMOTE_FORM_PAYLOAD_SERVER = "Form Record Server";
     public static final String LABEL_SUPPORT_EMAIL = "Support Email Address";
     public static final String LABEL_AUTO_UPDATE = "Auto Update Frequency";
     public static final String LABEL_FUZZY_SEARCH = "Fuzzy Search Matches";

--- a/app/src/org/commcare/google/services/analytics/GoogleAnalyticsFields.java
+++ b/app/src/org/commcare/google/services/analytics/GoogleAnalyticsFields.java
@@ -159,6 +159,7 @@ public final class GoogleAnalyticsFields {
     public static final String LABEL_DETAIL_TAB_SWIPE_ACTION = "Detail tab final swipe action enabled";
     public static final String LABEL_OFFLINE_UPDATE = "Offline Updates enabled";
     public static final String LABEL_CUSTOM_RESTORE = "Custom Restore Requested";
+    public static final String LABEL_FORM_RECORD_FILE_PATH = "Form Record File";
 
     // Labels for ACTION_OPTIONS_MENU_ITEM in CATEGORY_HOME_SCREEN
     public static final String LABEL_SETTINGS = "Settings";

--- a/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
+++ b/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
@@ -38,16 +38,12 @@ public class ArchivedFormRemoteRestore {
                                                  final FormRecordListActivity activity,
                                                  final CommCarePlatform platform) {
         if (filePath != null && !filePath.isEmpty()) {
-            if(FilenameUtils.getExtension(filePath).contentEquals("xml")) {
-                File file = new File(filePath);
-                if (file.exists()) {
-                    LocalFilePullResponseFactory.setRequestPayloads(new File[]{file});
-                    requestForms(activity, platform, "fake-server-that-is-never-used", LocalFilePullResponseFactory.INSTANCE, true);
-                } else {
-                    Toast.makeText(activity, Localization.get("payload.file.not.exist"), Toast.LENGTH_LONG).show();
-                }
-            }else {
-                Toast.makeText(activity, Localization.get("file.wrong.type", "xml"), Toast.LENGTH_LONG).show();
+            File file = new File(filePath);
+            if (file.exists()) {
+                LocalFilePullResponseFactory.setRequestPayloads(new File[]{file});
+                requestForms(activity, platform, "fake-server-that-is-never-used", LocalFilePullResponseFactory.INSTANCE, true);
+            } else {
+                Toast.makeText(activity, Localization.get("payload.file.not.exist"), Toast.LENGTH_LONG).show();
             }
         } else {
             Toast.makeText(activity, Localization.get("payload.file.not.set"), Toast.LENGTH_LONG).show();

--- a/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
+++ b/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
@@ -42,7 +42,7 @@ public class ArchivedFormRemoteRestore {
             LocalFilePullResponseFactory.setRequestPayloads(new File[]{file});
             requestForms(activity, platform, "fake-server-that-is-never-used", LocalFilePullResponseFactory.INSTANCE, true);
         } else {
-            Toast.makeText(activity, "Restore file doesn't exist", Toast.LENGTH_LONG).show();
+            Toast.makeText(activity, "Payload file doesn't exist", Toast.LENGTH_LONG).show();
         }
     }
 

--- a/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
+++ b/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
@@ -4,6 +4,8 @@ import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
 import org.commcare.activities.FormRecordListActivity;
+import org.commcare.network.DataPullRequester;
+import org.commcare.network.mocks.LocalFilePullResponseFactory;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.FormRecordCleanupTask;
@@ -11,6 +13,8 @@ import org.commcare.tasks.ResultAndError;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.model.User;
 import org.javarosa.core.services.locale.Localization;
+
+import java.io.File;
 
 /**
  * Only used for developer debugging.
@@ -25,11 +29,30 @@ public class ArchivedFormRemoteRestore {
     public static void pullArchivedFormsFromServer(String remoteUrl,
                                                    final FormRecordListActivity activity,
                                                    final CommCarePlatform platform) {
+
+        requestForms(activity, platform, remoteUrl, CommCareApplication.instance().getDataPullRequester(), false);
+    }
+
+    public static void pullArchivedFormsFromFile(String filePath,
+                                                 final FormRecordListActivity activity,
+                                                 final CommCarePlatform platform) {
+
+        File file = new File(filePath);
+        if (file != null && file.exists()) {
+            LocalFilePullResponseFactory.setRequestPayloads(new File[]{file});
+            requestForms(activity, platform, "fake-server-that-is-never-used", LocalFilePullResponseFactory.INSTANCE, true);
+        } else {
+            Toast.makeText(activity, "Restore file doesn't exist", Toast.LENGTH_LONG).show();
+        }
+    }
+
+    private static void requestForms(FormRecordListActivity activity, CommCarePlatform platform,
+                                     String remoteUrl, DataPullRequester dataPullRequester, boolean blockRemoteKeyManagement) {
         User u = CommCareApplication.instance().getSession().getLoggedInUser();
 
         // We should go digest auth this user on the server and see whether to pull them down.
         DataPullTask<FormRecordListActivity> pull = new DataPullTask<FormRecordListActivity>(u.getUsername(),
-                u.getCachedPwd(), u.getUniqueId(), remoteUrl, activity) {
+                u.getCachedPwd(), u.getUniqueId(), remoteUrl, activity, dataPullRequester, blockRemoteKeyManagement) {
             @Override
             protected void deliverResult(FormRecordListActivity receiver, ResultAndError<PullTaskResult> statusAndErrorMessage) {
                 PullTaskResult status = statusAndErrorMessage.data;

--- a/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
+++ b/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
@@ -19,7 +19,7 @@ import java.io.File;
 
 /**
  * Only used for developer debugging.
- * <p>
+ *
  * Load saved form instances manually from a xml payload.
  *
  * @author Phillip Mates (pmates@dimagi.com).

--- a/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
+++ b/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
@@ -2,6 +2,7 @@ package org.commcare.logic;
 
 import android.widget.Toast;
 
+import org.apache.commons.io.FilenameUtils;
 import org.commcare.CommCareApplication;
 import org.commcare.activities.FormRecordListActivity;
 import org.commcare.network.DataPullRequester;
@@ -18,7 +19,7 @@ import java.io.File;
 
 /**
  * Only used for developer debugging.
- *
+ * <p>
  * Load saved form instances manually from a xml payload.
  *
  * @author Phillip Mates (pmates@dimagi.com).
@@ -36,13 +37,20 @@ public class ArchivedFormRemoteRestore {
     public static void pullArchivedFormsFromFile(String filePath,
                                                  final FormRecordListActivity activity,
                                                  final CommCarePlatform platform) {
-
-        File file = new File(filePath);
-        if (file != null && file.exists()) {
-            LocalFilePullResponseFactory.setRequestPayloads(new File[]{file});
-            requestForms(activity, platform, "fake-server-that-is-never-used", LocalFilePullResponseFactory.INSTANCE, true);
+        if (filePath != null && !filePath.isEmpty()) {
+            if(FilenameUtils.getExtension(filePath).contentEquals("xml")) {
+                File file = new File(filePath);
+                if (file.exists()) {
+                    LocalFilePullResponseFactory.setRequestPayloads(new File[]{file});
+                    requestForms(activity, platform, "fake-server-that-is-never-used", LocalFilePullResponseFactory.INSTANCE, true);
+                } else {
+                    Toast.makeText(activity, Localization.get("payload.file.not.exist"), Toast.LENGTH_LONG).show();
+                }
+            }else {
+                Toast.makeText(activity, Localization.get("file.wrong.type", "xml"), Toast.LENGTH_LONG).show();
+            }
         } else {
-            Toast.makeText(activity, "Payload file doesn't exist", Toast.LENGTH_LONG).show();
+            Toast.makeText(activity, Localization.get("payload.file.not.set"), Toast.LENGTH_LONG).show();
         }
     }
 

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -237,7 +237,7 @@ public class CommCarePreferences
                 GoogleAnalyticsUtils.reportPrefItemClick(
                         GoogleAnalyticsFields.CATEGORY_CC_PREFS,
                         GoogleAnalyticsFields.LABEL_PRINT_TEMPLATE);
-                startFileBrowser();
+                startFileBrowser(CommCarePreferences.this, REQUEST_TEMPLATE, "cannot.set.template");
                 return true;
             }
         });
@@ -524,20 +524,6 @@ public class CommCarePreferences
             return;
         }
         app.getAppPreferences().edit().putBoolean(ANALYTICS_ENABLED, false).commit();
-    }
-
-    private void startFileBrowser() {
-        Intent chooseTemplateIntent = new Intent()
-                .setAction(Intent.ACTION_GET_CONTENT)
-                .setType("file/*")
-                .addCategory(Intent.CATEGORY_OPENABLE);
-        try {
-            startActivityForResult(chooseTemplateIntent, REQUEST_TEMPLATE);
-        } catch (ActivityNotFoundException e) {
-            // Means that there is no file browser installed on the device
-            TemplatePrinterUtils.showAlertDialog(getActivity(), Localization.get("cannot.set.template"),
-                    Localization.get("no.file.browser"), false);
-        }
     }
 
     private void startServerSettings() {

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -306,8 +306,8 @@ public class CommCarePreferences
             }
         }
         if (requestCode == REQUEST_DEVELOPER_PREFERENCES) {
-            if (resultCode == DeveloperPreferences.RESULT_SYNC_CUSTOM && data != null) {
-                getActivity().setResult(DeveloperPreferences.RESULT_SYNC_CUSTOM, data);
+            if (resultCode == DeveloperPreferences.RESULT_SYNC_CUSTOM) {
+                getActivity().setResult(DeveloperPreferences.RESULT_SYNC_CUSTOM);
                 getActivity().finish();
             }
         }

--- a/app/src/org/commcare/preferences/CommCareServerPreferences.java
+++ b/app/src/org/commcare/preferences/CommCareServerPreferences.java
@@ -96,6 +96,10 @@ public class CommCareServerPreferences
         return getServerProperty(PREFS_SUPPORT_ADDRESS_KEY, CommCareApplication.instance().getString(R.string.support_email_address_default)) ;
     }
 
+    public static String getFormRecordKey() {
+        return getServerProperty(PREFS_FORM_RECORD_KEY, CommCareApplication.instance().getString(R.string.form_record_url)) ;
+    }
+
     private static String getServerProperty(String key, String defaultValue) {
         CommCareApp app = CommCareApplication.instance().getCurrentApp();
         if (app == null) {

--- a/app/src/org/commcare/preferences/CommCareServerPreferences.java
+++ b/app/src/org/commcare/preferences/CommCareServerPreferences.java
@@ -27,7 +27,6 @@ public class CommCareServerPreferences
     public final static String PREFS_SUBMISSION_URL_KEY = "PostURL";
     public final static String PREFS_LOG_POST_URL_KEY = "log_receiver_url";
     private final static String PREFS_KEY_SERVER_KEY = "default_key_server";
-    public final static String PREFS_REMOTE_FORM_PAYLOAD_KEY = "remote-form-payload-url";
     public final static String PREFS_HEARTBEAT_URL_KEY = "heartbeat-url";
     public final static String PREFS_SUPPORT_ADDRESS_KEY = "support-email-address";
 
@@ -38,7 +37,6 @@ public class CommCareServerPreferences
         prefKeyToAnalyticsEvent.put(PREFS_DATA_SERVER_KEY, GoogleAnalyticsFields.LABEL_DATA_SERVER);
         prefKeyToAnalyticsEvent.put(PREFS_SUBMISSION_URL_KEY, GoogleAnalyticsFields.LABEL_SUBMISSION_SERVER);
         prefKeyToAnalyticsEvent.put(PREFS_KEY_SERVER_KEY, GoogleAnalyticsFields.LABEL_KEY_SERVER);
-        prefKeyToAnalyticsEvent.put(PREFS_REMOTE_FORM_PAYLOAD_KEY, GoogleAnalyticsFields.LABEL_REMOTE_FORM_PAYLOAD_SERVER);
         prefKeyToAnalyticsEvent.put(PREFS_SUPPORT_ADDRESS_KEY, GoogleAnalyticsFields.LABEL_SUPPORT_EMAIL);
     }
 
@@ -88,10 +86,6 @@ public class CommCareServerPreferences
 
     public static String getSupportEmailAddress() {
         return getServerProperty(PREFS_SUPPORT_ADDRESS_KEY, CommCareApplication.instance().getString(R.string.support_email_address_default)) ;
-    }
-
-    public static String getRemoteFormPayloadUrl() {
-        return getServerProperty(PREFS_REMOTE_FORM_PAYLOAD_KEY, CommCareApplication.instance().getString(R.string.remote_form_payload_url)) ;
     }
 
     private static String getServerProperty(String key, String defaultValue) {

--- a/app/src/org/commcare/preferences/CommCareServerPreferences.java
+++ b/app/src/org/commcare/preferences/CommCareServerPreferences.java
@@ -1,20 +1,14 @@
 package org.commcare.preferences;
 
 import android.content.SharedPreferences;
-import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.view.MenuItem;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
-import org.commcare.activities.SessionAwarePreferenceActivity;
-import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.commcare.fragments.CommCarePreferenceFragment;
 import org.commcare.google.services.analytics.GoogleAnalyticsFields;
-import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
 import org.javarosa.core.services.locale.Localization;
 
 import java.util.HashMap;
@@ -33,7 +27,7 @@ public class CommCareServerPreferences
     public final static String PREFS_SUBMISSION_URL_KEY = "PostURL";
     public final static String PREFS_LOG_POST_URL_KEY = "log_receiver_url";
     private final static String PREFS_KEY_SERVER_KEY = "default_key_server";
-    public final static String PREFS_FORM_RECORD_KEY = "form-record-url";
+    public final static String PREFS_REMOTE_FORM_PAYLOAD_KEY = "remote-form-payload-url";
     public final static String PREFS_HEARTBEAT_URL_KEY = "heartbeat-url";
     public final static String PREFS_SUPPORT_ADDRESS_KEY = "support-email-address";
 
@@ -44,7 +38,7 @@ public class CommCareServerPreferences
         prefKeyToAnalyticsEvent.put(PREFS_DATA_SERVER_KEY, GoogleAnalyticsFields.LABEL_DATA_SERVER);
         prefKeyToAnalyticsEvent.put(PREFS_SUBMISSION_URL_KEY, GoogleAnalyticsFields.LABEL_SUBMISSION_SERVER);
         prefKeyToAnalyticsEvent.put(PREFS_KEY_SERVER_KEY, GoogleAnalyticsFields.LABEL_KEY_SERVER);
-        prefKeyToAnalyticsEvent.put(PREFS_FORM_RECORD_KEY, GoogleAnalyticsFields.LABEL_FORM_RECORD_SERVER);
+        prefKeyToAnalyticsEvent.put(PREFS_REMOTE_FORM_PAYLOAD_KEY, GoogleAnalyticsFields.LABEL_REMOTE_FORM_PAYLOAD_SERVER);
         prefKeyToAnalyticsEvent.put(PREFS_SUPPORT_ADDRESS_KEY, GoogleAnalyticsFields.LABEL_SUPPORT_EMAIL);
     }
 
@@ -96,8 +90,8 @@ public class CommCareServerPreferences
         return getServerProperty(PREFS_SUPPORT_ADDRESS_KEY, CommCareApplication.instance().getString(R.string.support_email_address_default)) ;
     }
 
-    public static String getFormRecordKey() {
-        return getServerProperty(PREFS_FORM_RECORD_KEY, CommCareApplication.instance().getString(R.string.form_record_url)) ;
+    public static String getRemoteFormPayloadUrl() {
+        return getServerProperty(PREFS_REMOTE_FORM_PAYLOAD_KEY, CommCareApplication.instance().getString(R.string.remote_form_payload_url)) ;
     }
 
     private static String getServerProperty(String key, String defaultValue) {

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -172,24 +172,10 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
                 GoogleAnalyticsUtils.reportPrefItemClick(
                         GoogleAnalyticsFields.CATEGORY_DEV_PREFS,
                         GoogleAnalyticsFields.LABEL_CUSTOM_RESTORE);
-                startFileBrowser();
+                startFileBrowser(DeveloperPreferences.this, REQUEST_SYNC_FILE, "cannot.restore.xml");
                 return true;
             }
         });
-    }
-
-    private void startFileBrowser() {
-        Intent chooseTemplateIntent = new Intent()
-                .setAction(Intent.ACTION_GET_CONTENT)
-                .setType("file/*")
-                .addCategory(Intent.CATEGORY_OPENABLE);
-        try {
-            startActivityForResult(chooseTemplateIntent, REQUEST_SYNC_FILE);
-        } catch (ActivityNotFoundException e) {
-            // Means that there is no file browser installed on the device
-            TemplatePrinterUtils.showAlertDialog(getActivity(), "Can't restore custom XML File",
-                    Localization.get("no.file.browser"), false);
-        }
     }
 
     @Override

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -60,6 +60,8 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     public static final String ENABLE_BULK_PERFORMANCE = "cc-enable-bulk-performance";
     public static final String SHOW_UPDATE_OPTIONS_SETTING = "cc-show-update-target-options";
     public static final String LOCAL_FORM_PAYLOAD_FILE_PATH = "cc-local-form-payload-file-path";
+    public final static String REMOTE_FORM_PAYLOAD_URL = "remote-form-payload-url";
+
     /**
      * Stores last used password and performs auto-login when that password is
      * present
@@ -99,7 +101,8 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
         prefKeyToAnalyticsEvent.put(LOAD_FORM_PAYLOAD_AS, GoogleAnalyticsFields.LABEL_LOAD_FORM_PAYLOAD_AS);
         prefKeyToAnalyticsEvent.put(DETAIL_TAB_SWIPE_ACTION_ENABLED, GoogleAnalyticsFields.LABEL_DETAIL_TAB_SWIPE_ACTION);
         prefKeyToAnalyticsEvent.put(PREFS_CUSTOM_RESTORE_DOC_LOCATION, GoogleAnalyticsFields.LABEL_CUSTOM_RESTORE);
-        prefKeyToAnalyticsEvent.put(LOCAL_FORM_PAYLOAD_FILE_PATH, GoogleAnalyticsFields.LABEL_FORM_RECORD_FILE_PATH);
+        prefKeyToAnalyticsEvent.put(LOCAL_FORM_PAYLOAD_FILE_PATH, GoogleAnalyticsFields.LABEL_LOCAL_FORM_PAYLOAD_FILE_PATH);
+        prefKeyToAnalyticsEvent.put(REMOTE_FORM_PAYLOAD_URL, GoogleAnalyticsFields.LABEL_REMOTE_FORM_PAYLOAD_URL);
     }
 
     /**
@@ -405,6 +408,11 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     public static String getLocalFormPayloadFilePath() {
         SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
         return properties.getString(LOCAL_FORM_PAYLOAD_FILE_PATH, "");
+    }
+
+    public static String getRemoteFormPayloadUrl() {
+        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        return properties.getString(REMOTE_FORM_PAYLOAD_URL, CommCareApplication.instance().getString(R.string.remote_form_payload_url));
     }
 
     private void hideOrShowDangerousSettings() {

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -59,7 +59,7 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     public static final String USE_OBFUSCATED_PW = "cc-use-pw-obfuscation";
     public static final String ENABLE_BULK_PERFORMANCE = "cc-enable-bulk-performance";
     public static final String SHOW_UPDATE_OPTIONS_SETTING = "cc-show-update-target-options";
-    public static final String FORM_RECORD_FILE_PATH = "cc-form-record-file-path";
+    public static final String LOCAL_FORM_PAYLOAD_FILE_PATH = "cc-local-form-payload-file-path";
     /**
      * Stores last used password and performs auto-login when that password is
      * present
@@ -99,7 +99,7 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
         prefKeyToAnalyticsEvent.put(LOAD_FORM_PAYLOAD_AS, GoogleAnalyticsFields.LABEL_LOAD_FORM_PAYLOAD_AS);
         prefKeyToAnalyticsEvent.put(DETAIL_TAB_SWIPE_ACTION_ENABLED, GoogleAnalyticsFields.LABEL_DETAIL_TAB_SWIPE_ACTION);
         prefKeyToAnalyticsEvent.put(PREFS_CUSTOM_RESTORE_DOC_LOCATION, GoogleAnalyticsFields.LABEL_CUSTOM_RESTORE);
-        prefKeyToAnalyticsEvent.put(FORM_RECORD_FILE_PATH, GoogleAnalyticsFields.LABEL_FORM_RECORD_FILE_PATH);
+        prefKeyToAnalyticsEvent.put(LOCAL_FORM_PAYLOAD_FILE_PATH, GoogleAnalyticsFields.LABEL_FORM_RECORD_FILE_PATH);
     }
 
     /**
@@ -402,9 +402,9 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
                 CommCarePreferences.YES) || BuildConfig.DEBUG;
     }
 
-    public static String getFormRecordFilePath() {
+    public static String getLocalFormPayloadFilePath() {
         SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        return properties.getString(FORM_RECORD_FILE_PATH, "");
+        return properties.getString(LOCAL_FORM_PAYLOAD_FILE_PATH, "");
     }
 
     private void hideOrShowDangerousSettings() {

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -200,12 +200,8 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
             case PREFS_CUSTOM_RESTORE_DOC_LOCATION:
                 String filePath = getCustomRestoreDocLocation();
                 if (!filePath.isEmpty()) {
-                    if (FilenameUtils.getExtension(filePath).contentEquals("xml")) {
-                        getActivity().setResult(DeveloperPreferences.RESULT_SYNC_CUSTOM);
-                        getActivity().finish();
-                    } else {
-                        Toast.makeText(getActivity(), Localization.get("file.wrong.type", "xml"), Toast.LENGTH_LONG).show();
-                    }
+                    getActivity().setResult(DeveloperPreferences.RESULT_SYNC_CUSTOM);
+                    getActivity().finish();
                 }
                 break;
         }

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -238,15 +238,6 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
                     DevSessionRestorer.clearSession();
                 }
                 setSessionEditText();
-
-                break;
-            case LOAD_FORM_PAYLOAD_AS:
-                if (!formLoadPayloadStatus().equals(FormRecord.STATUS_SAVED)) {
-                    // clear submission server so that 'unsent' forms that are loaded don't get sent to HQ
-                    CommCareApplication.instance().getCurrentApp().getAppPreferences().edit()
-                            .putString(CommCareServerPreferences.PREFS_SUBMISSION_URL_KEY, "")
-                            .apply();
-                }
                 break;
         }
     }

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -59,6 +59,7 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     public static final String USE_OBFUSCATED_PW = "cc-use-pw-obfuscation";
     public static final String ENABLE_BULK_PERFORMANCE = "cc-enable-bulk-performance";
     public static final String SHOW_UPDATE_OPTIONS_SETTING = "cc-show-update-target-options";
+    public static final String FORM_RECORD_FILE_PATH = "cc-form-record-file-path";
     /**
      * Stores last used password and performs auto-login when that password is
      * present
@@ -98,6 +99,7 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
         prefKeyToAnalyticsEvent.put(LOAD_FORM_PAYLOAD_AS, GoogleAnalyticsFields.LABEL_LOAD_FORM_PAYLOAD_AS);
         prefKeyToAnalyticsEvent.put(DETAIL_TAB_SWIPE_ACTION_ENABLED, GoogleAnalyticsFields.LABEL_DETAIL_TAB_SWIPE_ACTION);
         prefKeyToAnalyticsEvent.put(PREFS_CUSTOM_RESTORE_DOC_LOCATION, GoogleAnalyticsFields.LABEL_CUSTOM_RESTORE);
+        prefKeyToAnalyticsEvent.put(FORM_RECORD_FILE_PATH, GoogleAnalyticsFields.LABEL_FORM_RECORD_FILE_PATH);
     }
 
     /**
@@ -407,6 +409,11 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     public static boolean shouldShowUpdateOptionsSetting() {
         return doesPropertyMatch(SHOW_UPDATE_OPTIONS_SETTING, CommCarePreferences.NO,
                 CommCarePreferences.YES) || BuildConfig.DEBUG;
+    }
+
+    public static String getFormRecordFilePath() {
+        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        return properties.getString(FORM_RECORD_FILE_PATH, "");
     }
 
     private void hideOrShowDangerousSettings() {

--- a/app/src/org/commcare/preferences/FilePreference.java
+++ b/app/src/org/commcare/preferences/FilePreference.java
@@ -11,6 +11,9 @@ public class FilePreference extends EditTextPreference {
 
     private String fileType;
 
+    // Title for error dialog that displays in case of no file manager installed
+    private String errorDialogTitle;
+
     public FilePreference(Context context, AttributeSet attrs) {
         super(context, attrs);
         setParams(context, attrs);
@@ -20,6 +23,7 @@ public class FilePreference extends EditTextPreference {
         final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.FilePreference, 0, 0);
         if (a.hasValue(R.styleable.FilePreference_file_type)) {
             fileType = a.getString(R.styleable.FilePreference_file_type);
+            errorDialogTitle = a.getString(R.styleable.FilePreference_error_dialog_title);
         }
         a.recycle();
         setDialogLayoutResource(R.layout.file_pref_dialog);
@@ -27,5 +31,9 @@ public class FilePreference extends EditTextPreference {
 
     public String getFileType() {
         return fileType;
+    }
+
+    public String getErrorDialogTitle() {
+        return errorDialogTitle;
     }
 }

--- a/app/src/org/commcare/preferences/FilePreference.java
+++ b/app/src/org/commcare/preferences/FilePreference.java
@@ -1,6 +1,7 @@
 package org.commcare.preferences;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.support.v7.preference.EditTextPreference;
 import android.util.AttributeSet;
 
@@ -8,8 +9,23 @@ import org.commcare.dalvik.R;
 
 public class FilePreference extends EditTextPreference {
 
+    private String fileType;
+
     public FilePreference(Context context, AttributeSet attrs) {
         super(context, attrs);
+        setParams(context, attrs);
+    }
+
+    public void setParams(Context context, AttributeSet attrs) {
+        final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.FilePreference, 0, 0);
+        if (a.hasValue(R.styleable.FilePreference_file_type)) {
+            fileType = a.getString(R.styleable.FilePreference_file_type);
+        }
+        a.recycle();
         setDialogLayoutResource(R.layout.file_pref_dialog);
+    }
+
+    public String getFileType() {
+        return fileType;
     }
 }

--- a/app/src/org/commcare/preferences/FilePreference.java
+++ b/app/src/org/commcare/preferences/FilePreference.java
@@ -11,9 +11,6 @@ public class FilePreference extends EditTextPreference {
 
     private String fileType;
 
-    // Title for error dialog that displays in case of no file manager installed
-    private String errorDialogTitle;
-
     public FilePreference(Context context, AttributeSet attrs) {
         super(context, attrs);
         setParams(context, attrs);
@@ -23,7 +20,6 @@ public class FilePreference extends EditTextPreference {
         final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.FilePreference, 0, 0);
         if (a.hasValue(R.styleable.FilePreference_file_type)) {
             fileType = a.getString(R.styleable.FilePreference_file_type);
-            errorDialogTitle = a.getString(R.styleable.FilePreference_error_dialog_title);
         }
         a.recycle();
         setDialogLayoutResource(R.layout.file_pref_dialog);
@@ -31,9 +27,5 @@ public class FilePreference extends EditTextPreference {
 
     public String getFileType() {
         return fileType;
-    }
-
-    public String getErrorDialogTitle() {
-        return errorDialogTitle;
     }
 }

--- a/app/src/org/commcare/preferences/FilePreference.java
+++ b/app/src/org/commcare/preferences/FilePreference.java
@@ -1,0 +1,15 @@
+package org.commcare.preferences;
+
+import android.content.Context;
+import android.support.v7.preference.EditTextPreference;
+import android.util.AttributeSet;
+
+import org.commcare.dalvik.R;
+
+public class FilePreference extends EditTextPreference {
+
+    public FilePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setDialogLayoutResource(R.layout.file_pref_dialog);
+    }
+}

--- a/app/src/org/commcare/preferences/FilePreferenceDialogFragmentCompat.java
+++ b/app/src/org/commcare/preferences/FilePreferenceDialogFragmentCompat.java
@@ -1,0 +1,61 @@
+package org.commcare.preferences;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.v7.preference.EditTextPreferenceDialogFragmentCompat;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import org.commcare.CommCareApplication;
+import org.commcare.dalvik.R;
+import org.commcare.utils.UriToFilePath;
+
+import java.io.File;
+
+import static android.app.Activity.RESULT_OK;
+
+public class FilePreferenceDialogFragmentCompat extends EditTextPreferenceDialogFragmentCompat {
+
+    public static final int REQUEST_FILE = 1;
+    private EditText mEditText;
+
+    public static FilePreferenceDialogFragmentCompat newInstance(String key) {
+        final FilePreferenceDialogFragmentCompat fragment = new FilePreferenceDialogFragmentCompat();
+        final Bundle b = new Bundle(1);
+        b.putString(ARG_KEY, key);
+        fragment.setArguments(b);
+        return fragment;
+    }
+
+    @Override
+    protected void onBindDialogView(View view) {
+        super.onBindDialogView(view);
+        mEditText = (EditText)view.findViewById(android.R.id.edit);
+        view.findViewById(R.id.filefetch).setOnClickListener(v -> {
+            CommCarePreferences.startFileBrowser(FilePreferenceDialogFragmentCompat.this, REQUEST_FILE, "cannot.set.payload");
+        });
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        if (requestCode == REQUEST_FILE) {
+            if (resultCode == RESULT_OK && intent != null) {
+                Uri uri = intent.getData();
+                String filePath = UriToFilePath.getPathFromUri(CommCareApplication.instance(), uri);
+                if (filePath != null) {
+                    File f = new File(filePath);
+                    if (f != null && f.exists()) {
+                        mEditText.setText(filePath);
+                    } else {
+                        Toast.makeText(getActivity(), "File does not exit", Toast.LENGTH_SHORT).show();
+                    }
+                }
+            } else {
+                //No file selected
+                Toast.makeText(getActivity(), "No file selected...", Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+}

--- a/app/src/org/commcare/preferences/FilePreferenceDialogFragmentCompat.java
+++ b/app/src/org/commcare/preferences/FilePreferenceDialogFragmentCompat.java
@@ -3,6 +3,7 @@ package org.commcare.preferences;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v7.preference.EditTextPreference;
 import android.support.v7.preference.EditTextPreferenceDialogFragmentCompat;
 import android.view.View;
 import android.widget.EditText;
@@ -36,7 +37,9 @@ public class FilePreferenceDialogFragmentCompat extends EditTextPreferenceDialog
         super.onBindDialogView(view);
         mEditText = (EditText)view.findViewById(android.R.id.edit);
         view.findViewById(R.id.filefetch).setOnClickListener(v -> {
-            CommCarePreferences.startFileBrowser(FilePreferenceDialogFragmentCompat.this, REQUEST_FILE, "cannot.set.payload");
+            CommCarePreferences.startFileBrowser(FilePreferenceDialogFragmentCompat.this,
+                    REQUEST_FILE,
+                    ((FilePreference)getPreference()).getErrorDialogTitle());
         });
     }
 

--- a/app/src/org/commcare/preferences/FilePreferenceDialogFragmentCompat.java
+++ b/app/src/org/commcare/preferences/FilePreferenceDialogFragmentCompat.java
@@ -39,7 +39,7 @@ public class FilePreferenceDialogFragmentCompat extends EditTextPreferenceDialog
         view.findViewById(R.id.filefetch).setOnClickListener(v -> {
             CommCarePreferences.startFileBrowser(FilePreferenceDialogFragmentCompat.this,
                     REQUEST_FILE,
-                    ((FilePreference)getPreference()).getErrorDialogTitle());
+                    Localization.get("no.file.browser.title"));
         });
     }
 
@@ -49,23 +49,48 @@ public class FilePreferenceDialogFragmentCompat extends EditTextPreferenceDialog
             if (resultCode == RESULT_OK && intent != null) {
                 Uri uri = intent.getData();
                 String filePath = UriToFilePath.getPathFromUri(CommCareApplication.instance(), uri);
-                String fileType = ((FilePreference)getPreference()).getFileType();
-                if (filePath != null) {
-                    if (fileType == null || FilenameUtils.getExtension(filePath).contentEquals(fileType)) {
-                        File f = new File(filePath);
-                        if (f.exists()) {
-                            mEditText.setText(filePath);
-                        } else {
-                            Toast.makeText(getActivity(), Localization.get("file.not.exist"), Toast.LENGTH_LONG).show();
-                        }
-                    } else {
-                        Toast.makeText(getActivity(), Localization.get("file.wrong.type", fileType), Toast.LENGTH_LONG).show();
-                    }
-                }
+                validateFile(filePath);
             } else {
                 //No file selected
                 Toast.makeText(getActivity(), Localization.get("file.not.selected"), Toast.LENGTH_LONG).show();
             }
         }
+    }
+
+    @Override
+    public void onDialogClosed(boolean positiveResult) {
+        if (positiveResult && validateFile(mEditText.getText().toString())) {
+            super.onDialogClosed(positiveResult);
+        }
+    }
+
+    /**
+     * Checks whether a file with given filepath is a valid file
+     *
+     * @param filePath filepath of file that needs to be validated
+     * @return true if filepath represents a valid file or if filepath is empty, false otherwise.
+     */
+    private boolean validateFile(String filePath) {
+        String fileType = ((FilePreference)getPreference()).getFileType();
+        if (filePath != null && !filePath.isEmpty()) {
+            if (fileType == null || FilenameUtils.getExtension(filePath).contentEquals(fileType)) {
+                File f = new File(filePath);
+                if (f.exists()) {
+                    if (!mEditText.getText().toString().contentEquals(filePath)) {
+                        mEditText.setText(filePath);
+                    }
+                    return true;
+                } else {
+                    Toast.makeText(getActivity(), Localization.get("file.not.exist"), Toast.LENGTH_LONG).show();
+                }
+            } else {
+                Toast.makeText(getActivity(), Localization.get("file.wrong.type", fileType), Toast.LENGTH_LONG).show();
+            }
+        } else {
+            Toast.makeText(getActivity(), Localization.get("file.not.selected"), Toast.LENGTH_LONG).show();
+            // We still want to reset the preference to empty file path
+            return true;
+        }
+        return false;
     }
 }

--- a/app/src/org/commcare/preferences/FilePreferenceDialogFragmentCompat.java
+++ b/app/src/org/commcare/preferences/FilePreferenceDialogFragmentCompat.java
@@ -8,9 +8,11 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.Toast;
 
+import org.apache.commons.io.FilenameUtils;
 import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
 import org.commcare.utils.UriToFilePath;
+import org.javarosa.core.services.locale.Localization;
 
 import java.io.File;
 
@@ -44,17 +46,22 @@ public class FilePreferenceDialogFragmentCompat extends EditTextPreferenceDialog
             if (resultCode == RESULT_OK && intent != null) {
                 Uri uri = intent.getData();
                 String filePath = UriToFilePath.getPathFromUri(CommCareApplication.instance(), uri);
+                String fileType = ((FilePreference)getPreference()).getFileType();
                 if (filePath != null) {
-                    File f = new File(filePath);
-                    if (f != null && f.exists()) {
-                        mEditText.setText(filePath);
+                    if (fileType == null || FilenameUtils.getExtension(filePath).contentEquals(fileType)) {
+                        File f = new File(filePath);
+                        if (f.exists()) {
+                            mEditText.setText(filePath);
+                        } else {
+                            Toast.makeText(getActivity(), Localization.get("file.not.exist"), Toast.LENGTH_LONG).show();
+                        }
                     } else {
-                        Toast.makeText(getActivity(), "File does not exit", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(getActivity(), Localization.get("file.wrong.type", fileType), Toast.LENGTH_LONG).show();
                     }
                 }
             } else {
                 //No file selected
-                Toast.makeText(getActivity(), "No file selected...", Toast.LENGTH_SHORT).show();
+                Toast.makeText(getActivity(), Localization.get("file.not.selected"), Toast.LENGTH_LONG).show();
             }
         }
     }


### PR DESCRIPTION
- Adds a feature to load forms from a local xml file containing Form Payload. Similar to https://github.com/dimagi/commcare-android/pull/1102/files which is loading forms from a server url.  Sample Payload file - https://gist.github.com/shubham1g5/f22cfd99decc68067190d37a63e0de6b

- No longer removing submission url on saving form payload status from Dev Preferences to allow for sync after we change the payload status

- Adds a custom preference FilePreference to have the ability to trigger file manager along with the file path editText