### PR TITLE
NPE in Update Activity

### DIFF
--- a/app/src/org/commcare/activities/UpdateUIController.java
+++ b/app/src/org/commcare/activities/UpdateUIController.java
@@ -220,9 +220,9 @@ class UpdateUIController implements CommCareActivityUIController {
     }
 
     private void refreshStatusText() {
-        CommCareApplication app = CommCareApplication.instance();
+        CommCareApplication commCareApplication = CommCareApplication.instance();
 
-        int version = app.getCommCarePlatform().getCurrentProfile().getVersion();
+        int version = commCareApplication.getCurrentApp().getAppRecord().getVersionNumber();
 
         currentVersionText.setText(Localization.get("install.current.version",
                 new String[]{Integer.toString(version)}));


### PR DESCRIPTION
CL: https://www.fabric.io/dimagi/android/apps/org.commcare.lts/issues/5c00a33df8b88c2963f30f9c?time=last-ninety-days

Gets version from app record instead of platform profile to avoid NPEs in case profile is not initialized