### PR TITLE
Cleanups for Asyncronous setup in badge processing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compile(name: 'htmlspanner-custom', ext: 'aar')
     compile(name: 'android-zebra-interface-1.1', ext: 'aar')
     compile 'com.simprints:LibSimprints:1.0.10'
+    compile 'com.android.support:multidex:1.0.1'
     compile 'com.android.support:cardview-v7:25.0.1'
     compile 'com.android.support:recyclerview-v7:25.0.1'
     compile 'com.android.support:support-v4:25.0.1'

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -57,6 +57,10 @@ import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
 
+import io.reactivex.Observable;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.disposables.Disposable;
+
 /**
  * Base class for CommCareActivities to simplify
  * common localization and workflow tasks
@@ -73,6 +77,8 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
     private int invalidTaskIdMessageThrown = -2;
     private TaskConnectorFragment<R> stateHolder;
+
+    CompositeDisposable disposableEventHost = new CompositeDisposable();
 
 
     // Fields for implementing task transitions for CommCareTaskConnector
@@ -288,6 +294,20 @@ public abstract class CommCareActivity<R> extends FragmentActivity
 
         areFragmentsPaused = true;
         AudioController.INSTANCE.systemInducedPause();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        disposableEventHost.dispose();
+    }
+
+    /**
+     * Attaches a reactivex disposable to the lifecycle of this activity, so the disposable
+     * will be cancelled / halted when this activity is destroyed.
+     */
+    public void attachDisposableToLifeCycle(Disposable subscribe) {
+        disposableEventHost.add(subscribe);
     }
 
     @Override

--- a/app/src/org/commcare/activities/MenuActivity.java
+++ b/app/src/org/commcare/activities/MenuActivity.java
@@ -58,12 +58,4 @@ public class MenuActivity extends SessionAwareCommCareActivity<MenuActivity> {
         onBackPressed();
         return true;
     }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        if (menuView != null) {
-            menuView.onDestroy();
-        }
-    }
 }

--- a/app/src/org/commcare/activities/RootMenuHomeActivity.java
+++ b/app/src/org/commcare/activities/RootMenuHomeActivity.java
@@ -90,10 +90,4 @@ public class RootMenuHomeActivity extends HomeScreenBaseActivity<RootMenuHomeAct
     public boolean usesSubmissionProgressBar() {
         return true;
     }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        menuView.onDestroy();
-    }
 }

--- a/app/src/org/commcare/activities/components/MenuList.java
+++ b/app/src/org/commcare/activities/components/MenuList.java
@@ -126,11 +126,4 @@ public class MenuList implements AdapterView.OnItemClickListener {
             activity.finish();
         }
     }
-
-    /**
-     * Call to bind Activity/Fragment onDestory to MenuList
-     */
-    public void onDestroy() {
-        adapter.onDestory();
-    }
 }

--- a/app/src/org/commcare/adapters/MenuAdapter.java
+++ b/app/src/org/commcare/adapters/MenuAdapter.java
@@ -59,7 +59,6 @@ public class MenuAdapter extends BaseAdapter {
     private String errorMessage = "";
     final CommCareActivity context;
     private final MenuDisplayable[] displayableData;
-    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
     private SparseArray<String> badgeCache = new SparseArray<>();
 
     private class MenuLogger implements LoggerInterface {
@@ -223,9 +222,9 @@ public class MenuAdapter extends BaseAdapter {
             if(badgeTextObject != null) {
                 Set<String> instancesNeededByBadgeCalculation =
                         (new InstanceNameAccumulatingAnalyzer()).accumulate(badgeTextObject);
-                compositeDisposable.add(
+                context.attachDisposableToLifeCycle(
                         menuDisplayable.getTextForBadge(asw.getRestrictedEvaluationContext(menuDisplayable.getCommandID(), instancesNeededByBadgeCalculation))
-                                .subscribeOn(Schedulers.computation())
+                                .subscribeOn(Schedulers.single())
                                 .observeOn(AndroidSchedulers.mainThread())
                                 .subscribe(badgeText -> {
                                             // Make sure that badgeView corresponds to the right position and update it
@@ -295,15 +294,6 @@ public class MenuAdapter extends BaseAdapter {
                     break;
             }
         }
-    }
-
-    /**
-     * Must be called in the activity/fragment containing the adapter onDestroy
-     * to clear Rx subscriptions
-     */
-    public void onDestory() {
-        compositeDisposable.clear();
-        badgeCache.clear();
     }
 
     @Override


### PR DESCRIPTION
Most of the actual fix is in commcare-core, but I cleaned up the processing a bit to unify where disposables are tracked.

One specific fix here is that I moved the execution of the badge lambdas into `Schedulers.single()`, since they end up unrolling a ton of state and it's _really_ easy for them to OOM the VM. At some point we may want to revisit whether we can set them up to process concurrently, but it'll take some thinking on how to make sure we're managing the memory pool.

Currently there are still some ~shaky semantics about the scheduler that I'm a bit concerned by (I'm pretty worried about leaving the Observables around and executing until onDestroy if, say, onStop has been fired, but our scope on using the new execution pattern is pretty limited.

cross-request: https://github.com/dimagi/commcare-core/pull/645