### PR TITLE
Throws error in case of space in select choices

### DIFF
--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -159,4 +159,11 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-enforce-secure-endpoint"
         android:title="Enforce Secure Endpoint"/>
+    <ListPreference
+        android:defaultValue="yes"
+        android:enabled="true"
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
+        android:key="cc-allow-space-in-select-choices"
+        android:title="Allow Space in Select Choices"/>
 </PreferenceScreen>

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -56,6 +56,7 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     public final static String REMOTE_FORM_PAYLOAD_URL = "remote-form-payload-url";
     public final static String HIDE_ISSUE_REPORT = "cc-hide-issue-report";
     public final static String ENFORCE_SECURE_ENDPOINT = "cc-enforce-secure-endpoint";
+    public final static String ALLOW_SPACE_IN_SELECT_CHOICES = "cc-allow-space-in-select-choices";
 
     public final static String PROJECT_SET_ACCESS_CODE = "cc-dev-prefs-access-code";
     public final static String USER_ENTERED_ACCESS_CODE = "cc-dev-prefs-user-entered-code";
@@ -405,6 +406,10 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
 
     public static boolean isEnforceSecureEndpointEnabled() {
         return doesPropertyMatch(ENFORCE_SECURE_ENDPOINT, PrefValues.NO, PrefValues.YES);
+    }
+
+    public static boolean isSpaceAllowedInSelectChoices() {
+        return doesPropertyMatch(ALLOW_SPACE_IN_SELECT_CHOICES, PrefValues.YES, PrefValues.YES);
     }
 
     private void hideOrShowDangerousSettings() {

--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -67,7 +67,7 @@ public class ComboboxWidget extends QuestionWidget {
     }
 
     private void initChoices(FormEntryPrompt prompt) {
-        choices = prompt.getSelectChoices();
+        choices = getSelectChoices();
         choiceTexts = new Vector<>();
         for (int i = 0; i < choices.size(); i++) {
             choiceTexts.add(prompt.getSelectChoiceText(choices.get(i)));

--- a/app/src/org/commcare/views/widgets/GridMultiWidget.java
+++ b/app/src/org/commcare/views/widgets/GridMultiWidget.java
@@ -59,7 +59,7 @@ public class GridMultiWidget extends QuestionWidget {
     @SuppressWarnings("unchecked")
     public GridMultiWidget(Context context, FormEntryPrompt prompt, int numColumns) {
         super(context, prompt);
-        mItems = mPrompt.getSelectChoices();
+        mItems = getSelectChoices();
 
         selected = new boolean[mItems.size()];
         String[] choices = new String[mItems.size()];

--- a/app/src/org/commcare/views/widgets/GridWidget.java
+++ b/app/src/org/commcare/views/widgets/GridWidget.java
@@ -67,7 +67,7 @@ public class GridWidget extends QuestionWidget {
     public GridWidget(Context context, FormEntryPrompt prompt,
                       int numColumns, final boolean quickAdvance) {
         super(context, prompt);
-        mItems = mPrompt.getSelectChoices();
+        mItems = getSelectChoices();
         listener = (AdvanceToNextListener)context;
 
         selected = new boolean[mItems.size()];

--- a/app/src/org/commcare/views/widgets/LabelWidget.java
+++ b/app/src/org/commcare/views/widgets/LabelWidget.java
@@ -50,11 +50,11 @@ public class LabelWidget extends QuestionWidget {
     public LabelWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
 
-        Vector<SelectChoice> mItems = mPrompt.getSelectChoices();
+        Vector<SelectChoice> mItems = getSelectChoices();
 
         LinearLayout buttonLayout = new LinearLayout(context);
 
-        if (mPrompt.getSelectChoices() != null) {
+        if (mItems != null) {
             for (int i = 0; i < mItems.size(); i++) {
 
                 String imageURI =

--- a/app/src/org/commcare/views/widgets/ListMultiWidget.java
+++ b/app/src/org/commcare/views/widgets/ListMultiWidget.java
@@ -67,7 +67,7 @@ public class ListMultiWidget extends QuestionWidget {
     public ListMultiWidget(Context context, FormEntryPrompt prompt, boolean displayLabel) {
         super(context, prompt);
 
-        mItems = mPrompt.getSelectChoices();
+        mItems = getSelectChoices();
         mCheckboxes = new Vector<>();
 
         // Layout holds the horizontal list of buttons
@@ -81,7 +81,7 @@ public class ListMultiWidget extends QuestionWidget {
         //Is this safe enough from collisions?
         buttonIdBase = Math.abs(mPrompt.getIndex().hashCode());
 
-        if (mPrompt.getSelectChoices() != null) {
+        if (mItems != null) {
             for (int i = 0; i < mItems.size(); i++) {
                 CheckBox c = new CheckBox(getContext());
 

--- a/app/src/org/commcare/views/widgets/ListWidget.java
+++ b/app/src/org/commcare/views/widgets/ListWidget.java
@@ -61,7 +61,7 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
     public ListWidget(Context context, FormEntryPrompt prompt, boolean displayLabel) {
         super(context, prompt);
 
-        mItems = mPrompt.getSelectChoices();
+        mItems = getSelectChoices();
         buttons = new Vector<>();
 
         // Layout holds the horizontal list of buttons
@@ -75,7 +75,7 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
         //Is this safe enough from collisions?
         buttonIdBase = Math.abs(mPrompt.getIndex().hashCode());
 
-        if (mPrompt.getSelectChoices() != null) {
+        if (mItems != null) {
             for (int i = 0; i < mItems.size(); i++) {
                 RadioButton r = new RadioButton(getContext());
 

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -29,6 +29,7 @@ import android.widget.TextView;
 import org.commcare.dalvik.R;
 import org.commcare.interfaces.WidgetChangedListener;
 import org.commcare.models.ODKStorage;
+import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.preferences.FormEntryPreferences;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.BlockingActionsManager;
@@ -52,6 +53,7 @@ import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
 
 import java.io.File;
+import java.util.Vector;
 
 public abstract class QuestionWidget extends LinearLayout implements QuestionExtensionReceiver {
     private final static String TAG = QuestionWidget.class.getSimpleName();
@@ -707,6 +709,20 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
                     FileUtil.getFileSize(file) + ""));
         }
         return false;
+    }
+
+
+    protected Vector<SelectChoice> getSelectChoices() {
+        Vector<SelectChoice> selectChoices = mPrompt.getSelectChoices();
+        if (!DeveloperPreferences.isSpaceAllowedInSelectChoices() && selectChoices != null) {
+            for (int i = 0; i < selectChoices.size(); i++) {
+                if (selectChoices.get(i).getValue().contains(" ")) {
+                    throw new IllegalArgumentException("Select answer option cannot contain spaces in question '" +
+                            mPrompt.getLongText() + "' with option '" + mPrompt.getSelectChoiceText(selectChoices.get(i)) + "'");
+                }
+            }
+        }
+        return selectChoices;
     }
 
     /*

--- a/app/src/org/commcare/views/widgets/SelectMultiWidget.java
+++ b/app/src/org/commcare/views/widgets/SelectMultiWidget.java
@@ -37,7 +37,7 @@ public class SelectMultiWidget extends QuestionWidget {
     public SelectMultiWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
         mCheckboxes = new Vector<>();
-        mItems = mPrompt.getSelectChoices();
+        mItems = getSelectChoices();
 
         setOrientation(LinearLayout.VERTICAL);
 
@@ -49,7 +49,7 @@ public class SelectMultiWidget extends QuestionWidget {
         //Is this safe enough from collisions?
         buttonIdBase = Math.abs(mPrompt.getIndex().hashCode());
 
-        if (mPrompt.getSelectChoices() != null) {
+        if (mItems != null) {
             for (int i = 0; i < mItems.size(); i++) {
                 // no checkbox group so id by answer + offset
                 final CheckBox c = new CheckBox(getContext());

--- a/app/src/org/commcare/views/widgets/SelectOneAutoAdvanceWidget.java
+++ b/app/src/org/commcare/views/widgets/SelectOneAutoAdvanceWidget.java
@@ -48,7 +48,7 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
 
         LayoutInflater inflater = LayoutInflater.from(getContext());
 
-        mItems = prompt.getSelectChoices();
+        mItems = getSelectChoices();
         buttons = new Vector<>();
         listener = (AdvanceToNextListener)context;
 
@@ -60,7 +60,7 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
         //Is this safe enough from collisions?
         buttonIdBase = Math.abs(prompt.getIndex().hashCode());
 
-        if (prompt.getSelectChoices() != null) {
+        if (mItems != null) {
             for (int i = 0; i < mItems.size(); i++) {
 
                 RelativeLayout thisParentLayout =

--- a/app/src/org/commcare/views/widgets/SelectOneWidget.java
+++ b/app/src/org/commcare/views/widgets/SelectOneWidget.java
@@ -38,7 +38,7 @@ public class SelectOneWidget extends QuestionWidget implements OnCheckedChangeLi
 
         int padding = (int)Math.floor(context.getResources().getDimension(R.dimen.select_padding));
 
-        mItems = prompt.getSelectChoices();
+        mItems = getSelectChoices();
         buttons = new Vector<>();
 
         String s = null;

--- a/app/src/org/commcare/views/widgets/SpinnerMultiWidget.java
+++ b/app/src/org/commcare/views/widgets/SpinnerMultiWidget.java
@@ -52,7 +52,7 @@ public class SpinnerMultiWidget extends QuestionWidget {
     @SuppressWarnings("unchecked")
     public SpinnerMultiWidget(final Context context, FormEntryPrompt prompt) {
         super(context, prompt);
-        mItems = mPrompt.getSelectChoices();
+        mItems = getSelectChoices();
 
         selections = new boolean[mItems.size()];
         answerItems = new CharSequence[mItems.size()];
@@ -130,7 +130,7 @@ public class SpinnerMultiWidget extends QuestionWidget {
             boolean first = true;
             for (int i = 0; i < selections.length; ++i) {
 
-                String value = mPrompt.getSelectChoices().get(i).getValue();
+                String value = mItems.get(i).getValue();
                 boolean found = false;
                 for (Selection s : ve) {
                     if (value.equals(s.getValue())) {

--- a/app/src/org/commcare/views/widgets/SpinnerWidget.java
+++ b/app/src/org/commcare/views/widgets/SpinnerWidget.java
@@ -37,7 +37,7 @@ public class SpinnerWidget extends QuestionWidget {
     public SpinnerWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
 
-        mItems = prompt.getSelectChoices();
+        mItems = getSelectChoices();
         spinner = new Spinner(context);
         choices = new String[mItems.size()];
 


### PR DESCRIPTION
Case: https://manage.dimagi.com/default.asp?266292#1427432

Configurable version of https://github.com/dimagi/commcare-core/pull/691

Product Note: Introduces a developer setting 'Allow spaces in Select choices' which if disabled (enabled by default currently) results in an error like 'Select answer option cannot contain spaces in question 'QuestionText' with option 'ChoiceWithSpaceText' ' in case spaces are present in lookup table options used for a lookup table select question's value field. The error occurs when user arrives on the relevant question with spacey choices in a form.