### PR TITLE
Prevent NPE when EntitySelectActivity has no command

### DIFF
--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -349,6 +349,10 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
     @Override
     protected void onResumeSessionSafe() {
+        if (session.getCommand() == null) {
+            setResult(RESULT_CANCELED);
+            this.finish();
+        }
         if (!isFinishing() && !isStartingDetailActivity) {
             if (adapter != null) {
                 adapter.registerDataSetObserver(mListStateObserver);
@@ -653,6 +657,11 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
+        if (session.getCommand() == null) {
+            // we're going to finish in onResume anyway
+            return false;
+        }
+
         super.onCreateOptionsMenu(menu);
         //use the old method here because some Android versions don't like Spannables for titles
         menu.add(0, MENU_SORT, MENU_SORT, Localization.get("select.menu.sort")).setIcon(


### PR DESCRIPTION
I believe this should fix https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59caaf16be077a4dcc4b044e?time=last-seven-days, though I would like someone else to think through if they agree with my logic.

The NPE is clearly happening because `entitySelectSearchUI` doesn't get initialized if `session.getCommand()` is null. What's unclear to me is the exact right way to handle it. I did some digging into the history of `EntitySelectActivity` and the comments surrounding what to do when there's no session command. My conclusion from that investigation is that the original intent here was for us to finish in onResume when in this state, but that wasn't actually happening. So I've added that, in addition to protecting `onCreateOptionsMenu` from doing anything if we're about to finish, because I _think_ there are instances in which onCreateOptionsMenu can get called before onResume.