### PR TITLE
Show Finish button on advancing to end of form

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -418,7 +418,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                             break group_skip;
                         case FormEntryController.EVENT_END_OF_FORM:
                             // auto-advance questions might advance past the last form quesion
-                            activity.triggerUserFormComplete();
+                            refreshCurrentView();
                             break group_skip;
                         case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
                             createRepeatDialog();

--- a/app/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
@@ -3,6 +3,7 @@ package org.commcare.android.tests.formnav;
 import android.content.Intent;
 import android.os.Environment;
 import android.util.Log;
+import android.view.View;
 import android.widget.ImageButton;
 
 import org.commcare.CommCareApplication;
@@ -76,16 +77,14 @@ public class EndOfFormTest {
                 Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
                         .create().start().resume().get();
 
-        ImageButton nextButton = formEntryActivity.findViewById(R.id.nav_btn_next);
+
 
         // enter an answer for the question
         QuestionsView questionsView = formEntryActivity.getODKView();
         IntegerWidget favoriteNumber = (IntegerWidget)questionsView.getWidgets().get(0);
         favoriteNumber.setAnswer("2");
-        assertTrue(nextButton.getTag().equals(FormEntryConstants.NAV_STATE_NEXT));
-        // Finish off the form even by clicking next.
-        // The form progress meter thinks there is more to do, but that is a bug.
-        nextButton.performClick();
+        View finishButton = formEntryActivity.findViewById(R.id.nav_btn_finish);
+        finishButton.performClick();
 
         ShadowActivity shadowFormEntryActivity = Shadows.shadowOf(formEntryActivity);
         while (!shadowFormEntryActivity.isFinishing()) {

--- a/app/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
@@ -3,6 +3,7 @@ package org.commcare.android.tests.formsave;
 import android.content.Intent;
 import android.os.Environment;
 import android.util.Log;
+import android.view.View;
 import android.widget.ImageButton;
 
 import org.commcare.CommCareApplication;
@@ -136,15 +137,15 @@ public class FormRecordProcessingTest {
                 Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
                         .create().start().resume().get();
 
-        ImageButton nextButton = formEntryActivity.findViewById(R.id.nav_btn_next);
-
         // enter an answer for the question
         QuestionsView questionsView = formEntryActivity.getODKView();
         IntegerWidget cohort = (IntegerWidget)questionsView.getWidgets().get(0);
         cohort.setAnswer("2");
 
+        ImageButton nextButton = formEntryActivity.findViewById(R.id.nav_btn_next);
         nextButton.performClick();
-        nextButton.performClick();
+        View finishButton = formEntryActivity.findViewById(R.id.nav_btn_finish);
+        finishButton.performClick();
 
         ShadowActivity shadowFormEntryActivity = Shadows.shadowOf(formEntryActivity);
 


### PR DESCRIPTION
Refreshes view to show Finish button on advancing to end of form instead of triggering auto-save. 

Jira: https://dimagi-dev.atlassian.net/browse/MOB-41

Product Note: If there is a required date widget on the last screen in the form, earlier swiping ahead would auto-save the form. We have now changed this behaviour to instead show Finish button on swiping ahead and user needs to click on the Finish button to trigger save on the form. 
