### PR TITLE
Update Markdown llibrary

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -44,7 +44,8 @@
         android:name="android.hardware.camera"
         android:required="false"/>
 
-    <uses-sdk tools:overrideLibrary="com.dimagi.android.zebraprinttool, com.simprints.libsimprints"/>
+    <uses-sdk tools:overrideLibrary="com.dimagi.android.zebraprinttool, com.simprints.libsimprints,
+    ru.noties.markwon.il, ru.noties.markwon.view, ru.noties.markwon.renderer"/>
 
     <permission
         android:name="${applicationId}.provider.cases.read"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,9 +78,11 @@ dependencies {
     compile('com.crashlytics.sdk.android:crashlytics:2.6.8@aar') {
         transitive = true;
     }
+    // Markdown
+    compile 'com.github.budsmile:bypass-android:1.0.5' //Needed for Ice Cream Sandwich (14&15)
     compile 'ru.noties:markwon:1.0.4'
-    compile 'ru.noties:markwon-image-loader:1.0.4' // optional
-    compile 'ru.noties:markwon-view:1.0.4' // optional
+    compile 'ru.noties:markwon-image-loader:1.0.4'
+    compile 'ru.noties:markwon-view:1.0.4'
 }
 
 ext {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,10 @@ repositories {
     }
     maven { url 'https://maven.fabric.io/public' }
     maven { url "https://jitpack.io" }
+    maven {
+        url 'https://maven.google.com/'
+        name 'Google'
+    }
 }
 
 configurations {
@@ -37,7 +41,6 @@ dependencies {
     testCompile 'org.robolectric:shadows-multidex:3.2.2'
     testCompile 'org.robolectric:shadows-core:3.2.2'
     testCompile 'org.json:json:20140107'
-
     testCompile project(path: ':commcare-core', configuration: 'testsAsJar')
     // release build type expects commcare jars to be in app/libs
     debugCompile project(':commcare-core')
@@ -75,7 +78,9 @@ dependencies {
     compile('com.crashlytics.sdk.android:crashlytics:2.6.8@aar') {
         transitive = true;
     }
-    compile 'com.github.budsmile:bypass-android:1.0.5'
+    compile 'ru.noties:markwon:1.0.4'
+    compile 'ru.noties:markwon-image-loader:1.0.4' // optional
+    compile 'ru.noties:markwon-view:1.0.4' // optional
 }
 
 ext {

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -108,3 +108,7 @@
 -keep public class * extends java.lang.Exception
 -keep class com.crashlytics.** { *; }
 -dontwarn com.crashlytics.**
+-keep public class com.google.android.gms.* { public *; }
+-dontwarn com.google.android.gms.**
+-dontwarn com.caverock.androidsvg.**
+-keep class com.caverock.androidsvg.** { *; }

--- a/app/src/org/commcare/utils/MarkupUtil.java
+++ b/app/src/org/commcare/utils/MarkupUtil.java
@@ -17,6 +17,7 @@ import org.commcare.preferences.DeveloperPreferences;
 import org.htmlcleaner.TagNode;
 import org.javarosa.core.services.locale.Localization;
 
+import in.uncod.android.bypass.Bypass;
 import ru.noties.markwon.Markwon;
 import ru.noties.markwon.SpannableBuilder;
 import ru.noties.markwon.renderer.SpannableRenderer;
@@ -67,15 +68,16 @@ public class MarkupUtil {
     }
 
     public static Spannable returnCSS(String message) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
-            return new SpannableString(Html.fromHtml(message));
-        } else {
-            return htmlspanner.fromHtml(MarkupUtil.getStyleString() + message);
-        }
+        return htmlspanner.fromHtml(MarkupUtil.getStyleString() + message);
     }
 
     private static CharSequence generateMarkdown(Context c, String message) {
-        return trimTrailingWhitespace(Markwon.markdown(c, convertCharacterEncodings(message)));
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+            return trimTrailingWhitespace(
+                    Markwon.markdown(c, convertCharacterEncodings(message)));
+        }
+        return trimTrailingWhitespace(
+                new Bypass(c).markdownToSpannable(convertCharacterEncodings(message)));
     }
 
     /**

--- a/app/src/org/commcare/utils/MarkupUtil.java
+++ b/app/src/org/commcare/utils/MarkupUtil.java
@@ -74,10 +74,10 @@ public class MarkupUtil {
     private static CharSequence generateMarkdown(Context c, String message) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
             return trimTrailingWhitespace(
-                    Markwon.markdown(c, convertCharacterEncodings(message)));
+                    new Bypass(c).markdownToSpannable(convertCharacterEncodings(message)));
         }
         return trimTrailingWhitespace(
-                new Bypass(c).markdownToSpannable(convertCharacterEncodings(message)));
+                Markwon.markdown(c, convertCharacterEncodings(message)));
     }
 
     /**

--- a/app/src/org/commcare/utils/MarkupUtil.java
+++ b/app/src/org/commcare/utils/MarkupUtil.java
@@ -17,7 +17,9 @@ import org.commcare.preferences.DeveloperPreferences;
 import org.htmlcleaner.TagNode;
 import org.javarosa.core.services.locale.Localization;
 
-import in.uncod.android.bypass.Bypass;
+import ru.noties.markwon.Markwon;
+import ru.noties.markwon.SpannableBuilder;
+import ru.noties.markwon.renderer.SpannableRenderer;
 
 public class MarkupUtil {
 
@@ -73,8 +75,7 @@ public class MarkupUtil {
     }
 
     private static CharSequence generateMarkdown(Context c, String message) {
-        Bypass bypass = new Bypass(c);
-        return trimTrailingWhitespace(bypass.markdownToSpannable(convertCharacterEncodings(message)));
+        return trimTrailingWhitespace(Markwon.markdown(c, convertCharacterEncodings(message)));
     }
 
     /**


### PR DESCRIPTION
Addresses [this ticket](https://manage.dimagi.com/default.asp?271507) by updating us to a newer, CommonMark-compliant library. It looks like the old `bypass` library has also been abandoned so good to address this tech debt anyways.

Surprisingly there doesn't seem to be a consensus-best markdown library for Android, though this one has the best feedback and is the only one I could find that's CommonMark compliant. Unfortunately it supports only API 16 and above, so once we make our minimum 14 in the next release that will leave the Ice Cream Sandwich builds out in the cold (lol). For that reason we'll need to leave the `bypass` library in for the time being. 

For new APIs, needed to add the `maven.google.com` endpoint to repositories [SO](https://stackoverflow.com/a/45342389/2820312)