### PR TITLE
Prevent npe if `results` hasn't been initialized when task is canceled

### DIFF
--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -525,9 +525,11 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
 
     protected int getSuccessfulSends() {
         int successes = 0;
-        for (FormUploadResult formResult : results) {
-            if (formResult != null && FormUploadResult.FULL_SUCCESS == formResult) {
-                successes++;
+        if (results != null) {
+            for (FormUploadResult formResult : results) {
+                if (formResult != null && FormUploadResult.FULL_SUCCESS == formResult) {
+                    successes++;
+                }
             }
         }
         return successes;


### PR DESCRIPTION
Will fix https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59d38d28be077a4dccad737e/sessions/latest?build=65456794