### PR TITLE
Ignore missing resource lint errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -200,6 +200,7 @@ android {
     lintOptions {
         abortOnError false
         disable 'MissingTranslation'
+        disable "ResourceType"
     }
 
     packagingOptions {


### PR DESCRIPTION
Not sure when this got changed, but it's breaking the builds on whatever runner Jenkins is now using.