### PR TITLE
Fixes NPE on rotation for Update Prompts

### DIFF
--- a/app/src/org/commcare/activities/PromptUpdateActivity.java
+++ b/app/src/org/commcare/activities/PromptUpdateActivity.java
@@ -36,7 +36,9 @@ public abstract class PromptUpdateActivity extends SessionAwareCommCareActivity 
     @Override
     public void onCreateSessionSafe(Bundle savedInstanceState) {
         super.onCreateSessionSafe(savedInstanceState);
-        refreshUpdateToPromptObject();
+        if (updateToPrompt == null) {
+            refreshUpdateToPromptObject();
+        }
         setupUI();
     }
 
@@ -97,6 +99,9 @@ public abstract class PromptUpdateActivity extends SessionAwareCommCareActivity 
     }
 
     protected boolean inForceMode() {
+        if (updateToPrompt == null) {
+            refreshUpdateToPromptObject();
+        }
         return updateToPrompt.isForced();
     }
 


### PR DESCRIPTION
Case: https://manage.dimagi.com/default.asp?270185
Crash: https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5a300d4a8cb3c2fa63b92579/sessions/latest?build=69952000

On Rotation, before we could refresh the `updateToPrompt` in `onCreateSessionSafe ` `isBackEnabled`  gets called from `BreadcrumbBarFragment.configureSimpleNav` which results in this NPE.  I am now refreshing the `updateToPrompt` object again if it's null and have added the isNull check in onCreateSessionSafe to avoid duplicate initialization. 

Product Note: Fixes Commcare crash on rotation on the update prompt screen. 