### PR TITLE
Add '.' in MediaWidget

### DIFF
--- a/app/src/org/commcare/views/widgets/MediaWidget.java
+++ b/app/src/org/commcare/views/widgets/MediaWidget.java
@@ -210,7 +210,7 @@ public abstract class MediaWidget extends QuestionWidget {
             newMedia = new File(destMediaPath);
         } else {
             recordedFileName = FileUtil.getFileName(binaryPath);
-            destMediaPath = mInstanceFolder + System.currentTimeMillis() + customFileTag + FileUtil.getExtension(binaryPath);
+            destMediaPath = mInstanceFolder + System.currentTimeMillis() + customFileTag + "." + FileUtil.getExtension(binaryPath);
 
             // Copy to destMediaPath
             File source = new File(binaryPath);

--- a/app/src/org/commcare/views/widgets/MediaWidget.java
+++ b/app/src/org/commcare/views/widgets/MediaWidget.java
@@ -13,11 +13,13 @@ import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
+import org.commcare.activities.FormEntryActivity;
 import org.commcare.activities.components.FormEntryInstanceState;
 import org.commcare.dalvik.R;
 import org.commcare.logic.PendingCalloutInterface;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.FileUtil;
+import org.commcare.utils.FormUploadUtil;
 import org.commcare.utils.StringUtils;
 import org.commcare.utils.UriToFilePath;
 import org.javarosa.core.model.data.IAnswerData;
@@ -25,6 +27,7 @@ import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.data.InvalidData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryPrompt;
 
 import java.io.File;
@@ -210,6 +213,18 @@ public abstract class MediaWidget extends QuestionWidget {
             newMedia = new File(destMediaPath);
         } else {
             recordedFileName = FileUtil.getFileName(binaryPath);
+            String extension = FileUtil.getExtension(binaryPath);
+            if (!FormUploadUtil.isSupportedMultimediaFile(extension)) {
+                Toast.makeText(getContext(),
+                        Localization.get("form.attachment.invalid"),
+                        Toast.LENGTH_LONG).show();
+                Log.e(TAG, String.format(
+                        "Could not save file with URI %s because of bad extension %s.",
+                        binaryPath,
+                        extension
+                ));
+                return;
+            }
             destMediaPath = mInstanceFolder + System.currentTimeMillis() + customFileTag + "." + FileUtil.getExtension(binaryPath);
 
             // Copy to destMediaPath


### PR DESCRIPTION
Cause of the bug here https://manage.dimagi.com/default.asp?267070

For certain URIs (seems exclusive to 7.0 and certain media apps) we would set the path here, which resulted in the bug exposed here and thus the media not being recognized as valid on submission 