### PR TITLE
Set post-update sync flag back to false immediately

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -1048,10 +1048,11 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             return;
         }
 
-        if (CommCareApplication.instance().isSyncPending(false)) {
-            triggerSync(true);
-        } else if (CommCareApplication.instance().isPostUpdateSyncNeeded() && !isDemoUser()) {
+        if (CommCareApplication.instance().isPostUpdateSyncNeeded() && !isDemoUser()) {
+            CommCarePreferences.setPostUpdateSyncNeeded(false);
             triggerSync(false);
+        } else if (CommCareApplication.instance().isSyncPending(false)) {
+            triggerSync(true);
         } else if (UpdatePromptHelper.promptForUpdateIfNeeded(this)) {
             return;
         } else {


### PR DESCRIPTION
I had been relying on the call to `recordSyncAttempt()` that occurs in `DataPullTask.doTaskBackgroundHelper()` to set this flag back to false after a post-update sync is triggered. But if the form-send step prior to data pull fails, then we never even launch the data pull task at all. This would result in the app continually trying and failing to sync every single time the user comes back to the home screen until whatever is causing the form-send failure is resolved. 

Also switch the order of these 2 checks; in case of the situation where both are true at the same time, we would want the sync-after-update flag to take precedence so that the boolean gets set back to false.