### PR TITLE
Force SessionUnavailableException to happen immediately if it's going to

### DIFF
--- a/app/src/org/commcare/activities/SessionAwareCommCareActivity.java
+++ b/app/src/org/commcare/activities/SessionAwareCommCareActivity.java
@@ -2,6 +2,7 @@ package org.commcare.activities;
 
 import android.os.Bundle;
 
+import org.commcare.CommCareApplication;
 import org.commcare.utils.SessionActivityRegistration;
 import org.commcare.utils.SessionUnavailableException;
 
@@ -16,6 +17,7 @@ public abstract class SessionAwareCommCareActivity<R> extends CommCareActivity<R
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         try {
+            CommCareApplication.instance().getSession();
             onCreateSessionSafe(savedInstanceState);
         } catch (SessionUnavailableException e) {
             SessionActivityRegistration.redirectToLogin(this);


### PR DESCRIPTION
This should fix https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59cfab3ebe077a4dcc85c3a7?time=last-seven-days, and probably some other similar issues as well. The idea here is that our implementation of session-aware activities isn't always working, because there are places throughout our code where we respond to a `SessionUnavailableException` by returning `null` for some value (for instance: https://github.com/dimagi/commcare-android/blob/bd67a38fa49845c6c920693d998f38ce985d2b43/app/src/org/commcare/models/database/AndroidSandbox.java#L89-L95). In these situations, CommCare can end up crashing with a NPE, instead of  `SessionAwareCommCareActivity` catching and handling the `SessionUnavailableException`. By adding this call to `getSession()` before we execute `onCreateSessionSafe` this will ensure that if the session has died, it will immediately manifest itself in the proper way.