### PR TITLE
Shows a better error message instead of a NPE

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -92,6 +92,8 @@ menu.print.detail=Print Case Detail
 menu.enable.privileges=Mobile Privileges
 menu.privilege.claim.disable=Disable Privileges
 
+install.fail.error=We encountered an ${0} error processing your request. Please try again later. If the problem persists, contact technical support.
+
 sync.success.sent.none=No forms sent to server!
 sync.success.sent.singular=1 form sent to server!
 sync.success.sent=${0} forms sent to server!

--- a/app/src/org/commcare/engine/references/JavaHttpReference.java
+++ b/app/src/org/commcare/engine/references/JavaHttpReference.java
@@ -3,10 +3,14 @@ package org.commcare.engine.references;
 import org.commcare.interfaces.CommcareRequestEndpoints;
 import org.commcare.network.CommcareRequestGenerator;
 import org.javarosa.core.reference.Reference;
+import org.javarosa.core.services.locale.Localization;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+
+import okhttp3.ResponseBody;
+import retrofit2.Response;
 
 /**
  * @author ctsims
@@ -35,7 +39,12 @@ public class JavaHttpReference implements Reference {
 
     @Override
     public InputStream getStream() throws IOException {
-        return generator.simpleGet(uri).body().byteStream();
+        Response<ResponseBody> response = generator.simpleGet(uri);
+        if (response.isSuccessful()) {
+            return response.body().byteStream();
+        } else {
+            throw new RuntimeException(Localization.get("install.fail.error", Integer.toString(response.code())));
+        }
     }
 
     @Override

--- a/app/src/org/commcare/engine/references/JavaHttpReference.java
+++ b/app/src/org/commcare/engine/references/JavaHttpReference.java
@@ -43,7 +43,7 @@ public class JavaHttpReference implements Reference {
         if (response.isSuccessful()) {
             return response.body().byteStream();
         } else {
-            throw new RuntimeException(Localization.get("install.fail.error", Integer.toString(response.code())));
+            throw new IOException(Localization.get("install.fail.error", Integer.toString(response.code())));
         }
     }
 


### PR DESCRIPTION
Trying to display a better error on getting a 500 from Server during app update. Earlier app was failing with this error message - 
"Attempt to invoke virtual method 'java.io/InputStream okhttp3.ResponseBody.byteStream()' on a null object reference". 