### PR TITLE
Fixes Crash introduced by crashlytics changes

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -164,10 +164,11 @@ public class CommCareApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
-        CrashUtil.init(this);
-        configureCommCareEngineConstantsAndStaticRegistrations();
-
         CommCareApplication.app = this;
+
+        CrashUtil.init(this);
+
+        configureCommCareEngineConstantsAndStaticRegistrations();
         noficationManager = new CommCareNoficationManager(this);
 
         //TODO: Make this robust

--- a/app/src/org/commcare/android/logging/ReportingUtils.java
+++ b/app/src/org/commcare/android/logging/ReportingUtils.java
@@ -121,6 +121,10 @@ public class ReportingUtils {
     }
 
     public static String getDeviceId() {
-        return CommCareApplication.instance().getPhoneId();
+        try {
+            return CommCareApplication.instance().getPhoneId();
+        } catch (Exception e) {
+            return "NA";
+        }
     }
 }

--- a/app/src/org/commcare/utils/CrashUtil.java
+++ b/app/src/org/commcare/utils/CrashUtil.java
@@ -35,6 +35,11 @@ public class CrashUtil {
     public static void init(Context context) {
         if (crashlyticsEnabled) {
             Fabric.with(context, new Crashlytics());
+        }
+    }
+
+    public static void registerDeviceData() {
+        if (crashlyticsEnabled) {
             Crashlytics.setString(DEVICE_ID, ReportingUtils.getDeviceId());
         }
     }


### PR DESCRIPTION
Moved ` CrashUtil.init(this)` after ` CommCareApplication.app = this` to fix NPE while getting device id using `CommCareApplication.instance().getPhoneId()`. 

Crash - https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59b6c301be077a4dcc76e597?time=last-seven-days