### PR TITLE
remove unhelpful log statement

### DIFF
--- a/app/src/org/commcare/tasks/PurgeStaleArchivedFormsTask.java
+++ b/app/src/org/commcare/tasks/PurgeStaleArchivedFormsTask.java
@@ -84,10 +84,6 @@ public class PurgeStaleArchivedFormsTask
         Vector<Integer> toPurge = getSavedFormsToPurge(lastValidDate);
 
         for (int recordId : toPurge) {
-            FormRecord beingDeleted =
-                    CommCareApplication.instance().getUserStorage(FormRecord.class).read(recordId);
-            beingDeleted.logPendingDeletion(TAG,
-                    "it is a saved form that has surpassed the validity date set by the app");
             FormRecordCleanupTask.wipeRecord(CommCareApplication.instance(), recordId);
         }
     }


### PR DESCRIPTION
Remove this particular `form-deletion` log because it only ever applies to Saved Forms, which are not relevant to the debugging that this log category is being used for, and it is by far the most common instance of this log type, so it creates a lot of clutter when I'm trying to look for real issues.