### PR TITLE
Turns Image scaling code path off

### DIFF
--- a/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
+++ b/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
@@ -44,6 +44,12 @@ public class ImageCaptureProcessing {
         String finalFilePath = instanceFolder + imageFilename;
 
         boolean savedScaledImage = false;
+
+        // Turning off scaling for now, since current code never actually ends up using the
+        // final scaled image. We might wanna turn that later on again sometimes so leaving the scaling
+        // code as it is
+        shouldScale = false;
+
         if (shouldScale) {
             ImageWidget currentWidget = (ImageWidget)formEntryActivity.getPendingWidget();
             if (currentWidget != null) {

--- a/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
+++ b/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
@@ -46,7 +46,7 @@ public class ImageCaptureProcessing {
         boolean savedScaledImage = false;
 
         // Turning off scaling for now, since current code never actually ends up using the
-        // final scaled image. We might wanna turn that later on again sometimes so leaving the scaling
+        // final scaled image. We might wanna turn that later on again sometime so leaving the scaling
         // code as it is
         shouldScale = false;
 


### PR DESCRIPTION
Case: https://dimagi-dev.atlassian.net/projects/MOB/issues/MOB-14

We don't end up using the final scaled image currently. So switiching off the scaling code path completely since it deletes the images from gallery today.