### PR TITLE
Better Error messaging for Update 

### DIFF
--- a/app/assets/locales/android_startup_strings.txt
+++ b/app/assets/locales/android_startup_strings.txt
@@ -30,9 +30,13 @@ updates.resources.profile=Locating application...
 archive.install.prompt=Install your CommCare application from a .ccz file
 archive.install.button=Install App
 
-install.version.mismatch=The application requires CommCare version ${0}. You are running ${1}.
-install.major.mismatch=Please uninstall your CommCare Application from the phone Settings Menu, navigate to the marketplace, and install the proper version.
-install.minor.mismatch=Please update your version of CommCare from the Android Market to run this application.
+install.version.mismatch=The application requires CommCare version ${0}. You are currently running ${1}.
+install.major.mismatch=Please uninstall your CommCare Application from the phone Settings Menu, navigate to the Google Playstore, and install CommCare again.
+install.minor.mismatch=Please update CommCare from the Google Playstore to run this application.
+
+update.version.mismatch=This application update requires CommCare version ${0}. You are currently running ${1}.
+update.major.mismatch=Please uninstall your CommCare Application from the phone Settings Menu, navigate to the Google Playstore, and install CommCare again.
+update.minor.mismatch=Please update CommCare from the Google Playstore to update this application.
 
 # App manager strings
 app.manager.advanced.settings.title=App Manager > Advanced Settings

--- a/app/src/org/commcare/tasks/UpdateTask.java
+++ b/app/src/org/commcare/tasks/UpdateTask.java
@@ -22,6 +22,7 @@ import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.views.dialogs.PinnedNotificationWithProgress;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.locale.Localization;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 
 import java.util.Vector;
@@ -121,7 +122,19 @@ public class UpdateTask
         } catch (UnfullfilledRequirementsException e) {
             ResourceInstallUtils.logInstallError(e,
                     "App resources are incompatible with this device|");
-            return new ResultAndError<>(AppInstallStatus.IncompatibleReqs, e.getMessage());
+            String error;
+            if (e.isVersionMismatchException()) {
+                error = Localization.get("update.version.mismatch", new String[]{e.getRequiredVersionString(), e.getAvailableVesionString()});
+                error += " ";
+                if (e.getRequirementType() == UnfullfilledRequirementsException.RequirementType.MAJOR_APP_VERSION) {
+                    error += Localization.get("update.major.mismatch");
+                } else if (e.getRequirementType() == UnfullfilledRequirementsException.RequirementType.MINOR_APP_VERSION) {
+                    error += Localization.get("update.minor.mismatch");
+                }
+            } else {
+                error = e.getMessage();
+            }
+            return new ResultAndError<>(AppInstallStatus.IncompatibleReqs, error);
         } catch (UnresolvedResourceException e) {
             return new ResultAndError<>(ResourceInstallUtils.processUnresolvedResource(e), e.getMessage());
         } catch (Exception e) {


### PR DESCRIPTION
This came up in ICDS testing that we don't show a good error message when user tries to update to an app version targetting a greater CommCare version than currently installed. 

cross-request: https://github.com/dimagi/commcare-core/pull/828