### PR TITLE
Sort based on edit-distance when fuzzy

### DIFF
--- a/app/src/org/commcare/adapters/EntityStringFilterer.java
+++ b/app/src/org/commcare/adapters/EntityStringFilterer.java
@@ -121,7 +121,8 @@ public class EntityStringFilterer extends EntityFiltererBase {
                     matchScores.add(Pair.create(index, score));
                 }
             }
-            if (isAsyncMode) {
+            // If fuzzy search is enabled need to re-sort based on edit distance
+            if (isFuzzySearchEnabled) {
                 Collections.sort(matchScores, new Comparator<Pair<Integer, Integer>>() {
                     @Override
                     public int compare(Pair<Integer, Integer> lhs, Pair<Integer, Integer> rhs) {


### PR DESCRIPTION
fixes https://manage.dimagi.com/default.asp?261687

Not sure if this was a bug or intentional behavior that I'm missing but this change makes more sense to me. Previously, if we weren't using `asyncMode` (which I think we mostly aren't?) then we'd never sort filtered entities based on the edit distance from the search field (IE `score` was never used). This changes the behavior to re-sort the entities whenever we're in fuzzy mode. 