### PR TITLE
updates to preference-v14

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'com.android.support:cardview-v7:28.0.0'
     implementation 'com.android.support:recyclerview-v7:28.0.0'
     implementation 'com.android.support:support-v4:28.0.0'
-    implementation 'com.android.support:preference-v7:28.0.0'
+    implementation 'com.android.support:preference-v14:28.0.0'
     implementation 'com.android.support:gridlayout-v7:28.0.0'
     implementation 'com.madgag.spongycastle:core:1.54.0.0'
     implementation 'com.madgag.spongycastle:prov:1.54.0.0'

--- a/app/res/values/themes.xml
+++ b/app/res/values/themes.xml
@@ -21,7 +21,6 @@
     </style>
 
     <style name="PreferenceTheme" parent="AppBaseTheme">
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
         <item name="alertDialogTheme">@style/Theme.AppCompat.Light.Dialog.Alert</item>
     </style>
 


### PR DESCRIPTION
preference-v7:28.0.0 is causing some build issues on Jenkins due to recent changes in version 28. So think it's better to update to v14 lib since we have anyway dropped support for pre-14 devices. 