### PR TITLE
Fixes Crash due to SSD records getting detached in FormProvider Migration

### DIFF
--- a/app/src/org/commcare/android/database/user/models/SessionStateDescriptor.java
+++ b/app/src/org/commcare/android/database/user/models/SessionStateDescriptor.java
@@ -61,6 +61,10 @@ public class SessionStateDescriptor extends Persisted implements EncryptedModel 
         return formRecordId;
     }
 
+    public void setFormRecordId(int formRecordId) {
+        this.formRecordId = formRecordId;
+    }
+
     public SessionStateDescriptor reMapFormRecordId(int idForNewRecord) {
         SessionStateDescriptor copy = new SessionStateDescriptor();
         copy.formRecordId = idForNewRecord;

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -62,9 +62,10 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
      * V.22 - Add column for appId in entity_cache table
      * V.23 - Merges InstanceProvider to FormRecord (delete instanceUri, add displayName, filePath and canEditWhenComplete)
      * v.24 - Adds and indexes column for Case external_id
+     * v.25 - No DB changes, validates SessionStateDescriptor records corrupted due to an earlier bug in v23 migration (In 2.44 and 2.44.1)
      */
 
-    private static final int USER_DB_VERSION = 24;
+    private static final int USER_DB_VERSION = 25;
 
     private static final String USER_DB_LOCATOR = "database_sandbox_";
 

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -695,15 +695,9 @@ class UserDatabaseUpgrader {
                 // Since we have wiped out SSD records, we won't be able to resume
                 // incomplete forms with their earlier session state. Therfore we are
                 // going to delete all incomplete form records as well
-                Vector<Integer> incompleteRecords = new Vector();
-                for (FormRecord formRecord : formRecordStorage) {
-                    if (formRecord.getStatus().contentEquals(FormRecord.STATUS_INCOMPLETE)) {
-                        incompleteRecords.add(formRecord.getID());
-                    }
-                }
-
-                for (int incompleteRecordId : incompleteRecords) {
-                    formRecordStorage.remove(incompleteRecordId);
+                Vector<FormRecord> incompleteRecords = formRecordStorage.getRecordsForValue(FormRecord.META_STATUS, FormRecord.STATUS_INCOMPLETE);
+                for (FormRecord incompleteRecord : incompleteRecords) {
+                    formRecordStorage.remove(incompleteRecord);
                 }
             }
             db.setTransactionSuccessful();

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -695,10 +695,15 @@ class UserDatabaseUpgrader {
                 // Since we have wiped out SSD records, we won't be able to resume
                 // incomplete forms with their earlier session state. Therfore we are
                 // going to delete all incomplete form records as well
+                Vector<Integer> incompleteRecords = new Vector();
                 for (FormRecord formRecord : formRecordStorage) {
                     if (formRecord.getStatus().contentEquals(FormRecord.STATUS_INCOMPLETE)) {
-                        formRecordStorage.remove(formRecord);
+                        incompleteRecords.add(formRecord.getID());
                     }
+                }
+
+                for (int incompleteRecordId : incompleteRecords) {
+                    formRecordStorage.remove(incompleteRecordId);
                 }
             }
             db.setTransactionSuccessful();

--- a/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
+++ b/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
@@ -259,6 +259,7 @@ public class UserDbUpgradeUtils {
             try {
                 SessionStateDescriptor ssd = ssdStorage.getRecordForValue(SessionStateDescriptor.META_FORM_RECORD_ID, oldId);
                 ssd.setFormRecordId(newRecord.getID());
+                ssdStorage.write(ssd);
             } catch (Exception e) {
                 // Ignore failures in SSD Migration
             }

--- a/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
+++ b/app/src/org/commcare/models/database/user/UserDbUpgradeUtils.java
@@ -30,7 +30,6 @@ import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.storage.Persistable;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -198,7 +197,8 @@ public class UserDbUpgradeUtils {
 
     /**
      * Migrated form records to include data from corresponding Instance from InstanceProvider
-     * @param c Context
+     *
+     * @param c  Context
      * @param db User DB we are migrating
      * @return a Vector containing Instance Uris corresponding to InstanceProvider entries that got migrated successfully
      */
@@ -232,6 +232,7 @@ public class UserDbUpgradeUtils {
                     cursor.close();
                 }
             }
+            newRecord.setID(oldRecord.getID());
             newRecords.add(new Pair<>(newRecord, instanceUri));
         }
 
@@ -242,15 +243,33 @@ public class UserDbUpgradeUtils {
 
         // Write to the new table
         SqlStorage<FormRecord> newStorage = getFormRecordStorage(c, db, FormRecord.class);
+        SqlStorage<SessionStateDescriptor> ssdStorage = new SqlStorage<>(
+                SessionStateDescriptor.STORAGE_KEY,
+                SessionStateDescriptor.class,
+                new ConcreteAndroidDbHelper(c, db));
         for (Pair entry : newRecords) {
-            newStorage.write(((FormRecord)entry.first));
+            FormRecord newRecord = ((FormRecord)entry.first);
+            int oldId = newRecord.getID();
+
+            // Since we are writing in new table, reset the id before write
+            newRecord.setID(-1);
+            newStorage.write(newRecord);
+
+            // Migrate SSD
+            try {
+                SessionStateDescriptor ssd = ssdStorage.getRecordForValue(SessionStateDescriptor.META_FORM_RECORD_ID, oldId);
+                ssd.setFormRecordId(newRecord.getID());
+            } catch (Exception e) {
+                // Ignore failures in SSD Migration
+            }
+
             migratedInstances.add(((Uri)entry.second));
         }
 
         return migratedInstances;
     }
 
-    private static SqlStorage getFormRecordStorage(Context c, SQLiteDatabase db, Class formRecordClass) {
+    public static SqlStorage getFormRecordStorage(Context c, SQLiteDatabase db, Class formRecordClass) {
         return new SqlStorage<>(
                 FormRecord.STORAGE_KEY,
                 formRecordClass,


### PR DESCRIPTION
CL: https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59e2076c61b02d480d8ee18e?time=last-thirty-days

Repro: 
1. Install CommCare 2.43
2. Create 2 Forms A and B in that sequence
3. Delete A
4. Update to CommCare 2.44 or 2.44.1
5. Observe a crash on creating any new form

While migrating FormRecords in v23 migration, we delete the old table and rewrite all entries into a new FormRecord table which results in `id` of FormRecords getting changed to new values. Since `SessionStateDescriptor` records hold references to these ids, these ssd records need to be migrated as well. In a general case new form ids would be same as old causing this bug not to surface except when user or some process deletes a form record from the device which is not the latest. For example, I am highlighting the state of formRecord and SSD storage below after every step in repro above - 
```
Step		FormStorage Id              SSD Form Record Ids
2			1, 2			        1, 2 
3			2				2
4			1    			        2
5                       1, 2                           2, 2 (Unique Constraint Failure)

```


For devices which are already on 2.44, 2.44.1 I am checking if there are any ssd records who holds a form id not corresponding to any forms on the device to validate if there were forms deleted from device before updating to 2.44.0(1). In that case I am dropping the whole table since it means that records in SSD table holds references to either incorrect or non existent form records entries.

@ctsims Let me know if you can think of better strategies around this. 