### PR TITLE
Prevent 'Form Entry Completed' log from happening twice/incorrectly

### DIFF
--- a/app/src/org/commcare/provider/InstanceProvider.java
+++ b/app/src/org/commcare/provider/InstanceProvider.java
@@ -530,9 +530,6 @@ public class InstanceProvider extends ContentProvider {
             return;
         }
 
-        Logger.log(LogTypes.TYPE_FORM_ENTRY,
-                String.format("Form Entry Completed for record with id %s", current.getInstanceID()));
-
         // The form is either ready for processing, or not, depending on how it was saved
         if (complete) {
             // Form record should now be up to date now and stored correctly.

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -6,8 +6,10 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.util.Log;
 
+import org.commcare.CommCareApplication;
 import org.commcare.activities.FormEntryActivity;
 import org.commcare.activities.components.FormEntryInstanceState;
+import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.logging.ForceCloseLogger;
 import org.commcare.interfaces.FormSavedListener;
 import org.commcare.logging.XPathErrorLogger;
@@ -133,6 +135,9 @@ public class SaveToDiskTask extends
         }
 
         if (exitAfterSave) {
+            FormRecord saved = CommCareApplication.instance().getCurrentSessionWrapper().getFormRecord();
+            Logger.log(LogTypes.TYPE_FORM_ENTRY,
+                    String.format("Form Entry Completed for record with id %s", saved.getInstanceID()));
             return new ResultAndError<>(SaveStatus.SAVED_AND_EXIT);
         } else if (mMarkCompleted) {
             return new ResultAndError<>(SaveStatus.SAVED_COMPLETE);


### PR DESCRIPTION
Previously the place where this log was being written would cause it to get logged twice for every completion of form entry, and also when we were just saving a form but not leaving form entry. This fixes both of those issues.