### PR TITLE
Whitelist manual quarantining to UNSENT forms only

### DIFF
--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -454,10 +454,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         StandardAlertDialog dialog = StandardAlertDialog.getBasicAlertDialogWithIcon(this, title,
                 result.second, resId, null);
 
-        if (!record.getStatus().equals(FormRecord.STATUS_SAVED) &&
-                !record.getStatus().equals(FormRecord.STATUS_QUARANTINED)) {
-            // Only show the manual quarantine option if it's not already quarantined and it
-            // hasn't already been sent
+        if (record.getStatus().equals(FormRecord.STATUS_UNSENT)) {
             dialog.setNegativeButton(Localization.get("app.workflow.forms.quarantine"), new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {


### PR DESCRIPTION
@wpride I actually think this should be limited to _just_ `UNSENT` forms. It doesn't make sense to offer for `COMPLETE` forms either because of what Clayton said in that email thread earlier this week-- once a form is quarantined, it has the option to be sent back to the unsent queue, so if it's possible to manually quarantine a form with status `COMPLETE`, it could end up then getting to the unsent queue and skipping over the processing phase entirely.