### PR TITLE
Go back to getting fixture names as a Set for the migration

### DIFF
--- a/app/src/org/commcare/models/database/IndexedFixturePathUtils.java
+++ b/app/src/org/commcare/models/database/IndexedFixturePathUtils.java
@@ -61,6 +61,12 @@ public class IndexedFixturePathUtils {
         }
     }
 
+    public static Set<String> getAllIndexedFixtureNamesAsSet(SQLiteDatabase db) {
+        Set<String> fixtureNamesAsSet = new HashSet<>();
+        fixtureNamesAsSet.addAll(getAllIndexedFixtureNames(db));
+        return fixtureNamesAsSet;
+    }
+
     public static void insertIndexedFixturePathBases(SQLiteDatabase db, String fixtureName,
                                                      String baseName, String childName) {
         ContentValues contentValues = new ContentValues();

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -31,7 +31,6 @@ import org.commcare.modern.database.DatabaseIndexingUtils;
 import org.javarosa.core.model.User;
 import org.javarosa.core.services.storage.Persistable;
 
-import java.util.List;
 import java.util.Set;
 import java.util.Vector;
 
@@ -532,7 +531,7 @@ class UserDatabaseUpgrader {
     private boolean upgradeNineteenTwenty(SQLiteDatabase db) {
         db.beginTransaction();
         try {
-            List<String> allIndexedFixtures = IndexedFixturePathUtils.getAllIndexedFixtureNames(db);
+            Set<String> allIndexedFixtures = IndexedFixturePathUtils.getAllIndexedFixtureNamesAsSet(db);
             for (String fixtureName : allIndexedFixtures) {
                 String tableName = StorageIndexedTreeElementModel.getTableName(fixtureName);
                 SqlStorage<StorageIndexedTreeElementModel> storageForThisFixture =


### PR DESCRIPTION
This was a really really dumb regression on my part :( When I fixed the issue with the indexed fixture paths table allowing duplicates [here](https://github.com/dimagi/commcare-android/pull/1839), I somehow decided that that meant I could also change the migration method that originally revealed this bug to go back to fetching the names as a list. The problem of course is that people who are upgrading still have the old version and so still potentially have duplicate rows in that table.

@ctsims It's possible we want to hotfix this? Crashlytics shows it as only affecting 14 users so I'm not sure how to weight that: https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59d2e849be077a4dcca6ac46?time=last-thirty-days