### PR TITLE
Hide home screen training button if its menus are hidden

### DIFF
--- a/app/src/org/commcare/CommCareApp.java
+++ b/app/src/org/commcare/CommCareApp.java
@@ -300,8 +300,11 @@ public class CommCareApp implements AppFilePathBuilder {
     }
 
     public boolean hasVisibleTrainingMenu() {
+        // This is the same eval context that would be used to evaluate the relevancy conditions of
+        // these menus when they're actually loaded
         EvaluationContext ec =
-                CommCareApplication.instance().getCurrentSessionWrapper().getEvaluationContext();
+                CommCareApplication.instance().getCurrentSessionWrapper().getEvaluationContext(Menu.TRAINING_MENU_ROOT);
+
         for (Suite s : platform.getInstalledSuites()) {
             List<Menu> trainingMenus = s.getMenusWithRoot(Menu.TRAINING_MENU_ROOT);
             if (trainingMenus != null) {

--- a/app/src/org/commcare/activities/HomeNavDrawerController.java
+++ b/app/src/org/commcare/activities/HomeNavDrawerController.java
@@ -108,7 +108,7 @@ public class HomeNavDrawerController {
         int numItemsToInclude = allDrawerItems.size()
                 - (hideChangeLanguageItem ? 1 : 0)
                 - (hideSavedFormsItem ? 1 : 0);
-        boolean hideTrainingItem = !CommCareApplication.instance().getCurrentApp().hasTrainingMenu();
+        boolean hideTrainingItem = !CommCareApplication.instance().getCurrentApp().hasVisibleTrainingMenu();
 
         drawerItemsShowing = new NavDrawerItem[numItemsToInclude];
         int index = 0;

--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -63,7 +63,7 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
         if (!DeveloperPreferences.isHomeReportEnabled()) {
             hiddenButtons.add("report");
         }
-        if (!CommCareApplication.instance().getCurrentApp().hasTrainingMenu()) {
+        if (!CommCareApplication.instance().getCurrentApp().hasVisibleTrainingMenu()) {
             hiddenButtons.add("training");
         }
 


### PR DESCRIPTION
**Question for everyone**: I've created this PR as the easiest way to get input on the soundness of this -- the ICDS team would like to make it so that if an app contains 1 or more training menus, _but_ they all have display conditions which evaluate to false, then the home screen training button does not show up. I explained (in a simplified way) that this is not strictly doable within CommCare's model because at the time the home screen buttons are rendered, the proper evaluation context for the menus isn't present. However, I've realized that technically I can reconstruct it, as I've done in this PR. My question is whether anyone sees any risks associated with doing this that I'm missing, or if it just seems too gross to allow ourselves to do. (I've tested that it works from a desired functionality standpoint).