### PR TITLE
Refactor StorageManager

### DIFF
--- a/app/src/org/commcare/CommCareApp.java
+++ b/app/src/org/commcare/CommCareApp.java
@@ -199,18 +199,18 @@ public class CommCareApp implements AppFilePathBuilder {
 
         // See if any of our tables got left in a weird state
         if (global.getTableReadiness() == ResourceTable.RESOURCE_TABLE_UNCOMMITED) {
-            global.rollbackCommits();
+            global.rollbackCommits(platform);
             logTable("Global after rollback", global);
         }
         if (upgrade.getTableReadiness() == ResourceTable.RESOURCE_TABLE_UNCOMMITED) {
-            upgrade.rollbackCommits();
+            upgrade.rollbackCommits(platform);
             logTable("Upgrade after rollback", upgrade);
         }
 
         // See if we got left in the middle of an update
         if (global.getTableReadiness() == ResourceTable.RESOURCE_TABLE_UNSTAGED) {
             // If so, repair the global table. (Always takes priority over maintaining the update)
-            global.repairTable(upgrade);
+            global.repairTable(upgrade, platform);
         }
 
         Resource profile = global.getResourceWithId(CommCarePlatform.APP_PROFILE_RESOURCE_ID);

--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -60,12 +60,12 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     }
 
     @Override
-    public abstract boolean initialize(AndroidCommCarePlatform instance, boolean isUpgrade);
+    public abstract boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade);
 
     @Override
     public boolean install(Resource r, ResourceLocation location,
                            Reference ref, ResourceTable table,
-                           AndroidCommCarePlatform instance, boolean upgrade)
+                           AndroidCommCarePlatform platform, boolean upgrade)
             throws UnresolvedResourceException, UnfullfilledRequirementsException {
         try {
             InputStream inputFileStream;
@@ -157,7 +157,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     public abstract boolean requiresRuntimeInitialization();
 
     @Override
-    public boolean uninstall(Resource r, AndroidCommCarePlatform instance) throws UnresolvedResourceException {
+    public boolean uninstall(Resource r, AndroidCommCarePlatform platform) throws UnresolvedResourceException {
         try {
             return new File(ReferenceManager.instance().DeriveReference(this.localLocation).getLocalURI()).delete();
         } catch (InvalidReferenceException e) {
@@ -188,7 +188,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     }
 
     @Override
-    public boolean unstage(Resource r, int newStatus, AndroidCommCarePlatform instance) {
+    public boolean unstage(Resource r, int newStatus, AndroidCommCarePlatform platform) {
         try {
             //Our destination/source are different depending on where we're going
             if (newStatus == Resource.RESOURCE_STATUS_UNSTAGED) {
@@ -222,7 +222,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     }
 
     @Override
-    public boolean revert(Resource r, ResourceTable table, CommCarePlatform instance) {
+    public boolean revert(Resource r, ResourceTable table, CommCarePlatform platform) {
         String finalLocation = null;
         try {
             //use same filename as before
@@ -250,7 +250,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     }
 
     @Override
-    public int rollback(Resource r, CommCarePlatform instance) {
+    public int rollback(Resource r, CommCarePlatform platform) {
         //TODO: These filepath ops need to be the same for this all to work,
         //which is not super robust against changes right now.
 
@@ -342,7 +342,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
 
     @Override
     public boolean verifyInstallation(Resource r, Vector<MissingMediaException> issues,
-                                      CommCarePlatform instance) {
+                                      CommCarePlatform platform) {
         try {
             Reference ref = ReferenceManager.instance().DeriveReference(localLocation);
             if (!ref.doesBinaryExist()) {

--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -11,6 +11,7 @@ import org.commcare.resources.model.ResourceLocation;
 import org.commcare.resources.model.ResourceTable;
 import org.commcare.resources.model.UnreliableSourceException;
 import org.commcare.resources.model.UnresolvedResourceException;
+import org.commcare.util.CommCarePlatform;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.FileUtil;
@@ -156,7 +157,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     public abstract boolean requiresRuntimeInitialization();
 
     @Override
-    public boolean uninstall(Resource r) throws UnresolvedResourceException {
+    public boolean uninstall(Resource r, AndroidCommCarePlatform instance) throws UnresolvedResourceException {
         try {
             return new File(ReferenceManager.instance().DeriveReference(this.localLocation).getLocalURI()).delete();
         } catch (InvalidReferenceException e) {
@@ -187,7 +188,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     }
 
     @Override
-    public boolean unstage(Resource r, int newStatus) {
+    public boolean unstage(Resource r, int newStatus, AndroidCommCarePlatform instance) {
         try {
             //Our destination/source are different depending on where we're going
             if (newStatus == Resource.RESOURCE_STATUS_UNSTAGED) {
@@ -221,7 +222,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     }
 
     @Override
-    public boolean revert(Resource r, ResourceTable table) {
+    public boolean revert(Resource r, ResourceTable table, CommCarePlatform instance) {
         String finalLocation = null;
         try {
             //use same filename as before
@@ -249,7 +250,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     }
 
     @Override
-    public int rollback(Resource r) {
+    public int rollback(Resource r, CommCarePlatform instance) {
         //TODO: These filepath ops need to be the same for this all to work,
         //which is not super robust against changes right now.
 
@@ -340,7 +341,8 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     }
 
     @Override
-    public boolean verifyInstallation(Resource r, Vector<MissingMediaException> issues) {
+    public boolean verifyInstallation(Resource r, Vector<MissingMediaException> issues,
+                                      CommCarePlatform instance) {
         try {
             Reference ref = ReferenceManager.instance().DeriveReference(localLocation);
             if (!ref.doesBinaryExist()) {

--- a/app/src/org/commcare/android/resource/installers/LocaleAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/LocaleAndroidInstaller.java
@@ -32,7 +32,7 @@ public class LocaleAndroidInstaller extends FileSystemInstaller {
 
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform instance, boolean isUpgrade) {
+    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) {
         Localization.registerLanguageReference(locale, localLocation);
         return true;
     }

--- a/app/src/org/commcare/android/resource/installers/MediaFileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/MediaFileAndroidInstaller.java
@@ -36,8 +36,8 @@ public class MediaFileAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean uninstall(Resource r, AndroidCommCarePlatform instance) throws UnresolvedResourceException {
-        boolean success = super.uninstall(r, instance);
+    public boolean uninstall(Resource r, AndroidCommCarePlatform platform) throws UnresolvedResourceException {
+        boolean success = super.uninstall(r, platform);
         if (!success) {
             return false;
         }
@@ -56,7 +56,7 @@ public class MediaFileAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform instance, boolean isUpgrade) {
+    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) {
         return false;
     }
 

--- a/app/src/org/commcare/android/resource/installers/MediaFileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/MediaFileAndroidInstaller.java
@@ -5,6 +5,7 @@ import android.support.v4.util.Pair;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceLocation;
 import org.commcare.resources.model.UnresolvedResourceException;
+import org.commcare.util.CommCarePlatform;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.FileUtil;
 import org.javarosa.core.reference.Reference;
@@ -35,8 +36,8 @@ public class MediaFileAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean uninstall(Resource r) throws UnresolvedResourceException {
-        boolean success = super.uninstall(r);
+    public boolean uninstall(Resource r, AndroidCommCarePlatform instance) throws UnresolvedResourceException {
+        boolean success = super.uninstall(r, instance);
         if (!success) {
             return false;
         }

--- a/app/src/org/commcare/android/resource/installers/OfflineUserRestoreAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/OfflineUserRestoreAndroidInstaller.java
@@ -30,8 +30,8 @@ public class OfflineUserRestoreAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform instance, boolean isUpgrade) {
-        instance.registerDemoUserRestore(initDemoUserRestore());
+    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) {
+        platform.registerDemoUserRestore(initDemoUserRestore());
         return true;
     }
 

--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -45,16 +45,16 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
 
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform instance, boolean isUpgrade) {
+    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) {
         try {
 
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
 
-            ProfileParser parser = new ProfileParser(local.getStream(), instance, instance.getGlobalResourceTable(), null,
+            ProfileParser parser = new ProfileParser(local.getStream(), platform, platform.getGlobalResourceTable(), null,
                     Resource.RESOURCE_STATUS_INSTALLED, false);
 
             Profile p = parser.parse();
-            instance.setProfile(p);
+            platform.setProfile(p);
 
             return true;
         } catch (UnfullfilledRequirementsException | XmlPullParserException
@@ -68,15 +68,15 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
 
     @Override
     public boolean install(Resource r, ResourceLocation location, Reference ref,
-                           ResourceTable table, AndroidCommCarePlatform instance, boolean upgrade)
+                           ResourceTable table, AndroidCommCarePlatform platform, boolean upgrade)
             throws UnresolvedResourceException, UnfullfilledRequirementsException {
         //First, make sure all the file stuff is managed.
-        super.install(r, location, ref, table, instance, upgrade);
+        super.install(r, location, ref, table, platform, upgrade);
         try {
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
 
 
-            ProfileParser parser = new ProfileParser(local.getStream(), instance, table, r.getRecordGuid(),
+            ProfileParser parser = new ProfileParser(local.getStream(), platform, table, r.getRecordGuid(),
                     Resource.RESOURCE_STATUS_UNINITIALIZED, false);
 
             Profile p = parser.parse();

--- a/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
@@ -11,6 +11,7 @@ import org.commcare.resources.model.UnresolvedResourceException;
 import org.commcare.suite.model.Entry;
 import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.Suite;
+import org.commcare.util.CommCarePlatform;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.DummyResourceTable;
 import org.commcare.utils.FileUtil;
@@ -109,7 +110,9 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean verifyInstallation(Resource r, Vector<MissingMediaException> problems) {
+    public boolean verifyInstallation(Resource r,
+                                      Vector<MissingMediaException> problems,
+                                      CommCarePlatform instance) {
         try {
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
             Suite suite = AndroidSuiteParser.buildVerifyParser(local.getStream(), new DummyResourceTable()).parse();

--- a/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
@@ -47,7 +47,7 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean initialize(final AndroidCommCarePlatform instance, boolean isUpgrade) {
+    public boolean initialize(final AndroidCommCarePlatform platform, boolean isUpgrade) {
         try {
             if (localLocation == null) {
                 throw new RuntimeException("Error initializing the suite, its file location is null!");
@@ -56,14 +56,14 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
 
             SuiteParser parser;
             if (isUpgrade) {
-                parser = AndroidSuiteParser.buildUpgradeParser(local.getStream(), instance.getGlobalResourceTable(), instance.getFixtureStorage());
+                parser = AndroidSuiteParser.buildUpgradeParser(local.getStream(), platform.getGlobalResourceTable(), platform.getFixtureStorage());
             } else {
-                parser = AndroidSuiteParser.buildInitParser(local.getStream(), instance.getGlobalResourceTable(), instance.getFixtureStorage());
+                parser = AndroidSuiteParser.buildInitParser(local.getStream(), platform.getGlobalResourceTable(), platform.getFixtureStorage());
             }
 
             Suite s = parser.parse();
 
-            instance.registerSuite(s);
+            platform.registerSuite(s);
 
             return true;
         } catch (InvalidStructureException | InvalidReferenceException
@@ -77,15 +77,15 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
 
     @Override
     public boolean install(Resource r, ResourceLocation location, Reference ref,
-                           ResourceTable table, final AndroidCommCarePlatform instance,
+                           ResourceTable table, final AndroidCommCarePlatform platform,
                            boolean upgrade) throws UnresolvedResourceException, UnfullfilledRequirementsException {
         //First, make sure all the file stuff is managed.
-        super.install(r, location, ref, table, instance, upgrade);
+        super.install(r, location, ref, table, platform, upgrade);
 
         try {
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
 
-            AndroidSuiteParser.buildInstallParser(local.getStream(), table, r.getRecordGuid(), instance.getFixtureStorage()).parse();
+            AndroidSuiteParser.buildInstallParser(local.getStream(), table, r.getRecordGuid(), platform.getFixtureStorage()).parse();
 
             table.commitCompoundResource(r, upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED);
             return true;
@@ -112,7 +112,7 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
     @Override
     public boolean verifyInstallation(Resource r,
                                       Vector<MissingMediaException> problems,
-                                      CommCarePlatform instance) {
+                                      CommCarePlatform platform) {
         try {
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
             Suite suite = AndroidSuiteParser.buildVerifyParser(local.getStream(), new DummyResourceTable()).parse();

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -64,8 +64,8 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform instance, boolean isUpgrade) {
-        instance.registerXmlns(namespace, contentUri);
+    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) {
+        platform.registerXmlns(namespace, contentUri);
         return true;
     }
 

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -19,6 +19,7 @@ import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
 import org.commcare.resources.model.UnresolvedResourceException;
+import org.commcare.util.CommCarePlatform;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.GlobalConstants;
@@ -183,13 +184,13 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean revert(Resource r, ResourceTable table) {
-        return super.revert(r, table) && updateFilePath();
+    public boolean revert(Resource r, ResourceTable table, CommCarePlatform platform) {
+        return super.revert(r, table, platform) && updateFilePath();
     }
 
     @Override
-    public int rollback(Resource r) {
-        int newStatus = super.rollback(r);
+    public int rollback(Resource r, CommCarePlatform platform) {
+        int newStatus = super.rollback(r, platform);
         if (newStatus == Resource.RESOURCE_STATUS_INSTALLED) {
             if (updateFilePath()) {
                 return newStatus;
@@ -223,7 +224,9 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean verifyInstallation(Resource r, Vector<MissingMediaException> problems) {
+    public boolean verifyInstallation(Resource r,
+                                      Vector<MissingMediaException> problems,
+                                      CommCarePlatform platform) {
         //Check to see whether the formDef exists and reads correctly
         FormDef formDef;
         try {

--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -79,7 +79,7 @@ public class AndroidResourceManager extends ResourceManager {
 
                 if (updateNotNewer(getMasterProfile())) {
                     Logger.log(LogTypes.TYPE_RESOURCES, "App Resources up to Date");
-                    upgradeTable.clear();
+                    upgradeTable.clear(platform);
                     return AppInstallStatus.UpToDate;
                 }
 
@@ -205,7 +205,7 @@ public class AndroidResourceManager extends ResourceManager {
         updateStats.registerUpdateException(new Exception(result.toString()));
 
         if (!result.canReusePartialUpdateTable()) {
-            upgradeTable.clear();
+            upgradeTable.clear(platform);
         }
 
         retryUpdateOrGiveUp(ctx, isAutoUpdate);
@@ -224,7 +224,7 @@ public class AndroidResourceManager extends ResourceManager {
                 ResourceInstallUtils.recordAutoUpdateCompletion(app);
             }
 
-            upgradeTable.clear();
+            upgradeTable.clear(platform);
         } else {
             Log.w(TAG, "Retrying auto-update");
             UpdateStats.saveStatsPersistently(app, updateStats);

--- a/app/src/org/commcare/tasks/VerificationTask.java
+++ b/app/src/org/commcare/tasks/VerificationTask.java
@@ -33,7 +33,7 @@ public abstract class VerificationTask<Reciever>
                 new SizeBoundUniqueVector<>(10);
 
         setTableListeners(global);
-        global.verifyInstallation(problems);
+        global.verifyInstallation(problems, platform);
         unsetTableListeners(global);
 
         if (problems.size() > 0) {

--- a/app/src/org/commcare/utils/DummyResourceTable.java
+++ b/app/src/org/commcare/utils/DummyResourceTable.java
@@ -182,7 +182,7 @@ public class DummyResourceTable extends ResourceTable {
     }
 
     @Override
-    public void prepareResources(ResourceTable master, CommCarePlatform instance)
+    public void prepareResources(ResourceTable master, CommCarePlatform platform)
             throws UnresolvedResourceException,
             UnfullfilledRequirementsException {
     }

--- a/app/src/org/commcare/utils/DummyResourceTable.java
+++ b/app/src/org/commcare/utils/DummyResourceTable.java
@@ -80,14 +80,14 @@ public class DummyResourceTable extends ResourceTable {
                     }
 
                     @Override
-                    public boolean initialize(CommCarePlatform instance, boolean isUpgrade) {
+                    public boolean initialize(CommCarePlatform platform, boolean isUpgrade) {
                         return true;
                     }
 
                     @Override
                     public boolean install(Resource r,
                                            ResourceLocation location, Reference ref,
-                                           ResourceTable table, CommCarePlatform instance,
+                                           ResourceTable table, CommCarePlatform platform,
                                            boolean upgrade)
                             throws UnresolvedResourceException,
                             UnfullfilledRequirementsException {
@@ -95,23 +95,23 @@ public class DummyResourceTable extends ResourceTable {
                     }
 
                     @Override
-                    public int rollback(Resource r, CommCarePlatform instance) {
+                    public int rollback(Resource r, CommCarePlatform platform) {
                         throw new RuntimeException("Basic Installer resources can't rolled back");
                     }
 
                     @Override
-                    public boolean uninstall(Resource r, CommCarePlatform instance)
+                    public boolean uninstall(Resource r, CommCarePlatform platform)
                             throws UnresolvedResourceException {
                         return true;
                     }
 
                     @Override
-                    public boolean unstage(Resource r, int newStatus, CommCarePlatform instance) {
+                    public boolean unstage(Resource r, int newStatus, CommCarePlatform platform) {
                         return true;
                     }
 
                     @Override
-                    public boolean revert(Resource r, ResourceTable table, CommCarePlatform instance) {
+                    public boolean revert(Resource r, ResourceTable table, CommCarePlatform platform) {
                         return true;
                     }
 
@@ -127,7 +127,7 @@ public class DummyResourceTable extends ResourceTable {
                     }
 
                     @Override
-                    public boolean verifyInstallation(Resource r, Vector problems, CommCarePlatform instance) {
+                    public boolean verifyInstallation(Resource r, Vector problems, CommCarePlatform platform) {
                         return false;
                     }
                 };

--- a/app/src/org/commcare/utils/DummyResourceTable.java
+++ b/app/src/org/commcare/utils/DummyResourceTable.java
@@ -95,23 +95,23 @@ public class DummyResourceTable extends ResourceTable {
                     }
 
                     @Override
-                    public int rollback(Resource r) {
+                    public int rollback(Resource r, CommCarePlatform instance) {
                         throw new RuntimeException("Basic Installer resources can't rolled back");
                     }
 
                     @Override
-                    public boolean uninstall(Resource r)
+                    public boolean uninstall(Resource r, CommCarePlatform instance)
                             throws UnresolvedResourceException {
                         return true;
                     }
 
                     @Override
-                    public boolean unstage(Resource r, int newStatus) {
+                    public boolean unstage(Resource r, int newStatus, CommCarePlatform instance) {
                         return true;
                     }
 
                     @Override
-                    public boolean revert(Resource r, ResourceTable table) {
+                    public boolean revert(Resource r, ResourceTable table, CommCarePlatform instance) {
                         return true;
                     }
 
@@ -127,7 +127,7 @@ public class DummyResourceTable extends ResourceTable {
                     }
 
                     @Override
-                    public boolean verifyInstallation(Resource r, Vector problems) {
+                    public boolean verifyInstallation(Resource r, Vector problems, CommCarePlatform instance) {
                         return false;
                     }
                 };
@@ -202,7 +202,7 @@ public class DummyResourceTable extends ResourceTable {
     }
 
     @Override
-    public void clear() {
+    public void clear(CommCarePlatform instance) {
     }
 
     @Override


### PR DESCRIPTION
In the same vein as #718, refactor StorageManager to not use a static singleton and instead use CommCarePlatform as the delivery vector

cross-request: https://github.com/dimagi/commcare-core/pull/728