### PR TITLE
Answer questions and update cues after showNext

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -429,6 +429,8 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                             } else {
                                 showView(next, AnimationType.FADE, false);
                             }
+                            activity.saveAnswersForCurrentScreen(FormEntryConstants.EVALUATE_CONSTRAINTS);
+                            FormNavigationUI.updateNavigationCues(activity, FormEntryActivity.mFormController, next);
                             break group_skip;
                         case FormEntryController.EVENT_END_OF_FORM:
                             // auto-advance questions might advance past the last form quesion
@@ -450,6 +452,8 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                                 } else {
                                     showView(nextGroupView, AnimationType.FADE, false);
                                 }
+                                activity.saveAnswersForCurrentScreen(FormEntryConstants.EVALUATE_CONSTRAINTS);
+                                FormNavigationUI.updateNavigationCues(activity, FormEntryActivity.mFormController, nextGroupView);
                                 break group_skip;
                             }
                             // otherwise it's not a field-list group, so just skip it


### PR DESCRIPTION
Fixes https://manage.dimagi.com/default.asp?268210#edit_1_268210

After getting the next view for questions and groups, save answers (needed to catch the Android-level default value of the DateWidget) and update the navigation bar.

This is a pretty heavy-handed solution because when the DateWidget is created we're so far up the chain from the FormDef/TreeElement level that updating that node really isn't tenable from the Widget and this code path (`saveAnswersForCurrentScreen`) is the only extant one that allows you to set low-level values from Android. 

Hold off on merge because I have an idea for how this could be addressed on the HQ side.