### PR TITLE
Do fragment transaction properly when adding app code fragment

### DIFF
--- a/app/src/org/commcare/fragments/SelectInstallModeFragment.java
+++ b/app/src/org/commcare/fragments/SelectInstallModeFragment.java
@@ -101,7 +101,7 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
                 FragmentManager fm = getActivity().getSupportFragmentManager();
                 FragmentTransaction ft = fm.beginTransaction();
                 ft.remove(SelectInstallModeFragment.this);
-                ft.add(SelectInstallModeFragment.this.getId(), enterUrl);
+                ft.replace(SelectInstallModeFragment.this.getId(), enterUrl);
                 ft.commit();
             }
         });

--- a/app/src/org/commcare/fragments/SelectInstallModeFragment.java
+++ b/app/src/org/commcare/fragments/SelectInstallModeFragment.java
@@ -100,8 +100,8 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
                 // if we use getChildFragmentManager, we're going to have a crash
                 FragmentManager fm = getActivity().getSupportFragmentManager();
                 FragmentTransaction ft = fm.beginTransaction();
-                ft.replace(SelectInstallModeFragment.this.getId(), enterUrl);
-                ft.addToBackStack(null);
+                ft.remove(SelectInstallModeFragment.this);
+                ft.add(SelectInstallModeFragment.this.getId(), enterUrl);
                 ft.commit();
             }
         });


### PR DESCRIPTION
**Product Note**: Fixes a bug where if an incorrect app code was entered for installation, the install would fail but with no error message or indication of what went wrong. 

A very non-obvious fix for https://manage.dimagi.com/default.asp?269826. The reason no error message was showing up was that the `TextView` that contains it is on the `SelectInstallModeFragment`, but after installation by app code failed, we were failing to return to that fragment as we should have been. So that was the actual question here, and the cause turned out to be the following:

 The [implementation of `onURLChosen()` in `CommCareSetupActivity`](https://github.com/dimagi/commcare-android/blob/d15686feb4e41f8daa8cd3e0a5441435644f5a0a/app/src/org/commcare/activities/CommCareSetupActivity.java#L293-L297) sets the ui state to `UiState.READY_TO_INSTALL` and then calls `uiStateScreenTransition()`. This _should_ result in us being back on the `SelectInstallModeFragment`, but it wasn't because `fragment.isAdded()` was returning true at [this line](https://github.com/dimagi/commcare-android/blob/d15686feb4e41f8daa8cd3e0a5441435644f5a0a/app/src/org/commcare/activities/CommCareSetupActivity.java#L336-L336). This meant that somewhere previously, we hadn't _removed_ the `SelectInstallModeFragment` when we were supposed to. The culprit of that ended up being 2 things wrong with the `onClick` method that I've changed here:

- We weren't calling `remove()` on the `SelectInstallModeFragment` fragment. Since its container ID is different than the ID for which we call `replace()` here, that isn't sufficient for its removal.
- The call to `ft.addToBackStack(null)` made it so that when this fragment transaction was popped back off the stack, its effects would be reversed, which included reversing the `remove()` call. I'm not clear on what the purpose of that call was, but I tested that all operations around url entry install mode operate fine without it.