### PR TITLE
Prevent NPE stemming from onRetainCustomNonConfigurationInstance()

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -632,7 +632,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             return mSaveToDiskTask;
 
         // mFormEntryController is static so we don't need to pass it.
-        if (mFormController != null && currentPromptIsQuestion()) {
+        if (mFormController != null && currentPromptIsQuestion() && uiController.questionsView != null) {
             saveAnswersForCurrentScreen(FormEntryConstants.DO_NOT_EVALUATE_CONSTRAINTS);
         }
         return null;


### PR DESCRIPTION
I believe this will address https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59db367fbe077a4dccfd06ba?time=last-ninety-days, which I think is just a timing issue in form entry, where if a rotation of the device triggers a call to `onRetainCustomNonConfigurationInstance()` after form loading completes, but before the first view is actually rendered (a very short but presumably real window of time), then we would try to call `saveAnswersForCurrentScreen()` with a null `questionsView`. I wasn't able to replicate the crash based on this guess, but I think it's worth putting in this fix and seeing if that addresses it in the next release before digging much deeper.
