### PR TITLE
Fixes crash on startup introduced by crashlytics changes

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -164,10 +164,9 @@ public class CommCareApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
+        CommCareApplication.app = this;
         CrashUtil.init(this);
         configureCommCareEngineConstantsAndStaticRegistrations();
-
-        CommCareApplication.app = this;
         noficationManager = new CommCareNoficationManager(this);
 
         //TODO: Make this robust


### PR DESCRIPTION
Moved ` CrashUtil.init(this)` after ` CommCareApplication.app = this` to fix NPE while getting device id using `CommCareApplication.instance().getPhoneId()`. 

Crash - https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59b6c301be077a4dcc76e597?time=last-seven-days