### PR TITLE
Corrects External Id Migration for v17-18, Fixes case Relationship migration for v18-19

### DIFF
--- a/app/src/org/commcare/android/database/user/models/ACasePreV24Model.java
+++ b/app/src/org/commcare/android/database/user/models/ACasePreV24Model.java
@@ -1,0 +1,10 @@
+package org.commcare.android.database.user.models;
+
+public class ACasePreV24Model extends ACase {
+
+    @Override
+    public String[] getMetaDataFields() {
+        return new String[]{INDEX_CASE_ID, INDEX_CASE_TYPE, INDEX_CASE_STATUS, INDEX_OWNER_ID};
+    }
+
+}

--- a/app/src/org/commcare/android/database/user/models/ACasePreV24Model.java
+++ b/app/src/org/commcare/android/database/user/models/ACasePreV24Model.java
@@ -1,10 +1,38 @@
 package org.commcare.android.database.user.models;
 
+import org.commcare.cases.model.CaseIndex;
+
 public class ACasePreV24Model extends ACase {
+
 
     @Override
     public String[] getMetaDataFields() {
         return new String[]{INDEX_CASE_ID, INDEX_CASE_TYPE, INDEX_CASE_STATUS, INDEX_OWNER_ID};
+    }
+
+    @Override
+    public Object getMetaData(String fieldName) {
+        if (fieldName.equals(INDEX_CASE_ID)) {
+            return id;
+        } else if (fieldName.equals("case-type")) {
+            return typeId;
+        } else if (fieldName.equals(INDEX_CASE_STATUS)) {
+            return closed ? "closed" : "open";
+        } else if (fieldName.startsWith(INDEX_CASE_INDEX_PRE)) {
+            String name = fieldName.substring(fieldName.lastIndexOf('-') + 1, fieldName.length());
+
+            for (CaseIndex index : this.getIndices()) {
+                if (index.getName().equals(name)) {
+                    return index.getTarget();
+                }
+            }
+            return "";
+        } else if (fieldName.equals(INDEX_OWNER_ID)) {
+            String ownerId = getUserId();
+            return ownerId == null ? "" : ownerId;
+        } else {
+            throw new IllegalArgumentException("No metadata field " + fieldName + " in the case storage system");
+        }
     }
 
 }

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.user.models.ACasePreV24Model;
 import org.commcare.android.database.user.models.FormRecordV2;
 import org.commcare.android.database.user.models.FormRecordV3;
 import org.commcare.android.logging.ForceCloseLogEntry;
@@ -14,7 +15,7 @@ import org.commcare.android.javarosa.AndroidLogEntry;
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.StorageIndexedTreeElementModel;
 import org.commcare.logging.XPathErrorEntry;
-import org.commcare.models.database.user.models.AndroidCaseIndexTableV1;
+import org.commcare.models.database.user.models.AndroidCaseIndexTablePreV21;
 import org.commcare.modern.database.TableBuilder;
 import org.commcare.models.database.ConcreteAndroidDbHelper;
 import org.commcare.models.database.DbUtil;
@@ -246,9 +247,9 @@ class UserDatabaseUpgrader {
             db.execSQL(EntityStorageCache.getTableDefinition());
             EntityStorageCache.createIndexes(db);
 
-            db.execSQL(AndroidCaseIndexTableV1.getTableDefinition());
+            db.execSQL(AndroidCaseIndexTablePreV21.getTableDefinition());
             AndroidCaseIndexTable.createIndexes(db);
-            AndroidCaseIndexTableV1 cit = new AndroidCaseIndexTableV1(db);
+            AndroidCaseIndexTablePreV21 cit = new AndroidCaseIndexTablePreV21(db);
 
             //NOTE: Need to use the PreV6 case model any time we manipulate cases in this model for upgraders
             //below 6
@@ -520,7 +521,7 @@ class UserDatabaseUpgrader {
                     "owner_id",
                     "TEXT"));
 
-            SqlStorage<ACase> caseStorage = new SqlStorage<>(ACase.STORAGE_KEY, ACase.class,
+            SqlStorage<ACase> caseStorage = new SqlStorage<>(ACase.STORAGE_KEY, ACasePreV24Model.class,
                     new ConcreteAndroidDbHelper(c, db));
             updateModels(caseStorage);
 
@@ -536,10 +537,10 @@ class UserDatabaseUpgrader {
     private boolean upgradeEighteenNineteen(SQLiteDatabase db) {
         db.beginTransaction();
         try {
-            SqlStorage<ACase> caseStorage = new SqlStorage<>(ACase.STORAGE_KEY, ACase.class,
+            SqlStorage<ACase> caseStorage = new SqlStorage<>(ACase.STORAGE_KEY, ACasePreV24Model.class,
                     new ConcreteAndroidDbHelper(c, db));
 
-            AndroidCaseIndexTable indexTable = new AndroidCaseIndexTable(db);
+            AndroidCaseIndexTablePreV21 indexTable = new AndroidCaseIndexTablePreV21(db);
             indexTable.reIndexAllCases(caseStorage);
             db.setTransactionSuccessful();
             return true;

--- a/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
+++ b/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
@@ -9,6 +9,7 @@ import net.sqlcipher.database.SQLiteDatabase;
 import org.commcare.CommCareApplication;
 import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.android.database.user.models.ACase;
+import org.commcare.android.database.user.models.ACasePreV24Model;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.database.user.models.FormRecordV1;
 import org.commcare.android.database.user.models.FormRecordV2;
@@ -165,7 +166,7 @@ public class UserDbUpgradeUtils {
     }
 
     protected static void addRelationshipToAllCases(Context c, SQLiteDatabase db) {
-        SqlStorage<ACase> caseStorage = new SqlStorage<>(ACase.STORAGE_KEY, ACase.class,
+        SqlStorage<ACase> caseStorage = new SqlStorage<>(ACase.STORAGE_KEY, ACasePreV24Model.class,
                 new ConcreteAndroidDbHelper(c, db));
 
         db.execSQL(DbUtil.addColumnToTable(

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
@@ -92,36 +92,6 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
         }
     }
 
-    public Vector<CaseIndex> getIndicesForCase(int recordId) {
-        Vector<CaseIndex> indices = new Vector<>();
-
-        String[] projection = new String[] {COL_CASE_RECORD_ID, COL_INDEX_NAME, COL_INDEX_TYPE, COL_INDEX_TARGET, COL_INDEX_RELATIONSHIP};
-
-        if (SqlStorage.STORAGE_OUTPUT_DEBUG) {
-            String sqlStatement = String.format("SELECT %s, %s, %s, %s, %s FROM %s WHERE %s = %d",
-                    COL_CASE_RECORD_ID, COL_INDEX_NAME, COL_INDEX_TYPE, COL_INDEX_TARGET, COL_INDEX_RELATIONSHIP, TABLE_NAME, COL_CASE_RECORD_ID, recordId);
-            DbUtil.explainSql(db, sqlStatement, null);
-        }
-
-        //NOTE: This does terrible things to SQL's cache (not using parameters), but it's the only
-        //way to actually make the indexes seek properly
-        Cursor c = db.query(TABLE_NAME, projection, String.format("%s = %d", COL_CASE_RECORD_ID, recordId) ,null, null, null, null);
-        try {
-            c.moveToFirst();
-            while (!c.isAfterLast()) {
-                indices.add(new CaseIndex(c.getString(c.getColumnIndexOrThrow(COL_INDEX_NAME)),
-                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_TYPE)),
-                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_TARGET)),
-                        c.getString(c.getColumnIndexOrThrow(COL_INDEX_RELATIONSHIP))));
-                c.moveToNext();
-            }
-            return indices;
-        } finally {
-            c.close();
-        }
-
-    }
-
     public HashMap<Integer,Vector<Pair<String, String>>> getCaseIndexMap() {
         String[] projection = new String[] {COL_CASE_RECORD_ID, COL_INDEX_TARGET, COL_INDEX_RELATIONSHIP};
         HashMap<Integer,Vector<Pair<String, String>>> caseIndexMap = new HashMap<>();

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTablePreV21.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTablePreV21.java
@@ -4,11 +4,8 @@ import android.content.ContentValues;
 
 import net.sqlcipher.database.SQLiteDatabase;
 
-import org.commcare.CommCareApplication;
-import org.commcare.android.database.user.models.ACase;
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.CaseIndex;
-import org.commcare.models.database.SqlStorage;
 import org.commcare.modern.database.DatabaseHelper;
 
 // Case Index table extension for Pre user db model 21 to use in DB migration

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTablePreV21.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTablePreV21.java
@@ -4,12 +4,14 @@ import android.content.ContentValues;
 
 import net.sqlcipher.database.SQLiteDatabase;
 
+import org.commcare.android.database.user.models.ACase;
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.CaseIndex;
+import org.commcare.models.database.SqlStorage;
 import org.commcare.modern.database.DatabaseHelper;
 
 // Case Index table extension for Pre user db model 21 to use in DB migration
-public class AndroidCaseIndexTablePreV21 extends AndroidCaseIndexTable {
+public class AndroidCaseIndexTablePreV21  {
 
     public static final String TABLE_NAME = "case_index_storage";
 
@@ -21,12 +23,10 @@ public class AndroidCaseIndexTablePreV21 extends AndroidCaseIndexTable {
     private final SQLiteDatabase db;
 
     public AndroidCaseIndexTablePreV21(SQLiteDatabase db) {
-        super(db);
         this.db = db;
     }
 
 
-    @Override
     public void indexCase(Case c) {
         db.beginTransaction();
         try {
@@ -52,6 +52,23 @@ public class AndroidCaseIndexTablePreV21 extends AndroidCaseIndexTable {
                 COL_INDEX_TYPE + ", " +
                 COL_INDEX_TARGET +
                 ")";
+    }
+
+    public void reIndexAllCases(SqlStorage<ACase> caseStorage) {
+        db.beginTransaction();
+        try {
+            wipeTable();
+            for (ACase c : caseStorage) {
+                indexCase(c);
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+    }
+
+    public void wipeTable() {
+        SqlStorage.wipeTable(db, TABLE_NAME);
     }
 
 }

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTablePreV21.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTablePreV21.java
@@ -5,11 +5,14 @@ import android.content.ContentValues;
 import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.user.models.ACase;
 import org.commcare.cases.model.Case;
 import org.commcare.cases.model.CaseIndex;
+import org.commcare.models.database.SqlStorage;
 import org.commcare.modern.database.DatabaseHelper;
 
-public class AndroidCaseIndexTableV1 {
+// Case Index table extension for Pre user db model 21 to use in DB migration
+public class AndroidCaseIndexTablePreV21 extends AndroidCaseIndexTable {
 
     public static final String TABLE_NAME = "case_index_storage";
 
@@ -20,11 +23,13 @@ public class AndroidCaseIndexTableV1 {
 
     private final SQLiteDatabase db;
 
-    public AndroidCaseIndexTableV1(SQLiteDatabase db) {
+    public AndroidCaseIndexTablePreV21(SQLiteDatabase db) {
+        super(db);
         this.db = db;
     }
 
 
+    @Override
     public void indexCase(Case c) {
         db.beginTransaction();
         try {

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -312,6 +312,7 @@ public class FormStorageTest {
             , "org.commcare.android.database.app.models.FormDefRecord"
             , "org.commcare.android.resource.installers.XFormAndroidInstallerV1"
             , "org.commcare.android.resource.installers.XFormUpdateInfoInstaller"
+            , "org.commcare.android.database.user.models.ACasePreV24Model"
     );
 
 


### PR DESCRIPTION
Case: https://manage.dimagi.com/default.asp?278205
Extension of https://github.com/dimagi/commcare-android/pull/2013 to fix more migration bugs. 

Error 1: DB Migration v17->18 (Because of `external_id` addition to case model)

```
net.sqlcipher.database.SQLiteException: no such column: external_id: , while compiling: UPDATE AndroidCase SET external_id=?, case_id=?, owner_id=?, case_type=?, case_status=?, commcare_sql_record=? WHERE commcare_sql_id=?
        at net.sqlcipher.database.SQLiteCompiledSql.native_compile(Native Method)
        at net.sqlcipher.database.SQLiteCompiledSql.compile(SQLiteCompiledSql.java:91)
        at net.sqlcipher.database.SQLiteCompiledSql.<init>(SQLiteCompiledSql.java:64)
        at net.sqlcipher.database.SQLiteProgram.<init>(SQLiteProgram.java:89)
        at net.sqlcipher.database.SQLiteStatement.<init>(SQLiteStatement.java:39)
        at net.sqlcipher.database.SQLiteDatabase.compileStatement(SQLiteDatabase.java:1589)
        at net.sqlcipher.database.SQLiteDatabase.updateWithOnConflict(SQLiteDatabase.java:2208)
        at net.sqlcipher.database.SQLiteDatabase.update(SQLiteDatabase.java:2155)
        at org.commcare.models.database.SqlStorage.update(SqlStorage.java:565)
        at org.commcare.models.database.SqlStorage.write(SqlStorage.java:575)
        at org.commcare.models.database.user.UserDatabaseUpgrader.updateModels(UserDatabaseUpgrader.java:704)
        at org.commcare.models.database.user.UserDatabaseUpgrader.upgradeSeventeenEighteen(UserDatabaseUpgrader.java:524)
        at org.commcare.models.database.user.UserDatabaseUpgrader.upgrade(UserDatabaseUpgrader.java:156)
        at org.commcare.models.database.user.DatabaseUserOpenHelper.onUpgrade(DatabaseUserOpenHelper.java:199)

```

Error 2: DB migration v18-19 (Case Relationship) 

```
net.sqlcipher.database.SQLiteException: table case_index_storage has no column named relationship: , while compiling: INSERT INTO case_index_storage(name, relationship, type, case_rec_id, target) VALUES(?, ?, ?, ?, ?);
        at net.sqlcipher.database.SQLiteCompiledSql.native_compile(Native Method)
        at net.sqlcipher.database.SQLiteCompiledSql.compile(SQLiteCompiledSql.java:91)
        at net.sqlcipher.database.SQLiteCompiledSql.<init>(SQLiteCompiledSql.java:64)
        at net.sqlcipher.database.SQLiteProgram.<init>(SQLiteProgram.java:89)
        at net.sqlcipher.database.SQLiteStatement.<init>(SQLiteStatement.java:39)
        at net.sqlcipher.database.SQLiteDatabase.compileStatement(SQLiteDatabase.java:1589)
        at net.sqlcipher.database.SQLiteDatabase.insertWithOnConflict(SQLiteDatabase.java:2060)
        at net.sqlcipher.database.SQLiteDatabase.insert(SQLiteDatabase.java:1930)
        at org.commcare.models.database.user.models.AndroidCaseIndexTable.indexCase(AndroidCaseIndexTable.java:87)
        at org.commcare.models.database.user.models.AndroidCaseIndexTable.reIndexAllCases(AndroidCaseIndexTable.java:365)
        at org.commcare.models.database.user.UserDatabaseUpgrader.upgradeEighteenNineteen(UserDatabaseUpgrader.java:528)
        at org.commcare.models.database.user.UserDatabaseUpgrader.upgrade(UserDatabaseUpgrader.java:158)
        at org.commcare.models.database.user.DatabaseUserOpenHelper.onUpgrade(DatabaseUserOpenHelper.java:195)
```
This crashes silently today since inserts on Sqlite catches any exception and returns -1 in case of an error. Ideally we should always check for return value from insert and throw an exception ourselves so that these kind of error don't live silently in code base. 