### PR TITLE
Only trigger sync after update for release builds

### DIFF
--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -437,7 +437,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
     private void logoutOnSuccessfulUpdate() {
         final String upgradeFinishedText =
                 Localization.get("updates.install.finished");
-        CommCarePreferences.setPostUpdateSyncNeeded(!isLocalUpdate);
+        CommCarePreferences.setPostUpdateSyncNeeded(!isLocalUpdate && !BuildConfig.DEBUG);
         CommCareApplication.instance().expireUserSession();
         if (proceedAutomatically) {
             finishWithResult(RefreshToLatestBuildActivity.UPDATE_SUCCESS);


### PR DESCRIPTION
This behavior is annoying and pointless on debug builds, so limit it to release builds only