### PR TITLE
Makes CommCareActivity implement DetailCalloutListener

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -31,8 +31,10 @@ import org.commcare.fragments.BreadcrumbBarFragment;
 import org.commcare.fragments.ContainerFragment;
 import org.commcare.fragments.TaskConnectorFragment;
 import org.commcare.interfaces.WithUIController;
+import org.commcare.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.session.SessionFrame;
 import org.commcare.session.SessionInstanceBuilder;
+import org.commcare.suite.model.CalloutData;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.StackFrameStep;
 import org.commcare.tasks.templates.CommCareTask;
@@ -40,6 +42,7 @@ import org.commcare.tasks.templates.CommCareTaskConnector;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidUtil;
 import org.commcare.utils.ConnectivityStatus;
+import org.commcare.utils.DetailCalloutListener;
 import org.commcare.utils.MarkupUtil;
 import org.commcare.utils.SessionStateUninitException;
 import org.commcare.views.ManagedUiFramework;
@@ -61,7 +64,7 @@ import org.javarosa.core.util.NoLocalizedTextException;
  * @author ctsims
  */
 public abstract class CommCareActivity<R> extends FragmentActivity
-        implements CommCareTaskConnector<R>, DialogController, OnGestureListener {
+        implements CommCareTaskConnector<R>, DialogController, OnGestureListener, DetailCalloutListener{
 
     private static final String TAG = CommCareActivity.class.getSimpleName();
 
@@ -872,5 +875,25 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     protected boolean shouldShowBreadcrumbBar() {
         return true;
+    }
+
+    @Override
+    public void callRequested(String phoneNumber) {
+        DetailCalloutListenerDefaultImpl.callRequested(this, phoneNumber);
+    }
+
+    @Override
+    public void addressRequested(String address) {
+        DetailCalloutListenerDefaultImpl.addressRequested(this, address);
+    }
+
+    @Override
+    public void playVideo(String videoRef) {
+        DetailCalloutListenerDefaultImpl.playVideo(this, videoRef);
+    }
+
+    @Override
+    public void performCallout(CalloutData callout, int id) {
+        DetailCalloutListenerDefaultImpl.performCallout(this, callout, id);
     }
 }

--- a/app/src/org/commcare/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/activities/EntityDetailActivity.java
@@ -25,10 +25,8 @@ import org.commcare.print.PrintableDetailField;
 import org.commcare.print.TemplatePrinterActivity;
 import org.commcare.session.CommCareSession;
 import org.commcare.session.SessionFrame;
-import org.commcare.suite.model.CalloutData;
 import org.commcare.suite.model.Detail;
 import org.commcare.util.DetailFieldPrintInfo;
-import org.commcare.utils.DetailCalloutListener;
 import org.commcare.utils.SerializationUtil;
 import org.commcare.utils.SessionStateUninitException;
 import org.commcare.views.ManagedUi;
@@ -44,8 +42,7 @@ import java.util.HashMap;
  */
 @ManagedUi(R.layout.entity_detail)
 public class EntityDetailActivity
-        extends SessionAwareCommCareActivity
-        implements DetailCalloutListener {
+        extends SessionAwareCommCareActivity {
 
     // reference id of selected element being detailed
     public static final String CONTEXT_REFERENCE = "eda_crid";
@@ -194,26 +191,6 @@ public class EntityDetailActivity
             default:
                 super.onActivityResult(requestCode, resultCode, intent);
         }
-    }
-
-    @Override
-    public void callRequested(String phoneNumber) {
-        DetailCalloutListenerDefaultImpl.callRequested(this, phoneNumber);
-    }
-
-    @Override
-    public void addressRequested(String address) {
-        DetailCalloutListenerDefaultImpl.addressRequested(this, address);
-    }
-
-    @Override
-    public void playVideo(String videoRef) {
-        DetailCalloutListenerDefaultImpl.playVideo(this, videoRef);
-    }
-
-    @Override
-    public void performCallout(CalloutData callout, int id) {
-        DetailCalloutListenerDefaultImpl.performCallout(this, callout, id);
     }
 
     @Override

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -28,6 +28,7 @@ import org.commcare.CommCareApplication;
 import org.commcare.activities.components.EntitySelectCalloutSetup;
 import org.commcare.activities.components.EntitySelectViewSetup;
 import org.commcare.adapters.EntityListAdapter;
+import org.commcare.android.javarosa.IntentCallout;
 import org.commcare.android.logging.ReportingUtils;
 import org.commcare.cases.entity.Entity;
 import org.commcare.cases.entity.NodeEntityFactory;
@@ -35,7 +36,6 @@ import org.commcare.dalvik.R;
 import org.commcare.fragments.ContainerFragment;
 import org.commcare.google.services.ads.AdLocation;
 import org.commcare.google.services.ads.AdMobManager;
-import org.commcare.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.models.AndroidSessionWrapper;
 import org.commcare.preferences.CommCarePreferences;
 import org.commcare.provider.SimprintsCalloutProcessing;
@@ -43,14 +43,12 @@ import org.commcare.session.CommCareSession;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.Action;
 import org.commcare.suite.model.Callout;
-import org.commcare.suite.model.CalloutData;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.DetailField;
 import org.commcare.suite.model.EntityDatum;
 import org.commcare.tasks.EntityLoaderListener;
 import org.commcare.tasks.EntityLoaderTask;
 import org.commcare.utils.AndroidInstanceInitializer;
-import org.commcare.utils.DetailCalloutListener;
 import org.commcare.utils.EntityDetailUtils;
 import org.commcare.utils.EntitySelectRefreshTimer;
 import org.commcare.utils.HereFunctionHandler;
@@ -69,7 +67,6 @@ import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.xpath.XPathTypeMismatchException;
-import org.commcare.android.javarosa.IntentCallout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -78,7 +75,7 @@ import java.util.List;
  * @author ctsims
  */
 public class EntitySelectActivity extends SaveSessionCommCareActivity
-        implements EntityLoaderListener, OnItemClickListener, DetailCalloutListener {
+        implements EntityLoaderListener, OnItemClickListener {
     private CommCareSession session;
     private AndroidSessionWrapper asw;
 
@@ -874,26 +871,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     public void attachLoader(EntityLoaderTask task) {
         findViewById(R.id.entity_select_loading).setVisibility(View.VISIBLE);
         this.loader = task;
-    }
-
-    @Override
-    public void callRequested(String phoneNumber) {
-        DetailCalloutListenerDefaultImpl.callRequested(this, phoneNumber);
-    }
-
-    @Override
-    public void addressRequested(String address) {
-        DetailCalloutListenerDefaultImpl.addressRequested(this, address);
-    }
-
-    @Override
-    public void playVideo(String videoRef) {
-        DetailCalloutListenerDefaultImpl.playVideo(this, videoRef);
-    }
-
-    @Override
-    public void performCallout(CalloutData callout, int id) {
-        DetailCalloutListenerDefaultImpl.performCallout(this, callout, id);
     }
 
     private void displayReferenceAwesome(final TreeReference selection, int detailIndex) {

--- a/app/src/org/commcare/activities/MenuActivity.java
+++ b/app/src/org/commcare/activities/MenuActivity.java
@@ -5,12 +5,15 @@ import android.support.annotation.Nullable;
 
 import org.commcare.CommCareApplication;
 import org.commcare.activities.components.MenuList;
+import org.commcare.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.preferences.CommCarePreferences;
 import org.commcare.session.SessionFrame;
+import org.commcare.suite.model.CalloutData;
 import org.commcare.suite.model.Menu;
 import org.commcare.utils.AndroidCommCarePlatform;
+import org.commcare.utils.DetailCalloutListener;
 
-public class MenuActivity extends SessionAwareCommCareActivity<MenuActivity> {
+public class MenuActivity extends SessionAwareCommCareActivity<MenuActivity> implements DetailCalloutListener {
 
     private static final String MENU_STYLE_GRID = "grid";
     @Nullable
@@ -65,5 +68,25 @@ public class MenuActivity extends SessionAwareCommCareActivity<MenuActivity> {
         if (menuView != null) {
             menuView.onDestroy();
         }
+    }
+
+    @Override
+    public void callRequested(String phoneNumber) {
+        DetailCalloutListenerDefaultImpl.callRequested(this, phoneNumber);
+    }
+
+    @Override
+    public void addressRequested(String address) {
+        DetailCalloutListenerDefaultImpl.addressRequested(this, address);
+    }
+
+    @Override
+    public void playVideo(String videoRef) {
+        DetailCalloutListenerDefaultImpl.playVideo(this, videoRef);
+    }
+
+    @Override
+    public void performCallout(CalloutData callout, int id) {
+        DetailCalloutListenerDefaultImpl.performCallout(this, callout, id);
     }
 }

--- a/app/src/org/commcare/activities/MenuActivity.java
+++ b/app/src/org/commcare/activities/MenuActivity.java
@@ -5,15 +5,12 @@ import android.support.annotation.Nullable;
 
 import org.commcare.CommCareApplication;
 import org.commcare.activities.components.MenuList;
-import org.commcare.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.preferences.CommCarePreferences;
 import org.commcare.session.SessionFrame;
-import org.commcare.suite.model.CalloutData;
 import org.commcare.suite.model.Menu;
 import org.commcare.utils.AndroidCommCarePlatform;
-import org.commcare.utils.DetailCalloutListener;
 
-public class MenuActivity extends SessionAwareCommCareActivity<MenuActivity> implements DetailCalloutListener {
+public class MenuActivity extends SessionAwareCommCareActivity<MenuActivity> {
 
     private static final String MENU_STYLE_GRID = "grid";
     @Nullable
@@ -68,25 +65,5 @@ public class MenuActivity extends SessionAwareCommCareActivity<MenuActivity> imp
         if (menuView != null) {
             menuView.onDestroy();
         }
-    }
-
-    @Override
-    public void callRequested(String phoneNumber) {
-        DetailCalloutListenerDefaultImpl.callRequested(this, phoneNumber);
-    }
-
-    @Override
-    public void addressRequested(String address) {
-        DetailCalloutListenerDefaultImpl.addressRequested(this, address);
-    }
-
-    @Override
-    public void playVideo(String videoRef) {
-        DetailCalloutListenerDefaultImpl.playVideo(this, videoRef);
-    }
-
-    @Override
-    public void performCallout(CalloutData callout, int id) {
-        DetailCalloutListenerDefaultImpl.performCallout(this, callout, id);
     }
 }


### PR DESCRIPTION
Fixes: https://manage.dimagi.com/default.asp?260852

Not sure if we should add this implementation to the base `CommCareActivity` instead as thats where we are creating `BreadcrumbBarFragment` which has an instance of `TabbedDetailView`  and thus `EntityDetailPagerAdapter` and thus `EntityDetailFragment` which potentially can contain phone numbers etc. as layout fields. So it seems to me from code that every `CommCareActivity` should potentially handle these callouts. 