### PR TITLE
Quarantining forms instead of wiping on File not Found

### DIFF
--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -77,6 +77,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
     public static final String QuarantineReason_LOCAL_PROCESSING_ERROR = "local-processing-error";
     public static final String QuarantineReason_RECORD_ERROR = "record-error";
     public static final String QuarantineReason_MANUAL = "manual-quarantine";
+    public static final String QuarantineReason_FILE_NOT_FOUND = "file-not-found";
 
     @Persisting(1)
     @MetaField(META_XMLNS)


### PR DESCRIPTION
Workaround for this - https://manage.dimagi.com/default.asp?261911#1394223

Right now when in recovery mode if for one of the form we could not find any instances, it blocks the whole sending forms task and user gets stuck with the blocking recovery mode screen. Hence in such a case we are now quarantining that form so that forms upload can proceed without sending the buggy form and user can get out of recovery mode. 