### PR TITLE
Handle possibility of onCreateOptionsMenu getting called before onCreate finishes

### DIFF
--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -189,6 +189,13 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
             boolean isOrientationChange = savedInstanceState != null;
             setupUI(isOrientationChange);
+
+            // On some devices, onCreateOptionsMenu() can get called before onCreate() has completed
+            // if the action bar is in use. Since we can't deploy all of the logic in onCreateOptionsMenu
+            // until this has happened, we should try to do it again when onCreate is complete
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                invalidateOptionsMenu();
+            }
         }
     }
 
@@ -654,7 +661,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
-        //use the old method here because some Android versions don't like Spannables for titles
         menu.add(0, MENU_SORT, MENU_SORT, Localization.get("select.menu.sort")).setIcon(
                 android.R.drawable.ic_menu_sort_alphabetically);
         if (isMappingEnabled) {
@@ -662,8 +668,12 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
                     android.R.drawable.ic_menu_mapmode);
         }
 
-        tryToAddSearchActionToAppBar(this, menu, entitySelectSearchUI.getActionBarInstantiator());
-        setupActionOptionsMenu(menu);
+        if (entitySelectSearchUI != null) {
+            // Only execute this portion if setupUI() has completed; the presence of the action bar
+            // can sometimes cause this method to get called before onCreate() has completed
+            tryToAddSearchActionToAppBar(this, menu, entitySelectSearchUI.getActionBarInstantiator());
+            setupActionOptionsMenu(menu);
+        }
         return true;
     }
 


### PR DESCRIPTION
Apparently if the action bar is being used in an activity, it is possible for `onCreateOptionsMenu` to get called before `onCreate` has finished executing (see https://stackoverflow.com/questions/7705927/android-when-is-oncreateoptionsmenu-called-during-activity-lifecycle/7706597#7706597). Although this definitely doesn't happen on all phones, it's the best explanation I can find for [this crash](https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59caaf16be077a4dcc4b044e/sessions/59E0B141028000014ABF51F37354211A_f3dbf274b01111e7919a56847afe9799_0_v2?) (after determining that the cause I was proposing in https://github.com/dimagi/commcare-android/pull/1853 doesn't seem possible).