### PR TITLE
Prevent null form controller after rotate during form load

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -116,6 +116,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     // rotation (or similar)
     private static final String KEY_FORM_LOAD_HAS_TRIGGERED = "newform";
     private static final String KEY_FORM_LOAD_FAILED = "form-failed";
+    private static final String KEY_FORM_LOAD_COMPLETED = "form-load-completed";
     private static final String KEY_LOC_ERROR = "location-not-enabled";
     private static final String KEY_LOC_ERROR_PATH = "location-based-xpath-error";
     private static final String KEY_IS_READ_ONLY = "instance-is-read-only";
@@ -130,6 +131,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     private boolean mIncompleteEnabled = true;
     private boolean instanceIsReadOnly = false;
     private boolean hasFormLoadBeenTriggered = false;
+    private boolean hasFormLoadCompleted = false;
     private boolean hasFormLoadFailed = false;
     private String locationRecieverErrorAction = null;
     private String badLocationXpath = null;
@@ -192,7 +194,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         } else if (data instanceof SaveToDiskTask) {
             mSaveToDiskTask = (SaveToDiskTask)data;
             mSaveToDiskTask.setFormSavedListener(this);
-        } else if (hasFormLoadBeenTriggered && !hasFormLoadFailed) {
+        } else if (hasFormLoadCompleted && !hasFormLoadFailed) {
             // Screen orientation change
             uiController.refreshView();
         }
@@ -250,6 +252,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
         outState.putBoolean(KEY_FORM_LOAD_HAS_TRIGGERED, hasFormLoadBeenTriggered);
         outState.putBoolean(KEY_FORM_LOAD_FAILED, hasFormLoadFailed);
+        outState.putBoolean(KEY_FORM_LOAD_COMPLETED, hasFormLoadCompleted);
         outState.putString(KEY_LOC_ERROR, locationRecieverErrorAction);
         outState.putString(KEY_LOC_ERROR_PATH, badLocationXpath);
 
@@ -942,6 +945,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     }
 
     private void handleFormLoadCompletion(AndroidFormController fc) {
+        hasFormLoadCompleted = true;
         if (GeoUtils.ACTION_CHECK_GPS_ENABLED.equals(locationRecieverErrorAction)) {
             FormEntryDialogs.handleNoGpsBroadcast(this);
         } else if (PollSensorAction.XPATH_ERROR_ACTION.equals(locationRecieverErrorAction)) {
@@ -1277,6 +1281,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             }
             if (savedInstanceState.containsKey(KEY_FORM_LOAD_FAILED)) {
                 hasFormLoadFailed = savedInstanceState.getBoolean(KEY_FORM_LOAD_FAILED, false);
+            }
+            if (savedInstanceState.containsKey(KEY_FORM_LOAD_COMPLETED)) {
+                hasFormLoadCompleted = savedInstanceState.getBoolean(KEY_FORM_LOAD_COMPLETED, false);
             }
 
             locationRecieverErrorAction = savedInstanceState.getString(KEY_LOC_ERROR);


### PR DESCRIPTION
I _think_ this is the fix for: https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59c6c7cabe077a4dcc21be3b?time=last-seven-days.

Logically, it makes perfect sense that this is what would have been causing the issue; if you rotated while the form was still loading, then `hasFormLoadBeenTriggered` would have been true in the call to `onCreate()`, causing us to call `uiController.refreshView()`. But `mFormController` doesn't get initialized until `handleFormLoadCompletion()`, hence it would be null. The only problem with this theory is that I couldn't actually reproduce it when I tried opening a form that took a while to load, and rotated it a couple of times before loading finished. Somewhat inexplicably to me, it seemed that the call to `onCreate` that would be triggered by the rotation was queued up in some way by the OS, and not called until `FormLoaderTask` finished (this I surmised from using the debugger). Does this make any sense to anyone? Given how odd this behavior does seem, combined with how much sense this hypothesis makes from a codepath perspective, I'm guessing that the behavior on rotation when a task is in progress is inconsistent between devices in some way, and still think this is likely to be the correct bug and the correct fix. But let me know if others know more that might discredit this.