### PR TITLE
Prevent deleting unsent forms

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -175,6 +175,7 @@ app.workflow.incomplete.heading=Incomplete Forms
 app.workflow.saved.heading=Saved Forms
 app.workflow.forms.open=Open
 app.workflow.forms.delete=Delete Record
+app.workflow.forms.quarantine=QUARANTINE FORM
 app.workflow.forms.fetch=Fetch Forms from Server
 app.workflow.forms.restore=Add Record Back to Unsent Queue
 app.workflow.forms.scan=Scan Record Integrity

--- a/app/res/layout/custom_alert_dialog.xml
+++ b/app/res/layout/custom_alert_dialog.xml
@@ -83,7 +83,7 @@
 
                     android:layout_toLeftOf="@id/neutral_button"
 
-                    android:layout_marginRight="@dimen/standard_spacer"
+                    android:layout_marginRight="@dimen/standard_spacer_double"
                     android:layout_marginLeft="@dimen/standard_spacer"
 
                     android:background="@android:color/transparent"

--- a/app/res/layout/custom_alert_dialog.xml
+++ b/app/res/layout/custom_alert_dialog.xml
@@ -83,7 +83,7 @@
 
                     android:layout_toLeftOf="@id/neutral_button"
 
-                    android:layout_marginRight="@dimen/standard_spacer_double"
+                    android:layout_marginRight="@dimen/standard_spacer"
                     android:layout_marginLeft="@dimen/standard_spacer"
 
                     android:background="@android:color/transparent"

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -455,17 +455,25 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         StandardAlertDialog dialog = StandardAlertDialog.getBasicAlertDialogWithIcon(this, title,
                 result.second, resId, null);
 
-        if (FormRecord.STATUS_UNSENT.equals(record.getStatus())) {
-            dialog.setNegativeButton(Localization.get("app.workflow.forms.delete"), new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    FormRecordListActivity.this.formRecordProcessor.updateRecordStatus(
-                            record, FormRecord.STATUS_QUARANTINED);
-                }
-            });
-        }
+        dialog.setNegativeButton(Localization.get("app.workflow.forms.quarantine"), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                quarantineRecord(record);
+                dismissAlertDialog();
+            }
+        });
 
         showAlertDialog(dialog);
+    }
+
+    private void quarantineRecord(FormRecord record) {
+        this.formRecordProcessor.updateRecordStatus(record, FormRecord.STATUS_QUARANTINED);
+        listView.post(new Runnable() {
+            @Override
+            public void run() {
+                adapter.notifyDataSetInvalidated();
+            }
+        });
     }
 
     /**

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -474,6 +474,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
                 adapter.notifyDataSetInvalidated();
             }
         });
+        record.logManualQuarantine();
     }
 
     /**

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -228,4 +228,12 @@ public class FormRecord extends Persisted implements EncryptedModel {
         Logger.log(AndroidLogger.TYPE_FORM_DELETION, logMessage);
     }
 
+    public void logManualQuarantine() {
+        String logMessage = String.format(
+                "User manually quarantined form record with id %s and submission ordering number %s ",
+                getInstanceID(),
+                getSubmissionOrderingNumber());
+        Logger.log(AndroidLogger.TYPE_FORM_DELETION, logMessage);
+    }
+
 }

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -61,7 +61,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
      * This form was complete, but something blocked it from processing and it's in a damaged
      * state (a.k.a. "quarantined")
      */
-    public static final String STATUS_LIMBO = "limbo";
+    public static final String STATUS_QUARANTINED = "limbo";
 
     /**
      * This form has been downloaded, but not processed for metadata

--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -314,7 +314,8 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                             //We tried to submit multiple times and there was a local problem (not a remote problem).
                             //This implies that something is wrong with the current record, and we need to quarantine it.
                             processor.updateRecordStatus(record, FormRecord.STATUS_QUARANTINED);
-                            Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Quarantined Form Record");
+                            Logger.log(AndroidLogger.TYPE_ERROR_STORAGE,
+                                    "Quarantined Form Record due to local problem with record");
                             CommCareApplication.notificationManager().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.RecordQuarantined), true);
                         }
                     } catch (FileNotFoundException e) {

--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -313,7 +313,7 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                         if (results[i] == FormUploadResult.RECORD_FAILURE) {
                             //We tried to submit multiple times and there was a local problem (not a remote problem).
                             //This implies that something is wrong with the current record, and we need to quarantine it.
-                            processor.updateRecordStatus(record, FormRecord.STATUS_LIMBO);
+                            processor.updateRecordStatus(record, FormRecord.STATUS_QUARANTINED);
                             Logger.log(AndroidLogger.TYPE_ERROR_STORAGE, "Quarantined Form Record");
                             CommCareApplication.notificationManager().reportNotificationMessage(NotificationMessageFactory.message(ProcessIssues.RecordQuarantined), true);
                         }

--- a/app/src/org/commcare/utils/StorageUtils.java
+++ b/app/src/org/commcare/utils/StorageUtils.java
@@ -8,7 +8,6 @@ import org.commcare.android.database.user.models.FormRecord;
 
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Vector;
 
 /**
@@ -57,7 +56,7 @@ public class StorageUtils {
     }
 
     public static int getNumQuarantinedForms() {
-        return getNumFormsWithStatus(FormRecord.STATUS_LIMBO);
+        return getNumFormsWithStatus(FormRecord.STATUS_QUARANTINED);
     }
 
     public static int getNumUnsentForms() {


### PR DESCRIPTION
This PR makes the following changes to prevent users from deleting unsent form records:

- The option to delete a form record on long-click doesn't appear for unsent forms:
![screenshot](https://user-images.githubusercontent.com/3723143/28933500-434c362e-784b-11e7-868b-41e7fb58992f.png)

- In place of the delete option, an option to quarantine a form has been added to the end of the record integrity scan result dialog:
![screenshot_20170803-125311](https://user-images.githubusercontent.com/3723143/28933396-ea5ae010-784a-11e7-9ed1-8763250ae7bb.png)

@ctsims As it turns out, the ability to move a quarantined form back into the unsent queue already exists:
![screenshot_20170803-125557](https://user-images.githubusercontent.com/3723143/28933452-1dd0bad2-784b-11e7-9717-ade0f1d3bf65.png)