### PR TITLE
Fix indexed fixture paths table

### DIFF
--- a/app/src/org/commcare/models/database/AndroidSandbox.java
+++ b/app/src/org/commcare/models/database/AndroidSandbox.java
@@ -98,4 +98,8 @@ public class AndroidSandbox extends UserSandbox {
     public void setLoggedInUser(User user) {
 
     }
+
+    public SQLiteDatabase getUserDb() {
+        return app.getUserDbHandle();
+    }
 }

--- a/app/src/org/commcare/models/database/IndexedFixturePathUtils.java
+++ b/app/src/org/commcare/models/database/IndexedFixturePathUtils.java
@@ -38,30 +38,7 @@ public class IndexedFixturePathUtils {
         }
     }
 
-    public static Set<String> getAllIndexedFixtureNames(SQLiteDatabase db) {
-        Cursor c = db.query(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_TABLE,
-                new String[]{IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_NAME},
-                null, null, null, null, null);
-        Set<String> fixtureNames = new HashSet<>();
-        try {
-            if (c.moveToFirst()) {
-                int desiredColumnIndex = c.getColumnIndexOrThrow(
-                        IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_NAME);
-                while (!c.isAfterLast()) {
-                    String name = c.getString(desiredColumnIndex);
-                    fixtureNames.add(name);
-                    c.moveToNext();
-                }
-            }
-            return fixtureNames;
-        } finally {
-            if (c != null) {
-                c.close();
-            }
-        }
-    }
-
-    public static List<String> getAllIndexedFixtureNamesAsList(SQLiteDatabase db) {
+    public static List<String> getAllIndexedFixtureNames(SQLiteDatabase db) {
         Cursor c = db.query(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_TABLE,
                 new String[]{IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_NAME},
                 null, null, null, null, null);

--- a/app/src/org/commcare/models/database/IndexedFixturePathUtils.java
+++ b/app/src/org/commcare/models/database/IndexedFixturePathUtils.java
@@ -61,6 +61,29 @@ public class IndexedFixturePathUtils {
         }
     }
 
+    public static List<String> getAllIndexedFixtureNamesAsList(SQLiteDatabase db) {
+        Cursor c = db.query(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_TABLE,
+                new String[]{IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_NAME},
+                null, null, null, null, null);
+        List<String> fixtureNames = new ArrayList<>();
+        try {
+            if (c.moveToFirst()) {
+                int desiredColumnIndex = c.getColumnIndexOrThrow(
+                        IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_NAME);
+                while (!c.isAfterLast()) {
+                    String name = c.getString(desiredColumnIndex);
+                    fixtureNames.add(name);
+                    c.moveToNext();
+                }
+            }
+            return fixtureNames;
+        } finally {
+            if (c != null) {
+                c.close();
+            }
+        }
+    }
+
     public static void insertIndexedFixturePathBases(SQLiteDatabase db, String fixtureName,
                                                      String baseName, String childName) {
         ContentValues contentValues = new ContentValues();

--- a/app/src/org/commcare/models/database/IndexedFixturePathUtils.java
+++ b/app/src/org/commcare/models/database/IndexedFixturePathUtils.java
@@ -93,9 +93,11 @@ public class IndexedFixturePathUtils {
 
         db.beginTransaction();
         try {
-            long ret = db.insertOrThrow(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_TABLE,
+            long ret = db.insertWithOnConflict(
+                    IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_TABLE,
                     IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_BASE,
-                    contentValues);
+                    contentValues,
+                    SQLiteDatabase.CONFLICT_REPLACE);
 
             if (ret > Integer.MAX_VALUE) {
                 throw new RuntimeException("Waaaaaaaaaay too many values");

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -31,6 +31,7 @@ import org.commcare.modern.database.DatabaseIndexingUtils;
 import org.javarosa.core.model.User;
 import org.javarosa.core.services.storage.Persistable;
 
+import java.util.List;
 import java.util.Set;
 import java.util.Vector;
 
@@ -546,7 +547,7 @@ class UserDatabaseUpgrader {
     private boolean upgradeNineteenTwenty(SQLiteDatabase db) {
         db.beginTransaction();
         try {
-            Set<String> allIndexedFixtures = IndexedFixturePathUtils.getAllIndexedFixtureNames(db);
+            List<String> allIndexedFixtures = IndexedFixturePathUtils.getAllIndexedFixtureNames(db);
             for (String fixtureName : allIndexedFixtures) {
                 String tableName = StorageIndexedTreeElementModel.getTableName(fixtureName);
                 SqlStorage<StorageIndexedTreeElementModel> storageForThisFixture =

--- a/app/unit-tests/src/org/commcare/android/tests/database/SqlStorageBaseTests.java
+++ b/app/unit-tests/src/org/commcare/android/tests/database/SqlStorageBaseTests.java
@@ -1,16 +1,11 @@
 package org.commcare.android.tests.database;
 
-import org.commcare.CommCareApplication;
 import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestUtils;
-import org.commcare.models.database.SqlStorage;
-import org.commcare.modern.database.TableBuilder;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
-import org.javarosa.core.services.storage.util.DummyIndexedStorageUtility;
 import org.javarosa.core.storage.IndexedStorageUtilityTests;
 import org.javarosa.core.storage.Shoe;
-import org.javarosa.core.util.externalizable.LivePrototypeFactory;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
@@ -29,4 +24,5 @@ public class SqlStorageBaseTests extends IndexedStorageUtilityTests {
         TestUtils.initializeStaticTestStorage();
         return TestUtils.getStorage("ShoeStorage", Shoe.class);
     }
+
 }

--- a/app/unit-tests/src/org/commcare/android/tests/processing/IndexedFixtureLoadingTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/IndexedFixtureLoadingTest.java
@@ -111,10 +111,12 @@ public class IndexedFixtureLoadingTest {
                 this.getClass(),
                 "indexed_fixture_restore.xml");
 
+        // Parse the same fixture a 2nd time so that IndexedFixturePathUtils.insertIndexedFixturePathBases()
+        // has to handle receiving a row with a duplicate name
         try {
-            // parse the same fixture a 2nd time
             StoreFixturesOnFilesystemTests.parseIntoSandbox(
-                    this.getClass().getClassLoader().getResourceAsStream("indexed_fixture_restore.xml"), false);
+                    this.getClass().getClassLoader().getResourceAsStream("indexed_fixture_restore.xml"),
+                    false);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/app/unit-tests/src/org/commcare/android/tests/processing/IndexedFixtureLoadingTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/IndexedFixtureLoadingTest.java
@@ -123,7 +123,7 @@ public class IndexedFixtureLoadingTest {
 
         SQLiteDatabase db = sandbox.getUserDb();
         List<String> allIndexedFixtures =
-                IndexedFixturePathUtils.getAllIndexedFixtureNamesAsList(db);
+                IndexedFixturePathUtils.getAllIndexedFixtureNames(db);
 
         List<String> comparisonList = new ArrayList<>();
         for (String fixtureName : allIndexedFixtures) {


### PR DESCRIPTION
Fixes a bug where the indexed fixture paths table would contain duplicate rows for the same fixture if CommCare processed a transaction containing the same fixture multiple times

cross-request: https://github.com/dimagi/commcare-core/pull/655