### PR TITLE
Bugfix: Update from pre relationship index table when origin db is v5 or below

### DIFF
--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -230,7 +230,7 @@ class UserDatabaseUpgrader {
             db.execSQL(EntityStorageCache.getTableDefinition());
             EntityStorageCache.createIndexes(db);
 
-            db.execSQL(AndroidCaseIndexTable.getTableDefinition());
+            db.execSQL(UserDbUpgradeUtils.getCreateV6AndroidCaseIndexTableSqlDef());
             AndroidCaseIndexTable.createIndexes(db);
             AndroidCaseIndexTable cit = new AndroidCaseIndexTable(db);
 

--- a/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
+++ b/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
@@ -198,4 +198,14 @@ public class UserDbUpgradeUtils {
             newStorage.write(newRecord);
         }
     }
+
+    public static String getCreateV6AndroidCaseIndexTableSqlDef() {
+        return "CREATE TABLE " + "case_index_storage" + "(" +
+                "commcare_sql_id" + " INTEGER PRIMARY KEY, " +
+                "case_rec_id" + ", " +
+                "name" + ", " +
+                "type" + ", " +
+                "target" +
+                ")";
+    }
 }


### PR DESCRIPTION
Fixes an issue where upgrades which occur from a build after db v20 from a pre v6 build will fail due to the newest (rather than original) definition of the case index table being created in the initial update.