### PR TITLE
NPE fix in case of a failed request in ForceCloseLogger

### DIFF
--- a/app/src/org/commcare/android/logging/ForceCloseLogger.java
+++ b/app/src/org/commcare/android/logging/ForceCloseLogger.java
@@ -115,9 +115,11 @@ public class ForceCloseLogger {
 
         try {
             Response<ResponseBody> response = generator.postMultipart(submissionUri, parts);
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            StreamsUtil.writeFromInputToOutput(response.body().byteStream(), bos);
-            Log.d(TAG, "Response: " + new String(bos.toByteArray()));
+            if (response.body() != null) {
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                StreamsUtil.writeFromInputToOutput(response.body().byteStream(), bos);
+                Log.d(TAG, "Response: " + new String(bos.toByteArray()));
+            }
         } catch (IOException e) {
             e.printStackTrace();
             return false;

--- a/app/src/org/commcare/android/logging/ForceCloseLogger.java
+++ b/app/src/org/commcare/android/logging/ForceCloseLogger.java
@@ -115,11 +115,13 @@ public class ForceCloseLogger {
 
         try {
             Response<ResponseBody> response = generator.postMultipart(submissionUri, parts);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
             if (response.body() != null) {
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
                 StreamsUtil.writeFromInputToOutput(response.body().byteStream(), bos);
-                Log.d(TAG, "Response: " + new String(bos.toByteArray()));
+            } else if (response.errorBody() != null) {
+                StreamsUtil.writeFromInputToOutput(response.errorBody().byteStream(), bos);
             }
+            Log.d(TAG, "Response: " + new String(bos.toByteArray()));
         } catch (IOException e) {
             e.printStackTrace();
             return false;


### PR DESCRIPTION
Case : https://manage.dimagi.com/default.asp?262186
Crash: https://fabric.io/dimagi/android/apps/org.commcare.lts/issues/59c0ec25be077a4dccdf1c16?time=last-seven-days

Not sure why are we converting response to String just to log it to adb. Also for a successful request  response is just a empty String. 