### PR TITLE
Write a uuid to the log submission XML to prevent duplicate submissions

### DIFF
--- a/app/src/org/commcare/logging/DeviceReportWriter.java
+++ b/app/src/org/commcare/logging/DeviceReportWriter.java
@@ -6,6 +6,7 @@ import org.commcare.android.javarosa.DeviceReportRecord;
 import org.commcare.models.database.SqlStorage;
 import org.javarosa.core.model.User;
 import org.javarosa.core.model.utils.DateUtils;
+import org.javarosa.core.util.PropertyUtils;
 import org.kxml2.io.KXmlSerializer;
 import org.xmlpull.v1.XmlSerializer;
 
@@ -68,6 +69,8 @@ public class DeviceReportWriter {
                     } catch (Exception e) {
                     }
                 }
+
+                writeMetaBlock();
             } finally {
                 serializer.endTag(XMLNS, "device_report");
             }
@@ -79,6 +82,12 @@ public class DeviceReportWriter {
             } catch (IOException e) {
             }
         }
+    }
+
+    private void writeMetaBlock() throws IllegalArgumentException, IllegalStateException, IOException {
+        serializer.startTag(XMLNS, "meta");
+        writeText("instanceID", PropertyUtils.genUUID());
+        serializer.endTag(XMLNS, "meta");
     }
 
     private void writeHeader() throws IllegalArgumentException, IllegalStateException, IOException {


### PR DESCRIPTION
With help from @emord I confirmed that HQ does treat device log xforms the same way as normal forms in that it checks for a unique id included in a <meta> block on the form. Mobile was previously not including any <meta> block in device log submissions, so adding one now will prevent duplicate logs from being included in device reports on HQ in the future.

I was also able to confirm this theory via manual testing by observing that duplicate logs would previously show up on HQ if we prevented the deletion of a DeviceReportRecord after it was submitted, and observing that this PR fixes that behavior.  