### PR TITLE
Close resources

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'com.android.support:gridlayout-v7:25.2.0'
     implementation 'com.madgag.spongycastle:core:1.54.0.0'
     implementation 'com.madgag.spongycastle:prov:1.54.0.0'
-    implementation 'com.google.android.gms:play-services-maps:10.0.1'
+    implementation 'com.google.android.gms:play-services-maps:15.0.1'
     implementation 'joda-time:joda-time:2.9.4'
     implementation 'net.zetetic:android-database-sqlcipher:3.5.7@aar'
     implementation ('org.apache.james:apache-mime4j:0.7.2') {
@@ -68,8 +68,8 @@ dependencies {
     implementation('org.apache.httpcomponents:httpmime:4.3.6')
     implementation 'net.sourceforge.htmlcleaner:htmlcleaner:2.16'
     implementation 'org.jsoup:jsoup:1.8.3'
-    implementation 'com.google.firebase:firebase-core:10.0.1'
-    implementation 'com.google.firebase:firebase-ads:10.0.1'
+    implementation 'com.google.firebase:firebase-core:15.0.2'
+    implementation 'com.google.firebase:firebase-ads:15.0.1'
     implementation 'com.carrotsearch:hppc:0.7.2'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
     implementation 'com.journeyapps:zxing-android-embedded:3.5.0'
@@ -222,7 +222,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 9
+        minSdkVersion 14
         targetSdkVersion 25
         multiDexEnabled true
         applicationId "org.commcare.dalvik"

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -14,6 +14,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.os.IBinder;
 import android.os.Looper;
+import android.os.StrictMode;
 import android.preference.PreferenceManager;
 import android.provider.Settings.Secure;
 import android.support.annotation.NonNull;
@@ -167,6 +168,15 @@ public class CommCareApplication extends MultiDexApplication {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        if (BuildConfig.DEBUG) {
+            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+                    .detectLeakedSqlLiteObjects()
+                    .detectLeakedClosableObjects()
+                    .penaltyLog()
+                    .penaltyDeath()
+                    .build());
+        }
 
         CommCareApplication.app = this;
         CrashUtil.init(this);

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -168,16 +168,6 @@ public class CommCareApplication extends MultiDexApplication {
     @Override
     public void onCreate() {
         super.onCreate();
-
-        if (BuildConfig.DEBUG) {
-            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-                    .detectLeakedSqlLiteObjects()
-                    .detectLeakedClosableObjects()
-                    .penaltyLog()
-                    .penaltyDeath()
-                    .build());
-        }
-
         CommCareApplication.app = this;
         CrashUtil.init(this);
         DataChangeLogger.init(this);

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -14,7 +14,6 @@ import android.os.Build;
 import android.os.Environment;
 import android.os.IBinder;
 import android.os.Looper;
-import android.os.StrictMode;
 import android.preference.PreferenceManager;
 import android.provider.Settings.Secure;
 import android.support.annotation.NonNull;

--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -27,6 +27,7 @@ import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 
 /**
@@ -48,11 +49,13 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
 
     @Override
     public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) {
+        InputStream inputStream = null;
         try {
 
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
+            inputStream = local.getStream();
 
-            ProfileParser parser = new ProfileParser(local.getStream(), platform, platform.getGlobalResourceTable(), null,
+            ProfileParser parser = new ProfileParser(inputStream, platform, platform.getGlobalResourceTable(), null,
                     Resource.RESOURCE_STATUS_INSTALLED, false);
 
             Profile p = parser.parse();
@@ -64,6 +67,14 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
                 | InvalidReferenceException e) {
             e.printStackTrace();
             Logger.log(LogTypes.TYPE_RESOURCES, "Initialization failed for Profile resource with exception " + e.getMessage());
+        } finally {
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
         }
 
         return false;
@@ -75,11 +86,11 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
             throws UnresolvedResourceException, UnfullfilledRequirementsException {
         //First, make sure all the file stuff is managed.
         super.install(r, location, ref, table, platform, upgrade);
+        InputStream inputStream = null;
         try {
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
-
-
-            ProfileParser parser = new ProfileParser(local.getStream(), platform, table, r.getRecordGuid(),
+            inputStream = local.getStream();
+            ProfileParser parser = new ProfileParser(inputStream, platform, table, r.getRecordGuid(),
                     Resource.RESOURCE_STATUS_UNINITIALIZED, false);
 
             Profile p = parser.parse();
@@ -96,6 +107,14 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
             e.printStackTrace();
         } catch (InvalidStructureException e) {
             throw new UnresolvedResourceException(r, "Invalid content in the Profile Definition: " + e.getMessage(), true);
+        } finally {
+            try {
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
 
         return false;

--- a/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
@@ -28,6 +28,7 @@ import org.javarosa.xpath.XPathException;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
@@ -49,17 +50,18 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
 
     @Override
     public boolean initialize(final AndroidCommCarePlatform platform, boolean isUpgrade) {
+        InputStream inputStream = null;
         try {
             if (localLocation == null) {
                 throw new RuntimeException("Error initializing the suite, its file location is null!");
             }
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
-
+            inputStream = local.getStream();
             SuiteParser parser;
             if (isUpgrade) {
-                parser = AndroidSuiteParser.buildUpgradeParser(local.getStream(), platform.getGlobalResourceTable(), platform.getFixtureStorage());
+                parser = AndroidSuiteParser.buildUpgradeParser(inputStream, platform.getGlobalResourceTable(), platform.getFixtureStorage());
             } else {
-                parser = AndroidSuiteParser.buildInitParser(local.getStream(), platform.getGlobalResourceTable(), platform.getFixtureStorage());
+                parser = AndroidSuiteParser.buildInitParser(inputStream, platform.getGlobalResourceTable(), platform.getFixtureStorage());
             }
 
             Suite s = parser.parse();
@@ -72,6 +74,14 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
                 | UnfullfilledRequirementsException e) {
             e.printStackTrace();
             Logger.log(LogTypes.TYPE_RESOURCES, "Initialization failed for Suite resource with exception " + e.getMessage());
+        } finally {
+            try {
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
 
         return false;
@@ -83,11 +93,11 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
                            boolean upgrade) throws UnresolvedResourceException, UnfullfilledRequirementsException {
         //First, make sure all the file stuff is managed.
         super.install(r, location, ref, table, platform, upgrade);
-
+        InputStream inputStream = null;
         try {
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
-
-            AndroidSuiteParser.buildInstallParser(local.getStream(), table, r.getRecordGuid(), platform.getFixtureStorage()).parse();
+            inputStream = local.getStream();
+            AndroidSuiteParser.buildInstallParser(inputStream, table, r.getRecordGuid(), platform.getFixtureStorage()).parse();
 
             table.commitCompoundResource(r, upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED);
             return true;
@@ -96,6 +106,14 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
             throw new InvalidResourceException(r.getDescriptor(), e.getMessage());
         } catch (XmlPullParserException | InvalidReferenceException | IOException e) {
             e.printStackTrace();
+        } finally {
+            try {
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
 
         return false;

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -33,6 +33,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -72,8 +73,8 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     protected int customInstall(Resource r, Reference local, boolean upgrade, AndroidCommCarePlatform platform) throws IOException, UnresolvedResourceException {
         registerAndroidLevelFormParsers();
         FormDef formDef;
-        try {
-            formDef = XFormExtensionUtils.getFormFromInputStream(local.getStream());
+        try (InputStream inputStream = local.getStream()) {
+            formDef = XFormExtensionUtils.getFormFromInputStream(inputStream);
         } catch (XFormParseException xfpe) {
             throw new UnresolvedResourceException(r, xfpe.getMessage(), true);
         }

--- a/app/src/org/commcare/models/database/AndroidPrototypeFactorySetup.java
+++ b/app/src/org/commcare/models/database/AndroidPrototypeFactorySetup.java
@@ -63,6 +63,7 @@ public class AndroidPrototypeFactorySetup {
             String cn = en.nextElement();
             loadClass(cn, classNames);
         }
+        df.close();
 
         return classNames;
     }

--- a/app/src/org/commcare/tasks/LogSubmissionTask.java
+++ b/app/src/org/commcare/tasks/LogSubmissionTask.java
@@ -260,7 +260,7 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
                 "text/xml",
                 new SecretKeySpec(slr.getKey(), "AES")));
 
-        Response<ResponseBody> response;
+        Response<ResponseBody> response = null;
         try {
             response = generator.postMultipart(submissionUrl, parts);
         } catch (IOException e) {
@@ -269,6 +269,10 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
         } catch (IllegalStateException e) {
             e.printStackTrace();
             return false;
+        } finally {
+            if (response != null && response.body() != null) {
+                response.body().close();
+            }
         }
 
         int responseCode = response.code();

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
-        classpath 'com.google.gms:google-services:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.google.gms:google-services:3.2.0'
         classpath 'io.fabric.tools:gradle:1.24.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ org.gradle.parallel=true
 # Enables new incubating mode that makes Gradle selective when configuring projects.
 # Only relevant projects are configured which results in faster builds for large multi-projects.
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:configuration_on_demand
-org.gradle.configureondemand=true
+org.gradle.configureondemand=false
 
 
 # We are doing this in order to get around this robolectirc bug -


### PR DESCRIPTION
Investigating [this ticket](https://manage.dimagi.com/default.asp?276201) we located the crash [here](https://fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5ad5a4cd36c7b23527007bc6?time=last-seven-days) and noticed that the crash reported over 900 open cursors causing an OOM error.

Looking for a way to investigate I found [this](https://stackoverflow.com/a/28155638/2820312) pretty nifty profiling mode that hard-crashes the application whenever you leave a resource unclosed. This turned up a bunch of `File`s and `InputStream`s that we weren't closing which is nice. The only hanging `Cursor` I found seemed to be coming from [firebase](https://github.com/firebase/quickstart-android/issues/176) so I updated the library (and was required to update play services and change this param `org.gradle.configureondemand=false` as a result) and that made it go away.

I removed the strict mode enforcement in [this commit](https://github.com/dimagi/commcare-android/commit/118dd441a50bba7443038089876ccf9d0fcb1455) but now I'm wondering if it makes sense for us to keep this in our debug builds? Seems maybe heavy handed but would also help us catch any of these issues pronto.

Includes update to API 14 as minimumSdk