### PR TITLE
Session expiration crash fixes

### DIFF
--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
 import org.commcare.google.services.analytics.AnalyticsParamValue;
@@ -99,7 +100,12 @@ public class StandardHomeActivity
             return;
         }
         CommCareApplication.notificationManager().clearNotifications(AIRPLANE_MODE_CATEGORY);
-        sendFormsOrSync(true);
+
+        try {
+            sendFormsOrSync(true);
+        } catch (SessionUnavailableException e) {
+            // do nothing
+        }
     }
 
     @Override
@@ -245,5 +251,5 @@ public class StandardHomeActivity
     public void refreshUI() {
         uiController.refreshView();
     }
-    
+
 }

--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -18,6 +18,7 @@ import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.DummyResourceTable;
 import org.commcare.xml.ProfileParser;
+import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceManager;
@@ -89,7 +90,7 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
 
             if (!upgrade) {
                 initProperties(p);
-                if(!recovery) {
+                if (!recovery) {
                     checkDuplicate(p);
                     checkAppTarget();
                 }
@@ -161,12 +162,13 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
         if (!super.upgrade(r, platform)) {
             return false;
         }
-
+        InputStream profileStream = null;
         try {
             Reference local = ReferenceManager.instance().DeriveReference(localLocation);
 
+            profileStream = local.getStream();
             //Create a parser with no side effects
-            ProfileParser parser = new ProfileParser(local.getStream(), null, new DummyResourceTable(), null, Resource.RESOURCE_STATUS_INSTALLED, false);
+            ProfileParser parser = new ProfileParser(profileStream, null, new DummyResourceTable(), null, Resource.RESOURCE_STATUS_INSTALLED, false);
 
             //Parse just the file (for the properties)
             Profile p = parser.parse();
@@ -177,6 +179,8 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
             e.printStackTrace();
             Logger.log(LogTypes.TYPE_RESOURCES, "Profile not available after upgrade: " + e.getMessage());
             return false;
+        } finally {
+            StreamsUtil.closeStream(profileStream);
         }
 
         return true;

--- a/app/src/org/commcare/heartbeat/HeartbeatRequester.java
+++ b/app/src/org/commcare/heartbeat/HeartbeatRequester.java
@@ -65,6 +65,8 @@ public class HeartbeatRequester {
             } catch (IOException e) {
                 Logger.log(LogTypes.TYPE_ERROR_SERVER_COMMS,
                         "IO error while processing heartbeat response: " + e.getMessage());
+            } finally {
+                StreamsUtil.closeStream(responseData);
             }
         }
 

--- a/app/src/org/commcare/tasks/EntityLoaderTask.java
+++ b/app/src/org/commcare/tasks/EntityLoaderTask.java
@@ -12,6 +12,7 @@ import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.suite.model.Detail;
 import org.commcare.tasks.templates.ManagedAsyncTask;
 import org.commcare.util.LogTypes;
+import org.commcare.utils.SessionUnavailableException;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.Logger;
@@ -77,6 +78,9 @@ public class EntityLoaderTask
             xe.printStackTrace();
             Logger.exception("Error during EntityLoaderTask: " + ForceCloseLogger.getStackTrace(xe), xe);
             mException = xe;
+            return null;
+        } catch (SessionUnavailableException e) {
+            mException = e;
             return null;
         }
     }

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -21,6 +21,7 @@ import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.GlobalConstants;
+import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.model.instance.TreeElement;
@@ -294,13 +295,14 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Integer, String, Fo
      * Read serialized {@link FormDef} from file and recreate as object.
      */
     private static FormDef deserializeFormDef(Context context, File formDefFile) {
-        FileInputStream fis;
+        FileInputStream fis = null;
+        DataInputStream dis = null;
         FormDef fd;
         try {
             // create new form def
             fd = new FormDef(DeveloperPreferences.useExpressionCachingInForms());
             fis = new FileInputStream(formDefFile);
-            DataInputStream dis = new DataInputStream(new BufferedInputStream(fis));
+            dis = new DataInputStream(new BufferedInputStream(fis));
 
             // read serialized formdef into new formdef
             fd.readExternal(dis, CommCareApplication.instance().getPrototypeFactory(context));
@@ -308,6 +310,9 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Integer, String, Fo
         } catch (Throwable e) {
             e.printStackTrace();
             fd = null;
+        } finally {
+            StreamsUtil.closeStream(fis);
+            StreamsUtil.closeStream(dis);
         }
 
         return fd;

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -306,7 +306,6 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Integer, String, Fo
 
             // read serialized formdef into new formdef
             fd.readExternal(dis, CommCareApplication.instance().getPrototypeFactory(context));
-            dis.close();
         } catch (Throwable e) {
             e.printStackTrace();
             fd = null;

--- a/app/src/org/commcare/tasks/PurgeStaleArchivedFormsTask.java
+++ b/app/src/org/commcare/tasks/PurgeStaleArchivedFormsTask.java
@@ -5,6 +5,7 @@ import org.commcare.CommCareApplication;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.util.LogTypes;
+import org.commcare.utils.SessionUnavailableException;
 import org.javarosa.core.services.Logger;
 import org.joda.time.DateTime;
 
@@ -54,8 +55,11 @@ public class PurgeStaleArchivedFormsTask
     @Override
     protected Void doInBackground(Void... params) {
         CommCareApp app = CommCareApplication.instance().getCurrentApp();
-
-        performArchivedFormPurge(app);
+        try {
+            performArchivedFormPurge(app);
+        } catch (SessionUnavailableException e) {
+            // do nothing
+        }
         return null;
     }
 


### PR DESCRIPTION
CL: 
[1](https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5a8e74bc8cb3c2fa63919665?time=last-ninety-days) , [2](https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5b35f0126007d59fcd255e73?time=last-ninety-days), [3](https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5a38128c8cb3c2fa632ab59f?time=last-ninety-days)

Better to catch these then crashing the app. This should ideally be a checked expression so that all code paths are required to handle this. 