### PR TITLE
Revert "Sort completed forms in form record list by submission ordering number"

### DIFF
--- a/app/src/org/commcare/adapters/IncompleteFormListAdapter.java
+++ b/app/src/org/commcare/adapters/IncompleteFormListAdapter.java
@@ -23,6 +23,7 @@ import org.commcare.views.IncompleteFormRecordView;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
@@ -165,7 +166,23 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
                     new Object[]{status, currentAppId}));
         }
 
-        sortRecordsInReverseChronological();
+        // Sort FormRecords by modification time, most recent first.
+        Collections.sort(records, new Comparator<FormRecord>() {
+            @Override
+            public int compare(FormRecord left, FormRecord right) {
+                long leftModTime = left.lastModified().getTime();
+                long rightModTime = right.lastModified().getTime();
+
+                if (leftModTime > rightModTime) {
+                    return -1;
+                } else if (leftModTime == rightModTime) {
+                    return 0;
+                } else {
+                    return 1;
+                }
+            }
+        });
+
         searchCache.clear();
         current.clear();
         notifyDataSetChanged();
@@ -174,45 +191,6 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
         // record title, form name, modified date
         loader.init(searchCache, names);
         loader.executeParallel(records.toArray(new FormRecord[records.size()]));
-    }
-
-    private void sortRecordsInReverseChronological() {
-        if (filter.equals(FormRecordFilter.Submitted) || filter.equals(FormRecordFilter.Pending) ||
-                filter.equals(FormRecordFilter.SubmittedAndPending)) {
-            sortBySubmissionOrderingNumber();
-        } else {
-            sortByModificationTime();
-        }
-    }
-
-    private void sortBySubmissionOrderingNumber() {
-        Collections.sort(records, (left, right) -> {
-            int leftOrdering = left.getSubmissionOrderingNumber();
-            long rightOrdering = right.getSubmissionOrderingNumber();
-
-            if (leftOrdering > rightOrdering) {
-                return -1;
-            } else if (leftOrdering == rightOrdering) {
-                return 0;
-            } else {
-                return 1;
-            }
-        });
-    }
-
-    private void sortByModificationTime() {
-        Collections.sort(records, (left, right) -> {
-            long leftModTime = left.lastModified().getTime();
-            long rightModTime = right.lastModified().getTime();
-
-            if (leftModTime > rightModTime) {
-                return -1;
-            } else if (leftModTime == rightModTime) {
-                return 0;
-            } else {
-                return 1;
-            }
-        });
     }
 
     public int findRecordPosition(int formRecordId) {


### PR DESCRIPTION
Reverts dimagi/commcare-android#1939. I realized thanks to https://manage.dimagi.com/default.asp?271707 that this change makes no sense because the submission ordering number resets once forms are submitted successfully, so it can't be relied upon as a global comparator for already-sent forms. Sorting based on ordering number is theoretically still valid for _unsent_ forms, but I don't think it makes sense to make the sort behavior for that one filter different, so let's just revert to the way things were. 

Waiting for input from @ctsims to decide whether this is also hotfix-worthy.

**Product Note**: Undoes the change in dimagi/commcare-android#1939, meaning that we're back to sorting unsent/saved forms by their last-modified date.