### PR TITLE
Increase badge text length limit from 2 to 3

### DIFF
--- a/app/src/org/commcare/adapters/MenuAdapter.java
+++ b/app/src/org/commcare/adapters/MenuAdapter.java
@@ -227,9 +227,9 @@ public class MenuAdapter extends BaseAdapter {
 
     private void updateBadgeView(View badgeView, String badgeText) {
         if (badgeText != null && !"".equals(badgeText) && !"0".equals(badgeText)) {
-            if (badgeText.length() > 2) {
-                // A badge can only fit up to 2 characters
-                badgeText = badgeText.substring(0, 2);
+            if (badgeText.length() > 3) {
+                // A badge can only fit up to 3 characters
+                badgeText = badgeText.substring(0, 3);
             }
             TextView badgeTextView = (TextView)badgeView.findViewById(R.id.badge_text);
             badgeTextView.setText(badgeText);


### PR DESCRIPTION
I just tested this out on a phone and 3 characters fits fine, so it was stupid to limit this to only 2, especially when it is very reasonable that people would have expressions that evaluate to > 99 (but much less reasonable to have ones that evaluated to > 999, so this seems like a more correct cut-off point anyway).