### PR TITLE
Instantiate BarcodeWidget intent for quick appearance

### DIFF
--- a/app/src/org/commcare/views/widgets/BarcodeWidget.java
+++ b/app/src/org/commcare/views/widgets/BarcodeWidget.java
@@ -33,6 +33,14 @@ public class BarcodeWidget extends IntentWidget implements TextWatcher {
         this.intent = new IntentIntegrator((Activity)getContext()).createScanIntent();
     }
 
+    @Override
+    protected void performCallout() {
+        if (this.intent == null) {
+            this.intent = new IntentIntegrator((Activity)getContext()).createScanIntent();
+        }
+        super.performCallout();
+    }
+
     public void processBarcodeResponse(TreeReference intentQuestionRef, String scanResult) {
         IntentCallout.setNodeValue(this.formDef, intentQuestionRef, scanResult);
     }


### PR DESCRIPTION
addresses https://manage.dimagi.com/default.asp?268210

Looks like the [refactor](https://github.com/dimagi/commcare-android/commit/f1f8204bc51b85947c51bb00272adcd586967aa2#diff-42be99734c63ffc769073deecabd62ff) to make the `BarcodeWidget` use the ZXing library postponed the instantiation of the `intent` class variable (see comment on line 32) such that this is still null when the `quick` appearance attribute is used. Unfortunate edge case. 