### PR TITLE
Prevent npe in onPrepareOptionsMenu too

### DIFF
--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -696,7 +696,13 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         menu.findItem(MENU_SORT).setEnabled(adapter != null);
         // hide sorting menu when using async loading strategy
         menu.findItem(MENU_SORT).setVisible((shortSelect == null || shortSelect.hasSortField()));
-        menu.findItem(R.id.menu_settings).setVisible(!CommCareApplication.instance().isConsumerApp());
+
+        if (entitySelectSearchUI != null) {
+            // For the same reason as in onCreateOptionsMenu(), we may be trying to call this
+            // before we're ready
+            menu.findItem(R.id.menu_settings).setVisible(!CommCareApplication.instance().isConsumerApp());
+        }
+
         return super.onPrepareOptionsMenu(menu);
     }
 

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -697,7 +697,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         // hide sorting menu when using async loading strategy
         menu.findItem(MENU_SORT).setVisible((shortSelect == null || shortSelect.hasSortField()));
 
-        if (entitySelectSearchUI != null) {
+        if (menu.findItem(R.id.menu_settings) != null) {
             // For the same reason as in onCreateOptionsMenu(), we may be trying to call this
             // before we're ready
             menu.findItem(R.id.menu_settings).setVisible(!CommCareApplication.instance().isConsumerApp());


### PR DESCRIPTION
Fix for https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59fb2ad261b02d480da4d741?time=last-seven-days, which is unfortunately a regression in 2.40 due to the fix I implemented in https://github.com/dimagi/commcare-android/pull/1860 for https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59caaf16be077a4dcc4b044e/sessions/59E0B141028000014ABF51F37354211A_f3dbf274b01111e7919a56847afe9799_0_v2?. I now realize that the fix I implemented basically just pushed off this crash to `onPrepareOptionsMenu` instead of `onCreateOptionsMenu`. This will now prevent it from happening in either. (I don't think a hotfix is necessary since the previous crash was equivalent and around for quite a while).