### PR TITLE
Fix for Session expiration Crashes

### DIFF
--- a/app/src/org/commcare/activities/SessionAwareHelper.java
+++ b/app/src/org/commcare/activities/SessionAwareHelper.java
@@ -32,7 +32,11 @@ public class SessionAwareHelper {
                 SessionActivityRegistration.handleOrListenForSessionExpiration(a) ||
                         redirectedInOnCreate;
         if (!redirectedToLogin) {
-            sessionAware.onResumeSessionSafe();
+            try {
+                sessionAware.onResumeSessionSafe();
+            } catch (SessionUnavailableException e) {
+                SessionActivityRegistration.redirectToLogin(a);
+            }
         }
     }
 

--- a/app/src/org/commcare/utils/CommCareExceptionHandler.java
+++ b/app/src/org/commcare/utils/CommCareExceptionHandler.java
@@ -2,8 +2,10 @@ package org.commcare.utils;
 
 import android.content.Context;
 import android.content.Intent;
+import android.widget.Toast;
 
 import org.commcare.activities.CrashWarningActivity;
+import org.commcare.activities.SessionAwareCommCareActivity;
 import org.commcare.android.logging.ForceCloseLogger;
 import org.javarosa.core.util.NoLocalizedTextException;
 
@@ -56,6 +58,9 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
             i.putExtra(WARNING_MESSAGE_KEY, ex.getMessage());
             ctx.startActivity(i);
             return true;
+        } else if (causedBySessionUnavailableException(ex)) {
+            SessionActivityRegistration.redirectToLogin(ctx);
+            return true;
         }
         return false;
     }
@@ -63,5 +68,10 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
     private static boolean causedByLocalizationException(Throwable ex) {
         return ex != null &&
                 (ex instanceof NoLocalizedTextException || causedByLocalizationException(ex.getCause()));
+    }
+
+    private static boolean causedBySessionUnavailableException(Throwable ex) {
+        return ex != null &&
+                (ex instanceof SessionUnavailableException || causedBySessionUnavailableException(ex.getCause()));
     }
 }


### PR DESCRIPTION
* Catches all unhandled SessionExpiration crashes in ExceptionHandler and redirects to login
* Make `onResumeSessionSafe` actually session safe by catching SessionUnavaialableException