### PR TITLE
Prevent NSD crash in Android 4

### DIFF
--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -569,8 +569,6 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
 
     @Override
     public synchronized void onMicronodeDiscovery() {
-        boolean appsAvailable = false;
-
         //If we aren't staged, don't go down this road
         if (CommCareApplication.instance().getCurrentApp() == null) {
             return;

--- a/app/src/org/commcare/android/nsd/NSDDiscoveryTools.java
+++ b/app/src/org/commcare/android/nsd/NSDDiscoveryTools.java
@@ -48,7 +48,7 @@ public class NSDDiscoveryTools {
     private static NsdState state = NsdState.Init;
 
     public static void registerForNsdServices(Context context, NsdServiceListener listener) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return;
         }
 
@@ -57,6 +57,10 @@ public class NSDDiscoveryTools {
     }
 
     public static void unregisterForNsdServices(NsdServiceListener listener) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return;
+        }
+
         removeListener(listener);
     }
 
@@ -94,7 +98,7 @@ public class NSDDiscoveryTools {
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private static void doDiscovery(Context context) {
         synchronized (nsdToolsLock) {
             if (mNsdManager == null) {
@@ -112,7 +116,7 @@ public class NSDDiscoveryTools {
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private static boolean connectNsdManager(final Context context) {
         synchronized (nsdToolsLock) {
             //sometimes the service fetch  basically times out forever, thanks for the clear
@@ -148,7 +152,7 @@ public class NSDDiscoveryTools {
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private static void initializeDiscoveryListener() {
 
         // Instantiate a new DiscoveryListener
@@ -203,7 +207,7 @@ public class NSDDiscoveryTools {
         };
     }
 
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private static NsdManager.ResolveListener getResolveListener() {
         return new NsdManager.ResolveListener() {
 


### PR DESCRIPTION
Fix for https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59c55824be077a4dcc126d60?time=last-thirty-days

Change min Android version for NSD to 5.0 to avoid this Android bug: https://issuetracker.google.com/issues/36952181