### PR TITLE
Fix String.format for integrity scan log

### DIFF
--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -620,7 +620,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         String passOrFail = integrityScanResult.first ? "PASSED:" : "FAILED:";
         Logger.log(
                 LogTypes.TYPE_ERROR_STORAGE,
-                String.format("Integrity scan for form record with ID %s has %s. Report Details: %",
+                String.format("Integrity scan for form record with ID %s has %s. Report Details: %s",
                         r.getInstanceID(),
                         passOrFail,
                         integrityScanResult.second));


### PR DESCRIPTION
Fixes crash by UI tests:

https://us-west-2.console.aws.amazon.com/devicefarm/home?#/projects/5aba0e8d-7e3a-4563-a73c-4fc0e5e80b95/runs/0320be9f-d0a2-4853-a900-1311319113e0/jobs/00000/suites/00001/tests/00000

11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: java.util.UnknownFormatConversionException: Conversion: 
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at java.util.Formatter$FormatSpecifierParser.unknownFormatConversionException(Formatter.java:2321)
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at java.util.Formatter$FormatSpecifierParser.advance(Formatter.java:2315)
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at java.util.Formatter$FormatSpecifierParser.parseConversionType(Formatter.java:2394)
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at java.util.Formatter$FormatSpecifierParser.parseArgumentIndexAndFlags(Formatter.java:2365)
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at java.util.Formatter$FormatSpecifierParser.parseFormatToken(Formatter.java:2298)
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at java.util.Formatter.doFormat(Formatter.java:1071)
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at java.util.Formatter.format(Formatter.java:1042)
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at java.util.Formatter.format(Formatter.java:1011)
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at java.lang.String.format(String.java:1803)
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at java.lang.String.format(String.java:1777)
11-05 00:05:13.908  8986  8986 E MessageQueue-JNI: 	at org.commcare.activities.FormRecordListActivity.logIntegrityScanResult(FormRecordListActivity.java:623)