### PR TITLE
Quarantining forms instead of wiping on File not Found

### DIFF
--- a/app/src/org/commcare/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/activities/RecoveryActivity.java
@@ -31,7 +31,7 @@ import org.javarosa.core.services.locale.Localization;
 public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActivity> {
 
     @UiElement(R.id.screen_recovery_unsent_message)
-    TextView txtUnsentForms;
+    TextView txtUnsentAndQuarantineForms;
 
     @UiElement(R.id.screen_recovery_unsent_button)
     Button sendForms;
@@ -166,29 +166,35 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
     private void updateSendFormsState() {
         sendForms.setEnabled(false);
         if (!CommCareApplication.instance().isStorageAvailable()) {
-            txtUnsentForms.setText("unsent forms unavailable.");
+            txtUnsentAndQuarantineForms.setText("Forms are not available.");
             return;
         }
 
         try {
             CommCareApplication.instance().getSession();
         } catch (SessionUnavailableException sue) {
-            txtUnsentForms.setText("Couldn't read unsent forms. Not Logged in");
+            txtUnsentAndQuarantineForms.setText("Couldn't read forms. Not Logged in");
             return;
         }
 
         SqlStorage<FormRecord> recordStorage = CommCareApplication.instance().getUserStorage(FormRecord.class);
         try {
+            StringBuilder sb = new StringBuilder();
             FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(recordStorage);
             if (records.length == 0) {
-                txtUnsentForms.setText("This device has no unsent forms");
+                sb.append("This device has no unsent forms");
             } else {
-                txtUnsentForms.setText("There are " + records.length + " unsent form(s) on this device");
+                sb.append("There are " + records.length + " unsent form(s)");
                 sendForms.setEnabled(true);
             }
+            int quarantineForms = StorageUtils.getNumQuarantinedForms();
+            if (quarantineForms != 0) {
+                sb.append(" and " + quarantineForms + " quarantine form(s)");
+            }
+            txtUnsentAndQuarantineForms.setText(sb.toString());
         } catch (Exception e) {
             Logger.log(LogTypes.TYPE_ERROR_ASSERTION, e.getMessage());
-            txtUnsentForms.setText("Couldn't read unsent forms. Error : " + e.getMessage());
+            txtUnsentAndQuarantineForms.setText("Couldn't read forms. Error : " + e.getMessage());
         }
     }
 }

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -77,6 +77,7 @@ public class FormRecord extends Persisted implements EncryptedModel {
     public static final String QuarantineReason_LOCAL_PROCESSING_ERROR = "local-processing-error";
     public static final String QuarantineReason_RECORD_ERROR = "record-error";
     public static final String QuarantineReason_MANUAL = "manual-quarantine";
+    public static final String QuarantineReason_FILE_NOT_FOUND = "file-not-found";
 
     @Persisting(1)
     @MetaField(META_XMLNS)

--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -296,7 +296,17 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                     //Good!
                     //Time to Send!
                     try {
-                        folder = new File(record.getPath(c)).getCanonicalFile().getParentFile();
+                        try {
+                            folder = new File(record.getPath(c)).getCanonicalFile().getParentFile();
+                        } catch (FileNotFoundException e) {
+                            //This will put us in the same "Missing Form" handling path as below
+                            throw e;
+                        } catch (IOException e) {
+                            // Unexpected/Unknown IO Error path from cannonical file
+                            Logger.log(LogTypes.TYPE_ERROR_WORKFLOW, "Bizarre. Exception just getting the file reference. Not removing." + getExceptionText(e));
+                            continue;
+                        }
+
                         User mUser = CommCareApplication.instance().getSession().getLoggedInUser();
                         int attemptsMade = 0;
                         logSubmissionAttempt(record);
@@ -342,10 +352,6 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                                     NotificationMessageFactory.message(ProcessIssues.StorageRemoved), true);
                             break;
                         }
-                        continue;
-                    } catch (IOException e) {
-                        // thrown from File.getCanonicalFile().getParentFile()
-                        Logger.log(LogTypes.TYPE_ERROR_WORKFLOW, "Bizarre. Exception just getting the file reference. Not removing." + getExceptionText(e));
                         continue;
                     }
 


### PR DESCRIPTION
Workaround for this - https://manage.dimagi.com/default.asp?261911#1394223

Right now when in recovery mode if for one of the form we could not find any instances, it blocks the whole sending forms task and user gets stuck with the blocking recovery mode screen. Hence in such a case we are now quarantining that form so that forms upload can proceed without sending the buggy form and user can get out of recovery mode.