### PR TITLE
Fixes User DB v5->6 migration caused by Case Relationship

### DIFF
--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -14,6 +14,7 @@ import org.commcare.android.javarosa.AndroidLogEntry;
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.StorageIndexedTreeElementModel;
 import org.commcare.logging.XPathErrorEntry;
+import org.commcare.models.database.user.models.AndroidCaseIndexTableV1;
 import org.commcare.modern.database.TableBuilder;
 import org.commcare.models.database.ConcreteAndroidDbHelper;
 import org.commcare.models.database.DbUtil;
@@ -245,9 +246,9 @@ class UserDatabaseUpgrader {
             db.execSQL(EntityStorageCache.getTableDefinition());
             EntityStorageCache.createIndexes(db);
 
-            db.execSQL(UserDbUpgradeUtils.getCreateV6AndroidCaseIndexTableSqlDef());
+            db.execSQL(AndroidCaseIndexTableV1.getTableDefinition());
             AndroidCaseIndexTable.createIndexes(db);
-            AndroidCaseIndexTable cit = new AndroidCaseIndexTable(db);
+            AndroidCaseIndexTableV1 cit = new AndroidCaseIndexTableV1(db);
 
             //NOTE: Need to use the PreV6 case model any time we manipulate cases in this model for upgraders
             //below 6

--- a/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
+++ b/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
@@ -255,14 +255,4 @@ public class UserDbUpgradeUtils {
                 formRecordClass,
                 new ConcreteAndroidDbHelper(c, db));
     }
-    
-    public static String getCreateV6AndroidCaseIndexTableSqlDef() {
-        return "CREATE TABLE " + "case_index_storage" + "(" +
-                "commcare_sql_id" + " INTEGER PRIMARY KEY, " +
-                "case_rec_id" + ", " +
-                "name" + ", " +
-                "type" + ", " +
-                "target" +
-                ")";
-    }
 }

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTableV1.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTableV1.java
@@ -21,7 +21,7 @@ public class AndroidCaseIndexTableV1 {
     private final SQLiteDatabase db;
 
     public AndroidCaseIndexTableV1(SQLiteDatabase db) {
-        this.db = CommCareApplication.instance().getUserDbHandle();
+        this.db = db;
     }
 
 

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTableV1.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTableV1.java
@@ -1,0 +1,55 @@
+package org.commcare.models.database.user.models;
+
+import android.content.ContentValues;
+
+import net.sqlcipher.database.SQLiteDatabase;
+
+import org.commcare.CommCareApplication;
+import org.commcare.cases.model.Case;
+import org.commcare.cases.model.CaseIndex;
+import org.commcare.modern.database.DatabaseHelper;
+
+public class AndroidCaseIndexTableV1 {
+
+    public static final String TABLE_NAME = "case_index_storage";
+
+    private static final String COL_CASE_RECORD_ID = "case_rec_id";
+    private static final String COL_INDEX_NAME = "name";
+    private static final String COL_INDEX_TYPE = "type";
+    private static final String COL_INDEX_TARGET = "target";
+
+    private final SQLiteDatabase db;
+
+    public AndroidCaseIndexTableV1(SQLiteDatabase db) {
+        this.db = CommCareApplication.instance().getUserDbHandle();
+    }
+
+
+    public void indexCase(Case c) {
+        db.beginTransaction();
+        try {
+            for (CaseIndex ci : c.getIndices()) {
+                ContentValues cv = new ContentValues();
+                cv.put(COL_CASE_RECORD_ID, c.getID());
+                cv.put(COL_INDEX_NAME, ci.getName());
+                cv.put(COL_INDEX_TYPE, ci.getTargetType());
+                cv.put(COL_INDEX_TARGET, ci.getTarget());
+                db.insert(TABLE_NAME, null, cv);
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+    }
+
+    public static String getTableDefinition() {
+        return "CREATE TABLE " + TABLE_NAME + "(" +
+                DatabaseHelper.ID_COL + " INTEGER PRIMARY KEY, " +
+                COL_CASE_RECORD_ID + ", " +
+                COL_INDEX_NAME + ", " +
+                COL_INDEX_TYPE + ", " +
+                COL_INDEX_TARGET +
+                ")";
+    }
+
+}


### PR DESCRIPTION
Fixes migration bug due to using new case index definition in old migration.

Case: https://manage.dimagi.com/default.asp?278205

Error Stack - 

```
net.sqlcipher.database.SQLiteException: table case_index_storage has no column named relationship: , while compiling: INSERT INTO case_index_storage(name, relationship, type, case_rec_id, target) VALUES(?, ?, ?, ?, ?);
        at net.sqlcipher.database.SQLiteCompiledSql.native_compile(Native Method)
        at net.sqlcipher.database.SQLiteCompiledSql.compile(SQLiteCompiledSql.java:91)
        at net.sqlcipher.database.SQLiteCompiledSql.<init>(SQLiteCompiledSql.java:64)
        at net.sqlcipher.database.SQLiteProgram.<init>(SQLiteProgram.java:89)
        at net.sqlcipher.database.SQLiteStatement.<init>(SQLiteStatement.java:39)
        at net.sqlcipher.database.SQLiteDatabase.compileStatement(SQLiteDatabase.java:1589)
        at net.sqlcipher.database.SQLiteDatabase.insertWithOnConflict(SQLiteDatabase.java:2060)
        at net.sqlcipher.database.SQLiteDatabase.insert(SQLiteDatabase.java:1930)
        at org.commcare.models.database.user.models.AndroidCaseIndexTable.indexCase(AndroidCaseIndexTable.java:87)
        at org.commcare.models.database.user.UserDatabaseUpgrader.upgradeFiveSix(UserDatabaseUpgrader.java:257)
        at org.commcare.models.database.user.UserDatabaseUpgrader.upgrade(UserDatabaseUpgrader.java:88)
        at org.commcare.models.database.user.DatabaseUserOpenHelper.onUpgrade(DatabaseUserOpenHelper.java:199)

```