### PR TITLE
Decrease volume of analytics events 

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -214,8 +214,6 @@ public class CommCareApplication extends MultiDexApplication {
             AppUtils.checkForIncompletelyUninstalledApps();
             initializeAnAppOnStartup();
         }
-
-        FirebaseAnalyticsUtil.reportAppStartup();
     }
 
     /**

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -408,9 +408,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             return;
         }
 
-        if (lastInstallMode == INSTALL_MODE_FROM_LIST) {
-            FirebaseAnalyticsUtil.reportFeatureUsage(AnalyticsParamValue.FEATURE_INSTALL_FROM_LIST);
-        }
         setReadyToInstall(result);
     }
 
@@ -934,6 +931,10 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 return AnalyticsParamValue.SMS_INSTALL;
             case INSTALL_MODE_URL:
                 return AnalyticsParamValue.URL_INSTALL;
+            case INSTALL_MODE_FROM_LIST:
+                return AnalyticsParamValue.FROM_LIST_INSTALL;
+            case INSTALL_MODE_MANAGED_CONFIGURATION:
+                return AnalyticsParamValue.MANAGED_CONFIG_INSTALL;
             default:
                 return "";
         }

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -36,7 +36,6 @@ import org.commcare.activities.components.FormEntrySessionWrapper;
 import org.commcare.activities.components.FormFileSystemHelpers;
 import org.commcare.activities.components.FormNavigationUI;
 import org.commcare.activities.components.ImageCaptureProcessing;
-import org.commcare.android.javarosa.IntentCallout;
 import org.commcare.android.javarosa.PollSensorAction;
 import org.commcare.android.javarosa.PollSensorController;
 import org.commcare.dalvik.BuildConfig;
@@ -179,9 +178,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         // needed to override rms property manager
         PropertyManager.setPropertyManager(new AndroidPropertyManager(getApplicationContext()));
 
-        if (savedInstanceState == null) {
-            FirebaseAnalyticsUtil.reportFormEntry(Localization.getCurrentLocale());
-        } else {
+        if (savedInstanceState != null) {
             loadStateFromBundle(savedInstanceState);
         }
 
@@ -443,8 +440,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             // Do not show options menu at all if this is a consumer app
             return super.onPrepareOptionsMenu(menu);
         }
-
-        FirebaseAnalyticsUtil.reportOptionsMenuEntry(this.getClass());
 
         menu.removeItem(FormEntryConstants.MENU_LANGUAGES);
         menu.removeItem(FormEntryConstants.MENU_HIERARCHY_VIEW);

--- a/app/src/org/commcare/activities/HomeButtons.java
+++ b/app/src/org/commcare/activities/HomeButtons.java
@@ -134,7 +134,6 @@ public class HomeButtons {
         return new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                reportButtonClick(AnalyticsParamValue.START_BUTTON);
                 activity.enterRootModule();
             }
         };
@@ -185,7 +184,6 @@ public class HomeButtons {
         return new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                reportButtonClick(AnalyticsParamValue.LOGOUT_BUTTON);
                 activity.userTriggeredLogout();
             }
         };

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -332,11 +332,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     }
 
     protected void goToFormArchive(boolean incomplete, FormRecord record) {
-        if (incomplete) {
-            FirebaseAnalyticsUtil.reportViewArchivedFormsList(AnalyticsParamValue.INCOMPLETE);
-        } else {
-            FirebaseAnalyticsUtil.reportViewArchivedFormsList(AnalyticsParamValue.SAVED);
-        }
+        FirebaseAnalyticsUtil.reportViewArchivedFormsList(incomplete);
         Intent i = new Intent(getApplicationContext(), FormRecordListActivity.class);
         if (incomplete) {
             i.putExtra(FormRecord.META_STATUS, FormRecord.STATUS_INCOMPLETE);

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -133,7 +133,6 @@ public class StandardHomeActivity
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
 
-        FirebaseAnalyticsUtil.reportOptionsMenuEntry(this.getClass());
         //In Holo theme this gets called on startup
         boolean enableMenus = !isDemoUser();
         menu.findItem(MENU_UPDATE).setVisible(enableMenus);

--- a/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
+++ b/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
@@ -41,7 +41,6 @@ public class ImageCaptureProcessing {
             if (currentWidget != null) {
                 int maxDimen = currentWidget.getMaxDimen();
                 if (maxDimen != -1) {
-                    FirebaseAnalyticsUtil.reportFeatureUsage(AnalyticsParamValue.FEATURE_RESIZE_IMAGE_CAPTURE);
                     savedScaledImage = FileUtil.scaleAndSaveImage(originalImage, finalFilePath, maxDimen);
                 }
             }

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -38,7 +38,6 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
-        FirebaseAnalyticsUtil.reportPreferenceActivityEntry(this.getClass());
         setTitle();
         initPrefsFile();
         loadPrefs();

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -6,15 +6,6 @@ package org.commcare.google.services.analytics;
 
 public class AnalyticsParamValue {
 
-    // Param values for audio widget interaction
-    static final String CHOOSE_AUDIO_FILE = "choose_audio_file";
-    static final String START_RECORDING = "start_recording_audio";
-    static final String STOP_RECORDING = "stop_recording";
-    static final String SAVE_RECORDING = "save_recording";
-    static final String PLAY_AUDIO = "play_audio";
-    static final String PAUSE_AUDIO = "pause_audio";
-    static final String RECORD_AGAIN = "record_again";
-
     // Param values for graphing actions
     static final String GRAPH_ATTACH = "start_viewing_graph";
     static final String GRAPH_DETACH = "stop_viewing_graph";
@@ -63,10 +54,7 @@ public class AnalyticsParamValue {
     // Param values for feature usage
     public static final String FEATURE_SET_PIN = "set_pin";
     public static final String FEATURE_PRINT = "print_from_form_or_detail";
-    public static final String FEATURE_RESIZE_IMAGE_CAPTURE = "resize_image_capture";
     public static final String FEATURE_CASE_AUTOSELECT = "case_autoselect";
-    public static final String FEATURE_SMART_IMG_INFLATION = "smart_image_inflation";
-    public static final String FEATURE_INSTALL_FROM_LIST = "install_from_app_list";
     static final String FEATURE_PRACTICE_MODE = "practice_mode";
     static final String PRACTICE_MODE_CUSTOM = "custom_practice_user";
     static final String PRACTICE_MODE_DEFAULT = "default_practice_user";
@@ -76,6 +64,8 @@ public class AnalyticsParamValue {
     public static final String OFFLINE_INSTALL = "offline_install";
     public static final String URL_INSTALL = "url_install";
     public static final String SMS_INSTALL = "sms_install";
+    public static final String FROM_LIST_INSTALL = "from_list_install";
+    public static final String MANAGED_CONFIG_INSTALL = "managed_configuration_install";
 
     // Param values for app manager actions
     public static final String OPEN_APP_MANAGER = "open_app_manager";
@@ -84,11 +74,9 @@ public class AnalyticsParamValue {
     public static final String INSTALL_FROM_MANAGER = "install_app";
 
     // Param values for home buttons
-    public static final String START_BUTTON = "start";
     public static final String SAVED_FORMS_BUTTON = "saved_forms";
     public static final String INCOMPLETE_FORMS_BUTTON = "incomplete_forms";
     public static final String SYNC_BUTTON = "sync";
-    public static final String LOGOUT_BUTTON = "logout";
     public static final String REPORT_BUTTON = "report_an_issue";
 
     // Param values for form types

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -9,12 +9,8 @@ public class CCAnalyticsEvent {
     static final String ADVANCED_ACTION_SELECTED = "advanced_action_selected";
     static final String APP_MANAGER_ACTION = "app_manager_action";
     static final String APP_INSTALL = "app_install";
-    static final String APP_STARTUP = "app_startup";
-    static final String AUDIO_WIDGET_INTERACTION = "audio_widget_interaction";
     static final String EDIT_PREFERENCE_ITEM = "edit_preference_item";
     static final String ENABLE_PRIVILEGE = "enable_privilege";
-    static final String ENTER_FORM = "enter_form";
-    static final String ENTER_PREF_MENU = "enter_a_preference_menu";
     static final String ENTITY_DETAIL_NAVIGATION = "entity_detail_navigation";
     static final String FEATURE_USAGE = "feature_usage";
     static final String FORM_EXIT_ATTEMPT = "form_exit_attempt";
@@ -22,7 +18,6 @@ public class CCAnalyticsEvent {
     static final String GRAPH_ACTION = "graphing_action";
     static final String HOME_BUTTON_CLICK = "home_button_click";
     static final String OPEN_ARCHIVED_FORM = "open_archived_form";
-    static final String OPEN_OPTIONS_MENU = "open_options_menu";
     static final String SELECT_OPTIONS_MENU_ITEM = "select_options_menu_item";
     static final String SYNC_ATTEMPT = "sync_attempt";
     static final String TIMED_SESSION = "timed_session";

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -40,11 +40,6 @@ public class FirebaseAnalyticsUtil {
         CommCareApplication.instance().getAnalyticsInstance().logEvent(eventName, b);
     }
 
-    public static void reportOptionsMenuEntry(Class location) {
-        reportEvent(CCAnalyticsEvent.OPEN_OPTIONS_MENU,
-                FirebaseAnalytics.Param.LOCATION, location.getSimpleName());
-    }
-
     /**
      * Report a user event of selecting an item within an options menu
      */
@@ -52,11 +47,6 @@ public class FirebaseAnalyticsUtil {
         reportEvent(CCAnalyticsEvent.SELECT_OPTIONS_MENU_ITEM,
                 new String[]{FirebaseAnalytics.Param.LOCATION, CCAnalyticsParam.OPTIONS_MENU_ITEM},
                 new String[]{location.getSimpleName(), itemLabel});
-    }
-
-    public static void reportPreferenceActivityEntry(Class location) {
-        reportEvent(CCAnalyticsEvent.ENTER_PREF_MENU,
-                FirebaseAnalytics.Param.LOCATION, location.getSimpleName());
     }
 
     /**
@@ -77,7 +67,8 @@ public class FirebaseAnalyticsUtil {
                 FirebaseAnalytics.Param.ITEM_NAME, buttonName);
     }
 
-    public static void reportViewArchivedFormsList(String formType) {
+    public static void reportViewArchivedFormsList(boolean forIncomplete) {
+        String formType = forIncomplete ? AnalyticsParamValue.INCOMPLETE : AnalyticsParamValue.SAVED;
         reportEvent(CCAnalyticsEvent.VIEW_ARCHIVED_FORMS_LIST,
                 CCAnalyticsParam.FORM_TYPE, formType);
     }
@@ -92,47 +83,9 @@ public class FirebaseAnalyticsUtil {
                 CCAnalyticsParam.METHOD, installMethod);
     }
 
-    public static void reportAppStartup() {
-        reportEvent(CCAnalyticsEvent.APP_STARTUP,
-                CCAnalyticsParam.API_LEVEL, "" + Build.VERSION.SDK_INT);
-    }
-
     public static void reportAppManagerAction(String action) {
         reportEvent(CCAnalyticsEvent.APP_MANAGER_ACTION,
                 CCAnalyticsParam.ACTION_TYPE, action);
-    }
-
-    public static void reportAudioFileSelected() {
-        reportAudioWidgetInteraction(AnalyticsParamValue.CHOOSE_AUDIO_FILE);
-    }
-
-    public static void reportAudioPlayed() {
-        reportAudioWidgetInteraction(AnalyticsParamValue.PLAY_AUDIO);
-    }
-
-    public static void reportAudioPaused() {
-        reportAudioWidgetInteraction(AnalyticsParamValue.PAUSE_AUDIO);
-    }
-
-    public static void reportAudioFileSaved() {
-        reportAudioWidgetInteraction(AnalyticsParamValue.SAVE_RECORDING);
-    }
-
-    public static void reportRecordingStarted() {
-        reportAudioWidgetInteraction(AnalyticsParamValue.START_RECORDING);
-    }
-
-    public static void reportRecordingStopped() {
-        reportAudioWidgetInteraction(AnalyticsParamValue.STOP_RECORDING);
-    }
-
-    public static void reportRecordingRecycled() {
-        reportAudioWidgetInteraction(AnalyticsParamValue.RECORD_AGAIN);
-    }
-
-    private static void reportAudioWidgetInteraction(String interactionType) {
-        reportEvent(CCAnalyticsEvent.AUDIO_WIDGET_INTERACTION,
-                CCAnalyticsParam.ACTION_TYPE, interactionType);
     }
 
     public static void reportGraphViewAttached() {
@@ -157,17 +110,15 @@ public class FirebaseAnalyticsUtil {
     }
 
     public static void reportFormNav(String direction, String method) {
-        reportEvent(CCAnalyticsEvent.FORM_NAVIGATION,
-                new String[]{ CCAnalyticsParam.DIRECTION, CCAnalyticsParam.METHOD},
-                new String[]{direction, method});
+        if (rateLimitReporting(.1)) {
+            reportEvent(CCAnalyticsEvent.FORM_NAVIGATION,
+                    new String[]{ CCAnalyticsParam.DIRECTION, CCAnalyticsParam.METHOD },
+                    new String[]{ direction, method });
+        }
     }
 
     public static void reportFormQuitAttempt(String method) {
         reportEvent(CCAnalyticsEvent.FORM_EXIT_ATTEMPT, CCAnalyticsParam.METHOD, method);
-    }
-
-    public static void reportFormEntry(String currentLocale) {
-        reportEvent(CCAnalyticsEvent.ENTER_FORM, CCAnalyticsParam.LOCALE, currentLocale);
     }
 
     /**
@@ -240,13 +191,15 @@ public class FirebaseAnalyticsUtil {
     }
 
     public static void reportTimedSession(String sessionType, double timeInSeconds, double timeInMinutes) {
-        reportEvent(CCAnalyticsEvent.TIMED_SESSION,
-                new String[]{ CCAnalyticsParam.SESSION_TYPE,
-                        CCAnalyticsParam.TIME_IN_SECONDS,
-                        CCAnalyticsParam.TIME_IN_MINUTES},
-                new String[]{sessionType,
-                        ""+roundToOneDecimal(timeInSeconds),
-                        ""+roundToOneDecimal(timeInMinutes)});
+        if (rateLimitReporting(.25)) {
+            reportEvent(CCAnalyticsEvent.TIMED_SESSION,
+                    new String[]{ CCAnalyticsParam.SESSION_TYPE,
+                            CCAnalyticsParam.TIME_IN_SECONDS,
+                            CCAnalyticsParam.TIME_IN_MINUTES },
+                    new String[]{ sessionType,
+                            "" + roundToOneDecimal(timeInSeconds),
+                            "" + roundToOneDecimal(timeInMinutes) });
+        }
     }
 
     private static double roundToOneDecimal(double d) {
@@ -261,5 +214,9 @@ public class FirebaseAnalyticsUtil {
         // According to https://firebase.google.com/docs/android/setup,
         // Firebase should only be used on devices running Android 4.0 and above
         return Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH;
+    }
+
+    private static boolean rateLimitReporting(double percentOfEventsToReport) {
+        return Math.random() < percentOfEventsToReport;
     }
 }

--- a/app/src/org/commcare/utils/MediaUtil.java
+++ b/app/src/org/commcare/utils/MediaUtil.java
@@ -87,7 +87,6 @@ public class MediaUtil {
             }
 
             if (HiddenPreferences.isSmartInflationEnabled()) {
-                FirebaseAnalyticsUtil.reportFeatureUsage(AnalyticsParamValue.FEATURE_SMART_IMG_INFLATION);
                 // scale based on bounding dimens AND native density
                 return getBitmapScaledForNativeDensity(
                         context.getResources().getDisplayMetrics(), imageFile.getAbsolutePath(),

--- a/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
+++ b/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
@@ -70,7 +70,6 @@ public class CommCareAudioWidget extends AudioWidget
         chooseButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioFileSelected();
                 Intent i = new Intent(Intent.ACTION_GET_CONTENT);
                 i.setType("audio/*");
                 try {
@@ -91,7 +90,6 @@ public class CommCareAudioWidget extends AudioWidget
         mPlayButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioPlayed();
                 playAudio();
             }
         });
@@ -164,7 +162,6 @@ public class CommCareAudioWidget extends AudioWidget
         mPlayButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioPaused();
                 pauseAudioPlayer();
             }
         });
@@ -176,7 +173,6 @@ public class CommCareAudioWidget extends AudioWidget
         mPlayButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioPlayed();
                 resumeAudioPlayer();
             }
         });
@@ -188,7 +184,6 @@ public class CommCareAudioWidget extends AudioWidget
         mPlayButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioPaused();
                 pauseAudioPlayer();
             }
         });
@@ -200,7 +195,6 @@ public class CommCareAudioWidget extends AudioWidget
         mPlayButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioPlayed();
                 playAudio();
             }
         });

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -128,14 +128,12 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
         toggleRecording.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportRecordingStarted();
                 startRecording();
             }
         });
         saveRecording.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioFileSaved();
                 saveRecording();
             }
         });
@@ -164,7 +162,6 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
         saveRecording.setVisibility(View.INVISIBLE);
         recordAgain.setVisibility(View.INVISIBLE);
         recordingDuration.setVisibility(View.INVISIBLE);
-        FirebaseAnalyticsUtil.reportRecordingRecycled();
     }
 
     private void startRecording() {
@@ -177,7 +174,6 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
         toggleRecording.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportRecordingStopped();
                 stopRecording();
             }
         });
@@ -218,7 +214,6 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
             @Override
             public void onClick(View v) {
                 playAudio();
-                FirebaseAnalyticsUtil.reportAudioPlayed();
             }
         });
         saveRecording.setEnabled(true);
@@ -296,7 +291,6 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
         toggleRecording.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioPaused();
                 pauseAudioPlayer();
             }
         });
@@ -310,7 +304,6 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
         toggleRecording.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioPlayed();
                 resumeAudioPlayer();
             }
         });
@@ -324,7 +317,6 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
         toggleRecording.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioPaused();
                 pauseAudioPlayer();
             }
         });
@@ -337,7 +329,6 @@ public class RecordingFragment extends android.support.v4.app.DialogFragment {
         toggleRecording.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                FirebaseAnalyticsUtil.reportAudioPlayed();
                 playAudio();
             }
         });


### PR DESCRIPTION
In the course of doing some research on Firebase analytics before we migrated, 1 of the warnings I read was that while Firebase _will_ queue up events to send later if a device is offline, the amount of storage space that it will devote to that is limited. This means that if you're logging too much while a user is offline for an extended period of time, you may lose data. In retrospect, it seems more than likely that the same was true for Google Analytics, since the storage available to use would be limited no matter what. 

So in the hopes of keeping that storage free for the events that are most important, this PR does 2 things:

1. Removes any events that seem both not particularly important and likely to be happening a lot.
2. Adds a method for rate-limiting the logging of those events that I felt were too important to remove, but are sure to be happening a ton. 