### PR TITLE
Disable the finish button after first click

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -713,6 +713,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             }
             return;
         }
+
         // save current answer; if headless, don't evaluate the constraints
         // before doing so.
         boolean wasScreenSaved =
@@ -724,6 +725,11 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         // If a save task is already running, just let it do its thing
         if ((mSaveToDiskTask != null) &&
                 (mSaveToDiskTask.getStatus() != AsyncTask.Status.FINISHED)) {
+            return;
+        }
+
+        // A form save has already been triggered, ignore subsequent form saves
+        if (FormEntryActivity.mFormController.isFormSaveTriggered()) {
             return;
         }
 
@@ -988,6 +994,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
      * Call when the user is ready to save and return the current form as complete
      */
     protected void triggerUserFormComplete() {
+
         if (mFormController.isFormReadOnly()) {
             finishReturnInstance(false);
         } else {

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -81,7 +81,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.trace.EvaluationTraceReporter;
 import org.javarosa.core.model.trace.ReducingTraceReporter;
-import org.javarosa.core.model.utils.InstrumentationUtils;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryController;
@@ -729,7 +728,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
 
         // A form save has already been triggered, ignore subsequent form saves
-        if (FormEntryActivity.mFormController.isFormSaveTriggered()) {
+        if (FormEntryActivity.mFormController.isFormSaveComplete()) {
             return;
         }
 

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -122,7 +122,6 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         });
 
         finishButton.setOnClickListener(v -> {
-            finishButton.setEnabled(false);
             FirebaseAnalyticsUtil.reportFormNav(
                     AnalyticsParamValue.DIRECTION_FORWARD,
                     AnalyticsParamValue.NAV_BUTTON_PRESS);

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -122,6 +122,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         });
 
         finishButton.setOnClickListener(v -> {
+            finishButton.setEnabled(false);
             FirebaseAnalyticsUtil.reportFormNav(
                     AnalyticsParamValue.DIRECTION_FORWARD,
                     AnalyticsParamValue.NAV_BUTTON_PRESS);

--- a/app/src/org/commcare/logic/AndroidFormController.java
+++ b/app/src/org/commcare/logic/AndroidFormController.java
@@ -16,6 +16,7 @@ public class AndroidFormController extends FormController implements PendingCall
     private FormIndex mPendingCalloutFormIndex = null;
     private boolean wasPendingCalloutCancelled;
     private FormIndex formIndexToReturnTo = null;
+    private boolean formSaveTriggered = false;
 
     public AndroidFormController(FormEntryController fec, boolean readOnly) {
         super(fec, readOnly);
@@ -63,4 +64,11 @@ public class AndroidFormController extends FormController implements PendingCall
         this.formIndexToReturnTo = null;
     }
 
+    public boolean isFormSaveTriggered() {
+        return formSaveTriggered;
+    }
+
+    public void setFormSaveTriggered(boolean formSaveTriggered) {
+        this.formSaveTriggered = formSaveTriggered;
+    }
 }

--- a/app/src/org/commcare/logic/AndroidFormController.java
+++ b/app/src/org/commcare/logic/AndroidFormController.java
@@ -16,7 +16,7 @@ public class AndroidFormController extends FormController implements PendingCall
     private FormIndex mPendingCalloutFormIndex = null;
     private boolean wasPendingCalloutCancelled;
     private FormIndex formIndexToReturnTo = null;
-    private boolean formSaveTriggered = false;
+    private boolean formSaveComplete = false;
 
     public AndroidFormController(FormEntryController fec, boolean readOnly) {
         super(fec, readOnly);
@@ -64,11 +64,11 @@ public class AndroidFormController extends FormController implements PendingCall
         this.formIndexToReturnTo = null;
     }
 
-    public boolean isFormSaveTriggered() {
-        return formSaveTriggered;
+    public boolean isFormSaveComplete() {
+        return formSaveComplete;
     }
 
-    public void setFormSaveTriggered(boolean formSaveTriggered) {
-        this.formSaveTriggered = formSaveTriggered;
+    public void markFormSaveProcessComplete(boolean formSaveComplete) {
+        this.formSaveComplete = formSaveComplete;
     }
 }

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -97,7 +97,6 @@ public class SaveToDiskTask extends
             return new ResultAndError<>(SaveStatus.SAVE_ERROR, cleanedMessage);
         }
 
-        FormEntryActivity.mFormController.setFormSaveTriggered(true);
         FormEntryActivity.mFormController.postProcessInstance();
 
         try {
@@ -124,6 +123,7 @@ public class SaveToDiskTask extends
             return new ResultAndError<>(SaveStatus.SAVE_ERROR, cleanedMessage);
         }
 
+        FormEntryActivity.mFormController.markFormSaveProcessComplete(true);
         if (exitAfterSave) {
             FormRecord saved = CommCareApplication.instance().getCurrentSessionWrapper().getFormRecord();
             Logger.log(LogTypes.TYPE_FORM_ENTRY,

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -94,10 +94,10 @@ public class SaveToDiskTask extends
         } catch (XPathException xpe) {
             String cleanedMessage = "An error in your form prevented it from saving: \n" +
                     xpe.getMessage();
-
             return new ResultAndError<>(SaveStatus.SAVE_ERROR, cleanedMessage);
         }
 
+        FormEntryActivity.mFormController.setFormSaveTriggered(true);
         FormEntryActivity.mFormController.postProcessInstance();
 
         try {
@@ -216,7 +216,7 @@ public class SaveToDiskTask extends
             if (!instanceXml.delete()) {
                 Log.e(TAG,
                         "Error deleting " + instanceXml.getAbsolutePath()
-                        + " prior to renaming submission.xml");
+                                + " prior to renaming submission.xml");
                 return;
             }
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/projects/MOB/issues/MOB-38

There are 3 forms across 3 different users for which users were getting an error like - 
`Error during task execution: XML Syntax Error at Line: 1, Column: 251!]` on opening these forms from Saved Forms and these forms were also causing syncs to fail as well with 500 response code. 

Itnerpreting logs, there exists a loose pattern with all these 3 forms. For two users, Form Entry successfully completes for the respective forms but soon after (~2 mins) we get an error arising from form save code stack. The exact error being - 

`Error during task execution: Attempt to invoke virtual method 'void org.commcare.android.database.user.models.FormRecord.setFilePath(java.lang.String)' on a null object reference]`

This suggests that the saveTask got triggered twice one after the other and the second one failed since we had already wiped the formRecord from session as a result of successful completion of first instance. 

For another user, form entry again completes successfully but soon after (~20 secs) there is another log for successful form entry completion again suggesting that the save task got triggered twice and both of them succedded.

I am not exactly sure how duplicate instances of saveTask are corrupting the form and causing the 'XML Syntax Error' when user tries to open that form through Saved forms. 

After doing some testing the only reason that I can see SaveTask would have got triggered twice is user pressing the Finish button again at the same time when first task finishes. Since we don't disable the finish button after user presses it first time there is a small timeframe when user has the opportunity to click the finish button again at the same time when the Save Form dialog finishes. I was able to repro this and create another instane of Save Form Task which always fails for me wih the same NPE on `FormRecord.setFilePath` . 

Though I was not able to the repro the xml error arising because of this behaviour , think that it's arising as some consequence of duplication of save task. 