### PR TITLE
Use RGB_565 config for Signature Bitmaps

### DIFF
--- a/app/src/org/commcare/activities/DrawActivity.java
+++ b/app/src/org/commcare/activities/DrawActivity.java
@@ -221,7 +221,7 @@ public class DrawActivity extends Activity {
             FileOutputStream fos;
             fos = new FileOutputStream(f);
             Bitmap bitmap = Bitmap.createBitmap(drawView.getWidth(),
-                    drawView.getHeight(), Bitmap.Config.ARGB_8888);
+                    drawView.getHeight(), Bitmap.Config.RGB_565);
             Canvas canvas = new Canvas(bitmap);
             drawView.draw(canvas);
             bitmap.compress(Bitmap.CompressFormat.JPEG, 70, fos);
@@ -348,7 +348,7 @@ public class DrawActivity extends Activity {
                 // w, h, true);
                 mCanvas = new Canvas(mBitmap);
             } else {
-                mBitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+                mBitmap = Bitmap.createBitmap(w, h, Bitmap.Config.RGB_565);
                 mCanvas = new Canvas(mBitmap);
                 mCanvas.drawColor(0xFFFFFFFF);
                 if (isSignature) {


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/MOB-18
 CL: https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59caaf6bbe077a4dcc4b084c?time=last-ninety-days 
https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/59fa5c6561b02d480d9b5247?time=last-ninety-days

Problem: We are hitting OOMs frequently for some users on signature questions which is becoming a operational problem for them. 

Optimisation: RGB_565 uses 2 byte per pixel in comparison to 4 bytes per pixel used by ARG_8888. This results in less memory consumption when creating these bitmaps. In terms of quality, I couldn't see any difference from naked eye when comparing the 2 configs. Maybe since we are only using black and white colors it doesn't make much of a difference.