### PR TITLE
Return RESULT_OK for external callouts

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -805,7 +805,11 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     private void clearSessionAndExit(AndroidSessionWrapper currentState, boolean shouldWarnUser) {
         currentState.reset();
         if (wasExternal) {
-            setResult(RESULT_OK);
+            if (shouldWarnUser) {
+                setResult(RESULT_CANCELED);
+            } else {
+                setResult(RESULT_OK);
+            }
             this.finish();
         }
         refreshUI();

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -805,7 +805,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     private void clearSessionAndExit(AndroidSessionWrapper currentState, boolean shouldWarnUser) {
         currentState.reset();
         if (wasExternal) {
-            setResult(RESULT_CANCELED);
+            setResult(RESULT_OK);
             this.finish();
         }
         refreshUI();


### PR DESCRIPTION
Ran into this while dog fooding, we are always returning `RESULT_CANCELED` for external callouts into CommCare, even when we succeed. Conveniently we already have a boolean corresponding to whether the event succeeded or failing, so we should set the result based on that. 