### PR TITLE
Remove unneeded uses-library block

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -278,13 +278,7 @@
         </activity>
         <activity android:name="org.commcare.activities.InstallFromListActivity">
         </activity>
-
-        <uses-library
-            android:name="org.javarosa"
-            android:required="false"/>
-        <uses-library
-            android:name="org.commcare"
-            android:required="false"/>
+        
         <uses-library
             android:name="com.google.android.maps"
             android:required="false"/>


### PR DESCRIPTION
I don't believe we actually need these elements; the `uses-library` tag is for libraries that you require to be on the device *in order to* install, not libraries that you include in your install (such as `javarosa` and `commcare`)

https://stackoverflow.com/questions/9868393/android-requires-unavailable-shared-library-com-google-android-maps-failing
https://stackoverflow.com/a/45357556/2820312
  