### PR TITLE
Add external_id as indexable case property

### DIFF
--- a/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
@@ -28,7 +28,6 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
+++ b/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
@@ -9,15 +9,15 @@ import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteException;
 import net.sqlcipher.database.SQLiteOpenHelper;
 
+import org.commcare.android.database.global.models.AndroidSharedKeyRecord;
 import org.commcare.android.database.global.models.AppAvailableToInstall;
-import org.commcare.android.logging.ForceCloseLogEntry;
+import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.android.javarosa.AndroidLogEntry;
+import org.commcare.android.logging.ForceCloseLogEntry;
 import org.commcare.logging.DataChangeLog;
 import org.commcare.logging.DataChangeLogger;
-import org.commcare.modern.database.TableBuilder;
 import org.commcare.models.database.DbUtil;
-import org.commcare.android.database.global.models.AndroidSharedKeyRecord;
-import org.commcare.android.database.global.models.ApplicationRecord;
+import org.commcare.modern.database.TableBuilder;
 
 /**
  * The helper for opening/updating the global (unencrypted) db space for CommCare.

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -142,6 +142,8 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
                     "case_status_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_CASE_STATUS)));
             database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
                     "case_owner_id_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_OWNER_ID)));
+            database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
+                    "case_external_id_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_EXTERNAL_ID)));
 
             database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
                     "case_status_open_index", "AndroidCase", "case_type,case_status"));

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -137,7 +137,7 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
             database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
                     "case_id_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_CASE_ID)));
             database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
-                    "case_type_index", "AndroidCase", TableBuilder.scrubName(Case.  INDEX_CASE_TYPE)));
+                    "case_type_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_CASE_TYPE)));
             database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
                     "case_status_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_CASE_STATUS)));
             database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -137,7 +137,7 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
             database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
                     "case_id_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_CASE_ID)));
             database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
-                    "case_type_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_CASE_TYPE)));
+                    "case_type_index", "AndroidCase", TableBuilder.scrubName(Case.  INDEX_CASE_TYPE)));
             database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
                     "case_status_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_CASE_STATUS)));
             database.execSQL(DatabaseIndexingUtils.indexOnTableCommand(

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -61,9 +61,10 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
      * V.21 - Reindex all cases to add relationship, and add reasonForQuarantine field to FormRecords
      * V.22 - Add column for appId in entity_cache table
      * V.23 - Merges InstanceProvider to FormRecord (delete instanceUri, add displayName, filePath and canEditWhenComplete)
+     * v.24 - Adds and indexes column for Case external_id
      */
 
-    private static final int USER_DB_VERSION = 23;
+    private static final int USER_DB_VERSION = 24;
 
     private static final String USER_DB_LOCATOR = "database_sandbox_";
 

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -280,7 +280,7 @@ class UserDatabaseUpgrader {
         long start = System.currentTimeMillis();
         db.beginTransaction();
         try {
-            SqlStorage<Persistable> userStorage = new SqlStorage<Persistable>(AUser.STORAGE_KEY, AUser.class, new ConcreteAndroidDbHelper(c, db));
+            SqlStorage<Persistable> userStorage = new SqlStorage<>(AUser.STORAGE_KEY, AUser.class, new ConcreteAndroidDbHelper(c, db));
             SqlStorageIterator<Persistable> iterator = userStorage.iterate();
             while (iterator.hasMore()) {
                 AUser oldUser = (AUser)iterator.next();

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,3 @@ org.gradle.parallel=true
 # Only relevant projects are configured which results in faster builds for large multi-projects.
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:configuration_on_demand
 org.gradle.configureondemand=false
-
-
-# We are doing this in order to get around this robolectirc bug -
-# https://github.com/robolectric/robolectric/issues/3157 and should
-# remove this line when this is fixed
-android.enableAapt2=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,9 @@ org.gradle.parallel=true
 # Only relevant projects are configured which results in faster builds for large multi-projects.
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:configuration_on_demand
 org.gradle.configureondemand=false
+
+
+# We are doing this in order to get around this robolectirc bug -
+# https://github.com/robolectric/robolectric/issues/3157 and should
+# remove this line when this is fixed
+android.enableAapt2=false


### PR DESCRIPTION
Enables indexed searches by an `external_id` property to be used by (you guessed it) external systems like SimPrints. The implementation uses the existing `external_id` case property as the value if it exists since this is already used by HQ in the same way. 

cross-request: https://github.com/dimagi/commcare-core/pull/814