### PR TITLE
Turning off sms install

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -24,7 +24,6 @@
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_SMS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -551,17 +551,22 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
         menu.add(0, MENU_ARCHIVE, 0, Localization.get("menu.archive")).setIcon(android.R.drawable.ic_menu_upload);
-        menu.add(0, MENU_SMS, 1, Localization.get("menu.sms")).setIcon(android.R.drawable.stat_notify_chat);
         menu.add(0, MENU_FROM_LIST, 2, Localization.get("menu.app.list.install"));
         return true;
     }
 
     /**
+     * UPDATE: 16/Jan/2019: This code path is no longer in use, since we have turned off sms install
+     * in response to Google play console policies for now. We are going to watch out for a while
+     * for any changes in policies in near future before completely removing the surrounding code
+     *
+     *
      * Scan SMS messages for texts with profile references.
      *
      * @param installTriggeredManually if scan was triggered manually, then
      *                                 install automatically if reference is found
      */
+
     private void performSMSInstall(boolean installTriggeredManually) {
         manualSMSInstall = installTriggeredManually;
         if (ContextCompat.checkSelfPermission(this,

--- a/app/src/org/commcare/utils/Permissions.java
+++ b/app/src/org/commcare/utils/Permissions.java
@@ -87,7 +87,6 @@ public class Permissions {
      * @return Permissions needed for _normal_ CommCare functionality
      */
     public static String[] getAppPermissions() {
-        // leaving out READ_SMS, which is only needed for sms installs
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
             // exclude READ_EXTERNAL_STORAGE which isn't compat. w/ API < 16
             return new String[]{Manifest.permission.READ_PHONE_STATE,


### PR DESCRIPTION
Turning off sms install in order to comply with Google Developer Policy Updates - https://support.google.com/googleplay/android-developer/answer/9047303

Going in as a hotfix CommCare 2.44.5

Product Note: Removes option to do CommCare App installation by using SMS based app code.  