### PR TITLE
Wi-Fi Direct Bug Fix

### DIFF
--- a/app/src/org/commcare/fragments/FileServerFragment.java
+++ b/app/src/org/commcare/fragments/FileServerFragment.java
@@ -72,9 +72,7 @@ public class FileServerFragment extends Fragment {
         Logger.log(TAG, "File Server starting...");
 
         mStatusText.setText("Starting server");
-
         mView.setVisibility(View.VISIBLE);
-
         if (mFileServer != null) {
             mFileServer.cancel(true);
         }
@@ -101,8 +99,7 @@ public class FileServerFragment extends Fragment {
         private final FileServerFragment mListener;
         private boolean socketOccupied;
 
-        public FileServerAsyncTask(FileServerFragment mListener) {
-            Log.d(TAG, "new fileasync task");
+        FileServerAsyncTask(FileServerFragment mListener) {
             this.mListener = mListener;
 
         }
@@ -120,12 +117,8 @@ public class FileServerFragment extends Fragment {
 
                 try {
                     publishProgress("Ready to accept new file transfer.", null);
-
                     Socket client = serverSocket.accept();
-
                     Logger.log(TAG, "Ready in wi-fi direct file server receive loop");
-
-                    Log.d(TAG, "server: copying files " + finalFileName);
 
                     final File f = new File(finalFileName);
 
@@ -144,12 +137,8 @@ public class FileServerFragment extends Fragment {
                     return f.getAbsolutePath();
 
                 } catch (IOException e) {
-                    Log.e(TAG, e.getMessage());
-                    final File f = new File(finalFileName);
-                    if (f.exists()) {
-                        FileUtil.deleteFileOrDir(f);
-                    }
-                    publishProgress("File Server crashed with an IO Exception: " + e.getMessage());
+                    Logger.log(TAG, e.getMessage());
+                    publishProgress("File Server crashed after transfer with IO Exception: " + e.getMessage());
                     return null;
                 } finally {
                     serverSocket.close();
@@ -181,7 +170,6 @@ public class FileServerFragment extends Fragment {
         @Override
         protected void onPreExecute() {
             Logger.log(TAG, "pre-execute of file server launch");
-            // statusText.setText("Opening a server socket");
         }
 
         @Override

--- a/app/src/org/commcare/fragments/FileServerFragment.java
+++ b/app/src/org/commcare/fragments/FileServerFragment.java
@@ -131,7 +131,6 @@ public class FileServerFragment extends Fragment {
                     Log.d(TAG, "server: copying files " + f.toString());
                     InputStream inputstream = client.getInputStream();
                     CommCareWiFiDirectActivity.copyFile(inputstream, new FileOutputStream(f));
-                    serverSocket.close();
                     publishProgress("copied files: " + f.getAbsolutePath(), f.getAbsolutePath());
                     publishProgress("File Server Resetting", null);
                     return f.getAbsolutePath();
@@ -141,7 +140,12 @@ public class FileServerFragment extends Fragment {
                     publishProgress("File Server crashed after transfer with IO Exception: " + e.getMessage());
                     return null;
                 } finally {
-                    serverSocket.close();
+                    try {
+                        serverSocket.close();
+                    } catch(IOException e) {
+                        // Can ignore
+                        e.printStackTrace();
+                    }
                 }
             } catch (IOException ioe) {
                 publishProgress("Ready to accept new file transfer.", null);


### PR DESCRIPTION
A line of the Wi-Fi Direct copy file code could result in the copy going through as successful (and the sender deleting their forms) but also triggering the receiver to delete the received payload (even though it would be, in fact, in tact).

This fix changes that by:

Catching the socket close IOException (which should really be ignored) outside the normal catch
Not deleting the forms in the event of an error (because the folder name is time-based we don't really need to worry about cleaning these up)