### PR TITLE
Fix for non-positive period (again)

### DIFF
--- a/app/src/org/commcare/tasks/AsyncRestoreHelper.java
+++ b/app/src/org/commcare/tasks/AsyncRestoreHelper.java
@@ -106,6 +106,9 @@ public class AsyncRestoreHelper {
         }
         long intervalAllottedPerProgressUnit =
                 millisUntilNextAttempt / amountOfProgressToCoverThisCycle;
+        if (intervalAllottedPerProgressUnit < 1) {
+            intervalAllottedPerProgressUnit = 1;
+        }
 
         final Timer reportServerProgressTimer = new Timer();
         reportServerProgressTimer.schedule(new TimerTask() {


### PR DESCRIPTION
Fix for http://manage.dimagi.com/default.asp?260714, which was previously incompletely addressed by https://github.com/dimagi/commcare-android/pull/1770. The non-positive period issue was still occurring in the async restore timer sometimes because I forgot to account for the wonders of integer division :( Thanks @shubham1g5 for figuring out what was up here.