### PR TITLE
Don't use dynamic action id intent filters that will be set/called from outside CommCare

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -387,7 +387,7 @@
             android:name="org.commcare.print.TemplatePrinterActivity"
             android:theme="@style/Theme.Dialog.NoTitle">
             <intent-filter>
-                <action android:name="${applicationId}.action.PRINT"/>
+                <action android:name="org.commcare.dalvik.action.PRINT"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </activity>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -140,7 +140,7 @@
         </activity>
         <activity android:name="org.commcare.activities.DotsEntryActivity">
             <intent-filter>
-                <action android:name="${applicationId}.action.DotsEntry"/>
+                <action android:name="org.commcare.dalvik.action.DotsEntry"/>
 
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
@@ -307,7 +307,7 @@
             android:name="org.commcare.activities.KeyAccessRequestActivity"
             android:exported="true">
             <intent-filter>
-                <action android:name="${applicationId}.action.CommCareKeyAccessRequest"/>
+                <action android:name="org.commcare.dalvik.action.CommCareKeyAccessRequest"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </activity>
@@ -326,7 +326,7 @@
 
         <receiver android:name="org.commcare.provider.ExternalApiReceiver">
             <intent-filter>
-                <action android:name="${applicationId}.api.action.ExternalAction"/>
+                <action android:name="org.commcare.dalvik.api.action.ExternalAction"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </receiver>
@@ -335,34 +335,34 @@
             android:enabled="true"
             android:exported="true" >
             <intent-filter>
-                <action android:name="${applicationId}.api.action.RefreshToLatestBuildAction"/>
+                <action android:name="org.commcare.dalvik.api.action.RefreshToLatestBuildAction"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </receiver>
 
         <receiver android:name="org.commcare.provider.DebugControlsReceiver">
             <intent-filter>
-                <action android:name="${applicationId}.api.action.SessionCaptureAction"/>
+                <action android:name="org.commcare.dalvik.api.action.SessionCaptureAction"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
             <intent-filter>
-                <action android:name="${applicationId}.api.action.UninstallApp"/>
+                <action android:name="org.commcare.dalvik.api.action.UninstallApp"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
             <intent-filter>
-                <action android:name="${applicationId}.api.action.LoginWithCreds"/>
+                <action android:name="org.commcare.dalvik.api.action.LoginWithCreds"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
             <intent-filter>
-                <action android:name="${applicationId}.api.action.TriggerSyncRecover"/>
+                <action android:name="org.commcare.dalvik.api.action.TriggerSyncRecover"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
             <intent-filter>
-                <action android:name="${applicationId}.api.action.ClearCacheOnRestore"/>
+                <action android:name="org.commcare.dalvik.api.action.ClearCacheOnRestore"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
             <intent-filter>
-                <action android:name="${applicationId}.api.action.ExpireUserKeyRecord"/>
+                <action android:name="org.commcare.dalvik.api.action.ExpireUserKeyRecord"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </receiver>


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?268446 made me realize that when we added the paradigm of using the `${applicationId}` placeholder in `AndroidManifest`, we went overboard with the switch. There are some places where we don't want to make the action ID for an intent filter dynamic, because they're referenced by some place outside of CommCare that has no notion of switching that request based on which flavor of CommCare it's calling out to. This is definitely true of `TemplatePrinterActivity` because HQ injects the intent ID into the XForm, so it has to be a static value. Note that this means printing has never worked on LTS.

@wpride and @ctsims Aside from printing, I've changed this in all of the other places that I _think_ it should be changed. I confirmed that for all of these, there is nothing _within_ CommCare that references them via the current package ID (and therefore requires them to use the dynamic filter ID). (And actually the `ccc` script is still relying on the static `org.commcare.dalvik` filter ID for all of the `DebugControlsReceiver` actions). But I'm not sure if there is anything set up externally to rely upon this dynamic system. An example of what I mean would be that I have already changed the CommCare Toolkit to allow you to change which CommCare package ID you're targetting (https://github.com/dimagi/commcare-developer-toolkit/blob/master/app/src/main/java/dalvik/commcare/org/commcaretoolkit/activities/RefreshToLatestBuildActivity.java#L31), but I can easily change that back. Can you think of any other issues that would be caused by any of these changes?