### PR TITLE
Fix error handling for non NDEFF NFC tags

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -796,6 +796,7 @@ nfc.missing.domain=A domain must be provided when specifying a custom type for y
 nfc.read.success=NFC read was successful!
 nfc.read.io.error=An IO error occurred while attempting to read the Ndef message
 nfc.read.msg.malformed=The Ndef message read from the NFC tag was malformed
+nfc.read.error.no.ndef=The message on this NFC tag is not of a format that Android devices can read
 nfc.read.no.data=The provided NFC tag had no data on it to read
 nfc.read.error.unsupported=The message read from the NFC tag is of a type not supported by CommCare
 nfc.read.error.mismatch=The message read from the NFC tag does not match the type specified by this app's configuration

--- a/app/src/org/commcare/android/nfc/NfcReadActivity.java
+++ b/app/src/org/commcare/android/nfc/NfcReadActivity.java
@@ -67,7 +67,13 @@ public class NfcReadActivity extends NfcActivity {
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     private void readFromNfcTag(Tag tag) {
         Ndef ndefObject = Ndef.get(tag);
+        if(ndefObject == null) {
+            finishWithErrorToast("nfc.read.msg.malformed");
+            return;
+        }
+
         try {
+            //This is how Ndef.get reports an NFC datatype which isn't an NDEF
             ndefObject.connect();
             NdefMessage msg = ndefObject.getNdefMessage();
             if (msg == null) {

--- a/app/src/org/commcare/android/nfc/NfcReadActivity.java
+++ b/app/src/org/commcare/android/nfc/NfcReadActivity.java
@@ -67,13 +67,14 @@ public class NfcReadActivity extends NfcActivity {
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     private void readFromNfcTag(Tag tag) {
         Ndef ndefObject = Ndef.get(tag);
+
+        //This is how Ndef.get reports an NFC tag which doesn't support NDEF
         if(ndefObject == null) {
             finishWithErrorToast("nfc.read.msg.malformed");
             return;
         }
 
         try {
-            //This is how Ndef.get reports an NFC datatype which isn't an NDEF
             ndefObject.connect();
             NdefMessage msg = ndefObject.getNdefMessage();
             if (msg == null) {

--- a/app/src/org/commcare/android/nfc/NfcReadActivity.java
+++ b/app/src/org/commcare/android/nfc/NfcReadActivity.java
@@ -68,9 +68,9 @@ public class NfcReadActivity extends NfcActivity {
     private void readFromNfcTag(Tag tag) {
         Ndef ndefObject = Ndef.get(tag);
 
-        //This is how Ndef.get reports an NFC tag which doesn't support NDEF
-        if(ndefObject == null) {
-            finishWithErrorToast("nfc.read.msg.malformed");
+        // This is how Ndef.get() reports an NFC tag which doesn't support Ndef
+        if (ndefObject == null) {
+            finishWithErrorToast("nfc.read.error.no.ndef");
             return;
         }
 


### PR DESCRIPTION
CommCare was crashing when scanning NFC tags which didn't support NDEF.