### PR TITLE
Fixes NPE in AlertDialog after process kill

### DIFF
--- a/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
@@ -1,10 +1,12 @@
 package org.commcare.views.dialogs;
 
 import android.app.Dialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
+import android.util.Log;
 
 /**
  * Wrapper for CommCareAlertDialogs that allows them to persist across screen orientation changes,
@@ -34,6 +36,9 @@ public class AlertDialogFragment extends DialogFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setRetainInstance(true);
+        if (underlyingDialog == null) {
+            dismiss();
+        }
     }
 
     @Override
@@ -51,8 +56,13 @@ public class AlertDialogFragment extends DialogFragment {
     @Override
     @NonNull
     public Dialog onCreateDialog(Bundle savedInstanceState) {
+        if (underlyingDialog == null) {
+            return super.onCreateDialog(savedInstanceState);
+        }
         return underlyingDialog.getDialog();
     }
+
+
 
     @Override
     public void onDestroyView() {

--- a/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
@@ -60,8 +60,6 @@ public class AlertDialogFragment extends DialogFragment {
         return underlyingDialog.getDialog();
     }
 
-
-
     @Override
     public void onDestroyView() {
         // Ohh, you know, just a 5 year old Android bug ol' G hasn't fixed yet

--- a/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
@@ -34,9 +34,6 @@ public class AlertDialogFragment extends DialogFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setRetainInstance(true);
-        if (underlyingDialog == null) {
-            dismiss();
-        }
     }
 
     @Override
@@ -55,6 +52,9 @@ public class AlertDialogFragment extends DialogFragment {
     @NonNull
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         if (underlyingDialog == null) {
+            // We are in a bad state likely caused by fragment state restore after it got killed,
+            // return an empty dialogue to prevent NPE and dismiss it so that users don't see it
+            dismiss();
             return super.onCreateDialog(savedInstanceState);
         }
         return underlyingDialog.getDialog();

--- a/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
@@ -1,12 +1,10 @@
 package org.commcare.views.dialogs;
 
 import android.app.Dialog;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
-import android.util.Log;
 
 /**
  * Wrapper for CommCareAlertDialogs that allows them to persist across screen orientation changes,


### PR DESCRIPTION
Case: https://manage.dimagi.com/default.asp?265664#1422233
Crash: https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59d3443bbe077a4dcca9ffff?time=last-thirty-days

@amstone326 The reason behind this crash wasn't configuration change as it was working properly on rotaion but Android killing the process(Both Activity and Fragment) in case of low memory conditions. I was able to reproduce it by following @ctsims protip on turning the 'Don't keep Activities' developer options on and then leaving the activity when AlertDialog is open and returning to it.  

I am now dismissing these dialogues safely when such a case surfaces so that user can atleast access the corresponding activity. Though if we see value in retaining these dialogues in such cases we will need a way to recreate these dialogues whenever it happens. 