### PR TITLE
Change definition of successful Simprints callout processing

### DIFF
--- a/app/src/org/commcare/provider/SimprintsCalloutProcessing.java
+++ b/app/src/org/commcare/provider/SimprintsCalloutProcessing.java
@@ -110,7 +110,7 @@ public class SimprintsCalloutProcessing {
                 Localization.get("fingerprints.scanned", new String[]{"" + numOfFingersScanned});
         IntentCallout.setNodeValue(formDef, intentQuestionRef, resultMessage);
 
-        return (numOfFingersScanned > 0);
+        return guid != null || numOfFingersScanned > 0;
     }
 
     private static int countTemplateScanned(byte[] template) {


### PR DESCRIPTION
Since it's possible/valid in a Simprints callout question specification to only provide a node at which to store the `guid` response (and none of the fingerprint responses themselves), we should define successful processing of the callout response to be getting _either_ the guid or the fingerprints (or both).

This issue was brought to my attention by https://manage.dimagi.com/default.asp?274249. The root issue in that ticket is a bit different than the potential situation I outlined here (there appears to actually be a bug with the returning of the fingerprint values), but nonetheless I think this is the correct thing for us to be doing.