### PR TITLE
Updates landscape layout for update activity with recent changes

### DIFF
--- a/app/res/layout-land/update_activity.xml
+++ b/app/res/layout-land/update_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:RectangleButtonWithText="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:background="@color/cc_core_bg"
@@ -19,16 +20,40 @@
             android:gravity="center"
             android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/update_progress_text"
-                android:layout_width="fill_parent"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/content_min_margin"
                 android:layout_marginLeft="@dimen/content_min_margin"
                 android:layout_marginRight="@dimen/content_min_margin"
                 android:layout_marginTop="@dimen/content_min_margin"
                 android:gravity="center"
-                android:textSize="@dimen/font_size_medium"/>
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/update_progress_text"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textSize="@dimen/font_size_medium"/>
+
+                <FrameLayout
+                    android:id="@+id/btn_view_errors_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/tile_drop_shadow_small_margins"
+                    android:visibility="gone">
+
+                    <org.commcare.views.RectangleButtonWithText
+                        android:id="@+id/update_btn_view_notifications"
+                        android:layout_width="match_parent"
+                        android:layout_height="@dimen/rectangle_button_height"
+                        RectangleButtonWithText:backgroundColor="@color/cc_attention_negative_bg"
+                        RectangleButtonWithText:img="@drawable/ic_list_error"
+                        RectangleButtonWithText:textColor="@color/cc_attention_negative_text"/>
+
+                </FrameLayout>
+            </LinearLayout>
 
             <ProgressBar
                 android:id="@+id/update_progress_bar"

--- a/app/res/layout/update_activity.xml
+++ b/app/res/layout/update_activity.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:SquareButtonWithText="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    xmlns:RectangleButtonWithText="http://schemas.android.com/apk/res-auto"
-    android:background="@color/cc_core_bg"
-    android:scrollbars="none">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:RectangleButtonWithText="http://schemas.android.com/apk/res-auto"
+            xmlns:SquareButtonWithText="http://schemas.android.com/apk/res-auto"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:background="@color/cc_core_bg"
+            android:scrollbars="none">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -23,28 +23,29 @@
             android:gravity="center"
             android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/update_progress_text"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:textSize="@dimen/font_size_medium"/>
-        <FrameLayout
-            android:id="@+id/btn_view_errors_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/tile_drop_shadow_small_margins"
-            android:visibility="gone">
-            <org.commcare.views.RectangleButtonWithText
-                android:id="@+id/update_btn_view_notifications"
+            <TextView
+                android:id="@+id/update_progress_text"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textSize="@dimen/font_size_medium"/>
+
+            <FrameLayout
+                android:id="@+id/btn_view_errors_container"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/rectangle_button_height"
+                android:layout_height="wrap_content"
+                android:background="@drawable/tile_drop_shadow_small_margins"
+                android:visibility="gone">
 
-                RectangleButtonWithText:backgroundColor="@color/cc_attention_negative_bg"
-                RectangleButtonWithText:img="@drawable/ic_list_error"
-                RectangleButtonWithText:textColor="@color/cc_attention_negative_text"/>
+                <org.commcare.views.RectangleButtonWithText
+                    android:id="@+id/update_btn_view_notifications"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/rectangle_button_height"
+                    RectangleButtonWithText:backgroundColor="@color/cc_attention_negative_bg"
+                    RectangleButtonWithText:img="@drawable/ic_list_error"
+                    RectangleButtonWithText:textColor="@color/cc_attention_negative_text"/>
 
-        </FrameLayout>
+            </FrameLayout>
         </LinearLayout>
 
 


### PR DESCRIPTION
Crash: https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5a8dad6d8cb3c2fa6387e5a0/sessions/5A8ED8FF00BC00012D0FE83CC2E3B097_DNE_0_v2?select_key=user

Regression from https://github.com/dimagi/commcare-android/pull/1946, we missed out on adding the new error view to landscape layout causing a NPE in landscape mode. 

Side Note: I stumbled on this while working on integration tests. This was appearing as the infamous `HTTPClient::KeepAliveDisconnected: (HTTPClient::KeepAliveDisconnected` error on device farm with no crash logs in logcat logs. So it seems like logcat provided by device farm is not always complete/accurate. 