### PR TITLE
Fix overriding of last username

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -272,6 +272,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if (requestCode == SEAT_APP_ACTIVITY && resultCode == RESULT_OK) {
             uiController.refreshForNewApp();
+            usernameBeforeRotation = passwordOrPinBeforeRotation = null;
         }
 
         super.onActivityResult(requestCode, resultCode, intent);


### PR DESCRIPTION
The restoration of the last-logged-in username for a given app was getting overridden by the call to `restoreEnteredTextFromRotation()` made by `LoginActivityUIController.refreshView()`. This change solves that by clearing out the saved "before rotation" values if we've just returned from a successful `SeatAppActivity`. The thing that's bothering me is I cannot figure out what changed recently to cause this to break. It definitely worked properly for a long time, but I can't find anywhere in the relevant code that's been touched recently. I already spend a little too long looking for the root cause though so going to be satisfied with just fixing it. If anyone sees what I'm missing, let me know.

**Product Note**: Fixes a small regression where switching between apps on the login screen would not automatically restore the last-logged-in user for that app.