### PR TITLE
Turn off lint for gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,3 +17,9 @@ plugins {
     // Pulls 3rd party license agreements for all of our libs
     id "com.github.hierynomus.license" version "0.13.1"
 }
+
+tasks.whenTaskAdded { task ->
+    if (task.name.equals("lint")) {
+        task.enabled = false
+    }
+}


### PR DESCRIPTION
As suggested in https://android.jlelse.eu/speeding-up-gradle-builds-619c442113cb