### PR TITLE
Don't allow Required DateWidget to be skipped without user changing them

### DIFF
--- a/app/src/org/commcare/views/widgets/DateWidget.java
+++ b/app/src/org/commcare/views/widgets/DateWidget.java
@@ -33,10 +33,13 @@ public class DateWidget extends QuestionWidget {
 
     private final DatePicker mDatePicker;
     private final DatePicker.OnDateChangedListener mDateListener;
+    private boolean isFilled = false;
 
     @SuppressLint("NewApi")
     public DateWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
+
+        resetIsFilled();
 
         mDatePicker = buildDatePicker(!prompt.isReadOnly());
         mDateListener = buildDateListener();
@@ -79,6 +82,7 @@ public class DateWidget extends QuestionWidget {
                 }
             }
 
+            isFilled = true;
             widgetEntryChangedDelayed();
         };
     }
@@ -103,6 +107,7 @@ public class DateWidget extends QuestionWidget {
 
             mDatePicker.init(adjustedDate.getYear(), adjustedDate.getMonthOfYear() - 1, adjustedDate.getDayOfMonth(),
                     mDateListener);
+            isFilled = true;
         } else {
             // create date widget with current time as of right now
             clearAnswer();
@@ -117,15 +122,28 @@ public class DateWidget extends QuestionWidget {
         DateTime ldt = new DateTime();
         mDatePicker.init(ldt.getYear(), ldt.getMonthOfYear() - 1, ldt.getDayOfMonth(),
                 mDateListener);
+        resetIsFilled();
+    }
+
+    private void resetIsFilled() {
+        // if it's not editable, assume it to be filled.
+        if (mPrompt.isReadOnly()) {
+            isFilled = true;
+        } else {
+            isFilled = false;
+        }
     }
 
     @Override
     public IAnswerData getAnswer() {
-        mDatePicker.clearFocus();
+        if (isFilled) {
+            mDatePicker.clearFocus();
 
-        LocalDate ldt = new LocalDate(mDatePicker.getYear(), mDatePicker.getMonth() + 1,
-                mDatePicker.getDayOfMonth());
-        return new DateData(ldt.toDate());
+            LocalDate ldt = new LocalDate(mDatePicker.getYear(), mDatePicker.getMonth() + 1,
+                    mDatePicker.getDayOfMonth());
+            return new DateData(ldt.toDate());
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/MOB-41

It's steming from the above issue but fixes a rather important anamoly where we were allowing users to skip a date question without them changing them. 

Product Note: Bug Fix: Not allows users to skip a required date question.  