### PR TITLE
Submitting logs on hitting Recovery Mode

### DIFF
--- a/app/src/org/commcare/CommCareApp.java
+++ b/app/src/org/commcare/CommCareApp.java
@@ -233,7 +233,7 @@ public class CommCareApp implements AppFilePathBuilder {
         }
 
         String failureReason = profile == null ? "profle being null" : "profile status value " + String.valueOf(profile.getStatus());
-        Logger.log(LogTypes.TYPE_ERROR_STORAGE, "Initializing application failed because of " + failureReason);
+        Logger.log(LogTypes.TYPE_RESOURCES, "Initializing application failed because of " + failureReason);
         return false;
     }
 

--- a/app/src/org/commcare/CommCareApp.java
+++ b/app/src/org/commcare/CommCareApp.java
@@ -231,6 +231,9 @@ public class CommCareApp implements AppFilePathBuilder {
             }
             return true;
         }
+
+        String failureReason = profile == null ? "profle being null" : "profile status value " + String.valueOf(profile.getStatus());
+        Logger.log(LogTypes.TYPE_ERROR_STORAGE, "Initializing application failed because of " + failureReason);
         return false;
     }
 

--- a/app/src/org/commcare/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/activities/RecoveryActivity.java
@@ -16,6 +16,7 @@ import org.commcare.models.database.SqlStorage;
 import org.commcare.preferences.CommCareServerPreferences;
 import org.commcare.tasks.ProcessAndSendTask;
 import org.commcare.util.LogTypes;
+import org.commcare.utils.CommCareUtil;
 import org.commcare.utils.FormUploadResult;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.utils.StorageUtils;
@@ -48,7 +49,7 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
+        CommCareUtil.triggerLogSubmission(this);
         if (savedInstanceState == null) {
             // launching activity, not just changing orientation
             updateSendFormsState();

--- a/app/src/org/commcare/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/activities/RecoveryActivity.java
@@ -49,9 +49,10 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        CommCareUtil.triggerLogSubmission(this);
+
         if (savedInstanceState == null) {
             // launching activity, not just changing orientation
+            CommCareUtil.triggerLogSubmission(this);
             updateSendFormsState();
             updateRecoverAppState();
         }


### PR DESCRIPTION
Triggers logs submission on Entering Recovery to debug corrupt storage error issues.

Case: https://manage.dimagi.com/default.asp?262385

Targeting 2.39 since there are increasing reports for corrupt-storage issue and users can't do log submission right now after encountering corrupt storage dialogue and it's pretty dark without logs when it comes to corrupt storage bugs. 

Though let me know if this is too late for 2.39 and need to target master instead.  