### PR TITLE
gradle.properties changes for build speed

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,18 @@
-org.gradle.jvmargs=-Xmx1536M
+# The Gradle daemon aims to improve the startup and execution time of Gradle.
+# When set to true the Gradle daemon is to run the build.
+org.gradle.daemon=true
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx10248m -XX:MaxPermSize=256m
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+org.gradle.parallel=true
+
+# Enables new incubating mode that makes Gradle selective when configuring projects.
+# Only relevant projects are configured which results in faster builds for large multi-projects.
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:configuration_on_demand
+org.gradle.configureondemand=true


### PR DESCRIPTION
I know that https://android.jlelse.eu/speeding-up-gradle-builds-619c442113cb suggests putting these changes in your global `gradle.properties` file, but I figured committing them here is the best way to ensure that they continue to get used by other developers in the future. I confirmed that the `gradle.properties` file on the Jenkins mobile agent already has `org.gradle.daemon` set to `false`, so that will override this on the build server.