### PR TITLE
Send users to the proper location settings page for the situation

### DIFF
--- a/app/src/org/commcare/activities/GeoPointActivity.java
+++ b/app/src/org/commcare/activities/GeoPointActivity.java
@@ -10,6 +10,7 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.location.LocationProvider;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.view.View;
@@ -87,32 +88,7 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
 
         providers = GeoUtils.evaluateProviders(locationManager);
         if (providers.isEmpty()) {
-            DialogInterface.OnCancelListener onCancelListener = new DialogInterface.OnCancelListener() {
-                @Override
-                public void onCancel(DialogInterface dialog) {
-                    location = null;
-                    GeoPointActivity.this.finish();
-                }
-            };
-
-            DialogInterface.OnClickListener onChangeListener = new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int i) {
-                    switch (i) {
-                        case DialogInterface.BUTTON_POSITIVE:
-                            Intent intent = new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
-                            startActivity(intent);
-                            break;
-                        case DialogInterface.BUTTON_NEGATIVE:
-                            location = null;
-                            GeoPointActivity.this.finish();
-                            break;
-                    }
-                    dialog.dismiss();
-                }
-            };
-
-            GeoUtils.showNoGpsDialog(this, onChangeListener, onCancelListener);
+            handleNoLocationProviders();
         } else {
             for (String provider : providers) {
                 if ((provider.equals(LocationManager.GPS_PROVIDER) && ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) ||
@@ -123,6 +99,45 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
             // TODO PLM: warn user and ask for permissions if the user has disabled them
             locationDialog.show();
         }
+    }
+
+    private void handleNoLocationProviders() {
+        DialogInterface.OnCancelListener onCancelListener = new DialogInterface.OnCancelListener() {
+            @Override
+            public void onCancel(DialogInterface dialog) {
+                location = null;
+                GeoPointActivity.this.finish();
+            }
+        };
+
+        DialogInterface.OnClickListener onChangeListener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int i) {
+                switch (i) {
+                    case DialogInterface.BUTTON_POSITIVE:
+                        goToProperLocationSettingsScreen();
+                        break;
+                    case DialogInterface.BUTTON_NEGATIVE:
+                        location = null;
+                        GeoPointActivity.this.finish();
+                        break;
+                }
+                dialog.dismiss();
+            }
+        };
+
+        GeoUtils.showNoGpsDialog(this, onChangeListener, onCancelListener);
+    }
+
+    private void goToProperLocationSettingsScreen() {
+        Intent intent;
+        if (GeoUtils.locationServicesEnabledGlobally(this.locationManager)) {
+            intent = new Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+            intent.setData(Uri.fromParts("package", getPackageName(), null));
+        } else {
+            intent = new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+        }
+        startActivity(intent);
     }
 
     /**

--- a/app/src/org/commcare/activities/GeoPointActivity.java
+++ b/app/src/org/commcare/activities/GeoPointActivity.java
@@ -115,7 +115,7 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
             public void onClick(DialogInterface dialog, int i) {
                 switch (i) {
                     case DialogInterface.BUTTON_POSITIVE:
-                        goToProperLocationSettingsScreen();
+                        GeoUtils.goToProperLocationSettingsScreen(GeoPointActivity.this);
                         break;
                     case DialogInterface.BUTTON_NEGATIVE:
                         location = null;
@@ -127,17 +127,6 @@ public class GeoPointActivity extends Activity implements LocationListener, Time
         };
 
         GeoUtils.showNoGpsDialog(this, onChangeListener, onCancelListener);
-    }
-
-    private void goToProperLocationSettingsScreen() {
-        Intent intent;
-        if (GeoUtils.locationServicesEnabledGlobally(this.locationManager)) {
-            intent = new Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-            intent.setData(Uri.fromParts("package", getPackageName(), null));
-        } else {
-            intent = new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
-        }
-        startActivity(intent);
     }
 
     /**

--- a/app/src/org/commcare/activities/components/FormEntryDialogs.java
+++ b/app/src/org/commcare/activities/components/FormEntryDialogs.java
@@ -143,8 +143,7 @@ public class FormEntryDialogs {
                 @Override
                 public void onClick(DialogInterface dialog, int i) {
                     if (i == DialogInterface.BUTTON_POSITIVE) {
-                        Intent intent = new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
-                        activity.startActivity(intent);
+                        GeoUtils.goToProperLocationSettingsScreen(activity);
                     }
                     activity.dismissAlertDialog();
                 }

--- a/app/src/org/commcare/utils/GeoUtils.java
+++ b/app/src/org/commcare/utils/GeoUtils.java
@@ -149,12 +149,16 @@ public class GeoUtils {
         boolean gpsEnabled = false, networkEnabled = false;
         try {
             gpsEnabled = lm.isProviderEnabled(LocationManager.GPS_PROVIDER);
-        } catch (Exception ex){
+        } catch (Exception ex) {
+            // Prior to API level 21, this will throw a SecurityException if the location
+            // permissions are not sufficient to use the specified provider
         }
 
         try {
             networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-        } catch (Exception ex){
+        } catch (Exception ex) {
+            // Prior to API level 21, this will throw a SecurityException if the location
+            // permissions are not sufficient to use the specified provider
         }
         return gpsEnabled || networkEnabled;
     }

--- a/app/src/org/commcare/utils/GeoUtils.java
+++ b/app/src/org/commcare/utils/GeoUtils.java
@@ -71,7 +71,7 @@ public class GeoUtils {
      * Gets the same list of providers returned by evaluateProviders, but filtered out
      * to include only providers with the appropriate permissions granted.
      */
-    public static Set<String> evaluateProvidersWithPermissions(LocationManager manager, Context context) {
+    protected static Set<String> evaluateProvidersWithPermissions(LocationManager manager, Context context) {
         HashSet<String> set = new HashSet<>();
 
         List<String> providers = manager.getProviders(true);
@@ -129,6 +129,21 @@ public class GeoUtils {
             factory.setOnCancelListener(onCancel);
         }
         return factory;
+    }
+
+    public static boolean locationServicesEnabledGlobally(LocationManager lm) {
+        boolean gpsEnabled = false, networkEnabled = false;
+        try {
+            gpsEnabled = lm.isProviderEnabled(LocationManager.GPS_PROVIDER);
+        } catch (Exception ex){
+        }
+
+        try {
+            networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+        } catch (Exception ex){
+        }
+
+        return gpsEnabled || networkEnabled;
     }
 
     /**

--- a/app/src/org/commcare/utils/GeoUtils.java
+++ b/app/src/org/commcare/utils/GeoUtils.java
@@ -4,9 +4,11 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationManager;
+import android.net.Uri;
 import android.support.v4.content.ContextCompat;
 
 import org.commcare.activities.CommCareActivity;
@@ -131,7 +133,19 @@ public class GeoUtils {
         return factory;
     }
 
-    public static boolean locationServicesEnabledGlobally(LocationManager lm) {
+    public static void goToProperLocationSettingsScreen(Context context) {
+        Intent intent;
+        LocationManager lm = (LocationManager)context.getSystemService(Context.LOCATION_SERVICE);
+        if (locationServicesEnabledGlobally(lm)) {
+            intent = new Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+            intent.setData(Uri.fromParts("package", context.getPackageName(), null));
+        } else {
+            intent = new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+        }
+        context.startActivity(intent);
+    }
+
+    private static boolean locationServicesEnabledGlobally(LocationManager lm) {
         boolean gpsEnabled = false, networkEnabled = false;
         try {
             gpsEnabled = lm.isProviderEnabled(LocationManager.GPS_PROVIDER);
@@ -142,7 +156,6 @@ public class GeoUtils {
             networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
         } catch (Exception ex){
         }
-
         return gpsEnabled || networkEnabled;
     }
 

--- a/app/src/org/commcare/views/dialogs/LocationNotificationHandler.java
+++ b/app/src/org/commcare/views/dialogs/LocationNotificationHandler.java
@@ -1,7 +1,6 @@
 package org.commcare.views.dialogs;
 
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.os.Handler;
 import android.os.Message;
 
@@ -36,8 +35,7 @@ public class LocationNotificationHandler extends Handler {
                 public void onClick(DialogInterface dialog, int i) {
                     switch (i) {
                         case DialogInterface.BUTTON_POSITIVE:
-                            Intent intent = new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
-                            activity.startActivity(intent);
+                            GeoUtils.goToProperLocationSettingsScreen(activity);
                             EntitySelectActivity.getHereFunctionHandler().allowGpsUse();
                             break;
                         case DialogInterface.BUTTON_NEGATIVE:


### PR DESCRIPTION
@Ben-Talbot pointed out that when location services are missing, we were previously not always sending users to the proper settings page for them to fix it. This is because there are 2 different situations that can cause location services to be unavailable in CommCare: one is if location services are turned off globally for the device, and one is if they have been disabled (or never granted in the first place) for CommCare specifically. The settings pages on which the user can toggle these 2 things are different, so we should detect which situation the user is in and send them to the proper screen.