### PR TITLE
onCreate --> onCreateSessionSafe

### DIFF
--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -139,9 +139,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
+    protected void onCreateSessionSafe(Bundle savedInstanceState) {
         platform = CommCareApplication.instance().getCommCarePlatform();
         setContentView(R.layout.entity_select_layout);
         findViewById(R.id.entity_select_loading).setVisibility(View.GONE);


### PR DESCRIPTION
Should fix https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59c3fc75be077a4dcc02c8f0?time=last-seven-days. `FormRecordListActivity` was implementing `SessionAwareCommCareActivity`, but not actually utilizing `onCreateSessionSafe`, which defeats the whole point.