### PR TITLE
Logs resource init failures to Device Logs

### DIFF
--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -63,6 +63,7 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
                 | InvalidStructureException | IOException
                 | InvalidReferenceException e) {
             e.printStackTrace();
+            Logger.log(LogTypes.TYPE_RESOURCES, "Initialization failed for Profile resource with exception " + e.getMessage());
         }
 
         return false;

--- a/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
@@ -12,6 +12,7 @@ import org.commcare.suite.model.Entry;
 import org.commcare.suite.model.Menu;
 import org.commcare.suite.model.Suite;
 import org.commcare.util.CommCarePlatform;
+import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.DummyResourceTable;
 import org.commcare.utils.FileUtil;
@@ -70,6 +71,7 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
                 | IOException | XmlPullParserException
                 | UnfullfilledRequirementsException e) {
             e.printStackTrace();
+            Logger.log(LogTypes.TYPE_RESOURCES, "Initialization failed for Suite resource with exception " + e.getMessage());
         }
 
         return false;
@@ -92,7 +94,7 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
         } catch (InvalidStructureException | XPathException e) {
             // push up suite config issues so user can act on them
             throw new InvalidResourceException(r.getDescriptor(), e.getMessage());
-        } catch (XmlPullParserException  | InvalidReferenceException | IOException e) {
+        } catch (XmlPullParserException | InvalidReferenceException | IOException e) {
             e.printStackTrace();
         }
 


### PR DESCRIPTION
Ideally we sould not be catching exceptions at all but for time being just logging the catched exceptions to see if it has any thing to do with profile being null errors. 