### PR TITLE
Don't have a translatable string span multiple lines

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -74,20 +74,7 @@
 
     <string name="url_prompt">Choose a URL</string>
 
-    <string name="about_dialog" formatted="false" cc:translatable="true">%s\n\n
-_Copyright 2016, Dimagi inc, All rights reserved_ \n\n
-
----------------- \n\n
-__Acknowledgements:__ \n\n
-%s
-Some images in CommCare are graciously used under Creative Commons Licensing from thenounproject.com collection:\n\n
-* “Door” symbol by Tak Imoto \n
-* “Pencil” symbol by Creologica \n
-* “Notebook” symbol by Carlo \n
-* “Antenna” symbol by Dima \n
-* “Map Marker” symbol by P.J. Onori \n
-* "List" by Landan Lloyd \n
-* broken screen by Sam Martin from the Noun Project \n\n
+    <string name="about_dialog" formatted="false" cc:translatable="true">%s\n\n_Copyright 2016, Dimagi inc, All rights reserved_ \n\n---------------- \n\n__Acknowledgements:__ \n\n%sSome images in CommCare are graciously used under Creative Commons Licensing from thenounproject.com collection:\n\n* “Door” symbol by Tak Imoto \n* “Pencil” symbol by Creologica \n* “Notebook” symbol by Carlo \n* “Antenna” symbol by Dima \n* “Map Marker” symbol by P.J. Onori \n* "List" by Landan Lloyd \n* broken screen by Sam Martin from the Noun Project \n\n
 
 </string>
     <string name="notification_message_title">CommCare Notification</string>


### PR DESCRIPTION
Now that this string is translatable, having it span multiple lines in the strings.xml file results in breaking behavior when the update_translations script moves it to the `messages_en-2.txt` file in the commcare-translations repo. These physical newlines weren't actually doing anything except making the string easier to read in the file itself, so we can just get rid of them.