### PR TITLE
Use new file access format for Audio and Video Widget

### DIFF
--- a/app/src/org/commcare/views/widgets/AudioWidget.java
+++ b/app/src/org/commcare/views/widgets/AudioWidget.java
@@ -107,8 +107,9 @@ public class AudioWidget extends MediaWidget {
 
     protected void playAudio() {
         Intent i = new Intent("android.intent.action.VIEW");
-        File f = new File(mInstanceFolder + mBinaryName);
-        i.setDataAndType(Uri.fromFile(f), "audio/*");
+        File audioFile = new File(mInstanceFolder + mBinaryName);
+        Uri audioUri = FileUtil.getUriForExternalFile(getContext(), audioFile);
+        i.setDataAndType(audioUri, "audio/*");
         try {
             getContext().startActivity(i);
         } catch (ActivityNotFoundException e) {

--- a/app/src/org/commcare/views/widgets/VideoWidget.java
+++ b/app/src/org/commcare/views/widgets/VideoWidget.java
@@ -104,8 +104,9 @@ public class VideoWidget extends MediaWidget {
             @Override
             public void onClick(View v) {
                 Intent i = new Intent("android.intent.action.VIEW");
-                File f = new File(mInstanceFolder + "/" + mBinaryName);
-                i.setDataAndType(Uri.fromFile(f), "video/*");
+                File videoFile = new File(mInstanceFolder + "/" + mBinaryName);
+                Uri videoUri = FileUtil.getUriForExternalFile(getContext(), videoFile);
+                i.setDataAndType(videoUri, "video/*");
                 try {
                     getContext().startActivity(i);
                 } catch (ActivityNotFoundException e) {


### PR DESCRIPTION
Fix for https://manage.dimagi.com/default.asp?264387

Makes Audio and Video widget conform to the new File access protocol for Android 7+

Tested on my Alcatel running 7.0