### PR TITLE
Revert "Update Gradle dependencies for latest AndroidStudio builds"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,6 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 import com.android.builder.core.DefaultManifestParser
 
-import java.util.function.BooleanSupplier
-
 ////////////
 // README //
 ////////////
@@ -349,12 +347,7 @@ android {
             // next to play store version
 
             // grab commcare version from manifest
-            def manifestParser = new DefaultManifestParser(android.sourceSets.main.manifest.srcFile, new BooleanSupplier() {
-                @Override
-                boolean getAsBoolean() {
-                    return true
-                }
-            }, null)
+            def manifestParser = new DefaultManifestParser(android.sourceSets.main.manifest.srcFile)
             def ccVersion = manifestParser.getVersionName()
             // convert numbers to words to use in app id
             def ccVersionSafe = numbersToLetters(ccVersion)

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.51'
+    ext.kotlin_version = '1.2.31'
     repositories {
         mavenCentral()
         jcenter()
@@ -8,9 +8,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.google.gms:google-services:3.2.0'
-        classpath 'io.fabric.tools:gradle:1.25.4'
+        classpath 'io.fabric.tools:gradle:1.24.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Reverts dimagi/commcare-android#2044

- Reverting since Roblectric version we are using breaks with AGP 3.2.+