### PR TITLE
Refreshes menu on app change

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -276,6 +276,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if (requestCode == SEAT_APP_ACTIVITY && resultCode == RESULT_OK) {
             uiController.refreshForNewApp();
+            invalidateOptionsMenu();
             usernameBeforeRotation = passwordOrPinBeforeRotation = null;
         }
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/MOB-60

Seems like not all phones refreshes menu by default on returning to an activity, so signalling it explicitly to Android to refresh menu.

Product Note: Fixes a bug where Menu translations won't update on switching the apps in CommCare. 