### PR TITLE
Don't allow manual quarantine of Saved or already-quarantined forms

### DIFF
--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -454,7 +454,10 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         StandardAlertDialog dialog = StandardAlertDialog.getBasicAlertDialogWithIcon(this, title,
                 result.second, resId, null);
 
-        if (!record.getStatus().equals(FormRecord.STATUS_SAVED)) {
+        if (!record.getStatus().equals(FormRecord.STATUS_SAVED) &&
+                !record.getStatus().equals(FormRecord.STATUS_QUARANTINED)) {
+            // Only show the manual quarantine option if it's not already quarantined and it
+            // hasn't already been sent
             dialog.setNegativeButton(Localization.get("app.workflow.forms.quarantine"), new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -454,13 +454,15 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         StandardAlertDialog dialog = StandardAlertDialog.getBasicAlertDialogWithIcon(this, title,
                 result.second, resId, null);
 
-        dialog.setNegativeButton(Localization.get("app.workflow.forms.quarantine"), new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                quarantineRecord(record);
-                dismissAlertDialog();
-            }
-        });
+        if (!record.getStatus().equals(FormRecord.STATUS_SAVED)) {
+            dialog.setNegativeButton(Localization.get("app.workflow.forms.quarantine"), new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    quarantineRecord(record);
+                    dismissAlertDialog();
+                }
+            });
+        }
 
         showAlertDialog(dialog);
     }


### PR DESCRIPTION
We shouldn't be exposing the button to manually quarantine a form after doing a record integrity scan when the record in question is already sent or already quarantined