### PR TITLE
Potential Fix for Fragment already added crash

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -336,6 +336,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         if(!fragment.isAdded()) {
             ft.replace(R.id.setup_fragment_container, fragment);
             ft.commit();
+            fm.executePendingTransactions();
         }
     }
 

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -333,8 +333,10 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 return;
         }
 
-        ft.replace(R.id.setup_fragment_container, fragment);
-        ft.commit();
+        if(!fragment.isAdded()) {
+            ft.replace(R.id.setup_fragment_container, fragment);
+            ft.commit();
+        }
     }
 
     private Fragment restoreInstallSetupFragment() {


### PR DESCRIPTION
CL: https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59cee64dbe077a4dcc7dc848?time=last-ninety-days

I am not able to reproduce this crash and also not able to really grasp what exactly might be going wrong here. Though looking at some stackoverflow posts it seems like a FragmentActivity bug happening when user presses back before fragment Transaction could finish completing. so I have basically followed the suggestion given here -
 https://stackoverflow.com/questions/13745787/fragment-already-added-support-lib/14298328

Though what's really confusing me is how is backstack popping the `SelectInstallModeFragment` when we are not adding the fragment to backstack anywhere in code. 
