### PR TITLE
Make noun project credit translatable (for CAS)

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -73,7 +73,7 @@
 
     <string name="url_prompt">Choose a URL</string>
 
-    <string name="about_dialog" formatted="false">%s\n\n
+    <string name="about_dialog" formatted="false" cc:translatable="true">%s\n\n
 _Copyright 2016, Dimagi inc, All rights reserved_ \n\n
 
 ---------------- \n\n


### PR DESCRIPTION
Note that I'm not 100% sure how the `update_translations` script in the release process is going to react to a multi-line translations value like this. If we're concerned I could try testing it ahead of time, but I didn't do so right now because it's a pain to run that in isolation without all of the surrounding harnessing.