### PR TITLE
Reverts to not showing warning when saving Incomplete forms

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -751,7 +751,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                         Toast.LENGTH_LONG).show();
                 Logger.log(LogTypes.TYPE_ERROR_WORKFLOW,
                         "Form Entry did not return a form");
-                clearSessionAndExit(currentState, true);
+                clearSessionAndExit(currentState, false);
                 return false;
             }
         } else if (resultCode == RESULT_CANCELED) {


### PR DESCRIPTION
This is  a regression from form provider refactor. I mistakenly turned on the warning when saving incomplete forms which shouldn't be the case. 