### PR TITLE
Add more logs to debug missing app files issue

### DIFF
--- a/app/src/org/commcare/android/resource/installers/FileSystemUtils.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemUtils.java
@@ -1,7 +1,9 @@
 package org.commcare.android.resource.installers;
 
+import org.commcare.util.LogTypes;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.services.Logger;
 
 import java.io.File;
 
@@ -52,6 +54,16 @@ public class FileSystemUtils {
             }
         }
 
-        return oldFile.renameTo(newFile);
+        boolean suceess = oldFile.renameTo(newFile);
+
+        if (suceess && oldFile.exists()) {
+            Logger.log(LogTypes.SOFT_ASSERT, "Old File exists after rename");
+        }
+
+        if (suceess && newFile.exists()) {
+            Logger.log(LogTypes.SOFT_ASSERT, "New File doesn't exist after rename");
+        }
+
+        return suceess;
     }
 }

--- a/app/src/org/commcare/android/resource/installers/FileSystemUtils.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemUtils.java
@@ -54,16 +54,16 @@ public class FileSystemUtils {
             }
         }
 
-        boolean suceess = oldFile.renameTo(newFile);
+        boolean success = oldFile.renameTo(newFile);
 
-        if (suceess && oldFile.exists()) {
+        if (success && oldFile.exists()) {
             Logger.log(LogTypes.SOFT_ASSERT, "Old File exists after rename");
         }
 
-        if (suceess && newFile.exists()) {
+        if (success && !newFile.exists()) {
             Logger.log(LogTypes.SOFT_ASSERT, "New File doesn't exist after rename");
         }
 
-        return suceess;
+        return success;
     }
 }

--- a/app/src/org/commcare/logging/DataChangeLogger.kt
+++ b/app/src/org/commcare/logging/DataChangeLogger.kt
@@ -77,8 +77,9 @@ object DataChangeLogger {
      */
     @JvmStatic
     fun log(dataChangeLog: DataChangeLog) {
-        // Include this info as part of any crash reports
+        // Include this info as part of any crash reports and the normal device logs
         CrashUtil.log(dataChangeLog.message);
+        Logger.log(LogTypes.TYPE_DATA_CHANGE, dataChangeLog.message);
 
         // Write to local storage
         if (primaryFile != null && primaryFile!!.exists()) {


### PR DESCRIPTION
I saw some instances on Sumo that suggests that this issue starts occurring either after an app auto update. Furthermore, Sachit from Community health got back to us saying that there are users in the field who are facing storage corrupt issue after a playstore update. I am hoping sending data change logs to device logs will help us in determining the exact sequence of events for that particular update and would help us narrow down this bug. 

* Sends data change logs to device logs
* Logs result for auto update. 

cross-request: https://github.com/dimagi/commcare-core/pull/811