### PR TITLE
Error button visibility fix

### DIFF
--- a/app/res/layout/select_install_mode_fragment.xml
+++ b/app/res/layout/select_install_mode_fragment.xml
@@ -1,121 +1,120 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
+    android:id="@+id/screen_first_start_main"
     xmlns:SquareButtonWithText="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:background="@color/cc_core_bg"
-    android:id="@+id/screen_first_start_main"
-    android:layout_height="fill_parent"
     android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:background="@color/cc_core_bg"
     android:orientation="vertical">
 
     <ScrollView
-        android:background="@color/cc_core_bg"
-        android:layout_height="wrap_content"
         android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/cc_core_bg"
         android:scrollbars="none">
 
         <LinearLayout
-            android:layout_height="wrap_content"
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <include layout="@layout/grid_header_top_banner"/>
 
             <LinearLayout
-                android:gravity="center_horizontal"
-                android:layout_height="match_parent"
                 android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center_horizontal"
                 android:orientation="vertical">
 
                 <TextView
-                    android:gravity="center"
                     android:id="@+id/str_setup_message"
+                    android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="@dimen/content_min_margin"
                     android:layout_marginRight="@dimen/content_min_margin"
-                    android:layout_width="fill_parent"
+                    android:gravity="center"
                     android:textSize="@dimen/text_small"
                     android:textStyle="bold"/>
 
                 <TextView
-                    android:gravity="center"
                     android:id="@+id/str_setup_message_2"
+                    android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="@dimen/content_min_margin"
                     android:layout_marginLeft="@dimen/content_min_margin"
                     android:layout_marginRight="@dimen/content_min_margin"
-                    android:layout_width="fill_parent"
+                    android:gravity="center"
                     android:textSize="@dimen/text_small"/>
 
                 <LinearLayout
                     android:id="@+id/screen_first_start_bottom"
-                    android:layout_height="wrap_content"
                     android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
                     <FrameLayout
-                        android:background="@drawable/tile_drop_shadow_small_margins"
                         android:id="@+id/btn_fetch_uri_container"
+                        android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_marginLeft="@dimen/standard_spacer"
                         android:layout_weight="1"
-                        android:layout_width="0dp">
+                        android:background="@drawable/tile_drop_shadow_small_margins">
 
                         <org.commcare.views.SquareButtonWithText
+                            android:id="@+id/btn_fetch_uri"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
                             SquareButtonWithText:backgroundColor="@color/cc_brand_color"
                             SquareButtonWithText:img="@drawable/startup_barcode"
                             SquareButtonWithText:subtitle="Scan Application Barcode"
-                            SquareButtonWithText:textColor="@color/white"
-                            android:id="@+id/btn_fetch_uri"
-                            android:layout_height="match_parent"
-                            android:layout_width="wrap_content"/>
+                            SquareButtonWithText:textColor="@color/white"/>
                     </FrameLayout>
 
                     <FrameLayout
-                        android:background="@drawable/tile_drop_shadow_small_margins"
+                        android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_marginRight="@dimen/standard_spacer"
                         android:layout_weight="1"
-                        android:layout_width="0dp">
+                        android:background="@drawable/tile_drop_shadow_small_margins">
 
                         <org.commcare.views.SquareButtonWithText
+                            android:id="@+id/enter_app_location"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:background="@drawable/tile_drop_shadow_small_margins"
+                            android:gravity="end"
                             SquareButtonWithText:backgroundColor="@color/cc_light_cool_accent_color"
                             SquareButtonWithText:img="@drawable/startup_url"
                             SquareButtonWithText:subtitle="Enter Code"
-                            SquareButtonWithText:textColor="@color/white"
-                            android:background="@drawable/tile_drop_shadow_small_margins"
-                            android:gravity="end"
-                            android:id="@+id/enter_app_location"
-                            android:layout_height="match_parent"
-                            android:layout_width="wrap_content"/>
+                            SquareButtonWithText:textColor="@color/white"/>
                     </FrameLayout>
                 </LinearLayout>
-
                 <LinearLayout
                     android:id="@+id/screen_first_start_second_row"
-                    android:layout_height="wrap_content"
                     android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     android:orientation="horizontal"
                     android:paddingBottom="@dimen/content_min_margin"
                     android:weightSum="2">
 
                     <FrameLayout
-                        android:background="@drawable/tile_drop_shadow_small_margins"
                         android:id="@+id/btn_fetch_hub_container"
+                        android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_marginLeft="@dimen/standard_spacer"
                         android:layout_weight="1"
-                        android:layout_width="0dp"
+                        android:background="@drawable/tile_drop_shadow_small_margins"
                         android:visibility="gone">
 
                         <org.commcare.views.SquareButtonWithText
+                            android:id="@+id/btn_fetch_hub"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
                             SquareButtonWithText:backgroundColor="@color/cc_neutral_color"
                             SquareButtonWithText:img="@drawable/startup_micronode"
                             SquareButtonWithText:subtitle="Install From Local"
-                            SquareButtonWithText:textColor="@color/white"
-                            android:id="@+id/btn_fetch_hub"
-                            android:layout_height="match_parent"
-                            android:layout_width="wrap_content"/>
+                            SquareButtonWithText:textColor="@color/white"/>
                     </FrameLayout>
 
                 </LinearLayout>
@@ -123,36 +122,36 @@
             </LinearLayout>
 
             <LinearLayout
-                android:gravity="center"
-                android:layout_height="wrap_content"
-                android:layout_margin="@dimen/standard_spacer"
                 android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:layout_margin="@dimen/standard_spacer"
                 android:orientation="vertical">
 
                 <TextView
-                    android:gravity="center"
                     android:id="@+id/install_error_text"
-                    android:layout_height="wrap_content"
                     android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:textColor="@color/red"
                     android:textStyle="bold"
+                    android:gravity="center"
                     android:visibility="gone"/>
 
 
                 <FrameLayout
-                    android:background="@drawable/tile_drop_shadow_small_margins"
                     android:id="@+id/btn_view_errors_container"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_width="match_parent">
+                    android:background="@drawable/tile_drop_shadow_small_margins">
+                <org.commcare.views.RectangleButtonWithText
+                    android:id="@+id/btn_view_errors"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/rectangle_button_height"
 
-                    <org.commcare.views.RectangleButtonWithText
-                        SquareButtonWithText:backgroundColor="@color/cc_attention_negative_bg"
-                        SquareButtonWithText:img="@drawable/ic_list_error"
-                        SquareButtonWithText:subtitle="See Error Details"
-                        SquareButtonWithText:textColor="@color/cc_attention_negative_text"
-                        android:id="@+id/btn_view_errors"
-                        android:layout_height="@dimen/rectangle_button_height"
-                        android:layout_width="match_parent"/>
+                    SquareButtonWithText:backgroundColor="@color/cc_attention_negative_bg"
+                    SquareButtonWithText:img="@drawable/ic_list_error"
+                    SquareButtonWithText:subtitle="See Error Details"
+                    SquareButtonWithText:textColor="@color/cc_attention_negative_text"/>
 
                 </FrameLayout>
 

--- a/app/res/layout/select_install_mode_fragment.xml
+++ b/app/res/layout/select_install_mode_fragment.xml
@@ -1,120 +1,121 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
-    android:id="@+id/screen_first_start_main"
     xmlns:SquareButtonWithText="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
     android:background="@color/cc_core_bg"
+    android:id="@+id/screen_first_start_main"
+    android:layout_height="fill_parent"
+    android:layout_width="fill_parent"
     android:orientation="vertical">
 
     <ScrollView
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
         android:background="@color/cc_core_bg"
+        android:layout_height="wrap_content"
+        android:layout_width="fill_parent"
         android:scrollbars="none">
 
         <LinearLayout
-            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_width="match_parent"
             android:orientation="vertical">
 
             <include layout="@layout/grid_header_top_banner"/>
 
             <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
                 android:gravity="center_horizontal"
+                android:layout_height="match_parent"
+                android:layout_width="match_parent"
                 android:orientation="vertical">
 
                 <TextView
+                    android:gravity="center"
                     android:id="@+id/str_setup_message"
-                    android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="@dimen/content_min_margin"
                     android:layout_marginRight="@dimen/content_min_margin"
-                    android:gravity="center"
+                    android:layout_width="fill_parent"
                     android:textSize="@dimen/text_small"
                     android:textStyle="bold"/>
 
                 <TextView
+                    android:gravity="center"
                     android:id="@+id/str_setup_message_2"
-                    android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="@dimen/content_min_margin"
                     android:layout_marginLeft="@dimen/content_min_margin"
                     android:layout_marginRight="@dimen/content_min_margin"
-                    android:gravity="center"
+                    android:layout_width="fill_parent"
                     android:textSize="@dimen/text_small"/>
 
                 <LinearLayout
                     android:id="@+id/screen_first_start_bottom"
-                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
                     android:orientation="horizontal">
 
                     <FrameLayout
+                        android:background="@drawable/tile_drop_shadow_small_margins"
                         android:id="@+id/btn_fetch_uri_container"
-                        android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_marginLeft="@dimen/standard_spacer"
                         android:layout_weight="1"
-                        android:background="@drawable/tile_drop_shadow_small_margins">
+                        android:layout_width="0dp">
 
                         <org.commcare.views.SquareButtonWithText
-                            android:id="@+id/btn_fetch_uri"
-                            android:layout_width="wrap_content"
-                            android:layout_height="match_parent"
                             SquareButtonWithText:backgroundColor="@color/cc_brand_color"
                             SquareButtonWithText:img="@drawable/startup_barcode"
                             SquareButtonWithText:subtitle="Scan Application Barcode"
-                            SquareButtonWithText:textColor="@color/white"/>
+                            SquareButtonWithText:textColor="@color/white"
+                            android:id="@+id/btn_fetch_uri"
+                            android:layout_height="match_parent"
+                            android:layout_width="wrap_content"/>
                     </FrameLayout>
 
                     <FrameLayout
-                        android:layout_width="0dp"
+                        android:background="@drawable/tile_drop_shadow_small_margins"
                         android:layout_height="match_parent"
                         android:layout_marginRight="@dimen/standard_spacer"
                         android:layout_weight="1"
-                        android:background="@drawable/tile_drop_shadow_small_margins">
+                        android:layout_width="0dp">
 
                         <org.commcare.views.SquareButtonWithText
-                            android:id="@+id/enter_app_location"
-                            android:layout_width="wrap_content"
-                            android:layout_height="match_parent"
-                            android:background="@drawable/tile_drop_shadow_small_margins"
-                            android:gravity="end"
                             SquareButtonWithText:backgroundColor="@color/cc_light_cool_accent_color"
                             SquareButtonWithText:img="@drawable/startup_url"
                             SquareButtonWithText:subtitle="Enter Code"
-                            SquareButtonWithText:textColor="@color/white"/>
+                            SquareButtonWithText:textColor="@color/white"
+                            android:background="@drawable/tile_drop_shadow_small_margins"
+                            android:gravity="end"
+                            android:id="@+id/enter_app_location"
+                            android:layout_height="match_parent"
+                            android:layout_width="wrap_content"/>
                     </FrameLayout>
                 </LinearLayout>
+
                 <LinearLayout
                     android:id="@+id/screen_first_start_second_row"
-                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
                     android:orientation="horizontal"
                     android:paddingBottom="@dimen/content_min_margin"
                     android:weightSum="2">
 
                     <FrameLayout
+                        android:background="@drawable/tile_drop_shadow_small_margins"
                         android:id="@+id/btn_fetch_hub_container"
-                        android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_marginLeft="@dimen/standard_spacer"
                         android:layout_weight="1"
-                        android:background="@drawable/tile_drop_shadow_small_margins"
+                        android:layout_width="0dp"
                         android:visibility="gone">
 
                         <org.commcare.views.SquareButtonWithText
-                            android:id="@+id/btn_fetch_hub"
-                            android:layout_width="wrap_content"
-                            android:layout_height="match_parent"
                             SquareButtonWithText:backgroundColor="@color/cc_neutral_color"
                             SquareButtonWithText:img="@drawable/startup_micronode"
                             SquareButtonWithText:subtitle="Install From Local"
-                            SquareButtonWithText:textColor="@color/white"/>
+                            SquareButtonWithText:textColor="@color/white"
+                            android:id="@+id/btn_fetch_hub"
+                            android:layout_height="match_parent"
+                            android:layout_width="wrap_content"/>
                     </FrameLayout>
 
                 </LinearLayout>
@@ -122,36 +123,36 @@
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
                 android:gravity="center"
+                android:layout_height="wrap_content"
                 android:layout_margin="@dimen/standard_spacer"
+                android:layout_width="match_parent"
                 android:orientation="vertical">
 
                 <TextView
+                    android:gravity="center"
                     android:id="@+id/install_error_text"
-                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_width="wrap_content"
                     android:textColor="@color/red"
                     android:textStyle="bold"
-                    android:gravity="center"
                     android:visibility="gone"/>
 
 
                 <FrameLayout
+                    android:background="@drawable/tile_drop_shadow_small_margins"
                     android:id="@+id/btn_view_errors_container"
-                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@drawable/tile_drop_shadow_small_margins">
-                <org.commcare.views.RectangleButtonWithText
-                    android:id="@+id/btn_view_errors"
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/rectangle_button_height"
+                    android:layout_width="match_parent">
 
-                    SquareButtonWithText:backgroundColor="@color/cc_attention_negative_bg"
-                    SquareButtonWithText:img="@drawable/ic_list_error"
-                    SquareButtonWithText:subtitle="See Error Details"
-                    SquareButtonWithText:textColor="@color/cc_attention_negative_text"/>
+                    <org.commcare.views.RectangleButtonWithText
+                        SquareButtonWithText:backgroundColor="@color/cc_attention_negative_bg"
+                        SquareButtonWithText:img="@drawable/ic_list_error"
+                        SquareButtonWithText:subtitle="See Error Details"
+                        SquareButtonWithText:textColor="@color/cc_attention_negative_text"
+                        android:id="@+id/btn_view_errors"
+                        android:layout_height="@dimen/rectangle_button_height"
+                        android:layout_width="match_parent"/>
 
                 </FrameLayout>
 

--- a/app/src/org/commcare/fragments/SelectInstallModeFragment.java
+++ b/app/src/org/commcare/fragments/SelectInstallModeFragment.java
@@ -53,7 +53,7 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
         super.onResume();
 
         NSDDiscoveryTools.registerForNsdServices(this.getContext(), this);
-        if(!CommCareApplication.notificationManager().messagesForCommCareArePending()) {
+        if (!CommCareApplication.notificationManager().messagesForCommCareArePending()) {
             mViewErrorContainer.setVisibility(View.GONE);
         }
 
@@ -200,15 +200,15 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
     public void showOrHideErrorMessage() {
         Activity currentActivity = getActivity();
         if (currentActivity instanceof CommCareSetupActivity) {
-            String msg = ((CommCareSetupActivity) currentActivity).getErrorMessageToDisplay();
+            String msg = ((CommCareSetupActivity)currentActivity).getErrorMessageToDisplay();
             if (msg != null && !"".equals(msg)) {
                 mErrorMessageView.setText(msg);
                 mErrorMessageView.setVisibility(View.VISIBLE);
-                if(((CommCareSetupActivity) this.getActivity()).shouldShowNotificationErrorButton()) {
+                if (((CommCareSetupActivity)this.getActivity()).shouldShowNotificationErrorButton()
+                        && CommCareApplication.notificationManager().messagesForCommCareArePending()) {
                     mViewErrorContainer.setVisibility(View.VISIBLE);
                 }
-
-                } else {
+            } else {
                 mErrorMessageView.setVisibility(View.GONE);
                 mViewErrorContainer.setVisibility(View.GONE);
             }


### PR DESCRIPTION
Even when we are making the error button invisible in fragment's onResume in case of no pending notifications, it becomes visible again  in `showOrHideErrorMessage` which gets called later from activity's `onResumeFragments`. I have added the same check in `showOrHideErrorMessage` as well, but let me know if you see a better way to handle it. 

Repro - 

1. An error occurs while install which makes error button visible
2. User clicks on error button to see more details about the error
3. User press back from Error detail screen to come back on Install screen
4. Error button is still visible even though there are no pending notifications