### PR TITLE
Refactors ModernHttpTask to handle response stream

### DIFF
--- a/app/src/org/commcare/tasks/ModernHttpTask.java
+++ b/app/src/org/commcare/tasks/ModernHttpTask.java
@@ -17,6 +17,8 @@ import java.util.HashMap;
 import javax.annotation.Nullable;
 
 import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.Response;
 
 /**
  * Makes get/post request and delegates http response to receiver on completion
@@ -25,14 +27,14 @@ import okhttp3.RequestBody;
  */
 public class ModernHttpTask
         extends CommCareTask<Void, Void, Void, HttpResponseProcessor>
-        implements HttpResponseProcessor, ResponseStreamAccessor {
+        implements ResponseStreamAccessor {
 
     public static final int SIMPLE_HTTP_TASK_ID = 11;
 
     private final ModernHttpRequester requester;
-    private int responseCode;
     private InputStream responseDataStream;
-    private IOException exception;
+    private IOException mException;
+    private Response<ResponseBody> mResponse;
 
     // Use for GET request
     public ModernHttpTask(Context context, String url, HashMap<String, String> params,
@@ -56,69 +58,51 @@ public class ModernHttpTask
                 null,
                 method,
                 usernameAndPasswordToAuthWith,
-                this);
+                null);
     }
 
     @Override
     protected Void doTaskBackground(Void... params) {
-        requester.makeRequestAndProcess();
+        try {
+            mResponse = requester.makeRequest();
+        } catch (IOException e) {
+            mException = e;
+        }
         return null;
     }
 
     @Override
     protected void deliverResult(HttpResponseProcessor httpResponseProcessor,
                                  Void result) {
-        if (exception != null) {
-            httpResponseProcessor.handleIOException(exception);
+
+        if (mException != null) {
+            httpResponseProcessor.handleIOException(mException);
         } else {
             // route to appropriate callback based on http response code
-            ModernHttpRequester.processResponse(
-                    httpResponseProcessor,
-                    responseCode,
-                    this);
+            try {
+                responseDataStream = requester.getResponseStream(mResponse);
+                ModernHttpRequester.processResponse(
+                        httpResponseProcessor,
+                        mResponse.code(),
+                        this);
+            } catch (IOException e) {
+                httpResponseProcessor.handleIOException(e);
+            }
         }
     }
 
     @Override
     protected void deliverUpdate(HttpResponseProcessor httpResponseProcessor,
                                  Void... update) {
-
     }
 
     @Override
     protected void deliverError(HttpResponseProcessor httpResponseProcessor,
                                 Exception e) {
-
     }
 
     @Override
-    public void processSuccess(int responseCode, InputStream responseData) {
-        this.responseCode = responseCode;
-        responseDataStream = responseData;
-    }
-
-    @Override
-    public void processClientError(int responseCode) {
-        this.responseCode = responseCode;
-    }
-
-    @Override
-    public void processServerError(int responseCode) {
-        this.responseCode = responseCode;
-    }
-
-    @Override
-    public void processOther(int responseCode) {
-        this.responseCode = responseCode;
-    }
-
-    @Override
-    public void handleIOException(IOException exception) {
-        this.exception = exception;
-    }
-
-    @Override
-    public InputStream getResponseStream() throws IOException {
+    public InputStream getResponseStream() {
         return responseDataStream;
     }
 }


### PR DESCRIPTION
https://github.com/dimagi/commcare-android/pull/2038 introduced a bug caused by ModernHttpTask operating on a closed stream. This happened because `ModernHttpTask` was trying to read from the stream in `deliverResult` after the stream got processed and closed in `doTaskBackground` . This PR refactors the `ModernHttpTask` to not process the response in `doTaskBackground` but only in `deliverResult`. 

cross-request: https://github.com/dimagi/commcare-core/pull/827