### PR TITLE
Re-download missing Resources from Recovery Screen 

### DIFF
--- a/app/res/layout/screen_recovery.xml
+++ b/app/res/layout/screen_recovery.xml
@@ -4,6 +4,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:layout_margin="10dp"
+              android:layout_marginHorizontal="@dimen/activity_horizontal_margin"
               android:orientation="vertical">
 
     <View
@@ -34,14 +35,14 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:layout_weight="0.75"
+            android:layout_weight="0.70"
             tools:text="This device has 4 unsent forms"/>
 
         <Button
             android:id="@+id/screen_recovery_unsent_button"
             style="?android:attr/buttonStyleSmall"
             android:layout_width="0dp"
-            android:layout_weight="0.25"
+            android:layout_weight="0.30"
             android:layout_height="wrap_content"
             android:text="@string/recovery_mode_send_data_btn"/>
 
@@ -50,6 +51,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/standard_spacer_double"
         android:weightSum="1">
 
         <TextView
@@ -57,7 +59,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:layout_weight="0.75"
+            android:layout_weight="0.70"
             tools:text="The current app install is OK"/>
 
         <Button
@@ -65,7 +67,7 @@
             style="?android:attr/buttonStyleSmall"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="0.25"
+            android:layout_weight="0.30"
             android:text="@string/recovery_mode_attempt_recovery_btn"/>
     </LinearLayout>
 
@@ -76,6 +78,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/standard_spacer_double"
         tools:text="Waiting"/>
 
     <View

--- a/app/res/layout/screen_recovery.xml
+++ b/app/res/layout/screen_recovery.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:layout_margin="10dp"
@@ -16,7 +17,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
         android:gravity="center"
-        android:text="CommCare has entered Recovery Mode due to a problem with the local device"/>
+        android:text="@string/recovery_mode_title"/>
 
     <View
         android:layout_width="wrap_content"
@@ -34,7 +35,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:layout_weight="0.75"
-            android:text="This device has 4 unsent forms"/>
+            tools:text="This device has 4 unsent forms"/>
 
         <Button
             android:id="@+id/screen_recovery_unsent_button"
@@ -42,7 +43,7 @@
             android:layout_width="0dp"
             android:layout_weight="0.25"
             android:layout_height="wrap_content"
-            android:text="Send Data"/>
+            android:text="@string/recovery_mode_send_data_btn"/>
 
     </LinearLayout>
 
@@ -57,7 +58,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:layout_weight="0.75"
-            android:text="The current app install is OK"/>
+            tools:text="The current app install is OK"/>
 
         <Button
             android:id="@+id/screen_recovery_app_install_button"
@@ -65,16 +66,17 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="0.25"
-            android:text="Attempt Reinstall"/>
+            android:text="@string/recovery_mode_attempt_recovery_btn"/>
     </LinearLayout>
 
     <TextView
         android:id="@+id/screen_recovery_progress"
         style="@style/TextInteractiveFreeFloating"
+        android:visibility="gone"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:text="Waiting"/>
+        tools:text="Waiting"/>
 
     <View
         android:layout_width="wrap_content"

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -362,4 +362,29 @@
     <string name="incorrect_time_dialog_message" cc:translatable="true">Your device time is incorrectly set. Please click the Correct Time button below to change your time settings.</string>
     <string name="incorrect_time_dialog_correct_time" cc:translatable="true">Correct Time</string>
     <string name="incorrect_time_dialog_cancel" cc:translatable="true">Cancel</string>
+
+    <!--Recovery Activity-->
+    <string name="recovery_mode_title">CommCare has entered Recovery Mode due to a problem with the local device</string>
+    <string name="recovery_mode_send_data_btn">Send Data</string>
+    <string name="recovery_mode_attempt_recovery_btn">Attempt Recovery</string>
+    <string name="recovering_resources_title">Recovering Missing Resources</string>
+    <string name="recovering_resources_progress">Installing missing resources...</string>
+    <string name="recovery_resource_progress">Recovered %1$s out of %2$s forms</string>
+    <string name="recovery_resource_error">Error while recovering resources</string>
+    <string name="recovery_resource_success">All missing resources are installed. Get back to work!</string>
+    <string name="recovery_app_state_unavailable">App state is unavailable. Make sure your phone storage is available</string>
+    <string name="recovery_app_state_corrupt">App state is unavailable. Make sure your phone storage is available</string>
+    <string name="recovery_app_state_valid">App is installed and valid</string>
+    <string name="recovery_forms_send_progress">Submitting form(s) to the server...</string>
+    <string name="recovery_forms_send_session_expired">Log-in expired during send. Please press back and log in again</string>
+    <string name="recovery_forms_send_successful">Send successful. All %s forms were submitted</string>
+    <string name="recovery_forms_send_failure">There were errors submitting the forms.</string>
+    <string name="recovery_forms_send_parital_success">There were errors submitting the forms. Only %s were submitted</string>
+    <string name="recovery_forms_send_network_error">Forms submissing failed due to poor network</string>
+    <string name="recovery_forms_send_error">Error while sending forms</string>
+    <string name="recovery_forms_state_unavailable">Forms are not available. Make sure your phone storage is available</string>
+    <string name="recovery_forms_state_logged_out">Could not read forms since your session has expired. Please login again</string>
+    <string name="recovery_forms_state_number_unsent_quarantine">This device has %1$s unsent forms and %2$s quarantine forms</string>
+    <string name="recovery_forms_state_error">Error while reading forms</string>
+
 </resources>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -386,5 +386,6 @@
     <string name="recovery_forms_state_logged_out">Could not read forms since your session has expired. Please login again</string>
     <string name="recovery_forms_state_number_unsent_quarantine">This device has %1$s unsent forms and %2$s quarantine forms</string>
     <string name="recovery_forms_state_error">Error while reading forms</string>
+    <string name="recovery_network_unavailable">No network connection. Please check your internet and try again.</string>
 
 </resources>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -370,10 +370,10 @@
     <string name="recovering_resources_title">Recovering Missing Resources</string>
     <string name="recovering_resources_progress">Installing missing resources...</string>
     <string name="recovery_resource_progress">Recovered %1$s out of %2$s forms</string>
-    <string name="recovery_resource_error">Error while recovering resources</string>
-    <string name="recovery_resource_success">All missing resources are installed. Get back to work!</string>
+    <string name="recovery_error">We were not able to recover your app. Please make sure all forms are submitted and reinstall your app</string>
+    <string name="recovery_success">App recovery has been successful. Get back to work!</string>
     <string name="recovery_app_state_unavailable">App state is unavailable. Make sure your phone storage is available</string>
-    <string name="recovery_app_state_corrupt">App state is unavailable. Make sure your phone storage is available</string>
+    <string name="recovery_app_state_corrupt">App install is corrupt. Make sure forms are sent before attempting recovery.</string>
     <string name="recovery_app_state_valid">App is installed and valid</string>
     <string name="recovery_forms_send_progress">Submitting form(s) to the server...</string>
     <string name="recovery_forms_send_session_expired">Log-in expired during send. Please press back and log in again</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -369,7 +369,7 @@
     <string name="recovery_mode_attempt_recovery_btn">Attempt Recovery</string>
     <string name="recovering_resources_title">Recovering Missing Resources</string>
     <string name="recovering_resources_progress">Installing missing resources...</string>
-    <string name="recovery_resource_progress">Recovered %1$s out of %2$s forms</string>
+    <string name="recovery_resource_progress">Recovered %1$s out of %2$s resources</string>
     <string name="recovery_error">We were not able to recover your app. Please make sure all forms are submitted and reinstall your app</string>
     <string name="recovery_success">App recovery has been successful. Get back to work!</string>
     <string name="recovery_app_state_unavailable">App state is unavailable. Make sure your phone storage is available</string>

--- a/app/src/org/commcare/CommCareApp.java
+++ b/app/src/org/commcare/CommCareApp.java
@@ -16,9 +16,9 @@ import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.UnencryptedHybridFileBackedSqlStorage;
 import org.commcare.models.database.app.DatabaseAppOpenHelper;
 import org.commcare.modern.database.Table;
-import org.commcare.preferences.PrefValues;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.preferences.MainConfigurablePreferences;
+import org.commcare.preferences.PrefValues;
 import org.commcare.provider.ProviderUtils;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceInitializationException;
@@ -225,6 +225,9 @@ public class CommCareApp implements AppFilePathBuilder {
         if (profile != null && profile.getStatus() == Resource.RESOURCE_STATUS_INSTALLED) {
             try {
                 platform.initialize(global, false);
+                if (!global.getMissingResources().isEmpty()) {
+                    return false;
+                }
                 Localization.setLocale(
                         getAppPreferences().getString(MainConfigurablePreferences.PREFS_LOCALE_KEY, "default"));
             } catch (UnregisteredLocaleException urle) {

--- a/app/src/org/commcare/CommCareApp.java
+++ b/app/src/org/commcare/CommCareApp.java
@@ -225,9 +225,12 @@ public class CommCareApp implements AppFilePathBuilder {
         if (profile != null && profile.getStatus() == Resource.RESOURCE_STATUS_INSTALLED) {
             try {
                 platform.initialize(global, false);
+
+                // Return false if resources are missing
                 if (!global.getMissingResources().isEmpty()) {
                     return false;
                 }
+
                 Localization.setLocale(
                         getAppPreferences().getString(MainConfigurablePreferences.PREFS_LOCALE_KEY, "default"));
             } catch (UnregisteredLocaleException urle) {

--- a/app/src/org/commcare/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/activities/RecoveryActivity.java
@@ -3,6 +3,7 @@ package org.commcare.activities;
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
@@ -14,14 +15,22 @@ import org.commcare.android.logging.ForceCloseLogger;
 import org.commcare.dalvik.R;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.preferences.ServerUrls;
+import org.commcare.resources.model.Resource;
+import org.commcare.resources.model.ResourceTable;
 import org.commcare.tasks.ProcessAndSendTask;
+import org.commcare.tasks.ResourceRecoveryTask;
+import org.commcare.util.CommCarePlatform;
 import org.commcare.util.LogTypes;
+import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.CommCareUtil;
+import org.commcare.utils.ConsumerAppsUtil;
 import org.commcare.utils.FormUploadResult;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.utils.StorageUtils;
+import org.commcare.utils.StringUtils;
 import org.commcare.views.ManagedUi;
 import org.commcare.views.UiElement;
+import org.commcare.views.dialogs.CustomProgressDialog;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 
@@ -31,6 +40,7 @@ import org.javarosa.core.services.locale.Localization;
 @ManagedUi(R.layout.screen_recovery)
 public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActivity> {
 
+    private static final int RECOVERY_TASK = 10000;
     @UiElement(R.id.screen_recovery_unsent_message)
     TextView txtUnsentAndQuarantineForms;
 
@@ -62,6 +72,7 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
             @SuppressLint("NewApi")
             @Override
             public void onClick(View v) {
+                txtUserMessage.setVisibility(View.GONE);
                 FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(
                         CommCareApplication.instance().getUserStorage(FormRecord.class));
                 SharedPreferences settings = CommCareApplication.instance().getCurrentApp().getAppPreferences();
@@ -74,26 +85,35 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
                             @Override
                             protected void onPreExecute() {
                                 super.onPreExecute();
-                                displayMessage("Submitting form(s) to the server...");
+                                displayMessage(StringUtils.getStringRobust(RecoveryActivity.this, R.string.recovery_forms_send_progress));
                             }
 
                             @Override
                             protected void deliverResult(RecoveryActivity receiver, FormUploadResult result) {
                                 if (result == FormUploadResult.PROGRESS_LOGGED_OUT) {
-
-                                    receiver.displayMessage("Log-in expired during send. Please press back and log in again");
+                                    receiver.displayMessage(StringUtils.getStringRobust(RecoveryActivity.this, R.string.recovery_forms_send_session_expired));
                                     return;
                                 }
 
                                 int successfulSends = this.getSuccessfulSends();
 
                                 if (result == FormUploadResult.FULL_SUCCESS) {
-                                    receiver.displayMessage("Send succesful. All  " + successfulSends + " forms were submitted");
+                                    receiver.displayMessage(StringUtils.getStringRobust(
+                                            RecoveryActivity.this,
+                                            R.string.recovery_forms_send_successful,
+                                            String.valueOf(successfulSends)));
                                 } else if (result == FormUploadResult.FAILURE) {
-                                    String remainder = successfulSends > 0 ? " Only " + successfulSends + " were submitted" : "";
-                                    receiver.displayMessage("There were errors submitting the forms." + remainder);
+                                    String failureMessage = successfulSends > 0 ?
+                                            StringUtils.getStringRobust(
+                                                    RecoveryActivity.this,
+                                                    R.string.recovery_forms_send_failure) :
+                                            StringUtils.getStringRobust(
+                                                    RecoveryActivity.this,
+                                                    R.string.recovery_forms_send_parital_success,
+                                                    String.valueOf(successfulSends));
+                                    receiver.displayMessage(failureMessage);
                                 } else if (result == FormUploadResult.TRANSPORT_FAILURE) {
-                                    receiver.displayMessage("Unable to contact the remote server.");
+                                    receiver.displayMessage(StringUtils.getStringRobust(RecoveryActivity.this, R.string.recovery_forms_send_network_error));
                                 } else if (result == FormUploadResult.RECORD_FAILURE) {
                                     receiver.displayMessage(Localization.get("sync.fail.individual"));
                                 } else if (result == FormUploadResult.AUTH_OVER_HTTP) {
@@ -109,7 +129,7 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
                             @Override
                             protected void deliverError(RecoveryActivity receiver, Exception e) {
                                 Logger.exception("Error in recovery form send: " + ForceCloseLogger.getStackTrace(e), e);
-                                receiver.displayMessage("Error while sending : " + e.getMessage());
+                                receiver.displayMessage(StringUtils.getStringRobust(receiver, R.string.recovery_forms_send_error) + ": " + e.getMessage());
                             }
 
                         };
@@ -124,21 +144,69 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
             }
         });
 
-        btnRecoverApp.setOnClickListener(v -> displayMessage("App recovery is not yet enabled. Please clear user data (After sending all of your forms!) and re-install."));
+        btnRecoverApp.setOnClickListener(v -> {
+            txtUserMessage.setVisibility(View.GONE);
+            attemptRecovery();
+        });
+    }
+
+    private void attemptRecovery() {
+        AndroidCommCarePlatform platform = CommCareApplication.instance().getCommCarePlatform();
+        ResourceTable global = platform.getGlobalResourceTable();
+        if (!global.getMissingResources().isEmpty()) {
+            int total = global.getMissingResources().size();
+            ResourceRecoveryTask<RecoveryActivity> task =
+                    new ResourceRecoveryTask<RecoveryActivity>(RECOVERY_TASK) {
+
+                        @Override
+                        protected void deliverResult(RecoveryActivity recoveryActivity, Boolean success) {
+                            if (success) {
+                                // Try Reinitializing and check if nothing is missing this time, if yes then auto recover again untill
+                                // there are no missing resources
+                                CommCareApplication.instance().initializeAppResources(CommCareApplication.instance().getCurrentApp());
+                                attemptRecovery();
+                            }
+                        }
+
+                        @Override
+                        protected void deliverUpdate(RecoveryActivity recoveryActivity, Integer... update) {
+                            int done = update[0];
+                            recoveryActivity.updateProgress(
+                                    StringUtils.getStringRobust(recoveryActivity, R.string.recovery_resource_progress,
+                                            new String[]{String.valueOf(done), String.valueOf(total)}),
+                                    RECOVERY_TASK);
+                            updateProgressBar(done, total, RECOVERY_TASK);
+                        }
+
+                        @Override
+                        protected void deliverError(RecoveryActivity recoveryActivity, Exception e) {
+                            Logger.exception("Error while recovering missing resources " + ForceCloseLogger.getStackTrace(e), e);
+                            recoveryActivity.displayMessage(StringUtils.getStringRobust(recoveryActivity, R.string.recovery_resource_error) + ": " + e.getMessage());
+                        }
+                    };
+            task.connect(this);
+            task.executeParallel();
+        } else {
+            updateRecoverAppState();
+            displayMessage(StringUtils.getStringRobust(this, R.string.recovery_resource_success));
+        }
     }
 
     private void displayMessage(String text) {
+        txtUserMessage.setVisibility(View.VISIBLE);
         txtUserMessage.setText(text);
     }
 
     @Override
     public void startBlockingForTask(int id) {
+        super.startBlockingForTask(id);
         btnRecoverApp.setEnabled(false);
         sendForms.setEnabled(false);
     }
 
     @Override
     public void stopBlockingForTask(int id) {
+        super.stopBlockingForTask(id);
         updateSendFormsState();
         updateRecoverAppState();
     }
@@ -146,15 +214,15 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
     private void updateRecoverAppState() {
         btnRecoverApp.setEnabled(false);
         if (!CommCareApplication.instance().isStorageAvailable()) {
-            appState.setText("app state unavailable.");
+            appState.setText(StringUtils.getStringRobust(this, R.string.recovery_app_state_unavailable));
             return;
         }
 
         if (CommCareApplication.instance().getCurrentApp().getAppResourceState() == CommCareApplication.STATE_CORRUPTED) {
-            appState.setText("App install is corrupt. Make sure forms are sent before attempting recovery.");
+            appState.setText(StringUtils.getStringRobust(this, R.string.recovery_app_state_corrupt));
             btnRecoverApp.setEnabled(true);
         } else {
-            appState.setText("App is installed and valid");
+            appState.setText(StringUtils.getStringRobust(this, R.string.recovery_app_state_valid));
             btnRecoverApp.setEnabled(false);
         }
     }
@@ -162,35 +230,45 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
     private void updateSendFormsState() {
         sendForms.setEnabled(false);
         if (!CommCareApplication.instance().isStorageAvailable()) {
-            txtUnsentAndQuarantineForms.setText("Forms are not available.");
+            txtUnsentAndQuarantineForms.setText(StringUtils.getStringRobust(this, R.string.recovery_forms_state_unavailable));
             return;
         }
 
         try {
             CommCareApplication.instance().getSession();
         } catch (SessionUnavailableException sue) {
-            txtUnsentAndQuarantineForms.setText("Couldn't read forms. Not Logged in");
+            txtUnsentAndQuarantineForms.setText(StringUtils.getStringRobust(this, R.string.recovery_forms_state_logged_out));
             return;
         }
 
         SqlStorage<FormRecord> recordStorage = CommCareApplication.instance().getUserStorage(FormRecord.class);
         try {
-            StringBuilder sb = new StringBuilder();
-            FormRecord[] records = StorageUtils.getUnsentRecordsForCurrentApp(recordStorage);
-            if (records.length == 0) {
-                sb.append("This device has no unsent forms");
-            } else {
-                sb.append("There are " + records.length + " unsent form(s)");
-                sendForms.setEnabled(true);
-            }
+            int unsentForms = StorageUtils.getUnsentRecordsForCurrentApp(recordStorage).length;
             int quarantineForms = StorageUtils.getNumQuarantinedForms();
-            if (quarantineForms != 0) {
-                sb.append(" and " + quarantineForms + " quarantine form(s)");
-            }
-            txtUnsentAndQuarantineForms.setText(sb.toString());
+            String formsStateMessage = StringUtils.getStringRobust(this,
+                    R.string.recovery_forms_state_number_unsent_quarantine,
+                    new String[]{String.valueOf(unsentForms), String.valueOf(quarantineForms)});
+            sendForms.setEnabled(unsentForms > 0);
+            txtUnsentAndQuarantineForms.setText(formsStateMessage);
         } catch (Exception e) {
             Logger.exception("Encountered exception during recovery attempt " + e.getMessage(), e);
-            txtUnsentAndQuarantineForms.setText("Couldn't read forms. Error : " + e.getMessage());
+            txtUnsentAndQuarantineForms.setText(
+                    StringUtils.getStringRobust(this, R.string.recovery_forms_state_error) + ": " + e.getMessage());
         }
+    }
+
+    @Override
+    public CustomProgressDialog generateProgressDialog(int taskId) {
+        if (taskId == RECOVERY_TASK) {
+            CustomProgressDialog dialog =
+                    CustomProgressDialog.newInstance(
+                            StringUtils.getStringRobust(this, R.string.recovering_resources_title),
+                            StringUtils.getStringRobust(this, R.string.recovering_resources_progress),
+                            taskId);
+            dialog.addProgressBar();
+            dialog.addCancelButton();
+            return dialog;
+        }
+        return null;
     }
 }

--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -66,14 +66,20 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     }
 
     @Override
-    public abstract boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
+    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
-            XmlPullParserException, UnfullfilledRequirementsException;
+            XmlPullParserException, UnfullfilledRequirementsException {
+        Reference ref = ReferenceManager.instance().DeriveReference(localLocation);
+        if (!ref.doesBinaryExist()) {
+            throw new FileNotFoundException("No file exists at " + ref.getLocalURI());
+        }
+        return true;
+    }
 
     @Override
     public boolean install(Resource r, ResourceLocation location,
                            Reference ref, ResourceTable table,
-                           AndroidCommCarePlatform platform, boolean upgrade)
+                           AndroidCommCarePlatform platform, boolean upgrade, boolean recovery)
             throws UnresolvedResourceException, UnfullfilledRequirementsException {
         try {
             InputStream inputFileStream;

--- a/app/src/org/commcare/android/resource/installers/LocaleAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/LocaleAndroidInstaller.java
@@ -39,6 +39,7 @@ public class LocaleAndroidInstaller extends FileSystemInstaller {
     public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
+        super.initialize(platform, isUpgrade);
         Localization.registerLanguageReference(locale, localLocation);
         return true;
     }

--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -74,10 +74,10 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
 
     @Override
     public boolean install(Resource r, ResourceLocation location, Reference ref,
-                           ResourceTable table, AndroidCommCarePlatform platform, boolean upgrade)
+                           ResourceTable table, AndroidCommCarePlatform platform, boolean upgrade, boolean recovery)
             throws UnresolvedResourceException, UnfullfilledRequirementsException {
         //First, make sure all the file stuff is managed.
-        super.install(r, location, ref, table, platform, upgrade);
+        super.install(r, location, ref, table, platform, upgrade, recovery);
         InputStream inputStream = null;
         try {
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
@@ -89,8 +89,10 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
 
             if (!upgrade) {
                 initProperties(p);
-                checkDuplicate(p);
-                checkAppTarget();
+                if(!recovery) {
+                    checkDuplicate(p);
+                    checkAppTarget();
+                }
             }
 
             table.commitCompoundResource(r, upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED, p.getVersion());

--- a/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
@@ -82,9 +82,9 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
     @Override
     public boolean install(Resource r, ResourceLocation location, Reference ref,
                            ResourceTable table, final AndroidCommCarePlatform platform,
-                           boolean upgrade) throws UnresolvedResourceException, UnfullfilledRequirementsException {
+                           boolean upgrade, boolean recovery) throws UnresolvedResourceException, UnfullfilledRequirementsException {
         //First, make sure all the file stuff is managed.
-        super.install(r, location, ref, table, platform, upgrade);
+        super.install(r, location, ref, table, platform, upgrade, recovery);
         InputStream inputStream = null;
         try {
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -70,6 +70,7 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
+        super.initialize(platform, isUpgrade);
         platform.registerXmlns(namespace, formDefId);
         return true;
     }

--- a/app/src/org/commcare/engine/references/JavaFileReference.java
+++ b/app/src/org/commcare/engine/references/JavaFileReference.java
@@ -5,6 +5,7 @@ import org.javarosa.core.reference.Reference;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,7 +42,7 @@ public class JavaFileReference implements Reference {
         File file = file();
         //CTS: Removed a thing here that created an empty file. Not sure why that was there.
         if (!file.exists()) {
-            throw new IOException("No file exists at " + file.getAbsolutePath());
+            throw new FileNotFoundException("No file exists at " + file.getAbsolutePath());
         }
         return new FileInputStream(file);
     }

--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -44,7 +44,6 @@ import javax.crypto.spec.SecretKeySpec;
  */
 public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Long, FormUploadResult, R> implements DataSubmissionListener {
 
-    private Context c;
     private String url;
     private FormUploadResult[] results;
 
@@ -81,7 +80,6 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
      * @param inSyncMode blocks the user with a sync dialog
      */
     public ProcessAndSendTask(Context c, String url, boolean inSyncMode) {
-        this.c = c;
         this.url = url;
         this.processor = new FormRecordProcessor(c);
         this.formSubmissionListeners = new ArrayList<>();
@@ -521,7 +519,6 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
     }
 
     private void clearState() {
-        c = null;
         url = null;
         results = null;
     }

--- a/app/src/org/commcare/tasks/ResourceRecoveryTask.java
+++ b/app/src/org/commcare/tasks/ResourceRecoveryTask.java
@@ -38,6 +38,10 @@ public abstract class ResourceRecoveryTask<Reciever>
         return success;
     }
 
+    /**
+     *
+     * @return CommCare App Profile url without query params
+     */
     private String getProfileReference() {
         String profileRef = ResourceInstallUtils.getDefaultProfileRef();
         return profileRef.split("\\?")[0];

--- a/app/src/org/commcare/tasks/ResourceRecoveryTask.java
+++ b/app/src/org/commcare/tasks/ResourceRecoveryTask.java
@@ -2,12 +2,15 @@ package org.commcare.tasks;
 
 import org.commcare.CommCareApplication;
 import org.commcare.resources.model.InstallCancelled;
+import org.commcare.resources.model.InstallCancelledException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
 import org.commcare.resources.model.TableStateListener;
 import org.commcare.resources.model.UnreliableSourceException;
+import org.commcare.resources.model.UnresolvedResourceException;
 import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.utils.AndroidCommCarePlatform;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
 
 import java.util.Vector;
 
@@ -23,7 +26,13 @@ public abstract class ResourceRecoveryTask<Reciever>
         AndroidCommCarePlatform platform = CommCareApplication.instance().getCommCarePlatform();
         ResourceTable global = platform.getGlobalResourceTable();
         setTableListeners(global);
-        boolean success = global.recoverResources(platform);
+        boolean success = false;
+        try {
+            success = global.recoverResources(platform);
+        } catch (InstallCancelledException | UnresolvedResourceException | UnfullfilledRequirementsException e) {
+            throw new RuntimeException(e);
+        }
+
         unsetTableListeners(global);
         return success;
     }

--- a/app/src/org/commcare/tasks/ResourceRecoveryTask.java
+++ b/app/src/org/commcare/tasks/ResourceRecoveryTask.java
@@ -1,0 +1,58 @@
+package org.commcare.tasks;
+
+import org.commcare.CommCareApplication;
+import org.commcare.resources.model.InstallCancelled;
+import org.commcare.resources.model.Resource;
+import org.commcare.resources.model.ResourceTable;
+import org.commcare.resources.model.TableStateListener;
+import org.commcare.resources.model.UnreliableSourceException;
+import org.commcare.tasks.templates.CommCareTask;
+import org.commcare.utils.AndroidCommCarePlatform;
+
+import java.util.Vector;
+
+public abstract class ResourceRecoveryTask<Reciever>
+        extends CommCareTask<Void, Integer, Boolean, Reciever> implements TableStateListener, InstallCancelled {
+
+    public ResourceRecoveryTask(int taskId) {
+        this.taskId = taskId;
+    }
+
+    @Override
+    protected Boolean doTaskBackground(Void... voids) {
+        AndroidCommCarePlatform platform = CommCareApplication.instance().getCommCarePlatform();
+        ResourceTable global = platform.getGlobalResourceTable();
+        setTableListeners(global);
+        boolean success = global.recoverResources(platform);
+        unsetTableListeners(global);
+        return success;
+    }
+
+    private void setTableListeners(ResourceTable table) {
+        table.setStateListener(this);
+        table.setInstallCancellationChecker(this);
+    }
+
+    private static void unsetTableListeners(ResourceTable table) {
+        table.setInstallCancellationChecker(null);
+        table.setStateListener(null);
+    }
+
+    @Override
+    public void simpleResourceAdded() {
+    }
+
+    @Override
+    public void compoundResourceAdded(ResourceTable table) {
+    }
+
+    @Override
+    public void incrementProgress(int complete, int total) {
+        this.publishProgress(complete);
+    }
+
+    @Override
+    public boolean wasInstallCancelled() {
+        return isCancelled();
+    }
+}

--- a/app/src/org/commcare/tasks/ResourceRecoveryTask.java
+++ b/app/src/org/commcare/tasks/ResourceRecoveryTask.java
@@ -1,6 +1,7 @@
 package org.commcare.tasks;
 
 import org.commcare.CommCareApplication;
+import org.commcare.engine.resource.ResourceInstallUtils;
 import org.commcare.resources.model.InstallCancelled;
 import org.commcare.resources.model.InstallCancelledException;
 import org.commcare.resources.model.Resource;
@@ -26,15 +27,21 @@ public abstract class ResourceRecoveryTask<Reciever>
         AndroidCommCarePlatform platform = CommCareApplication.instance().getCommCarePlatform();
         ResourceTable global = platform.getGlobalResourceTable();
         setTableListeners(global);
-        boolean success = false;
+        boolean success;
         try {
-            success = global.recoverResources(platform);
+            success = global.recoverResources(platform, getProfileReference());
         } catch (InstallCancelledException | UnresolvedResourceException | UnfullfilledRequirementsException e) {
             throw new RuntimeException(e);
+        } finally {
+            unsetTableListeners(global);
         }
-
-        unsetTableListeners(global);
         return success;
+    }
+
+    private String getProfileReference() {
+        String profileRef = ResourceInstallUtils.getDefaultProfileRef();
+        return profileRef.split("\\?")[0];
+
     }
 
     private void setTableListeners(ResourceTable table) {

--- a/app/src/org/commcare/tasks/ResourceRecoveryTask.java
+++ b/app/src/org/commcare/tasks/ResourceRecoveryTask.java
@@ -56,10 +56,12 @@ public abstract class ResourceRecoveryTask<Reciever>
 
     @Override
     public void simpleResourceAdded() {
+        // Do nothing
     }
 
     @Override
     public void compoundResourceAdded(ResourceTable table) {
+        // Do nothing
     }
 
     @Override

--- a/app/src/org/commcare/utils/DummyResourceTable.java
+++ b/app/src/org/commcare/utils/DummyResourceTable.java
@@ -93,7 +93,7 @@ public class DummyResourceTable extends ResourceTable {
                     public boolean install(Resource r,
                                            ResourceLocation location, Reference ref,
                                            ResourceTable table, CommCarePlatform platform,
-                                           boolean upgrade)
+                                           boolean upgrade, boolean recovery)
                             throws UnresolvedResourceException,
                             UnfullfilledRequirementsException {
                         return true;


### PR DESCRIPTION
* Implements 'Recover App' functionality in `RecoveryActivity` to re-download any missing resources
* `ResourceTable` now maintains a vector for `missingAppResources` which gets set while initializing an app

Screenshots - 

1. Storage Corrupt Warning - @ctsims I don't see any particular benefits of this screen since all this asks is whether to enter recovery screen or exit the app. Instead we can directly make user enter the recovery screen and user can always exit the app by pressing back. 

<img src="https://user-images.githubusercontent.com/4679137/42228039-920a93fc-7f00-11e8-8ac3-46d277aea508.png" width="400" height="600">

2. Recovery Screen
<img src="https://user-images.githubusercontent.com/4679137/42228044-95553e2c-7f00-11e8-82c9-0ef8bef8730d.png" width="400" height="600">

3. Recovery in progress
<img src="https://user-images.githubusercontent.com/4679137/42228045-96fe75f4-7f00-11e8-92d5-8a72406485c3.png" width="400" height="600">

4. Recovery Success
<img src="https://user-images.githubusercontent.com/4679137/42228051-9b0db75e-7f00-11e8-9a34-856bf2231baf.png" width="400" height="600">

cross-request: https://github.com/dimagi/commcare-core/pull/817

Product Note: Adds functionality to re-download missing app resources from Recovery Screen. 