### PR TITLE
Fixing Entity Detail View to not cut content

### DIFF
--- a/app/res/layout/component_entity_detail_item.xml
+++ b/app/res/layout/component_entity_detail_item.xml
@@ -48,7 +48,6 @@
             android:layout_marginRight="12dp"
             android:drawableLeft="@drawable/sym_action_call"
             android:drawablePadding="@dimen/content_min_margin"
-            android:inputType="phone"
             android:text="555-555-5555"
             android:typeface="monospace"
             android:visibility="gone"

--- a/app/res/layout/entity_detail_list.xml
+++ b/app/res/layout/entity_detail_list.xml
@@ -18,5 +18,5 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@id/screen_entity_detail_list"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="match_parent"/>
 </LinearLayout>


### PR DESCRIPTION
Jira:https://dimagi-dev.atlassian.net/projects/MOB/issues/MOB-65

Setting lisview height to `match_parent` to tackle variable text lengths. This also will make Android to handle listview's children variable heights more gracefully. Currently the `getView()` for `EntityDetailAdapter` ends up getting called multiple times per listview row. 


<img src="https://user-images.githubusercontent.com/4679137/52048264-f516fc80-2570-11e9-930c-6dd139e076fe.png" width="400" height="600">
