### PR TITLE
Set up ability to require PIN for dev options access

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -753,6 +753,9 @@ clear.user.data.warning.message=Are you sure you want to clear all mobile user d
 force.log.submit=Force Log Submission
 recovery.mode=Recovery Mode
 
+dev.options.code.incorrect=The Developer Options access code that you entered was incorrect
+dev.options.access.granted=Access to Developer Options granted!
+
 repeat.dialog.go.back=Go Back
 repeat.dialog.leave=Do Not Add
 repeat.dialog.exit=Do Not Add. I'm Finished.

--- a/app/res/xml/preferences_developer_access_code.xml
+++ b/app/res/xml/preferences_developer_access_code.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <EditTextPreference
+        android:dialogTitle="Enter Access Code"
+        android:key="cc-dev-prefs-user-entered-code"
+        android:title="Developer Options Access Code"
+        android:inputType="textPassword"/>
+</PreferenceScreen>

--- a/app/src/org/commcare/preferences/CommCarePreferences.java
+++ b/app/src/org/commcare/preferences/CommCarePreferences.java
@@ -205,21 +205,7 @@ public class CommCarePreferences
             }
         });
 
-        Preference developerSettingsButton = findPreference(DEVELOPER_SETTINGS);
-        if (DeveloperPreferences.isSuperuserEnabled()) {
-            developerSettingsButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-                @Override
-                public boolean onPreferenceClick(Preference preference) {
-                    GoogleAnalyticsUtils.reportPrefItemClick(
-                            GoogleAnalyticsFields.CATEGORY_CC_PREFS,
-                            GoogleAnalyticsFields.LABEL_DEVELOPER_OPTIONS);
-                    startDeveloperOptions();
-                    return true;
-                }
-            });
-        } else {
-            getPreferenceScreen().removePreference(developerSettingsButton);
-        }
+        configureDevPreferencesButton();
 
         Preference analyticsButton = findPreference(DISABLE_ANALYTICS);
         if (CommCarePreferences.isAnalyticsEnabled()) {
@@ -245,6 +231,24 @@ public class CommCarePreferences
                 return true;
             }
         });
+    }
+
+    private void configureDevPreferencesButton() {
+        Preference developerSettingsButton = findPreference(DEVELOPER_SETTINGS);
+        if (DeveloperPreferences.isSuperuserEnabled()) {
+            developerSettingsButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    GoogleAnalyticsUtils.reportPrefItemClick(
+                            GoogleAnalyticsFields.CATEGORY_CC_PREFS,
+                            GoogleAnalyticsFields.LABEL_DEVELOPER_OPTIONS);
+                    startDeveloperOptions();
+                    return true;
+                }
+            });
+        } else {
+            getPreferenceScreen().removePreference(developerSettingsButton);
+        }
     }
 
     private void setVisibilityOfUpdateOptionsPref() {
@@ -314,8 +318,10 @@ public class CommCarePreferences
                 getActivity().setResult(DeveloperPreferences.RESULT_SYNC_CUSTOM);
                 getActivity().finish();
             }
+            else if (resultCode == DeveloperPreferences.RESULT_DEV_OPTIONS_DISABLED) {
+                configureDevPreferencesButton();
+            }
         }
-
     }
 
     @Override


### PR DESCRIPTION
Addresses concerns laid out in https://manage.dimagi.com/default.asp?262779. This does the same thing as https://github.com/dimagi/commcare-android/pull/1850 but on master.

I've added internal documentation on confluence [here](https://confluence.dimagi.com/display/internal/CommCare+Android+Developer+Options+--+Internal#CommCareAndroidDeveloperOptions--Internal-HowtorestrictaccesstotheDeveloperOptions).