### PR TITLE
Markdown of constraint text

### DIFF
--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -239,7 +239,7 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
             }
         }
         TextView messageView = (TextView)this.warningView.findViewById(R.id.message);
-        messageView.setText(text);
+        messageView.setText(forceMarkdown(text));
 
         //If the warningView already exists, we can just scroll to it right now
         //if not, we actually have to do it later, when we lay this all back out


### PR DESCRIPTION
Addresses https://manage.dimagi.com/default.asp?266984

The only downside of this approach is if people have constraint text that uses markdown syntax but they do not want it parsed as markdown (for example, they just want asterisks around a word) then this will turn that into mark down.

The alternative is a heaver touch refactor that checks whether there's a markdown form of this text (and we'd have to build that setup mechanism in HQ too). I'm not too worried about the downside here but open for opinion