### PR TITLE
Migration fix for Upgrade and Recovery Table

### DIFF
--- a/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
@@ -90,8 +90,7 @@ class AppDatabaseUpgrader {
         }
 
         if (oldVersion == 8) {
-            if (upgradeEightNine(db)) {
-                // we are doing v9-v10 in upgradeEightNine now, so skip upgradeNineTen
+            if (upgradeEightTen(db)) {
                 oldVersion = 10;
             }
         }
@@ -227,7 +226,7 @@ class AppDatabaseUpgrader {
     }
 
     // Migrate records form FormProvider and InstanceProvider to new FormDefRecord and FormRecord respectively
-    private boolean upgradeEightNine(SQLiteDatabase db) {
+    private boolean upgradeEightTen(SQLiteDatabase db) {
         boolean success;
         db.beginTransaction();
         try {

--- a/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
@@ -305,13 +305,18 @@ class AppDatabaseUpgrader {
      * 2. v8-v9 upgrade was successful and resources are already in v9/v10 state (Resources downloaded after the update)
      *
      * So we wanna assume 1 and try updating the resources to v10,
-     * if above fails, we are checking for 2 i.e resources be in v10 state.
-     * If they are not we are going to wipe the tables
+     * if above fails, we are checking for 2 i.e if resources are in v10 state.
+     * If they are not we are going to wipe the table
      *
      * @param tableName Resource table that need to be upgraded
      * @param db        App DB
      */
     private void upgradeToResourcesV10(String tableName, SQLiteDatabase db) {
+        // Safe checking against calling this method by mistake for Global table
+        if (tableName.contentEquals(GLOBAL_RESOURCE_TABLE_NAME)) {
+            return;
+        }
+
         try {
             upgradeXFormAndroidInstallerV1(tableName, db);
         } catch (Exception e) {

--- a/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
@@ -260,8 +260,8 @@ class AppDatabaseUpgrader {
     }
 
     private boolean upgradeNineTen(SQLiteDatabase db) {
-        upgradeXFormAndroidInstallerV1(UPGRADE_RESOURCE_TABLE_NAME, db);
-        upgradeXFormAndroidInstallerV1(RECOVERY_RESOURCE_TABLE_NAME, db);
+        SqlStorage.wipeTable(db, UPGRADE_RESOURCE_TABLE_NAME);
+        SqlStorage.wipeTable(db, RECOVERY_RESOURCE_TABLE_NAME);
         return true;
     }
 

--- a/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
+++ b/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
@@ -37,7 +37,7 @@ public class DatabaseAppOpenHelper extends SQLiteOpenHelper {
      * V.9 - Adds FormRecord and Instance Record tables, XFormAndroidInstaller: contentUri -> formDefId
      * V.10 - No Change, Added because of incomplete resource table migration for v8 to v9
      */
-    private static final int DB_VERSION_APP = 9;
+    private static final int DB_VERSION_APP = 10;
 
     private static final String DB_LOCATOR_PREF_APP = "database_app_";
 

--- a/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
+++ b/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
@@ -1,6 +1,7 @@
 package org.commcare.models.database.app;
 
 import android.content.Context;
+import android.util.Log;
 
 import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteException;
@@ -34,6 +35,7 @@ public class DatabaseAppOpenHelper extends SQLiteOpenHelper {
      * V.7 - Update serialized fixtures in db to use new schema
      * V.8 - Add fields to UserKeyRecord to support PIN auth
      * V.9 - Adds FormRecord and Instance Record tables, XFormAndroidInstaller: contentUri -> formDefId
+     * V.10 - No Change, Added because of incomplete resource table migration for v8 to v9
      */
     private static final int DB_VERSION_APP = 9;
 

--- a/app/src/org/commcare/utils/AndroidCommCarePlatform.java
+++ b/app/src/org/commcare/utils/AndroidCommCarePlatform.java
@@ -23,6 +23,10 @@ import java.util.Vector;
  */
 public class AndroidCommCarePlatform extends CommCarePlatform {
 
+    public static final String GLOBAL_RESOURCE_TABLE_NAME = "GLOBAL_RESOURCE_TABLE";
+    public static final String UPGRADE_RESOURCE_TABLE_NAME = "UPGRADE_RESOURCE_TABLE";
+    public static final String RECOVERY_RESOURCE_TABLE_NAME = "RECOVERY_RESOURCE_TABLE";
+
     private final Hashtable<String, Integer> xmlnstable;
     private ResourceTable global;
     private ResourceTable upgrade;
@@ -59,21 +63,21 @@ public class AndroidCommCarePlatform extends CommCarePlatform {
 
     public ResourceTable getGlobalResourceTable() {
         if (global == null) {
-            global = new AndroidResourceTable(app.getStorage("GLOBAL_RESOURCE_TABLE", Resource.class), new AndroidResourceInstallerFactory());
+            global = new AndroidResourceTable(app.getStorage(GLOBAL_RESOURCE_TABLE_NAME, Resource.class), new AndroidResourceInstallerFactory());
         }
         return global;
     }
 
     public ResourceTable getUpgradeResourceTable() {
         if (upgrade == null) {
-            upgrade = new AndroidResourceTable(app.getStorage("UPGRADE_RESOURCE_TABLE", Resource.class), new AndroidResourceInstallerFactory());
+            upgrade = new AndroidResourceTable(app.getStorage(UPGRADE_RESOURCE_TABLE_NAME, Resource.class), new AndroidResourceInstallerFactory());
         }
         return upgrade;
     }
 
     public ResourceTable getRecoveryTable() {
         if (recovery == null) {
-            recovery = new AndroidResourceTable(app.getStorage("RECOVERY_RESOURCE_TABLE", Resource.class), new AndroidResourceInstallerFactory());
+            recovery = new AndroidResourceTable(app.getStorage(RECOVERY_RESOURCE_TABLE_NAME, Resource.class), new AndroidResourceInstallerFactory());
         }
         return recovery;
     }


### PR DESCRIPTION
CL: https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59dd64f2be077a4dcc14f222?time=last-twenty-four-hours

This issue is happening when apps having entries in update table are getting updated to CommCare 2.44 i.e if a user who have an app update staged but not installed update CommCare to 2.44 and login again his app crashes. I am able to repro it and have verified that this solution fixes the issue for both people updating to potential 2.44.1 from both 2.43 and 2.44 

I am stuck on a weird problem though, putting it as a comment inline. 

