### PR TITLE
Set submission ordering # at same time we mark a form as completed

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -61,7 +61,6 @@ import org.commcare.utils.CrashUtil;
 import org.commcare.utils.EntityDetailUtils;
 import org.commcare.utils.GlobalConstants;
 import org.commcare.utils.SessionUnavailableException;
-import org.commcare.utils.StorageUtils;
 import org.commcare.views.UserfacingErrorHandling;
 import org.commcare.views.dialogs.CommCareAlertDialog;
 import org.commcare.views.dialogs.DialogChoiceItem;
@@ -713,11 +712,6 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
             // The form is either ready for processing, or not, depending on how it was saved
             if (complete) {
-                // Now that we know this form is completed, we can give it the next available
-                // submission ordering number
-                current.setFormNumberForSubmissionOrdering(StorageUtils.getNextFormSubmissionNumber());
-                SqlStorage<FormRecord> formRecordStorage = CommCareApplication.instance().getUserStorage(FormRecord.class);
-                formRecordStorage.write(current);
                 checkAndStartUnsentFormsTask(false, false);
                 refreshUI();
 

--- a/app/src/org/commcare/android/database/app/models/FormDefRecord.java
+++ b/app/src/org/commcare/android/database/app/models/FormDefRecord.java
@@ -2,10 +2,8 @@ package org.commcare.android.database.app.models;
 
 import android.database.Cursor;
 import android.database.SQLException;
-import android.os.Environment;
 
 import org.apache.commons.lang3.StringUtils;
-import org.commcare.CommCareApplication;
 import org.commcare.android.storage.framework.Persisted;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.framework.Persisting;
@@ -18,8 +16,6 @@ import org.javarosa.core.services.Logger;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Vector;
 
 @Table(FormDefRecord.STORAGE_KEY)

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -319,13 +319,15 @@ public class FormRecord extends Persisted implements EncryptedModel {
         return formRecord != null && formRecord.status.contentEquals(STATUS_COMPLETE);
     }
 
-    public void updateStatus(SqlStorage<FormRecord> formRecordStorage, @FormRecordStatus String status, String displayName) {
-        this.displayName = displayName;
+    public void updateStatus(SqlStorage<FormRecord> formRecordStorage,
+                             @FormRecordStatus String status) {
         if (!this.status.equals(FormRecord.STATUS_COMPLETE) && status.equals(FormRecord.STATUS_COMPLETE)) {
             setFormNumberForSubmissionOrdering(StorageUtils.getNextFormSubmissionNumber());
         }
         this.status = status;
-        update(formRecordStorage);
+        lastModified = new Date();
+        formRecordStorage.update(getID(), this);
+        finalizeRecord();
     }
 
     private void finalizeRecord() {
@@ -428,12 +430,6 @@ public class FormRecord extends Persisted implements EncryptedModel {
         Logger.log(LogTypes.TYPE_FORM_ENTRY, loggerText);
         currentState.reset();
         throw new RuntimeException(loggerText);
-    }
-
-    public void update(SqlStorage<FormRecord> formRecordStorage) {
-        lastModified = new Date();
-        formRecordStorage.update(getID(), this);
-        finalizeRecord();
     }
 
     private static class InvalidStateException extends Exception {

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -167,7 +167,11 @@ public class SaveToDiskTask extends
         }
 
         if (formRecord != null) {
-            formRecord.updateStatus(formRecordStorage, status, recordName);
+            try {
+                formRecord.updateStatus(formRecordStorage, status, recordName);
+            } catch (IllegalStateException e) {
+                throw new FormInstanceTransactionException(e);
+            }
         }
     }
 

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -168,7 +168,8 @@ public class SaveToDiskTask extends
 
         if (formRecord != null) {
             try {
-                formRecord.updateStatus(formRecordStorage, status, recordName);
+                formRecord.setDisplayName(recordName);
+                formRecord.updateStatus(formRecordStorage, status);
             } catch (IllegalStateException e) {
                 throw new FormInstanceTransactionException(e);
             }


### PR DESCRIPTION
**Includes https://github.com/dimagi/commcare-android/pull/2004, review + merge that first.**

This will fix http://manage.dimagi.com/default.asp?276261. I realized what was happening here from examining the device logs surrounding submission of the forms that Derek linked in that ticket. Because of where we were previously calling `setFormNumberForSubmissionOrdering()`, a crash that occurred at the end of form entry would result in the `FormRecord` being successfully saved as complete, but never having its submission ordering number set (and therefore having a value of -1). This PR fixes that by setting the submission order number at the same time we update a `FormRecord`'s status to `STATUS_COMPLETE`. (The crashes themselves that were occurring post-form entry were varied and none of them seemed particularly alarming, so I chose to focus on fixing the fact that any sort of crash would cause this malfunction). 
