### PR TITLE
Purge Runtime Optimizations

### DIFF
--- a/app/src/org/commcare/engine/cases/AndroidLedgerInstanceTreeElement.java
+++ b/app/src/org/commcare/engine/cases/AndroidLedgerInstanceTreeElement.java
@@ -63,7 +63,7 @@ public class AndroidLedgerInstanceTreeElement extends LedgerInstanceTreeElement 
             int id = i.peekID();
             elements.addElement(buildElement(this, id, null, mult));
             objectIdMapping.put(DataUtil.integer(id), DataUtil.integer(mult));
-            primaryIdMapping.put(((SqlStorageIterator)i).getIncludedMetadata(Ledger.INDEX_ENTITY_ID), DataUtil.integer(id));
+            primaryIdMapping.put(((SqlStorageIterator)i).peekIncludedMetadata(Ledger.INDEX_ENTITY_ID), DataUtil.integer(id));
             mult++;
             i.nextID();
         }

--- a/app/src/org/commcare/engine/cases/AndroidLedgerInstanceTreeElement.java
+++ b/app/src/org/commcare/engine/cases/AndroidLedgerInstanceTreeElement.java
@@ -59,11 +59,11 @@ public class AndroidLedgerInstanceTreeElement extends LedgerInstanceTreeElement 
         elements = new Vector<>();
         primaryIdMapping = new Hashtable<>();
         int mult = 0;
-        for (IStorageIterator i = ((SqlStorage<ACase>)getStorage()).iterate(false, Ledger.INDEX_ENTITY_ID); i.hasMore(); ) {
+        for (IStorageIterator i = ((SqlStorage<ACase>)getStorage()).iterate(false, new String[]{Ledger.INDEX_ENTITY_ID}); i.hasMore(); ) {
             int id = i.peekID();
             elements.addElement(buildElement(this, id, null, mult));
             objectIdMapping.put(DataUtil.integer(id), DataUtil.integer(mult));
-            primaryIdMapping.put(((SqlStorageIterator)i).getPrimaryId(), DataUtil.integer(id));
+            primaryIdMapping.put(((SqlStorageIterator)i).getIncludedMetadata(Ledger.INDEX_ENTITY_ID), DataUtil.integer(id));
             mult++;
             i.nextID();
         }

--- a/app/src/org/commcare/engine/cases/CaseUtils.java
+++ b/app/src/org/commcare/engine/cases/CaseUtils.java
@@ -143,7 +143,7 @@ public class CaseUtils {
 
             Vector<Pair<String, String>> indices = caseIndexMap.get(caseRecordId);
 
-            if(indices != null) {
+            if (indices != null) {
                 // In order to deal with multiple indices pointing to the same case with different
                 // relationships, we'll need to traverse once to eliminate any ambiguity
                 for (Pair<String, String> index : indices) {

--- a/app/src/org/commcare/models/database/HybridFileBackedSqlStorage.java
+++ b/app/src/org/commcare/models/database/HybridFileBackedSqlStorage.java
@@ -571,7 +571,7 @@ public class HybridFileBackedSqlStorage<T extends Persistable> extends SqlStorag
     }
 
     @Override
-    public SqlStorageIterator<T> iterate(boolean includeData, String primaryId) {
+    public SqlStorageIterator<T> iterate(boolean includeData, String[] metadataKeys) {
         throw new UnsupportedOperationException("iterate method unsupported");
     }
 

--- a/app/src/org/commcare/models/database/HybridFileBackedStorageIterator.java
+++ b/app/src/org/commcare/models/database/HybridFileBackedStorageIterator.java
@@ -24,7 +24,7 @@ public class HybridFileBackedStorageIterator<T extends Persistable>
      */
     public HybridFileBackedStorageIterator(Cursor c,
                                            HybridFileBackedSqlStorage<T> storage) {
-        super(c, storage, null);
+        super(c, storage);
     }
 
     @Override

--- a/app/src/org/commcare/models/database/IndexSpanningIterator.java
+++ b/app/src/org/commcare/models/database/IndexSpanningIterator.java
@@ -192,9 +192,4 @@ public class IndexSpanningIterator<T extends Persistable> extends SqlStorageIter
     public int peekID() {
         return current;
     }
-
-    @Override
-    public String getPrimaryId() {
-        throw new RuntimeException("Primary ID Not requested by this iterator");
-    }
 }

--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -394,11 +394,11 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         int firstIndex = 0;
         projection[firstIndex] = DatabaseHelper.ID_COL;
         firstIndex++;
-        if(includeData) {
+        if (includeData) {
             projection[firstIndex] = DatabaseHelper.DATA_COL;
             firstIndex++;
         }
-        for(int i = 0; i < metaDataToInclude.length ; ++i) {
+        for (int i = 0; i < metaDataToInclude.length ; ++i) {
             projection[i + firstIndex] = TableBuilder.scrubName(metaDataToInclude[i]);
         }
 

--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -19,6 +19,7 @@ import org.javarosa.core.services.storage.EntityFilter;
 import org.javarosa.core.services.storage.IStorageIterator;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.services.storage.Persistable;
+import org.javarosa.core.util.ArrayUtilities;
 import org.javarosa.core.util.InvalidIndexException;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.Externalizable;
@@ -385,12 +386,24 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
      * have a method to query for all metadata?
      *
      * @param includeData True to return an iterator with all records. False to return only the index.
-     * @param primaryId   a metadata index that
+     * @param metaDataToInclude A set of metadata keys that should be included in the request,
+     *                          independently of any other data.
      */
-    public SqlStorageIterator<T> iterate(boolean includeData, String primaryId) {
-        String[] projection = includeData ? new String[]{DatabaseHelper.ID_COL, DatabaseHelper.DATA_COL, TableBuilder.scrubName(primaryId)} : new String[]{DatabaseHelper.ID_COL, TableBuilder.scrubName(primaryId)};
+    public SqlStorageIterator<T> iterate(boolean includeData, String[] metaDataToInclude) {
+        String[] projection = new String[metaDataToInclude.length + (includeData ? 2 : 1)];
+        int firstIndex = 0;
+        projection[firstIndex] = DatabaseHelper.ID_COL;
+        firstIndex++;
+        if(includeData) {
+            projection[firstIndex] = DatabaseHelper.DATA_COL;
+            firstIndex++;
+        }
+        for(int i = 0; i < metaDataToInclude.length ; ++i) {
+            projection[i + firstIndex] = TableBuilder.scrubName(metaDataToInclude[i]);
+        }
+
         Cursor c = helper.getHandle().query(table, projection, null, null, null, null, DatabaseHelper.ID_COL);
-        return new SqlStorageIterator<>(c, this, TableBuilder.scrubName(primaryId));
+        return new SqlStorageIterator<>(c, this, metaDataToInclude);
     }
 
     @Override
@@ -463,6 +476,27 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         }
     }
 
+    public Vector<Integer> removeAll(Vector<Integer> toRemove) {
+        if (toRemove.size() == 0) {
+            return toRemove;
+        }
+
+        List<Pair<String, String[]>> whereParamList = TableBuilder.sqlList(toRemove);
+
+        SQLiteDatabase db = helper.getHandle();
+        db.beginTransaction();
+        try {
+            for (Pair<String, String[]> whereParams : whereParamList) {
+                db.delete(table, DatabaseHelper.ID_COL + " IN " + whereParams.first, whereParams.second);
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+
+        return toRemove;
+    }
+
     @Override
     public Vector<Integer> removeAll(EntityFilter ef) {
         Vector<Integer> removed = new Vector<>();
@@ -480,25 +514,7 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
                     }
             }
         }
-
-        if (removed.size() == 0) {
-            return removed;
-        }
-
-        List<Pair<String, String[]>> whereParamList = TableBuilder.sqlList(removed);
-
-        SQLiteDatabase db = helper.getHandle();
-        db.beginTransaction();
-        try {
-            for (Pair<String, String[]> whereParams : whereParamList) {
-                db.delete(table, DatabaseHelper.ID_COL + " IN " + whereParams.first, whereParams.second);
-            }
-            db.setTransactionSuccessful();
-        } finally {
-            db.endTransaction();
-        }
-
-        return removed;
+        return removeAll(removed);
     }
 
     @Override

--- a/app/src/org/commcare/models/database/SqlStorageIterator.java
+++ b/app/src/org/commcare/models/database/SqlStorageIterator.java
@@ -34,7 +34,8 @@ public class SqlStorageIterator<T extends Persistable> implements IStorageIterat
         this.c = cursor;
         storage = null;
 
-        //This will result in the right exception being thrown if metadata is missing
+        //Since metadata requests fail if the key is missing, a blank set should be sufficient
+        //and not require subclasses to re-implement the peek method as not-implemented
         metaDataIndexSet = new HashSet<>();
         count = -1;
     }
@@ -124,6 +125,14 @@ public class SqlStorageIterator<T extends Persistable> implements IStorageIterat
 
     private HashMap<String, Integer> metaDataColumnMap = new HashMap<>();
 
+    /**
+     * Retrieves the indexed metadata for the current record _without_ advancing 
+     * the iterator, so this needs to be called _before_ next() or nextId()
+     *
+     * @param metadataKey The metadata key for this Serializable record. Would be
+     *                    the same key used with T.getMetaData()
+     * @throws RuntimeException If this iterator was not intialized with metadata
+     */
     public String peekIncludedMetadata(String metadataKey) {
         if (!metaDataIndexSet.contains(metadataKey)) {
             throw new RuntimeException("Invalid iterator metadata request for key: " + metadataKey);

--- a/app/src/org/commcare/models/database/SqlStorageIterator.java
+++ b/app/src/org/commcare/models/database/SqlStorageIterator.java
@@ -125,11 +125,11 @@ public class SqlStorageIterator<T extends Persistable> implements IStorageIterat
     private HashMap<String, Integer> metaDataColumnMap = new HashMap<>();
 
     public String peekIncludedMetadata(String metadataKey) {
-        if(!metaDataIndexSet.contains(metadataKey)) {
+        if (!metaDataIndexSet.contains(metadataKey)) {
             throw new RuntimeException("Invalid iterator metadata request for key: " + metadataKey);
         }
         int columnIndex;
-        if(metaDataColumnMap.containsKey(metadataKey)) {
+        if (metaDataColumnMap.containsKey(metadataKey)) {
             columnIndex = metaDataColumnMap.get(metadataKey);
         } else {
             String columnName = TableBuilder.scrubName(metadataKey);

--- a/app/src/org/commcare/models/database/SqlStorageIterator.java
+++ b/app/src/org/commcare/models/database/SqlStorageIterator.java
@@ -10,6 +10,7 @@ import org.javarosa.core.services.storage.Persistable;
 import org.javarosa.core.services.storage.StorageModifiedException;
 import org.javarosa.core.util.ArrayUtilities;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -121,11 +122,20 @@ public class SqlStorageIterator<T extends Persistable> implements IStorageIterat
         return c.getInt(c.getColumnIndexOrThrow(DatabaseHelper.ID_COL));
     }
 
-    public String getIncludedMetadata(String metadataKey) {
+    private HashMap<String, Integer> metaDataColumnMap = new HashMap<>();
+
+    public String peekIncludedMetadata(String metadataKey) {
         if(!metaDataIndexSet.contains(metadataKey)) {
             throw new RuntimeException("Invalid iterator metadata request for key: " + metadataKey);
         }
-        String columnName = TableBuilder.scrubName(metadataKey);
-        return c.getString(c.getColumnIndexOrThrow(columnName));
+        int columnIndex;
+        if(metaDataColumnMap.containsKey(metadataKey)) {
+            columnIndex = metaDataColumnMap.get(metadataKey);
+        } else {
+            String columnName = TableBuilder.scrubName(metadataKey);
+            columnIndex = c.getColumnIndexOrThrow(columnName);
+            metaDataColumnMap.put(metadataKey, columnIndex);
+        }
+        return c.getString(columnIndex);
     }
 }

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -57,9 +57,10 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
      * V.18 - Add index on @owner_id for cases
      * V.19 - Rebuild case index table due to the possibility of previous 412 indexing issues
      * V.20 - Migrate index names on indexed fixtures so that multiple fixtures are able to have an index on the same column name
+     * V.21 - Reindex all cases to add relationship
      */
 
-    private static final int USER_DB_VERSION = 20;
+    private static final int USER_DB_VERSION = 21;
 
     private static final String USER_DB_LOCATOR = "database_sandbox_";
 

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -160,6 +160,11 @@ class UserDatabaseUpgrader {
                 oldVersion = 20;
             }
         }
+        if (oldVersion == 20) {
+            if (upgradeTwentyTwentyOne(db)) {
+                oldVersion = 21;
+            }
+        }
     }
 
     private boolean upgradeOneTwo(final SQLiteDatabase db) {
@@ -557,6 +562,30 @@ class UserDatabaseUpgrader {
             db.endTransaction();
         }
     }
+
+
+    private boolean upgradeTwentyTwentyOne(SQLiteDatabase db) {
+        db.beginTransaction();
+        try {
+            SqlStorage<ACase> caseStorage = new SqlStorage<>(ACase.STORAGE_KEY, ACase.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            db.execSQL(DbUtil.addColumnToTable(
+                    AndroidCaseIndexTable.TABLE_NAME,
+                    "relationship",
+                    "TEXT"));
+
+
+            AndroidCaseIndexTable indexTable = new AndroidCaseIndexTable(db);
+            indexTable.reIndexAllCases(caseStorage);
+            db.setTransactionSuccessful();
+            return true;
+        } finally {
+            db.endTransaction();
+        }
+
+    }
+
 
     private void migrateV2FormRecordsForSingleApp(String appId,
                                                   SqlStorage<FormRecordV2> oldStorage,

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
@@ -28,12 +28,13 @@ import java.util.Vector;
  * @author ctsims
  */
 public class AndroidCaseIndexTable implements CaseIndexTable {
-    private static final String TABLE_NAME = "case_index_storage";
+    public static final String TABLE_NAME = "case_index_storage";
 
     private static final String COL_CASE_RECORD_ID = "case_rec_id";
     private static final String COL_INDEX_NAME = "name";
     private static final String COL_INDEX_TYPE = "type";
     private static final String COL_INDEX_TARGET = "target";
+    private static final String COL_INDEX_RELATIONSHIP = "relationship";
 
     private final SQLiteDatabase db;
 
@@ -54,6 +55,7 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
                 COL_CASE_RECORD_ID + ", " +
                 COL_INDEX_NAME + ", " +
                 COL_INDEX_TYPE + ", " +
+                COL_INDEX_RELATIONSHIP + ", " +
                 COL_INDEX_TARGET +
                 ")";
     }
@@ -81,6 +83,7 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
                 cv.put(COL_INDEX_NAME, ci.getName());
                 cv.put(COL_INDEX_TYPE, ci.getTargetType());
                 cv.put(COL_INDEX_TARGET, ci.getTarget());
+                cv.put(COL_INDEX_RELATIONSHIP, ci.getRelationship());
                 db.insert(TABLE_NAME, null, cv);
             }
             db.setTransactionSuccessful();
@@ -88,6 +91,69 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
             db.endTransaction();
         }
     }
+
+    public Vector<CaseIndex> getIndicesForCase(int recordId) {
+        Vector<CaseIndex> indices = new Vector<>();
+
+        String[] projection = new String[] {COL_CASE_RECORD_ID, COL_INDEX_NAME, COL_INDEX_TYPE, COL_INDEX_TARGET, COL_INDEX_RELATIONSHIP};
+
+        if (SqlStorage.STORAGE_OUTPUT_DEBUG) {
+            String sqlStatement = String.format("SELECT %s, %s, %s, %s, %s FROM %s WHERE %s = %d",
+                    COL_CASE_RECORD_ID, COL_INDEX_NAME, COL_INDEX_TYPE, COL_INDEX_TARGET, COL_INDEX_RELATIONSHIP, TABLE_NAME, COL_CASE_RECORD_ID, recordId);
+            DbUtil.explainSql(db, sqlStatement, null);
+        }
+
+        //NOTE: This does terrible things to SQL's cache (not using parameters), but it's the only
+        //way to actually make the indexes seek properly
+        Cursor c = db.query(TABLE_NAME, projection, String.format("%s = %d", COL_CASE_RECORD_ID, recordId) ,null, null, null, null);
+        try {
+            c.moveToFirst();
+            while (!c.isAfterLast()) {
+                indices.add(new CaseIndex(c.getString(c.getColumnIndexOrThrow(COL_INDEX_NAME)),
+                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_TYPE)),
+                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_TARGET)),
+                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_RELATIONSHIP))));
+                c.moveToNext();
+            }
+            return indices;
+        } finally {
+            c.close();
+        }
+
+    }
+
+    public HashMap<Integer,Vector<CaseIndex>> getCaseIndexMap() {
+        String[] projection = new String[] {COL_CASE_RECORD_ID, COL_INDEX_NAME, COL_INDEX_TYPE, COL_INDEX_TARGET, COL_INDEX_RELATIONSHIP};
+        HashMap<Integer,Vector<CaseIndex>> caseIndexMap = new HashMap<>();
+        Cursor c = db.query(TABLE_NAME, projection, null ,null, null, null, null);
+
+        try {
+            c.moveToFirst();
+            while (!c.isAfterLast()) {
+                int caseRecordId = c.getInt(c.getColumnIndexOrThrow(COL_CASE_RECORD_ID));
+
+                CaseIndex index  = new CaseIndex(c.getString(c.getColumnIndexOrThrow(COL_INDEX_NAME)),
+                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_TYPE)),
+                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_TARGET)),
+                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_RELATIONSHIP)));
+                c.moveToNext();
+
+                Vector<CaseIndex> indexList;
+                if(!caseIndexMap.containsKey(caseRecordId)) {
+                    indexList = new Vector<>();
+                } else {
+                    indexList = caseIndexMap.get(caseRecordId);
+                }
+                indexList.add(index);
+                caseIndexMap.put(caseRecordId, indexList);
+            }
+
+            return caseIndexMap;
+        } finally {
+            c.close();
+        }
+    }
+
 
     public void clearCaseIndices(Case c) {
         clearCaseIndices(c.getID());
@@ -236,6 +302,8 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
         DualTableSingleMatchModelQuerySet set = new DualTableSingleMatchModelQuerySet();
         String caseIdIndex = TableBuilder.scrubName(Case.INDEX_CASE_ID);
 
+        //NOTE: This is possibly slower than it appears. I think the cast screws up sqlites's
+        //ability to do an indexed match
         List<Pair<String, String[]>> whereParamList = TableBuilder.sqlList(cuedCases, "CAST(? as INT)");
         for(Pair<String, String[]> querySet : whereParamList) {
 
@@ -303,5 +371,4 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
             db.endTransaction();
         }
     }
-
 }

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
@@ -143,7 +143,7 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
                 Pair<String, String> index  = new Pair<> (targetCase, relationship);
 
                 Vector<Pair<String, String>> indexList;
-                if(!caseIndexMap.containsKey(caseRecordId)) {
+                if (!caseIndexMap.containsKey(caseRecordId)) {
                     indexList = new Vector<>();
                 } else {
                     indexList = caseIndexMap.get(caseRecordId);
@@ -276,7 +276,7 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
 
                     String cacheID = indexName + "|" + target;
                     Vector<Integer> cache;
-                    if(indexCache.containsKey(cacheID)){
+                    if (indexCache.containsKey(cacheID)){
                         cache = indexCache.get(cacheID);
                     } else {
                         cache = new Vector<>();
@@ -309,7 +309,7 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
         //NOTE: This is possibly slower than it appears. I think the cast screws up sqlites's
         //ability to do an indexed match
         List<Pair<String, String[]>> whereParamList = TableBuilder.sqlList(cuedCases, "CAST(? as INT)");
-        for(Pair<String, String[]> querySet : whereParamList) {
+        for (Pair<String, String[]> querySet : whereParamList) {
 
             String query =String.format(
                     "SELECT %s,%s " +
@@ -367,7 +367,7 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
         db.beginTransaction();
         try {
             wipeTable();
-            for(ACase c : caseStorage) {
+            for (ACase c : caseStorage) {
                 indexCase(c);
             }
             db.setTransactionSuccessful();

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
@@ -122,23 +122,27 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
 
     }
 
-    public HashMap<Integer,Vector<CaseIndex>> getCaseIndexMap() {
-        String[] projection = new String[] {COL_CASE_RECORD_ID, COL_INDEX_NAME, COL_INDEX_TYPE, COL_INDEX_TARGET, COL_INDEX_RELATIONSHIP};
-        HashMap<Integer,Vector<CaseIndex>> caseIndexMap = new HashMap<>();
+    public HashMap<Integer,Vector<Pair<String, String>>> getCaseIndexMap() {
+        String[] projection = new String[] {COL_CASE_RECORD_ID, COL_INDEX_TARGET, COL_INDEX_RELATIONSHIP};
+        HashMap<Integer,Vector<Pair<String, String>>> caseIndexMap = new HashMap<>();
         Cursor c = db.query(TABLE_NAME, projection, null ,null, null, null, null);
+
+        int recordColumn = c.getColumnIndexOrThrow(COL_CASE_RECORD_ID);
+        int targetColumn = c.getColumnIndexOrThrow(COL_INDEX_TARGET);
+        int relationshipColumn = c.getColumnIndexOrThrow(COL_INDEX_RELATIONSHIP);
 
         try {
             c.moveToFirst();
             while (!c.isAfterLast()) {
-                int caseRecordId = c.getInt(c.getColumnIndexOrThrow(COL_CASE_RECORD_ID));
+                int caseRecordId = c.getInt(recordColumn);
+                String targetCase = c.getString(targetColumn);
+                String relationship = c.getString(relationshipColumn);
 
-                CaseIndex index  = new CaseIndex(c.getString(c.getColumnIndexOrThrow(COL_INDEX_NAME)),
-                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_TYPE)),
-                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_TARGET)),
-                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_RELATIONSHIP)));
                 c.moveToNext();
 
-                Vector<CaseIndex> indexList;
+                Pair<String, String> index  = new Pair<> (targetCase, relationship);
+
+                Vector<Pair<String, String>> indexList;
                 if(!caseIndexMap.containsKey(caseRecordId)) {
                     indexList = new Vector<>();
                 } else {


### PR DESCRIPTION
Running a "Case Purge" with large databases was/is quite time consuming. This PR introduces some optimizations to improve the process

Current Performance Improvement on my phone is 8->10 seconds to 1.5-1.75 seconds

* Introduces the idea of metadata iteration for sqlstorage. 
* Add relationship to caseindex table, which can now provide all information about indexes that the casedb can. 
* Refactor purge to optimize for db read structure

cross-request: https://github.com/dimagi/commcare-core/pull/635