### PR TITLE
Move Multi-Key storage lookups to core

### DIFF
--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -89,11 +89,13 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         return getIDsForValues(new String[]{fieldName}, new Object[]{value});
     }
 
+    @Override
     public Vector<Integer> getIDsForValues(String[] fieldNames, Object[] values) {
         return getIDsForValues(fieldNames, values, null);
     }
 
-    public Vector<Integer> getIDsForValues(String[] fieldNames, Object[] values, LinkedHashSet<Integer> returnSet) {
+    @Override
+    public Vector<Integer> getIDsForValues(String[] fieldNames, Object[] values, LinkedHashSet returnSet) {
         SQLiteDatabase db = helper.getHandle();
 
         Pair<String, String[]> whereClause = helper.createWhereAndroid(fieldNames, values, em, null);

--- a/app/unit-tests/src/org/commcare/android/tests/database/SqlStorageBaseTests.java
+++ b/app/unit-tests/src/org/commcare/android/tests/database/SqlStorageBaseTests.java
@@ -1,6 +1,7 @@
 package org.commcare.android.tests.database;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestUtils;
 import org.commcare.models.database.SqlStorage;
@@ -19,10 +20,11 @@ import org.robolectric.annotation.Config;
  * Created by ctsims on 9/22/2017.
  */
 
-@Config(application = CommCareApplication.class)
+@Config(application = CommCareTestApplication.class)
 @RunWith(CommCareTestRunner.class)
 public class SqlStorageBaseTests extends IndexedStorageUtilityTests {
 
+    @Override
     protected IStorageUtilityIndexed<Shoe> createStorageUtility() {
         TestUtils.initializeStaticTestStorage();
         return TestUtils.getStorage("ShoeStorage", Shoe.class);

--- a/app/unit-tests/src/org/commcare/android/tests/database/SqlStorageBaseTests.java
+++ b/app/unit-tests/src/org/commcare/android/tests/database/SqlStorageBaseTests.java
@@ -1,0 +1,30 @@
+package org.commcare.android.tests.database;
+
+import org.commcare.CommCareApplication;
+import org.commcare.android.CommCareTestRunner;
+import org.commcare.android.util.TestUtils;
+import org.commcare.models.database.SqlStorage;
+import org.commcare.modern.database.TableBuilder;
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
+import org.javarosa.core.services.storage.util.DummyIndexedStorageUtility;
+import org.javarosa.core.storage.IndexedStorageUtilityTests;
+import org.javarosa.core.storage.Shoe;
+import org.javarosa.core.util.externalizable.LivePrototypeFactory;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+/**
+ * SqlStorage implementations for the base Storage Utility tests
+ *
+ * Created by ctsims on 9/22/2017.
+ */
+
+@Config(application = CommCareApplication.class)
+@RunWith(CommCareTestRunner.class)
+public class SqlStorageBaseTests extends IndexedStorageUtilityTests {
+
+    protected IStorageUtilityIndexed<Shoe> createStorageUtility() {
+        TestUtils.initializeStaticTestStorage();
+        return TestUtils.getStorage("ShoeStorage", Shoe.class);
+    }
+}

--- a/app/unit-tests/src/org/commcare/android/util/TestUtils.java
+++ b/app/unit-tests/src/org/commcare/android/util/TestUtils.java
@@ -18,6 +18,7 @@ import org.commcare.models.database.user.DatabaseUserOpenHelper;
 import org.commcare.android.database.user.models.ACase;
 import org.commcare.models.database.user.models.AndroidCaseIndexTable;
 import org.commcare.models.database.user.models.EntityStorageCache;
+import org.commcare.modern.database.TableBuilder;
 import org.commcare.network.CommcareRequestEndpointsMock;
 import org.commcare.test.utilities.CaseTestUtils;
 import org.commcare.utils.AndroidInstanceInitializer;
@@ -34,6 +35,7 @@ import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.services.storage.Persistable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
@@ -209,6 +211,30 @@ public class TestUtils {
      */
     public static SqlStorage<ACase> getCaseStorage() {
         return getCaseStorage(getTestDb());
+    }
+
+    public static <T extends Persistable> SqlStorage<T> getStorage(String storageKey, Class<T> prototypeModel) {
+        SQLiteDatabase db = getTestDb();
+        TableBuilder builder = new TableBuilder(storageKey);
+
+        try {
+            builder.addData(prototypeModel.newInstance());
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        String tableCreate = builder.getTableCreateString();
+        db.execSQL(tableCreate);
+
+        return new SqlStorage<T>(storageKey, prototypeModel, new ConcreteAndroidDbHelper(RuntimeEnvironment.application, db) {
+            @Override
+            public PrototypeFactory getPrototypeFactory() {
+                return getStaticPrototypeFactory();
+            }
+        });
+
     }
 
     /**


### PR DESCRIPTION
Move multikey lookups to core, so they can work for indexed fixtures 

cross-request: https://github.com/dimagi/commcare-core/pull/647