### PR TITLE
2.39.2 - Universal timeout increase on upgrades

### DIFF
--- a/app/src/org/commcare/models/database/migration/FixtureSerializationMigration.java
+++ b/app/src/org/commcare/models/database/migration/FixtureSerializationMigration.java
@@ -48,9 +48,6 @@ public class FixtureSerializationMigration {
     public static boolean migrateFixtureDbBytes(SQLiteDatabase db, Context c,
                                                 String directoryName,
                                                 byte[] fileMigrationKeySeed) {
-        // Not sure how long this process should take, so tell the service to
-        // wait longer to make sure this can finish.
-        CommCareApplication.instance().setCustomServiceBindTimeout(60 * 5 * 1000);
         long start = System.currentTimeMillis();
 
         ConcreteAndroidDbHelper helper = new ConcreteAndroidDbHelper(c, db);

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -53,6 +53,10 @@ class UserDatabaseUpgrader {
     }
 
     public void upgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        // A lot of the upgrade processes can take a little while, so we tell the service to wait
+        // longer than usual in order to make sure the upgrade has time to finish
+        CommCareApplication.instance().setCustomServiceBindTimeout(5 * 60 * 1000);
+
         if (oldVersion == 1) {
             if (upgradeOneTwo(db)) {
                 oldVersion = 2;
@@ -213,10 +217,6 @@ class UserDatabaseUpgrader {
     }
 
     private boolean upgradeFiveSix(SQLiteDatabase db) {
-        //On some devices this process takes a significant amount of time (sorry!) we should
-        //tell the service to wait longer to make sure this can finish.
-        CommCareApplication.instance().setCustomServiceBindTimeout(60 * 5 * 1000);
-
         db.beginTransaction();
         try {
             db.execSQL(DatabaseIndexingUtils.indexOnTableCommand("case_status_open_index", "AndroidCase", "case_type,case_status"));
@@ -246,10 +246,6 @@ class UserDatabaseUpgrader {
     }
 
     private boolean upgradeSixSeven(SQLiteDatabase db) {
-        //On some devices this process takes a significant amount of time (sorry!) we should
-        //tell the service to wait longer to make sure this can finish.
-        CommCareApplication.instance().setCustomServiceBindTimeout(60 * 5 * 1000);
-
         long start = System.currentTimeMillis();
         db.beginTransaction();
         try {
@@ -268,9 +264,6 @@ class UserDatabaseUpgrader {
      * to represents users
      */
     private boolean upgradeSevenEight(SQLiteDatabase db) {
-        //On some devices this process takes a significant amount of time (sorry!) we should
-        //tell the service to wait longer to make sure this can finish.
-        CommCareApplication.instance().setCustomServiceBindTimeout(60 * 5 * 1000);
         long start = System.currentTimeMillis();
         db.beginTransaction();
         try {
@@ -310,10 +303,6 @@ class UserDatabaseUpgrader {
      * Adding an appId field to FormRecords, for compatibility with multiple apps functionality
      */
     private boolean upgradeNineTen(SQLiteDatabase db) {
-        // This process could take a while, so tell the service to wait longer to make sure
-        // it can finish
-        CommCareApplication.instance().setCustomServiceBindTimeout(60 * 5 * 1000);
-
         db.beginTransaction();
         try {
 
@@ -415,10 +404,6 @@ class UserDatabaseUpgrader {
     }
 
     private boolean upgradeThirteenFourteen(SQLiteDatabase db) {
-        // This process could take a while, so tell the service to wait longer
-        // to make sure it can finish
-        CommCareApplication.instance().setCustomServiceBindTimeout(60 * 5 * 1000);
-
         db.beginTransaction();
         try {
             SqlStorage<FormRecordV2> formRecordSqlStorage = new SqlStorage<>(


### PR DESCRIPTION
Fixes https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59bab3f7be077a4dcca0087b?time=last-seven-days.

The stack trace in the above crash doesn't reveal what was really going on here (thanks @ctsims for getting to the bottom of it). The bug was that for the v20 --> v21 user db migration (which reindexes all cases), the migration was taking longer than 5 seconds, which is the default timeout set in `CommCareApplication` (`MAX_BIND_TIMEOUT`) for binding to the session service. Previously, we would selectively increase this timeout in certain migrations that we expected to take a long time, but this one was missed and is causing issues for a few users (thankfully only 3 so far, all in the same app, so seems quite rare). But since there's really not much harm in increasing this timeout even when it's not strictly necessary, we've decided to simplify matters and prevent this in the future by having a blanket increase in the timeout for all user db upgrades.