### PR TITLE
Removes incorrectly shown form lost warning on saving incomplete forms

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -760,14 +760,6 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                 // Otherwise, we want to keep proceeding in order
                 // to keep running the workflow
             } else {
-                CommCareApplication.notificationManager().reportNotificationMessage(
-                        NotificationMessageFactory.message(
-                                NotificationMessageFactory.StockMessages.FormEntry_Unretrievable));
-                Toast.makeText(this,
-                        "Error while trying to read the form! See the notification",
-                        Toast.LENGTH_LONG).show();
-                Logger.log(LogTypes.TYPE_ERROR_WORKFLOW,
-                        "Form Entry did not return a form");
                 clearSessionAndExit(currentState, false);
                 return false;
             }


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/MOB-19

Something that I overlooked during FormProvider refactoring. This warning message was earlier shown when `FormEntryActivity` didn't return any form instance uri. Though since now FormProvider is merged into FormRecord, don't think there is any valid scenario for this error anymore. 