### PR TITLE
Transactional Recoveries

### DIFF
--- a/app/src/org/commcare/models/database/SqlStorage.java
+++ b/app/src/org/commcare/models/database/SqlStorage.java
@@ -507,6 +507,10 @@ public class SqlStorage<T extends Persistable> implements IStorageUtilityIndexed
         wipeTable(helper.getHandle(), table);
     }
 
+    public static void wipeTableWithoutCommit(SQLiteDatabase db, String table) {
+        db.delete(table, null, null);
+    }
+
     public static void wipeTable(SQLiteDatabase db, String table) {
         db.beginTransaction();
         try {

--- a/app/src/org/commcare/models/database/user/models/EntityStorageCache.java
+++ b/app/src/org/commcare/models/database/user/models/EntityStorageCache.java
@@ -22,7 +22,7 @@ import java.util.List;
  */
 public class EntityStorageCache {
     private static final String TAG = EntityStorageCache.class.getSimpleName();
-    private static final String TABLE_NAME = "entity_cache";
+    public static final String TABLE_NAME = "entity_cache";
 
     private static final String COL_CACHE_NAME = "cache_name";
     private static final String COL_ENTITY_KEY = "entity_key";
@@ -133,11 +133,15 @@ public class EntityStorageCache {
         }
     }
 
+    public static void setCachedWipedPref() {
+        String uuid = CommCareApplication.instance().getSession().getLoggedInUser().getUniqueId();
+        setEntityCacheWipedPref(uuid, CommCareApplication.instance().getCurrentApp().getAppRecord().getVersionNumber());
+    }
+
     public static void tryWipeCache() {
         SQLiteDatabase userDb = CommCareApplication.instance().getUserDbHandle();
         SqlStorage.wipeTable(userDb, TABLE_NAME);
-        String uuid = CommCareApplication.instance().getSession().getLoggedInUser().getUniqueId();
-        setEntityCacheWipedPref(uuid, CommCareApplication.instance().getCurrentApp().getAppRecord().getVersionNumber());
+        setCachedWipedPref();
     }
 
     public static void setEntityCacheWipedPref(String username, int version) {

--- a/app/src/org/commcare/models/database/user/models/EntityStorageCache.java
+++ b/app/src/org/commcare/models/database/user/models/EntityStorageCache.java
@@ -133,20 +133,17 @@ public class EntityStorageCache {
         }
     }
 
-    public static void setCachedWipedPref() {
-        String uuid = CommCareApplication.instance().getSession().getLoggedInUser().getUniqueId();
-        setEntityCacheWipedPref(uuid, CommCareApplication.instance().getCurrentApp().getAppRecord().getVersionNumber());
-    }
-
     public static void tryWipeCache() {
         SQLiteDatabase userDb = CommCareApplication.instance().getUserDbHandle();
         SqlStorage.wipeTable(userDb, TABLE_NAME);
-        setCachedWipedPref();
+        setEntityCacheWipedPref();
     }
 
-    public static void setEntityCacheWipedPref(String username, int version) {
+    public static void setEntityCacheWipedPref() {
+        String uuid = CommCareApplication.instance().getSession().getLoggedInUser().getUniqueId();
+        int versionNumber = CommCareApplication.instance().getCurrentApp().getAppRecord().getVersionNumber();
         CommCareApplication.instance().getCurrentApp().getAppPreferences().edit()
-                .putInt(username + "_" + ENTITY_CACHE_WIPED_PREF_SUFFIX, version).apply();
+                .putInt(uuid + "_" + ENTITY_CACHE_WIPED_PREF_SUFFIX, versionNumber).apply();
     }
 
     public static int getEntityCacheWipedPref(String uuid) {

--- a/app/src/org/commcare/models/database/user/models/EntityStorageCache.java
+++ b/app/src/org/commcare/models/database/user/models/EntityStorageCache.java
@@ -137,9 +137,7 @@ public class EntityStorageCache {
 
     public static void wipeCacheForCurrentAppWithoutCommit(SQLiteDatabase userDb) {
         userDb.delete(TABLE_NAME, COL_APP_ID + " = ?", new String[]{AppUtils.getCurrentAppId()});
-        String uuid = CommCareApplication.instance().getSession().getLoggedInUser().getUniqueId();
         setEntityCacheWipedPref();
-        userDb.setTransactionSuccessful();
     }
 
     public static void wipeCacheForCurrentApp() {

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -545,7 +545,6 @@ public abstract class DataPullTask<R>
                 | UnfullfilledRequirementsException | SessionUnavailableException
                 | IOException e) {
             Logger.exception("Sync recovery failed|" + e.getLocalizedMessage(), e);
-            userDb.endTransaction();
         } finally {
             //destroy temp file
             userDb.endTransaction();

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -532,8 +532,8 @@ public abstract class DataPullTask<R>
 
         //Wipe storage
         SQLiteDatabase userDb = CommCareApplication.instance().getUserDbHandle();
-        wipeStorageForFourTwelveSync(userDb);
         userDb.beginTransaction();
+        wipeStorageForFourTwelveSync(userDb);
 
         try {
             String syncToken = readInputWithoutCommit(cache.retrieveCache(), factory);

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -544,7 +544,7 @@ public abstract class DataPullTask<R>
         } catch (InvalidStructureException | XmlPullParserException
                 | UnfullfilledRequirementsException | SessionUnavailableException
                 | IOException e) {
-            Logger.exception("Sync recovery failed|" + e.getMessage(), e);
+            Logger.exception("Sync recovery failed|" + e.getLocalizedMessage(), e);
             userDb.endTransaction();
         } finally {
             //destroy temp file

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -531,41 +531,36 @@ public abstract class DataPullTask<R>
         //this is the temporary implementation of everything past this point
 
         //Wipe storage
-        //TODO: move table instead. Should be straightforward with sandboxed db's
-        wipeStorageForFourTwelveSync();
+        SQLiteDatabase userDb = CommCareApplication.instance().getUserDbHandle();
+        wipeStorageForFourTwelveSync(userDb);
 
         String failureReason = "";
         try {
-            //Get new data
-            String syncToken = readInput(cache.retrieveCache(), factory);
+            String syncToken = readInputWithoutCommit(cache.retrieveCache(), factory);
             updateUserSyncToken(syncToken);
             Logger.log(LogTypes.TYPE_USER, "Sync Recovery Successful");
+            userDb.setTransactionSuccessful();
             return new Pair<>(PROGRESS_DONE, "");
-        } catch (ActionableInvalidStructureException e) {
-            e.printStackTrace();
-            failureReason = e.getLocalizedMessage();
         } catch (InvalidStructureException | XmlPullParserException
-                | UnfullfilledRequirementsException | SessionUnavailableException | IOException e) {
-            e.printStackTrace();
-            failureReason = e.getMessage();
+                | UnfullfilledRequirementsException | SessionUnavailableException
+                | IOException e) {
+            Logger.exception("Sync recovery failed|" + e.getMessage(), e);
+            userDb.endTransaction();
         } finally {
             //destroy temp file
+            userDb.endTransaction();
             cache.release();
         }
-
-        //OK, so we would have returned success by now if things had worked out, which means that instead we got an error
-        //while trying to parse everything out. We need to recover from that error here and rollback the changes
-
-        //TODO: Roll back changes
-        Logger.log(LogTypes.TYPE_USER, "Sync recovery failed|" + failureReason);
         return new Pair<>(PROGRESS_RECOVERY_FAIL_BAD, failureReason);
     }
 
-    private void wipeStorageForFourTwelveSync() {
-        CommCareApplication.instance().getUserStorage(ACase.STORAGE_KEY, ACase.class).removeAll();
-        new AndroidCaseIndexTable().wipeTable();
-        CommCareApplication.instance().getUserStorage(Ledger.STORAGE_KEY, Ledger.class).removeAll();
-        EntityStorageCache.tryWipeCache();
+    private void wipeStorageForFourTwelveSync(SQLiteDatabase userDb) {
+        userDb.beginTransaction();
+        SqlStorage.wipeTableWithoutCommit(userDb, ACase.STORAGE_KEY);
+        SqlStorage.wipeTableWithoutCommit(userDb, Ledger.STORAGE_KEY);
+        SqlStorage.wipeTableWithoutCommit(userDb, AndroidCaseIndexTable.TABLE_NAME);
+        SqlStorage.wipeTableWithoutCommit(userDb, EntityStorageCache.TABLE_NAME);
+        EntityStorageCache.setCachedWipedPref();
     }
 
     private void updateCurrentUser(String password) {
@@ -585,30 +580,35 @@ public abstract class DataPullTask<R>
         }
     }
 
+    private void initParsers(AndroidTransactionParserFactory factory) {
+        factory.initCaseParser();
+        factory.initStockParser();
+        Hashtable<String, String> formNamespaces = FormSaveUtil.getNamespaceToFilePathMap(context);
+        factory.initFormInstanceParser(formNamespaces);
+    }
+
+    private String readInputWithoutCommit(InputStream stream,
+                                          AndroidTransactionParserFactory factory)
+            throws InvalidStructureException, IOException, XmlPullParserException,
+            UnfullfilledRequirementsException {
+        initParsers(factory);
+        DataModelPullParser parser = new DataModelPullParser(stream, factory, true, false, this);
+        parser.parse();
+        //Return the sync token ID
+        return factory.getSyncToken();
+    }
+
     private String readInput(InputStream stream, AndroidTransactionParserFactory factory)
             throws InvalidStructureException, IOException, XmlPullParserException,
             UnfullfilledRequirementsException {
-        DataModelPullParser parser;
-
-        factory.initCaseParser();
-        factory.initStockParser();
-
-        Hashtable<String, String> formNamespaces = FormSaveUtil.getNamespaceToFilePathMap(context);
-        factory.initFormInstanceParser(formNamespaces);
-
         //this is _really_ coupled, but we'll tolerate it for now because of the absurd performance gains
         SQLiteDatabase db = CommCareApplication.instance().getUserDbHandle();
         db.beginTransaction();
         try {
-            parser = new DataModelPullParser(stream, factory, true, false, this);
-            parser.parse();
-            db.setTransactionSuccessful();
+            return readInputWithoutCommit(stream, factory);
         } finally {
             db.endTransaction();
         }
-
-        //Return the sync token ID
-        return factory.getSyncToken();
     }
 
     //BEGIN - OTA Listener methods below - Note that most of the methods


### PR DESCRIPTION
Fixes the issue in https://manage.dimagi.com/default.asp?265905. Specifically, crashes during recovery restore parse could result in the case database being left empty. Accomplish this by doing the wipe and restore parse in one transaction that we simply do not commit unless we fully succeed. A couple supporting refactors.

I tested this by throwing a `RuntimeException` right before the `readInput` call; previously this resulted in an empty user db, now this is successfully rolled back.

I think we should get this into 2.41.