### PR TITLE
Go straight to form entry for automatically-resumed incomplete form

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -135,6 +135,7 @@ form.entry.incomplete.save.success=Form saved as incomplete
 form.entry.save.error=Sorry, form save failed. Please contact technical support to look into the issue.
 form.entry.save.invalid.unicode=Could not save '${0}' text in form.
 form.entry.finish.button=FINISH
+form.entry.restart.after.expiration=You were logged out due to session expiration. The form you were in the middle of has been saved and resumed.
 
 login.attempt.badcred=Username or password are incorrect. Please try again.
 

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -106,6 +106,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     public static final String KEY_HEADER_STRING = "form_header";
     public static final String KEY_INCOMPLETE_ENABLED = "org.odk.collect.form.management";
     public static final String KEY_RESIZING_ENABLED = "org.odk.collect.resizing.enabled";
+    public static final String KEY_IS_RESTART_AFTER_EXPIRATION = "is-restart-after-session-expiration";
+
     private static final String KEY_HAS_SAVED = "org.odk.collect.form.has.saved";
     private static final String KEY_WIDGET_WITH_VIDEO_PLAYING = "index-of-widget-with-video-playing-on-pause";
     private static final String KEY_POSITION_OF_VIDEO_PLAYING = "position-of-video-playing-on-pause";
@@ -957,8 +959,10 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
         registerSessionFormSaveCallback();
 
+        boolean isRestartAfterSessionExpiration =
+                getIntent().getBooleanExtra(KEY_IS_RESTART_AFTER_EXPIRATION, false);
         // Set saved answer path
-        if (FormEntryInstanceState.mInstancePath == null) {
+        if (FormEntryInstanceState.mInstancePath == null || isRestartAfterSessionExpiration) {
             instanceState.initInstancePath();
         } else {
             // we've just loaded a saved form, so start in the hierarchy view
@@ -973,6 +977,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
         uiController.refreshView();
         FormNavigationUI.updateNavigationCues(this, mFormController, uiController.questionsView);
+        if (isRestartAfterSessionExpiration) {
+            Toast.makeText(this, Localization.get("form.entry.restart.after.expiration"), Toast.LENGTH_LONG).show();
+        }
     }
 
     private void handleXpathErrorBroadcast() {
@@ -1166,6 +1173,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                     FormEntryInstanceState.mInstancePath
             };
 
+
+            Intent formReturnIntent = new Intent();
             Cursor c = null;
             try {
                 c = getContentResolver().query(instanceProviderContentURI, null, selection, selectionArgs, null);
@@ -1174,20 +1183,22 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                     c.moveToFirst();
                     String id = c.getString(c.getColumnIndex(InstanceColumns._ID));
                     Uri instance = Uri.withAppendedPath(instanceProviderContentURI, id);
-
-                    Intent formReturnIntent = new Intent();
-                    formReturnIntent.putExtra(FormEntryConstants.IS_ARCHIVED_FORM, mFormController.isFormReadOnly());
-
-                    if (reportSaved || hasSaved) {
-                        setResult(RESULT_OK, formReturnIntent.setData(instance));
-                    } else {
-                        setResult(RESULT_CANCELED, formReturnIntent.setData(instance));
-                    }
+                    formReturnIntent.setData(instance);
                 }
             } finally {
                 if (c != null) {
                     c.close();
                 }
+            }
+
+            formReturnIntent.putExtra(FormEntryConstants.IS_ARCHIVED_FORM,
+                    mFormController.isFormReadOnly());
+            formReturnIntent.putExtra(KEY_IS_RESTART_AFTER_EXPIRATION,
+                    getIntent().getBooleanExtra(KEY_IS_RESTART_AFTER_EXPIRATION, false));
+            if (reportSaved || hasSaved) {
+                setResult(RESULT_OK, formReturnIntent);
+            } else {
+                setResult(RESULT_CANCELED, formReturnIntent);
             }
         }
 

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -247,7 +247,8 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             AndroidSessionWrapper state = CommCareApplication.instance().getCurrentSessionWrapper();
             state.loadFromStateDescription(existing);
             formEntry(CommCareApplication.instance().getCommCarePlatform()
-                    .getFormContentUri(state.getSession().getForm()), state.getFormRecord());
+                    .getFormContentUri(state.getSession().getForm()), state.getFormRecord(),
+                    null, true);
             return true;
         }
         return false;
@@ -686,7 +687,8 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             // Viewing an old form, so don't change the historical record
             // regardless of the exit code
             currentState.reset();
-            if (wasExternal) {
+            if (wasExternal ||
+                    intent.getBooleanExtra(FormEntryActivity.KEY_IS_RESTART_AFTER_EXPIRATION, false)) {
                 setResult(RESULT_CANCELED);
                 this.finish();
             } else {
@@ -783,7 +785,8 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                 setResult(RESULT_CANCELED);
                 this.finish();
                 return false;
-            } else if (current.getStatus().equals(FormRecord.STATUS_INCOMPLETE)) {
+            } else if (current.getStatus().equals(FormRecord.STATUS_INCOMPLETE) &&
+                    !intent.getBooleanExtra(FormEntryActivity.KEY_IS_RESTART_AFTER_EXPIRATION, false)) {
                 currentState.reset();
                 // We should head back to the incomplete forms screen
                 goToFormArchive(true, current);
@@ -1026,14 +1029,15 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
         FormRecord record = state.getFormRecord();
         AndroidCommCarePlatform platform = CommCareApplication.instance().getCommCarePlatform();
         formEntry(platform.getFormContentUri(record.getFormNamespace()), record,
-                CommCareActivity.getTitle(this, null));
+                CommCareActivity.getTitle(this, null), false);
     }
 
     private void formEntry(Uri formUri, FormRecord r) {
-        formEntry(formUri, r, null);
+        formEntry(formUri, r, null, false);
     }
 
-    private void formEntry(Uri formUri, FormRecord r, String headerTitle) {
+    private void formEntry(Uri formUri, FormRecord r, String headerTitle,
+                           boolean isRestartAfterSessionExpiration) {
         Logger.log(LogTypes.TYPE_FORM_ENTRY, "Form Entry Starting|" + r.getFormNamespace());
 
         //TODO: This is... just terrible. Specify where external instance data should come from
@@ -1060,6 +1064,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
         i.putExtra(FormEntryActivity.KEY_FORM_CONTENT_URI, FormsProviderAPI.FormsColumns.CONTENT_URI.toString());
         i.putExtra(FormEntryActivity.KEY_INSTANCE_CONTENT_URI, InstanceProviderAPI.InstanceColumns.CONTENT_URI.toString());
         i.putExtra(FormEntrySessionWrapper.KEY_RECORD_FORM_ENTRY_SESSION, DeveloperPreferences.isSessionSavingEnabled());
+        i.putExtra(FormEntryActivity.KEY_IS_RESTART_AFTER_EXPIRATION, isRestartAfterSessionExpiration);
         if (headerTitle != null) {
             i.putExtra(FormEntryActivity.KEY_HEADER_STRING, headerTitle);
         }


### PR DESCRIPTION
Small change to https://github.com/dimagi/commcare-android/pull/1883/ --> When we are automatically resuming an incomplete form after session expiration occurred in the middle of form entry, send the user straight to form entry instead of to the form hierarchy view. (And if they press back from there, don't send them to the form hierarchy view, either).

Also adds a toast message when we drop the user back into form entry to give them a clue as to what just happened.