### PR TITLE
Prevent NPE in `AppUtils.getCurrentAppId`

### DIFF
--- a/app/src/org/commcare/AppUtils.java
+++ b/app/src/org/commcare/AppUtils.java
@@ -165,8 +165,7 @@ public class AppUtils {
 
     public static String getCurrentAppId() {
         return CommCareApplication.instance()
-                .getCommCarePlatform()
-                .getCurrentProfile()
+                .getCurrentApp()
                 .getUniqueId();
     }
 }

--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -18,6 +18,7 @@ import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.DummyResourceTable;
 import org.commcare.xml.ProfileParser;
+import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceManager;
@@ -89,7 +90,7 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
 
             if (!upgrade) {
                 initProperties(p);
-                if(!recovery) {
+                if (!recovery) {
                     checkDuplicate(p);
                     checkAppTarget();
                 }
@@ -161,12 +162,13 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
         if (!super.upgrade(r, platform)) {
             return false;
         }
-
+        InputStream profileStream = null;
         try {
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
 
+            profileStream = local.getStream();
             //Create a parser with no side effects
-            ProfileParser parser = new ProfileParser(local.getStream(), null, new DummyResourceTable(), null, Resource.RESOURCE_STATUS_INSTALLED, false);
+            ProfileParser parser = new ProfileParser(profileStream, null, new DummyResourceTable(), null, Resource.RESOURCE_STATUS_INSTALLED, false);
 
             //Parse just the file (for the properties)
             Profile p = parser.parse();
@@ -177,6 +179,8 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
             e.printStackTrace();
             Logger.log(LogTypes.TYPE_RESOURCES, "Profile not available after upgrade: " + e.getMessage());
             return false;
+        } finally {
+            StreamsUtil.closeStream(profileStream);
         }
 
         return true;

--- a/app/src/org/commcare/heartbeat/HeartbeatRequester.java
+++ b/app/src/org/commcare/heartbeat/HeartbeatRequester.java
@@ -65,6 +65,8 @@ public class HeartbeatRequester {
             } catch (IOException e) {
                 Logger.log(LogTypes.TYPE_ERROR_SERVER_COMMS,
                         "IO error while processing heartbeat response: " + e.getMessage());
+            } finally {
+                StreamsUtil.closeStream(responseData);
             }
         }
 

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -21,6 +21,7 @@ import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.GlobalConstants;
+import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.model.instance.TreeElement;
@@ -294,13 +295,14 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Integer, String, Fo
      * Read serialized {@link FormDef} from file and recreate as object.
      */
     private static FormDef deserializeFormDef(Context context, File formDefFile) {
-        FileInputStream fis;
+        FileInputStream fis = null;
+        DataInputStream dis = null;
         FormDef fd;
         try {
             // create new form def
             fd = new FormDef(DeveloperPreferences.useExpressionCachingInForms());
             fis = new FileInputStream(formDefFile);
-            DataInputStream dis = new DataInputStream(new BufferedInputStream(fis));
+            dis = new DataInputStream(new BufferedInputStream(fis));
 
             // read serialized formdef into new formdef
             fd.readExternal(dis, CommCareApplication.instance().getPrototypeFactory(context));
@@ -308,6 +310,9 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Integer, String, Fo
         } catch (Throwable e) {
             e.printStackTrace();
             fd = null;
+        } finally {
+            StreamsUtil.closeStream(fis);
+            StreamsUtil.closeStream(dis);
         }
 
         return fd;

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -306,7 +306,6 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Integer, String, Fo
 
             // read serialized formdef into new formdef
             fd.readExternal(dis, CommCareApplication.instance().getPrototypeFactory(context));
-            dis.close();
         } catch (Throwable e) {
             e.printStackTrace();
             fd = null;


### PR DESCRIPTION
CL: https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5a3693468cb3c2fa631628df?time=last-ninety-days

Verified from sumo logs that profile being null seems to be a direct result of storage corrupt / app files missing issue. `Profile` doesn't get set when app state is corrupt and calling `AppUtils.getCurrentAppId` in those cases results in a NPE. A better approach is to utilize `ApplicationRecord` to get the app id since it's always set when user logins. 
