### PR TITLE
Removes unused intent key

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1147,9 +1147,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     private void finishReturnInstance(boolean reportSaved) {
         String action = getIntent().getAction();
         if (Intent.ACTION_PICK.equals(action) || Intent.ACTION_EDIT.equals(action)) {
-            FormRecord formRecord = CommCareApplication.instance().getCurrentSessionWrapper().getFormRecord();
             Intent formReturnIntent = new Intent();
-            formReturnIntent.putExtra(KEY_FORM_RECORD_ID, formRecord.getID());
             formReturnIntent.putExtra(FormEntryConstants.IS_ARCHIVED_FORM, mFormController.isFormReadOnly());
             formReturnIntent.putExtra(KEY_IS_RESTART_AFTER_EXPIRATION,
                     getIntent().getBooleanExtra(KEY_IS_RESTART_AFTER_EXPIRATION, false));


### PR DESCRIPTION
CL: https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5b3f408d6007d59fcdc44901?time=last-ninety-days

We no longer use `KEY_FORM_RECORD_ID` in the calling activity to get the instance of form record but directly utilize the CommCare Session to get us the filled form. 