### PR TITLE
Try to handle boolean and int prefs

### DIFF
--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -171,25 +171,13 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        String prefValue = getPrefValueAsString2(sharedPreferences, key);
+        String prefValue = getPrefValueAsString(sharedPreferences, key);
         if (prefValue != null) {
             FirebaseAnalyticsUtil.reportEditPreferenceItem(key, prefValue);
         }
     }
 
     private static String getPrefValueAsString(SharedPreferences sharedPreferences, String key) {
-        try {
-            return sharedPreferences.getString(key, null);
-        } catch (ClassCastException e) {
-            try {
-                return String.valueOf(sharedPreferences.getBoolean(key, false));
-            } catch (ClassCastException e2) {
-                return String.valueOf(sharedPreferences.getInt(key, -1));
-            }
-        }
-    }
-
-    private static String getPrefValueAsString2(SharedPreferences sharedPreferences, String key) {
         return String.valueOf(sharedPreferences.getAll().get(key));
     }
 }

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -171,7 +171,16 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        String prefValue = sharedPreferences.getString(key, null);
+        String prefValue;
+        try {
+            prefValue = sharedPreferences.getString(key, null);
+        } catch (ClassCastException e) {
+            try {
+                prefValue = String.valueOf(sharedPreferences.getBoolean(key, false));
+            } catch (ClassCastException e2) {
+                prefValue = String.valueOf(sharedPreferences.getInt(key, -1));
+            }
+        }
         if (prefValue != null) {
             FirebaseAnalyticsUtil.reportEditPreferenceItem(key, prefValue);
         }

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -171,18 +171,21 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        String prefValue;
-        try {
-            prefValue = sharedPreferences.getString(key, null);
-        } catch (ClassCastException e) {
-            try {
-                prefValue = String.valueOf(sharedPreferences.getBoolean(key, false));
-            } catch (ClassCastException e2) {
-                prefValue = String.valueOf(sharedPreferences.getInt(key, -1));
-            }
-        }
+        String prefValue = getPrefValueAsString(sharedPreferences, key);
         if (prefValue != null) {
             FirebaseAnalyticsUtil.reportEditPreferenceItem(key, prefValue);
+        }
+    }
+
+    private static String getPrefValueAsString(SharedPreferences sharedPreferences, String key) {
+        try {
+            return sharedPreferences.getString(key, null);
+        } catch (ClassCastException e) {
+            try {
+                return String.valueOf(sharedPreferences.getBoolean(key, false));
+            } catch (ClassCastException e2) {
+                return String.valueOf(sharedPreferences.getInt(key, -1));
+            }
         }
     }
 }

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -171,7 +171,7 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        String prefValue = getPrefValueAsString(sharedPreferences, key);
+        String prefValue = getPrefValueAsString2(sharedPreferences, key);
         if (prefValue != null) {
             FirebaseAnalyticsUtil.reportEditPreferenceItem(key, prefValue);
         }
@@ -187,5 +187,9 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
                 return String.valueOf(sharedPreferences.getInt(key, -1));
             }
         }
+    }
+
+    private static String getPrefValueAsString2(SharedPreferences sharedPreferences, String key) {
+        return String.valueOf(sharedPreferences.getAll().get(key));
     }
 }


### PR DESCRIPTION
The UI tests caught [this bug](https://gist.github.com/wpride/bc47750867cd87ef0ad9208d77898478) on opening Recovery Mode

One of Aliza's recent refactors expected `SharedPreference`s to only be of String type:

https://github.com/dimagi/commcare-android/commit/8f92adfae4226100083e1739e2cbce3c81c2d054#diff-0f317061966a57e0ec9feda1db245a00R174

Meanwhile one of Shubham's refactors added a boolean pref:

https://github.com/dimagi/commcare-android/commit/fd687a256e18acd26a1421e210c19c82fded1395#diff-48d5e471c4e5e4492d24f712bf5d37e9R571

I expect that we want the `onSharedPreferenceUpdated` code to be robust against all setting types,  but unfortunately [there doesn't seem to be a clean way to do this](https://stackoverflow.com/questions/29615920/android-check-sharedpreferences-for-value-type)

I don't like this PR but it might be the cleanest way to go