### PR TITLE
Displaying XPathErrors

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -396,7 +396,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
                 message, android.R.drawable.ic_dialog_info, listener));
     }
 
-    public void displayCaseListFilterException(Exception e) {
+    public void displayCaseListLoadException(Exception e) {
         displayException(
                 Localization.get("notification.case.predicate.title"),
                 Localization.get("notification.case.predicate.action", new String[]{e.getMessage()}));

--- a/app/src/org/commcare/activities/EntityDetailActivity.java
+++ b/app/src/org/commcare/activities/EntityDetailActivity.java
@@ -34,8 +34,10 @@ import org.commcare.utils.SessionStateUninitException;
 import org.commcare.views.ManagedUi;
 import org.commcare.views.TabbedDetailView;
 import org.commcare.views.UiElement;
+import org.commcare.views.UserfacingErrorHandling;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.locale.Localization;
+import org.javarosa.xpath.XPathException;
 
 import java.util.HashMap;
 
@@ -280,7 +282,7 @@ public class EntityDetailActivity
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch(item.getItemId()) {
+        switch (item.getItemId()) {
             case MENU_PRINT_DETAIL:
                 printDetail();
                 return true;
@@ -289,16 +291,19 @@ public class EntityDetailActivity
     }
 
     private void printDetail() {
-        Intent i = new Intent(this, TemplatePrinterActivity.class);
-        i.putExtra(TemplatePrinterActivity.PRINT_TEMPLATE_REF_STRING,
-                detail.getPrintTemplatePath());
+        try {
+            Intent i = new Intent(this, TemplatePrinterActivity.class);
+            i.putExtra(TemplatePrinterActivity.PRINT_TEMPLATE_REF_STRING,
+                    detail.getPrintTemplatePath());
 
-        HashMap<String, DetailFieldPrintInfo> keyValueMap =
-                detail.getKeyValueMapForPrint(mTreeReference, asw.getEvaluationContext());
-        for (String key : keyValueMap.keySet()) {
-            i.putExtra(key, new PrintableDetailField(keyValueMap.get(key)));
+            HashMap<String, DetailFieldPrintInfo> keyValueMap =
+                    detail.getKeyValueMapForPrint(mTreeReference, asw.getEvaluationContext());
+            for (String key : keyValueMap.keySet()) {
+                i.putExtra(key, new PrintableDetailField(keyValueMap.get(key)));
+            }
+            startActivityForResult(i, PRINT_DETAIL);
+        } catch (XPathException xe) {
+            UserfacingErrorHandling.logErrorAndShowDialog(this, xe, true);
         }
-        startActivityForResult(i, PRINT_DETAIL);
     }
-
 }

--- a/app/src/org/commcare/activities/EntityMapActivity.java
+++ b/app/src/org/commcare/activities/EntityMapActivity.java
@@ -28,10 +28,12 @@ import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.utils.AndroidInstanceInitializer;
 import org.commcare.utils.SerializationUtil;
+import org.commcare.views.UserfacingErrorHandling;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.xpath.XPathException;
 
 import java.util.HashMap;
 import java.util.Vector;
@@ -100,8 +102,12 @@ public class EntityMapActivity extends CommCareActivity implements OnMapReadyCal
                 selectDatum.getNodeset());
 
         Vector<Entity<TreeReference>> entities = new Vector<>();
-        for (TreeReference ref : references) {
-            entities.add(factory.getEntity(ref));
+        try {
+            for (TreeReference ref : references) {
+                entities.add(factory.getEntity(ref));
+            }
+        } catch (XPathException xe) {
+            UserfacingErrorHandling.logErrorAndShowDialog(this, xe, true);
         }
         return entities;
     }

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -956,7 +956,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
     @Override
     public void deliverLoadError(Exception e) {
-        displayCaseListFilterException(e);
+        displayCaseListLoadException(e);
     }
 
     @Override

--- a/app/src/org/commcare/fragments/BreadcrumbBarFragment.java
+++ b/app/src/org/commcare/fragments/BreadcrumbBarFragment.java
@@ -40,10 +40,12 @@ import org.commcare.utils.AndroidUtil;
 import org.commcare.utils.SessionStateUninitException;
 import org.commcare.views.EntityViewTile;
 import org.commcare.views.TabbedDetailView;
+import org.commcare.views.UserfacingErrorHandling;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.util.NoLocalizedTextException;
+import org.javarosa.xpath.XPathException;
 
 import java.util.Vector;
 
@@ -98,7 +100,11 @@ public class BreadcrumbBarFragment extends Fragment {
             attachBreadcrumbBar(activity, actionBar);
         }
 
-        this.tile = findAndLoadCaseTile(activity);
+        try {
+            this.tile = findAndLoadCaseTile(activity);
+        } catch (XPathException xe) {
+            UserfacingErrorHandling.logErrorAndShowDialog((CommCareActivity)getActivity(), xe, true);
+        }
     }
 
     private void configureSimpleNav(Activity activity, ActionBar actionBar) {
@@ -271,12 +277,12 @@ public class BreadcrumbBarFragment extends Fragment {
      */
     public boolean collapseTileIfExpanded(Activity activity) {
         View holder = tile;
-        if(holder == null) {
+        if (holder == null) {
             return false;
         }
 
         boolean isExpanded = INLINE_TILE_EXPANDED.equals(holder.getTag());
-        if(!isExpanded) {
+        if (!isExpanded) {
             return false;
         }
 

--- a/app/src/org/commcare/fragments/EntityDetailFragment.java
+++ b/app/src/org/commcare/fragments/EntityDetailFragment.java
@@ -11,9 +11,11 @@ import android.widget.ListAdapter;
 import android.widget.ListView;
 
 import org.commcare.CommCareApplication;
+import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.EntitySelectActivity;
 import org.commcare.adapters.EntityDetailAdapter;
 import org.commcare.adapters.ListItemViewModifier;
+import org.commcare.android.logging.ForceCloseLogger;
 import org.commcare.cases.entity.Entity;
 import org.commcare.cases.entity.NodeEntityFactory;
 import org.commcare.dalvik.R;
@@ -21,10 +23,14 @@ import org.commcare.interfaces.ModifiableEntityDetailAdapter;
 import org.commcare.models.AndroidSessionWrapper;
 import org.commcare.suite.model.Detail;
 import org.commcare.cases.entity.EntityUtil;
+import org.commcare.util.LogTypes;
 import org.commcare.utils.DetailCalloutListener;
 import org.commcare.utils.SerializationUtil;
+import org.commcare.views.UserfacingErrorHandling;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.services.Logger;
+import org.javarosa.xpath.XPathException;
 
 /**
  * Fragment to display Detail content. Not meant for handling nested Detail objects.
@@ -78,16 +84,20 @@ public class EntityDetailFragment extends Fragment {
         NodeEntityFactory factory = new NodeEntityFactory(detailForDisplay, contextForFactory);
 
         View rootView = inflater.inflate(R.layout.entity_detail_list, container, false);
-        final Activity thisActivity = getActivity();
-        final Entity entity = factory.getEntity(referenceToDisplay);
-        final DetailCalloutListener detailCalloutListener =
-                thisActivity instanceof DetailCalloutListener ? ((DetailCalloutListener)thisActivity) : null;
-        adapter = new EntityDetailAdapter(
-                thisActivity, detailForDisplay, entity,
-                detailCalloutListener, getArguments().getInt(DETAIL_INDEX),
-                modifier
-        );
-        ((ListView)rootView.findViewById(R.id.screen_entity_detail_list)).setAdapter((ListAdapter)adapter);
+        try {
+            final Activity thisActivity = getActivity();
+            final Entity entity = factory.getEntity(referenceToDisplay);
+            final DetailCalloutListener detailCalloutListener =
+                    thisActivity instanceof DetailCalloutListener ? ((DetailCalloutListener)thisActivity) : null;
+            adapter = new EntityDetailAdapter(
+                    thisActivity, detailForDisplay, entity,
+                    detailCalloutListener, getArguments().getInt(DETAIL_INDEX),
+                    modifier
+            );
+            ((ListView)rootView.findViewById(R.id.screen_entity_detail_list)).setAdapter((ListAdapter)adapter);
+        } catch (XPathException xe) {
+            UserfacingErrorHandling.logErrorAndShowDialog((CommCareActivity)getActivity(), xe, true);
+        }
 
         return rootView;
     }

--- a/app/src/org/commcare/fragments/EntitySubnodeDetailFragment.java
+++ b/app/src/org/commcare/fragments/EntitySubnodeDetailFragment.java
@@ -98,6 +98,6 @@ public class EntitySubnodeDetailFragment extends EntityDetailFragment implements
 
     @Override
     public void deliverLoadError(Exception e) {
-        ((CommCareActivity)getActivity()).displayCaseListFilterException(e);
+        ((CommCareActivity)getActivity()).displayCaseListLoadException(e);
     }
 }


### PR DESCRIPTION
Case: https://manage.dimagi.com/default.asp?261358

Catching XPathExceptions that can be thrown from NodeEntityFactory::getEntity

I removed XPathException catch block in this PR - https://github.com/dimagi/commcare-core/pull/617 without looking for all the paths that call `NodeEntityFactory::getEntity` that caused this issue. I am now catching it again at different UI level code blocks where this catch removal can surface.