### PR TITLE
Shows 406 error messages from HQ while App update

### DIFF
--- a/app/src/org/commcare/engine/references/JavaHttpReference.java
+++ b/app/src/org/commcare/engine/references/JavaHttpReference.java
@@ -2,6 +2,7 @@ package org.commcare.engine.references;
 
 import org.commcare.interfaces.CommcareRequestEndpoints;
 import org.commcare.network.CommcareRequestGenerator;
+import org.commcare.network.HttpUtils;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.services.locale.Localization;
 
@@ -43,6 +44,9 @@ public class JavaHttpReference implements Reference {
         if (response.isSuccessful()) {
             return response.body().byteStream();
         } else {
+            if (response.code() == 406) {
+                throw new IOException(HttpUtils.parseUserVisibleError(response));
+            }
             throw new IOException(Localization.get("install.fail.error", Integer.toString(response.code())));
         }
     }

--- a/app/src/org/commcare/network/HttpUtils.java
+++ b/app/src/org/commcare/network/HttpUtils.java
@@ -78,13 +78,15 @@ public class HttpUtils {
 
     public static String parseUserVisibleError(Response<ResponseBody> response) {
         String message;
+        String responseStr = null;
         try {
-            JSONObject errorKeyAndDefault = new JSONObject(response.errorBody().string());
+            responseStr = response.errorBody().string();
+            JSONObject errorKeyAndDefault = new JSONObject(responseStr);
             message = Localization.getWithDefault(
                     errorKeyAndDefault.getString("error"),
                     errorKeyAndDefault.getString("default_response"));
         } catch (JSONException | IOException e) {
-            message = "Unknown issue";
+            message = responseStr != null ? responseStr : "Unknown issue";
         }
         return message;
     }

--- a/app/src/org/commcare/network/HttpUtils.java
+++ b/app/src/org/commcare/network/HttpUtils.java
@@ -8,10 +8,17 @@ import org.commcare.utils.CredentialUtil;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.utils.StringUtils;
 import org.javarosa.core.model.User;
+import org.javarosa.core.services.locale.Localization;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
 
 import javax.annotation.Nullable;
 
 import okhttp3.Credentials;
+import okhttp3.ResponseBody;
+import retrofit2.Response;
 
 /**
  * @author Phillip Mates (pmates@dimagi.com)
@@ -67,5 +74,18 @@ public class HttpUtils {
         } else {
             return Credentials.basic(username, buildAppPassword(password));
         }
+    }
+
+    public static String parseUserVisibleError(Response<ResponseBody> response) {
+        String message;
+        try {
+            JSONObject errorKeyAndDefault = new JSONObject(response.errorBody().string());
+            message = Localization.getWithDefault(
+                    errorKeyAndDefault.getString("error"),
+                    errorKeyAndDefault.getString("default_response"));
+        } catch (JSONException | IOException e) {
+            message = "Unknown issue";
+        }
+        return message;
     }
 }

--- a/app/src/org/commcare/network/RemoteDataPullResponse.java
+++ b/app/src/org/commcare/network/RemoteDataPullResponse.java
@@ -115,8 +115,8 @@ public class RemoteDataPullResponse {
         return response.body().byteStream();
     }
 
-    public String getErrorBody() throws IOException {
-        return response.errorBody().string();
+    public Response<ResponseBody> getResponse() {
+        return response;
     }
 
     public String getRetryHeader() {

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -24,6 +24,7 @@ import org.commcare.models.database.user.models.EntityStorageCache;
 import org.commcare.models.encryption.ByteEncrypter;
 import org.commcare.modern.models.RecordTooLargeException;
 import org.commcare.network.DataPullRequester;
+import org.commcare.network.HttpUtils;
 import org.commcare.network.RemoteDataPullResponse;
 import org.commcare.preferences.ServerUrls;
 import org.commcare.preferences.HiddenPreferences;
@@ -307,17 +308,8 @@ public abstract class DataPullTask<R>
         }
     }
 
-    private ResultAndError<PullTaskResult> processErrorResponseWithMessage(RemoteDataPullResponse pullResponse) throws IOException {
-        String message;
-        try {
-            JSONObject errorKeyAndDefault = new JSONObject(pullResponse.getErrorBody());
-            message = Localization.getWithDefault(
-                    errorKeyAndDefault.getString("error"),
-                    errorKeyAndDefault.getString("default_response"));
-        } catch (JSONException e) {
-            message = "Unknown issue";
-        }
-        return new ResultAndError<>(PullTaskResult.ACTIONABLE_FAILURE, message);
+    private ResultAndError<PullTaskResult> processErrorResponseWithMessage(RemoteDataPullResponse pullResponse) {
+        return new ResultAndError<>(PullTaskResult.ACTIONABLE_FAILURE, HttpUtils.parseUserVisibleError(pullResponse.getResponse()));
     }
 
     private ResultAndError<PullTaskResult> handleAuthFailed() {

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -44,6 +44,8 @@ import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.Response;
 
+import static org.commcare.network.HttpUtils.parseUserVisibleError;
+
 public class FormUploadUtil {
     private static final String TAG = FormUploadUtil.class.getSimpleName();
 
@@ -216,16 +218,7 @@ public class FormUploadUtil {
     }
 
     private static FormUploadResult processActionableFaiure(Response<ResponseBody> response) {
-        String message;
-        try {
-            JSONObject errorKeyAndDefault = new JSONObject(response.errorBody().string());
-            message = Localization.getWithDefault(
-                    errorKeyAndDefault.getString("error"),
-                    errorKeyAndDefault.getString("default_response"));
-        } catch (JSONException | IOException e) {
-            message = "Unknown issue";
-        }
-
+        String message = parseUserVisibleError(response);
         FormUploadResult result = FormUploadResult.ACTIONABLE_FAILURE;
         result.setErrorMessage(message);
         return result;


### PR DESCRIPTION
Spec:https://docs.google.com/document/d/1xfOaDsV0gllRwZM2zWigc4BEHarDjPKuwbGYp50-Xt0/edit#heading=h.ty5i7ie0b8sj

This enables the functionality for HQ to pass mobile an error like - "You need to be logged in to do an app update". We are doing this to restrict app updates when user is logged out for Location based App Updates feature. 

PR also moves the common 406 parsing code from various places to `HTTPUtils`. 

