### PR TITLE
Use Standard Image inflate for Callout Menu Icons 

### DIFF
--- a/app/src/org/commcare/activities/components/EntitySelectCalloutSetup.java
+++ b/app/src/org/commcare/activities/components/EntitySelectCalloutSetup.java
@@ -5,7 +5,6 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.view.MenuItem;
@@ -15,16 +14,12 @@ import android.widget.Toast;
 
 import org.commcare.activities.EntitySelectActivity;
 import org.commcare.dalvik.R;
-import org.commcare.preferences.CommCarePreferences;
 import org.commcare.suite.model.Callout;
 import org.commcare.suite.model.CalloutData;
 import org.commcare.utils.MediaUtil;
 import org.javarosa.core.model.condition.EvaluationContext;
-import org.javarosa.core.reference.InvalidReferenceException;
-import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.locale.Localization;
 
-import java.io.IOException;
 import java.util.Map;
 
 public class EntitySelectCalloutSetup {

--- a/app/src/org/commcare/activities/components/EntitySelectCalloutSetup.java
+++ b/app/src/org/commcare/activities/components/EntitySelectCalloutSetup.java
@@ -15,8 +15,10 @@ import android.widget.Toast;
 
 import org.commcare.activities.EntitySelectActivity;
 import org.commcare.dalvik.R;
+import org.commcare.preferences.CommCarePreferences;
 import org.commcare.suite.model.Callout;
 import org.commcare.suite.model.CalloutData;
+import org.commcare.utils.MediaUtil;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
@@ -49,19 +51,14 @@ public class EntitySelectCalloutSetup {
     private static Drawable getCalloutDrawable(Context context, String imagePath){
         Bitmap b;
         if (!imagePath.equals("")) {
-            try {
-                b = BitmapFactory.decodeStream(ReferenceManager.instance().DeriveReference(imagePath).getStream());
-                if (b == null) {
-                    // Input stream could not be used to derive bitmap, so
-                    // showing error-indicating image
-                    return context.getResources().getDrawable(R.drawable.ic_menu_archive);
-                } else {
-                    return new BitmapDrawable(b);
-                }
-            } catch (IOException | InvalidReferenceException ex) {
-                ex.printStackTrace();
-                // Error loading image, default to folder button
+            int actionBarHeight = MediaUtil.getActionBarHeightInPixels(context);
+            b = MediaUtil.inflateDisplayImage(context, imagePath, -1,actionBarHeight);
+            if (b == null) {
+                // Input stream could not be used to derive bitmap, so
+                // showing error-indicating image
                 return context.getResources().getDrawable(R.drawable.ic_menu_archive);
+            } else {
+                return new BitmapDrawable(b);
             }
         } else {
             // no image passed in, draw a white background

--- a/app/src/org/commcare/utils/MediaUtil.java
+++ b/app/src/org/commcare/utils/MediaUtil.java
@@ -1,6 +1,7 @@
 package org.commcare.utils;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.DisplayMetrics;
@@ -101,6 +102,15 @@ public class MediaUtil {
             e.printStackTrace();
         }
         return null;
+    }
+
+    public static int getActionBarHeightInPixels(Context context) {
+        final TypedArray styledAttributes = context.getTheme().obtainStyledAttributes(
+                new int[] { android.R.attr.actionBarSize });
+        int actionBarSize = (int) styledAttributes.getDimension(0, 0);
+        styledAttributes.recycle();
+
+        return actionBarSize;
     }
 
     public static Bitmap inflateDisplayImage(Context context, String jrUri,


### PR DESCRIPTION
Super small change to use the normal dynamic image inflation strategy for callout icons