### PR TITLE
2.36.3 - Re-add the logic to hide 'Report Problem'

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -130,5 +130,10 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-enable-bulk-performance"
         android:title="Enable cutting-edge performance improvements"/>
-
+    <ListPreference
+        android:enabled="true"
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
+        android:key="cc-hide-issue-report"
+        android:title="Hide the 'Report an Issue' Menu Option"/>
 </PreferenceScreen>

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -131,6 +131,7 @@
         android:key="cc-enable-bulk-performance"
         android:title="Enable cutting-edge performance improvements"/>
     <ListPreference
+        android:defaultValue="no"
         android:enabled="true"
         android:entries="@array/pref_enabled_labels"
         android:entryValues="@array/pref_enabled_vals"

--- a/app/src/org/commcare/activities/AdvancedActionsActivity.java
+++ b/app/src/org/commcare/activities/AdvancedActionsActivity.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
+import android.preference.PreferenceScreen;
 import android.view.MenuItem;
 
 import org.commcare.AppUtils;
@@ -17,6 +18,7 @@ import org.commcare.google.services.analytics.GoogleAnalyticsFields;
 import org.commcare.google.services.analytics.GoogleAnalyticsUtils;
 import org.commcare.preferences.CommCarePreferences;
 import org.commcare.preferences.DevSessionRestorer;
+import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.tasks.DumpTask;
 import org.commcare.tasks.SendTask;
 import org.commcare.tasks.WipeTask;
@@ -88,6 +90,7 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
 
         CommCarePreferences.setupLocalizedText(this, keyToTitleMap);
         setupButtons();
+        hideReportIssueIfNeeded();
     }
 
     private void setupButtons() {
@@ -189,6 +192,13 @@ public class AdvancedActionsActivity extends SessionAwarePreferenceActivity {
                 return true;
             }
         });
+    }
+
+    private void hideReportIssueIfNeeded() {
+        Preference reportProblemPref = getPreferenceManager().findPreference(REPORT_PROBLEM);
+        if (reportProblemPref != null && DeveloperPreferences.shouldHideReportIssue()) {
+            getPreferenceScreen().removePreference(reportProblemPref);
+        }
     }
 
     private void startReportActivity() {

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -56,6 +56,8 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static final String USE_OBFUSCATED_PW = "cc-use-pw-obfuscation";
     public static final String ENABLE_BULK_PERFORMANCE = "cc-enable-bulk-performance";
     public static final String SHOW_UPDATE_OPTIONS_SETTING = "cc-show-update-target-options";
+    public final static String HIDE_ISSUE_REPORT = "cc-hide-issue-report";
+
     /**
      * Stores last used password and performs auto-login when that password is
      * present
@@ -391,6 +393,10 @@ public class DeveloperPreferences extends SessionAwarePreferenceActivity
     public static boolean shouldShowUpdateOptionsSetting() {
         return doesPropertyMatch(SHOW_UPDATE_OPTIONS_SETTING, CommCarePreferences.NO,
                 CommCarePreferences.YES) || BuildConfig.DEBUG;
+    }
+
+    public static boolean shouldHideReportIssue() {
+        return doesPropertyMatch(HIDE_ISSUE_REPORT, CommCarePreferences.NO, CommCarePreferences.YES);
     }
 
     private void hideOrShowDangerousSettings() {


### PR DESCRIPTION
(I'm only adding this cross request comment so that the PR builder will run with a version of CC that is compatible; the code in these 2 PRs is technically totally independent)

cross-request: https://github.com/dimagi/commcare-core/pull/633
