### PR TITLE
Add meta instanceId to log submissions to prevent duplicates

### DIFF
--- a/app/src/org/commcare/android/javarosa/DeviceReportRecord.java
+++ b/app/src/org/commcare/android/javarosa/DeviceReportRecord.java
@@ -13,7 +13,6 @@ import org.javarosa.core.util.PropertyUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Date;
 

--- a/app/src/org/commcare/android/javarosa/DeviceReportRecord.java
+++ b/app/src/org/commcare/android/javarosa/DeviceReportRecord.java
@@ -84,8 +84,7 @@ public class DeviceReportRecord extends Persisted implements EncryptedModel {
     }
 
     public final OutputStream openOutputStream() throws FileNotFoundException {
-        return new FileOutputStream(getFilePath());
-        //return EncryptionIO.createFileOutputStream(getFilePath(),
-          //      new SecretKeySpec(getKey(), "AES"));
+        return EncryptionIO.createFileOutputStream(getFilePath(),
+                new SecretKeySpec(getKey(), "AES"));
     }
 }

--- a/app/src/org/commcare/android/javarosa/DeviceReportRecord.java
+++ b/app/src/org/commcare/android/javarosa/DeviceReportRecord.java
@@ -9,9 +9,11 @@ import org.commcare.modern.models.EncryptedModel;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.GlobalConstants;
 import org.javarosa.core.model.utils.DateUtils;
+import org.javarosa.core.util.PropertyUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Date;
 
@@ -35,6 +37,8 @@ public class DeviceReportRecord extends Persisted implements EncryptedModel {
     private String fileName;
     @Persisting(2)
     private byte[] aesKey;
+    @Persisting(3)
+    private String uuid;
 
     public DeviceReportRecord() {
         // for externalization
@@ -52,6 +56,7 @@ public class DeviceReportRecord extends Persisted implements EncryptedModel {
                         + FileUtil.SanitizeFileName(File.separator
                         + DateUtils.formatDateTime(new Date(), DateUtils.FORMAT_ISO8601)) + ".xml").getAbsolutePath();
         slr.aesKey = CommCareApplication.instance().createNewSymmetricKey().getEncoded();
+        slr.uuid = PropertyUtils.genUUID();
         return slr;
     }
 
@@ -70,12 +75,17 @@ public class DeviceReportRecord extends Persisted implements EncryptedModel {
         return aesKey;
     }
 
+    public String getUuid() {
+        return uuid;
+    }
+
     public String getFilePath() {
         return fileName;
     }
 
     public final OutputStream openOutputStream() throws FileNotFoundException {
-        return EncryptionIO.createFileOutputStream(getFilePath(),
-                new SecretKeySpec(getKey(), "AES"));
+        return new FileOutputStream(getFilePath());
+        //return EncryptionIO.createFileOutputStream(getFilePath(),
+          //      new SecretKeySpec(getKey(), "AES"));
     }
 }

--- a/app/src/org/commcare/android/javarosa/DeviceReportRecordV1.java
+++ b/app/src/org/commcare/android/javarosa/DeviceReportRecordV1.java
@@ -1,0 +1,19 @@
+package org.commcare.android.javarosa;
+
+import org.commcare.models.framework.Persisting;
+
+/**
+ * Represents the format of DeviceReportRecord that existed on all devices on user DB versions 22
+ * and below (CommCare versions 2.41 and below)
+ *
+ * @author ctsims
+ */
+
+public class DeviceReportRecordV1 extends DeviceReportRecord {
+
+    @Persisting(1)
+    private String fileName;
+    @Persisting(2)
+    private byte[] aesKey;
+
+}

--- a/app/src/org/commcare/android/javarosa/DeviceReportRecordV1.java
+++ b/app/src/org/commcare/android/javarosa/DeviceReportRecordV1.java
@@ -6,7 +6,7 @@ import org.commcare.models.framework.Persisting;
  * Represents the format of DeviceReportRecord that existed on all devices on user DB versions 22
  * and below (CommCare versions 2.41 and below)
  *
- * @author ctsims
+ * @author Aliza Stone
  */
 
 public class DeviceReportRecordV1 extends DeviceReportRecord {

--- a/app/src/org/commcare/logging/DeviceReportWriter.java
+++ b/app/src/org/commcare/logging/DeviceReportWriter.java
@@ -70,16 +70,17 @@ public class DeviceReportWriter {
                     } catch (Exception e) {
                     }
                 }
+
+                if (this.uuid != null) {
+                    // If this write() was triggered by ForceCloseLogger.sendToServerOrStore(),
+                    // we have no uuid because we're sending a single log entry that just happened and
+                    // hasn't been written to the db
+                    writeMetaBlock();
+                }
             } finally {
                 serializer.endTag(XMLNS, "device_report");
             }
 
-            if (this.uuid != null) {
-                // If this write() was triggered by ForceCloseLogger.sendToServerOrStore(),
-                // we have no uuid because we're sending a single log entry that just happened and
-                // hasn't been written to the db
-                writeMetaBlock();
-            }
             serializer.endDocument();
         } finally {
             try {

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -59,9 +59,10 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
      * V.20 - Migrate index names on indexed fixtures so that multiple fixtures are able to have an index on the same column name
      * V.21 - Reindex all cases to add relationship, and add reasonForQuarantine field to FormRecords
      * V.22 - Add column for appId in entity_cache table
+     * V.23 - Add uuid to DeviceReportRecords
      */
 
-    private static final int USER_DB_VERSION = 22;
+    private static final int USER_DB_VERSION = 23;
 
     private static final String USER_DB_LOCATOR = "database_sandbox_";
 

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -307,6 +307,9 @@ public class FormStorageTest {
             , "org.javarosa.xpath.expr.XPathDistinctValuesFunc"
             , "org.javarosa.xpath.expr.XPathSleepFunc"
 
+            // Added in 2.42
+            , "org.commcare.android.javarosa.DeviceReportRecordV1"
+
             );
 
 


### PR DESCRIPTION
With help from @emord I confirmed that HQ does treat device log xforms the same way as normal forms in that it checks for a unique id included in a `<meta>` block on the form. Mobile was previously not including any `<meta>` block in device log submissions, so adding one now will prevent duplicate logs from being included in device reports on HQ in the future. 

I was also able to confirm this theory via manual testing by observing that duplicate logs would previously show up on HQ if we prevented the deletion of a DeviceReportRecord after it was submitted, and observing that this PR fixes that behavior.