### PR TITLE
ARGB_8888 -> RGB_565

### DIFF
--- a/app/src/org/commcare/activities/DrawActivity.java
+++ b/app/src/org/commcare/activities/DrawActivity.java
@@ -342,7 +342,7 @@ public class DrawActivity extends Activity {
             if (mBackgroundBitmapFile.exists()) {
                 mBitmap = MediaUtil.getBitmapScaledToContainer(
                         mBackgroundBitmapFile, w, h).copy(
-                        Bitmap.Config.ARGB_8888, true);
+                        Bitmap.Config.RGB_565, true);
                 // mBitmap =
                 // Bitmap.createScaledBitmap(BitmapFactory.decodeFile(mBackgroundBitmapFile.getPath()),
                 // w, h, true);


### PR DESCRIPTION
Context: https://github.com/dimagi/commcare-android/pull/2027

This got left behind in earlier PR where we made the shift from ARGB_8888 to RGB_565 for signature bitmaps