### PR TITLE
Target Oreo (Android 8.1)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,11 +52,11 @@ dependencies {
     implementation(name: 'android-zebra-interface-1.1', ext: 'aar')
     implementation 'com.simprints:LibSimprints:1.0.10'
     implementation 'com.android.support:multidex:1.0.3'
-    implementation 'com.android.support:cardview-v7:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.android.support:preference-v7:27.1.1'
-    implementation 'com.android.support:gridlayout-v7:27.1.1'
+    implementation 'com.android.support:cardview-v7:28.0.0'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:preference-v7:28.0.0'
+    implementation 'com.android.support:gridlayout-v7:28.0.0'
     implementation 'com.madgag.spongycastle:core:1.54.0.0'
     implementation 'com.madgag.spongycastle:prov:1.54.0.0'
     implementation 'com.google.android.gms:play-services-maps:15.0.1'
@@ -200,7 +200,7 @@ def getDate() {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
 
     lintOptions {
         abortOnError false
@@ -223,7 +223,7 @@ android {
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 27
         multiDexEnabled true
         applicationId "org.commcare.dalvik"
         project.ext.COMMCARE_APP_ID = applicationId

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -380,5 +380,11 @@
     <string name="recovery_forms_state_unavailable">Forms are not available. Make sure your phone storage is available</string>
     <string name="recovery_network_unavailable">No network connection. Please check your internet and try again.</string>
     <string name="recovery_app_manager">Go to App Manager</string>
+    <string name="notification_channel_errors_title">Errors</string>
+    <string name="notification_channel_errors_description">Notifications for error messages when something breaks say on installing a CommCare app or while syncing forms with server</string>
+    <string name="notification_channel_user_session_title">User Session</string>
+    <string name="notification_channel_user_session_description">Notification containing information around current user session like when the current session is scheduled to expire</string>
+    <string name="notification_channel_server_communication_title">Server Communications</string>
+    <string name="notification_channel_server_communication_description">Notifications for status of any background server communication happening at the moment like CommCare App updates, log submission etc.</string>
 
 </resources>

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -186,7 +186,7 @@ public class CommCareApplication extends MultiDexApplication {
         CommCarePreferenceManagerFactory.init(new AndroidPreferenceManager());
 
         configureCommCareEngineConstantsAndStaticRegistrations();
-        noficationManager = new CommCareNoficationManager(this);
+        initNotifications();
 
         //TODO: Make this robust
         PreInitLogger pil = new PreInitLogger();
@@ -219,6 +219,14 @@ public class CommCareApplication extends MultiDexApplication {
         if (dbState != STATE_MIGRATION_FAILED && dbState != STATE_MIGRATION_QUESTIONABLE) {
             AppUtils.checkForIncompletelyUninstalledApps();
             initializeAnAppOnStartup();
+        }
+    }
+
+    private void initNotifications() {
+        noficationManager = new CommCareNoficationManager(this);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            noficationManager.createNotificationChannels();
         }
     }
 

--- a/app/src/org/commcare/CommCareNoficationManager.java
+++ b/app/src/org/commcare/CommCareNoficationManager.java
@@ -1,16 +1,18 @@
 package org.commcare;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Message;
 import android.support.v4.app.NotificationCompat;
 
-import org.commcare.activities.LoginActivity;
 import org.commcare.activities.MessageActivity;
 import org.commcare.dalvik.R;
 import org.commcare.utils.PopupHandler;
@@ -30,6 +32,10 @@ public class CommCareNoficationManager {
     private static final String ACTION_PURGE_NOTIFICATIONS = "CommCareApplication_purge";
     private final ArrayList<NotificationMessage> pendingMessages = new ArrayList<>();
     public static final int MESSAGE_NOTIFICATION = R.string.notification_message_title;
+
+    public static final String NOTIFICATION_CHANNEL_ERRORS_ID = "notification-channel-errors";
+    public static final String NOTIFICATION_CHANNEL_USER_SESSION_ID = "notification-channel-user-session";
+    public static final String NOTIFICATION_CHANNEL_SERVER_COMMUNICATIONS_ID = "notification-channel-server-communications";
 
     /**
      * Handler to receive notifications and show them the user using toast.
@@ -60,7 +66,7 @@ public class CommCareNoficationManager {
 
             String additional = pendingMessages.size() > 1 ? Localization.get("notifications.prompt.more", new String[]{String.valueOf(pendingMessages.size() - 1)}) : "";
 
-            Notification messageNotification = new NotificationCompat.Builder(context)
+            Notification messageNotification = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ERRORS_ID)
                     .setContentTitle(title)
                     .setContentText(Localization.get("notifications.prompt.details", new String[]{additional}))
                     .setSmallIcon(R.drawable.notification)
@@ -76,24 +82,24 @@ public class CommCareNoficationManager {
     }
 
     public void clearNotifications(String category) {
-            synchronized (pendingMessages) {
-                NotificationManager mNM = (NotificationManager)context.getSystemService(NOTIFICATION_SERVICE);
-                Vector<NotificationMessage> toRemove = new Vector<>();
-                for (NotificationMessage message : pendingMessages) {
-                    if (category == null || category.equals(message.getCategory())) {
-                        toRemove.add(message);
-                    }
-                }
-
-                for (NotificationMessage message : toRemove) {
-                    pendingMessages.remove(message);
-                }
-                if (pendingMessages.size() == 0) {
-                    mNM.cancel(MESSAGE_NOTIFICATION);
-                } else {
-                    updateMessageNotification();
+        synchronized (pendingMessages) {
+            NotificationManager mNM = (NotificationManager)context.getSystemService(NOTIFICATION_SERVICE);
+            Vector<NotificationMessage> toRemove = new Vector<>();
+            for (NotificationMessage message : pendingMessages) {
+                if (category == null || category.equals(message.getCategory())) {
+                    toRemove.add(message);
                 }
             }
+
+            for (NotificationMessage message : toRemove) {
+                pendingMessages.remove(message);
+            }
+            if (pendingMessages.size() == 0) {
+                mNM.cancel(MESSAGE_NOTIFICATION);
+            } else {
+                updateMessageNotification();
+            }
+        }
     }
 
     public ArrayList<NotificationMessage> purgeNotifications() {
@@ -148,5 +154,31 @@ public class CommCareNoficationManager {
         synchronized (pendingMessages) {
             return pendingMessages.size() > 0;
         }
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    public void createNotificationChannels() {
+        createNotificationChannel(NOTIFICATION_CHANNEL_ERRORS_ID,
+                R.string.notification_channel_errors_title,
+                R.string.notification_channel_errors_description,
+                NotificationManager.IMPORTANCE_DEFAULT);
+
+        createNotificationChannel(NOTIFICATION_CHANNEL_USER_SESSION_ID,
+                R.string.notification_channel_user_session_title,
+                R.string.notification_channel_user_session_description,
+                NotificationManager.IMPORTANCE_LOW);
+
+        createNotificationChannel(NOTIFICATION_CHANNEL_SERVER_COMMUNICATIONS_ID,
+                R.string.notification_channel_server_communication_title,
+                R.string.notification_channel_server_communication_description,
+                NotificationManager.IMPORTANCE_DEFAULT);
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    private void createNotificationChannel(String channelId, int titleResource, int descriptionResource, int priority) {
+        NotificationChannel channel = new NotificationChannel(channelId, context.getString(titleResource), priority);
+        channel.setDescription(context.getString(descriptionResource));
+        NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+        notificationManager.createNotificationChannel(channel);
     }
 }

--- a/app/src/org/commcare/provider/DebugControlsReceiver.java
+++ b/app/src/org/commcare/provider/DebugControlsReceiver.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 
+import org.apache.commons.lang3.StringUtils;
 import org.commcare.AppUtils;
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
@@ -35,20 +36,22 @@ public class DebugControlsReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         String action = intent.getAction();
-        if (action.endsWith("SessionCaptureAction")) {
-            captureSession();
-        } else if (action.endsWith("UninstallApp")) {
-            uninstallApp(intent.getStringExtra("app_id"));
-        } else if (action.endsWith("LoginWithCreds")) {
-            login(context, intent.getStringExtra("username"), intent.getStringExtra("password"));
-        } else if (action.endsWith("TriggerSyncRecover")) {
-            storeFakeCaseDbHash();
-        } else if (action.endsWith("ExpireUserKeyRecord")) {
-            invalidateUserKeyRecord(intent.getStringExtra("username"));
-        } else if (action.endsWith("ClearCacheOnRestore")) {
-            CommCareApplication.instance().setInvalidateCacheFlag(true);
-        } else if (action.endsWith("SetImageWidgetPath")) {
-            ImageCaptureProcessing.setCustomImagePath(intent.getStringExtra("file_path"));
+        if (!StringUtils.isEmpty(action)) {
+            if (action.endsWith("SessionCaptureAction")) {
+                captureSession();
+            } else if (action.endsWith("UninstallApp")) {
+                uninstallApp(intent.getStringExtra("app_id"));
+            } else if (action.endsWith("LoginWithCreds")) {
+                login(context, intent.getStringExtra("username"), intent.getStringExtra("password"));
+            } else if (action.endsWith("TriggerSyncRecover")) {
+                storeFakeCaseDbHash();
+            } else if (action.endsWith("ExpireUserKeyRecord")) {
+                invalidateUserKeyRecord(intent.getStringExtra("username"));
+            } else if (action.endsWith("ClearCacheOnRestore")) {
+                CommCareApplication.instance().setInvalidateCacheFlag(true);
+            } else if (action.endsWith("SetImageWidgetPath")) {
+                ImageCaptureProcessing.setCustomImagePath(intent.getStringExtra("file_path"));
+            }
         }
     }
 

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -17,6 +17,7 @@ import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.AppUtils;
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareNoficationManager;
 import org.commcare.activities.DispatchActivity;
 import org.commcare.activities.UITestInfoActivity;
 import org.commcare.android.database.app.models.UserKeyRecord;
@@ -214,7 +215,7 @@ public class CommCareSessionService extends Service {
         }
 
         // Set the icon, scrolling text and timestamp
-        Notification notification = new NotificationCompat.Builder(this)
+        Notification notification = new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_ERRORS_ID)
                 .setContentTitle(notificationText)
                 .setContentText("Session Expires: " + DateFormat.format("MMM dd h:mmaa", sessionExpireDate))
                 .setSmallIcon(org.commcare.dalvik.R.drawable.notification)
@@ -237,7 +238,7 @@ public class CommCareSessionService extends Service {
         i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         PendingIntent contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        Notification notification = new NotificationCompat.Builder(this)
+        Notification notification = new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_USER_SESSION_ID)
                 .setContentTitle(this.getString(R.string.expirenotification))
                 .setContentText("Click here to log back into your session")
                 .setSmallIcon(org.commcare.dalvik.R.drawable.notification)
@@ -507,7 +508,8 @@ public class CommCareSessionService extends Service {
                 //TODO: Put something here that will, I dunno, cancel submission or something? Maybe show it live? 
                 PendingIntent contentIntent = PendingIntent.getActivity(CommCareSessionService.this, 0, callable, 0);
 
-                submissionNotification = new NotificationCompat.Builder(CommCareSessionService.this)
+                submissionNotification = new NotificationCompat.Builder(CommCareSessionService.this,
+                        CommCareNoficationManager.NOTIFICATION_CHANNEL_SERVER_COMMUNICATIONS_ID)
                         .setContentTitle(getString(notificationId))
                         .setContentInfo(getSubmittedFormCount(1, totalItems))
                         .setContentText("0b transmitted")

--- a/app/src/org/commcare/views/dialogs/PinnedNotificationWithProgress.java
+++ b/app/src/org/commcare/views/dialogs/PinnedNotificationWithProgress.java
@@ -8,6 +8,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.support.v4.app.NotificationCompat;
 
+import org.commcare.CommCareNoficationManager;
 import org.commcare.activities.UpdateActivity;
 import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.tasks.ResultAndError;
@@ -41,7 +42,7 @@ public class PinnedNotificationWithProgress
         Bitmap largeIcon =
                 BitmapFactory.decodeResource(ctx.getResources(), largeIconResource);
 
-        notificationBuilder = new NotificationCompat.Builder(ctx)
+        notificationBuilder = new NotificationCompat.Builder(ctx, CommCareNoficationManager.NOTIFICATION_CHANNEL_SERVER_COMMUNICATIONS_ID)
                 .setContentText(getProgressText(0, 0))
                 .setContentTitle(Localization.get(titleText))
                 .setProgress(100, 0, false)

--- a/scripts/ccc
+++ b/scripts/ccc
@@ -31,7 +31,7 @@ HELP_MSG = """'capture' saves the current session for restoring later.
 """
 BASE_RECEIVER_CMD = "adb shell am broadcast -a"
 BASE_ACTIVITY_CMD = "adb shell am start -n"
-PACKAGE_NAME = "org.commcare.dalvik.debug"
+PACKAGE_NAME = "org.commcare.dalvik"
 DEBUG_CONTROL_RECEIVER = "org.commcare.provider.DebugControlsReceiver"
 
 

--- a/scripts/ccc
+++ b/scripts/ccc
@@ -31,6 +31,8 @@ HELP_MSG = """'capture' saves the current session for restoring later.
 """
 BASE_RECEIVER_CMD = "adb shell am broadcast -a"
 BASE_ACTIVITY_CMD = "adb shell am start -n"
+PACKAGE_NAME = "org.commcare.dalvik.debug"
+DEBUG_CONTROL_RECEIVER = "org.commcare.provider.DebugControlsReceiver"
 
 
 # String -> None
@@ -64,7 +66,7 @@ def update():
     """
     extras = {"useLatestBuild": True}
     cmd = receiver_command("org.commcare.dalvik.api.action." +
-                           "RefreshToLatestBuildAction", extras)
+                           "RefreshToLatestBuildAction", extras, "org.commcare.provider.RefreshToLatestBuildReceiver")
     print(cmd)
     subprocess.call(cmd, shell=True)
 
@@ -105,12 +107,14 @@ def capture():
     subprocess.call(cmd, shell=True)
 
 
-def receiver_command(action, extras={}):
+def receiver_command(action, extras={}, receiverName=DEBUG_CONTROL_RECEIVER):
     """
     Build an ADB broadcast command.
     """
     cmd = "{} {}".format(BASE_RECEIVER_CMD, action)
-    return cmd + get_extras_string(extras)
+    cmd += get_extras_string(extras)
+    cmd += " -n {}/{}".format(PACKAGE_NAME, receiverName)
+    return cmd
 
 
 # String String String Boolean -> None


### PR DESCRIPTION
* Creates 3 Notifications Channels  - Errors, Server Communications, User Session and assigns notifications to one of these channels. 
* Update `ccc` broadcasts to use receiver names

Product Note: Add Support for Android Oreo