### PR TITLE
[HOTFIX] Vector drawable Crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -240,8 +240,6 @@ android {
                 googlePlayMapsApiKey: "${project.ext.GOOGLE_PLAY_MAPS_API_KEY}"
         ]
 
-        vectorDrawables.useSupportLibrary = true
-
         versionCode computeVersionCode()
 
         // when set, app won't show install screen and try to install


### PR DESCRIPTION
There are multiple crashes on fabric trying to load vector drawables on pre lolipop devices. 
1. https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59fc147461b02d480daf34cd
2. https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5af080c111e9fa0aa5c3f69b
3. https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5af1347311e9fa0aa5d23c48

I am guessing this is happening because I added vector support library in build.gradle though I have not been able to test this due to lack of a Android 4 device. I am guessting Boston has a Android 4 device. Can someone try going to CommCareSetupActivity on that device and see it doesn't crash with this fix.

I am still not sure how our vector drawables work on pre lolipop devices since without turning on `vectorDrawables.useSupportLibrary `  the flag.

Product Note: Fixes a bug in CommCare 2.43 due to which CommCare will crash on various screens on pre lolipop devices. 