### PR TITLE
Fixes NPE for Grid Menu when there is audioFile for a menu

### DIFF
--- a/app/src/org/commcare/adapters/MenuAdapter.java
+++ b/app/src/org/commcare/adapters/MenuAdapter.java
@@ -163,24 +163,24 @@ public class MenuAdapter extends BaseAdapter {
     }
 
     private void setupAudioButton(int rowId, AudioPlaybackButton audioPlaybackButton, MenuDisplayable menuDisplayable) {
-        final String audioURI = menuDisplayable.getAudioURI();
-        String audioFilename = "";
-        if (audioURI != null && !audioURI.equals("")) {
-            try {
-                audioFilename = ReferenceManager.instance().DeriveReference(audioURI).getLocalURI();
-            } catch (InvalidReferenceException e) {
-                Log.e("AVTLayout", "Invalid reference exception");
-                e.printStackTrace();
+        if (audioPlaybackButton != null) {
+            final String audioURI = menuDisplayable.getAudioURI();
+            String audioFilename = "";
+            if (audioURI != null && !audioURI.equals("")) {
+                try {
+                    audioFilename = ReferenceManager.instance().DeriveReference(audioURI).getLocalURI();
+                } catch (InvalidReferenceException e) {
+                    Log.e("AVTLayout", "Invalid reference exception");
+                    e.printStackTrace();
+                }
             }
-        }
 
-        File audioFile = new File(audioFilename);
-        // First set up the audio button
-        ViewId viewId = ViewId.buildListViewId(rowId);
-        if (!"".equals(audioFilename) && audioFile.exists()) {
-            audioPlaybackButton.modifyButtonForNewView(viewId, audioURI, true);
-        } else {
-            if (audioPlaybackButton != null) {
+            File audioFile = new File(audioFilename);
+            // First set up the audio button
+            ViewId viewId = ViewId.buildListViewId(rowId);
+            if (!"".equals(audioFilename) && audioFile.exists()) {
+                audioPlaybackButton.modifyButtonForNewView(viewId, audioURI, true);
+            } else {
                 audioPlaybackButton.modifyButtonForNewView(viewId, audioURI, false);
             }
         }


### PR DESCRIPTION
In 2.39, while refactoring for Menu Badges, I also refactored MenuAdapter and GridAdapter to use same getView code and what I didn't realise is there is not audio button in grid menu list item layout. This is causing a crash when we have anyway added a audio file for a Grid menu in HQ since right now mobile code is assuming that if there is a audio file there should also be a audioButton for it. 

https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59cf74adbe077a4dcc831241?time=last-ninety-days

This is impacting only the ICDS AWW app right now and it's causing a crash on clicking Start.