### PR TITLE
Fixes bug in updating File path for an existing Form with new file path

### DIFF
--- a/app/src/org/commcare/android/database/app/models/FormDefRecord.java
+++ b/app/src/org/commcare/android/database/app/models/FormDefRecord.java
@@ -138,6 +138,7 @@ public class FormDefRecord extends Persisted {
         }
 
         // Set new values now
+        mFormFilePath = newFilePath;
         mFormMediaPath = getMediaPath(newFilePath);
         formDefRecordStorage.write(this);
     }

--- a/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
@@ -3,6 +3,7 @@ package org.commcare.models.database.app;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
+import android.text.TextUtils;
 import android.util.Log;
 
 import net.sqlcipher.database.SQLiteDatabase;
@@ -24,9 +25,11 @@ import org.commcare.modern.database.TableBuilder;
 import org.commcare.provider.FormsProviderAPI;
 import org.commcare.resources.model.Resource;
 import org.commcare.util.LogTypes;
+import org.commcare.utils.GlobalConstants;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -101,6 +104,13 @@ class AppDatabaseUpgrader {
                 oldVersion = 10;
             }
         }
+
+        if (oldVersion == 10) {
+            if (upgradeTenEleven(db)) {
+                oldVersion = 11;
+            }
+        }
+
         //NOTE: If metadata changes are made to the Resource model, they need to be
         //managed by changing the TwoThree updater to maintain that metadata.
     }
@@ -266,6 +276,36 @@ class AppDatabaseUpgrader {
         try {
             upgradeToResourcesV10(UPGRADE_RESOURCE_TABLE_NAME, db);
             upgradeToResourcesV10(RECOVERY_RESOURCE_TABLE_NAME, db);
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+        return true;
+    }
+
+    // Corrects 'update' file references for FormDef Records that didn't
+    // change to 'install' path because of an earlier bug
+    private boolean upgradeTenEleven(SQLiteDatabase db) {
+        db.beginTransaction();
+        try {
+            SqlStorage<FormDefRecord> formDefRecordStorage = new SqlStorage<>(
+                    FormDefRecord.STORAGE_KEY,
+                    FormDefRecord.class,
+                    new ConcreteAndroidDbHelper(context, db));
+            for (FormDefRecord formDefRecord : formDefRecordStorage) {
+                String filePath = formDefRecord.getFilePath();
+                File formFile = new File(filePath);
+
+                // update the path for the record if it points to a non existent upgrade path and corresponding install path exists
+                if (!formFile.exists() && filePath.contains(GlobalConstants.FILE_CC_UPGRADE)) {
+                    String newFilePath = filePath.replace(GlobalConstants.FILE_CC_UPGRADE, GlobalConstants.FILE_CC_INSTALL + "/");
+                    if (new File(newFilePath).exists()) {
+                        formDefRecord.updateFilePath(formDefRecordStorage, newFilePath);
+                    } else {
+                        Logger.log(LogTypes.SOFT_ASSERT, "File not found at both upgrade and install path for form " + formDefRecord.getJrFormId());
+                    }
+                }
+            }
             db.setTransactionSuccessful();
         } finally {
             db.endTransaction();

--- a/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
+++ b/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
@@ -36,8 +36,9 @@ public class DatabaseAppOpenHelper extends SQLiteOpenHelper {
      * V.8 - Add fields to UserKeyRecord to support PIN auth
      * V.9 - Adds FormRecord and Instance Record tables, XFormAndroidInstaller: contentUri -> formDefId
      * V.10 - No Change, Added because of incomplete resource table migration for v8 to v9
+     * V.11 - No Change, Corrects FormDef references if corrupt (because of an earlier bug)
      */
-    private static final int DB_VERSION_APP = 10;
+    private static final int DB_VERSION_APP = 11;
 
     private static final String DB_LOCATOR_PREF_APP = "database_app_";
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/MOB-17

This was silly on my end. Form record path wasn't  getting updated to the  `install` path from `upgrade` path since `updateFilePath` in `FormDefRecord.java` was not actually setting the new filepath value for the form before updating the form record.

This bug doesn't surface in normal cases since generally form records filepath references doesn't change. The bug only gets exposed in cases when namespace of a form changes in between 2 updates since that's the only case where a form record with `upgrade` path gets created and then we later wanna change it to `install` file path.  For installations who have already encountered this scenario, we are applying an one time update which checks for non existent `upgrade` file references in FormDef Records and moves the path to correposnding `install` path. 