### PR TITLE
Fixes Save in FormEntry after Resuming Session

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -964,9 +964,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         boolean isRestartAfterSessionExpiration =
                 getIntent().getBooleanExtra(KEY_IS_RESTART_AFTER_EXPIRATION, false);
         // Set saved answer path
-        if (FormEntryInstanceState.mInstancePath == null || isRestartAfterSessionExpiration) {
+        if (FormEntryInstanceState.mInstancePath == null) {
             instanceState.initInstancePath();
-        } else {
+        } else if (!isRestartAfterSessionExpiration) {
             // we've just loaded a saved form, so start in the hierarchy view
             Intent i = new Intent(this, FormHierarchyActivity.class);
             startActivityForResult(i, FormEntryConstants.HIERARCHY_ACTIVITY_FIRST_START);


### PR DESCRIPTION
FB: https://manage.dimagi.com/default.asp?272815

Instance path should not be re-initialized on resuming form entry after form Entry session. This results in a buggy behaviour(data loss) where the incomplete form from session expiration doesn't get updated with the data that user enters after resuming session. Moreover this incomplete instance gets uploaded to server since it gets marked as complete on save. 

@ctsims Just realizing that we might want to hotfix this instead. What do you think ?

Product Note: Bug Fix: When a user gets logged out of CommCare while entering data in a form, on login again he gets redirected to the Form he was previously in. This bug was causing any new data entered in this specific form to not get saved resulting in loss of data entered by user for this form. 