### PR TITLE
Check for permissions error, show toast

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -821,3 +821,5 @@ quarantine.reason.record.error=There was an issue with the form record that prev
 quarantine.reason.manual=The form was manually quarantined by a user
 quarantine.reason.fnf=The file backing the form submission could not be found
 quarantine.reason.unknown=Reason for quarantine unknown
+
+camera.permissions.denied=CommCare does not have permission to use your camera. Please make sure your permissions are set correctly.

--- a/app/src/org/commcare/views/widgets/ImageWidget.java
+++ b/app/src/org/commcare/views/widgets/ImageWidget.java
@@ -35,6 +35,7 @@ import org.javarosa.core.model.QuestionDataExtension;
 import org.javarosa.core.model.UploadQuestionExtension;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryPrompt;
 
 import java.io.File;
@@ -114,6 +115,10 @@ public class ImageWidget extends QuestionWidget {
                     Toast.makeText(getContext(),
                             StringUtils.getStringSpannableRobust(getContext(),
                                     R.string.activity_not_found, "image capture"),
+                            Toast.LENGTH_SHORT).show();
+                } catch (SecurityException e) {
+                    Toast.makeText(getContext(),
+                            Localization.get("camera.permissions.denied"),
                             Toast.LENGTH_SHORT).show();
                 }
             }

--- a/app/src/org/commcare/views/widgets/VideoWidget.java
+++ b/app/src/org/commcare/views/widgets/VideoWidget.java
@@ -13,6 +13,7 @@ import org.commcare.activities.components.FormEntryConstants;
 import org.commcare.dalvik.R;
 import org.commcare.logic.PendingCalloutInterface;
 import org.commcare.utils.StringUtils;
+import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryPrompt;
 
 /**
@@ -51,6 +52,10 @@ public class VideoWidget extends MediaWidget {
                     Toast.makeText(getContext(),
                             StringUtils.getStringSpannableRobust(getContext(),
                                     R.string.activity_not_found, "capture video"),
+                            Toast.LENGTH_SHORT).show();
+                } catch (SecurityException e) {
+                    Toast.makeText(getContext(),
+                            Localization.get("camera.permissions.denied"),
                             Toast.LENGTH_SHORT).show();
                 }
             }


### PR DESCRIPTION
Fixes crash caused by denied camera permission: https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5a3354338cb3c2fa63e86e28/sessions/5A33536D001E000175226C21CDD3EC02_3f2824c2e15311e7a55656847afe9799_0_v2