### PR TITLE
Fixed Crash when selecting a file from Downloads folder

### DIFF
--- a/app/src/org/commcare/utils/UriToFilePath.java
+++ b/app/src/org/commcare/utils/UriToFilePath.java
@@ -54,7 +54,7 @@ public class UriToFilePath {
                 Uri contentUri;
                 try {
                     contentUri = ContentUris.withAppendedId(
-                            Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+                            Uri.parse(Environment.DIRECTORY_DOWNLOADS), Long.valueOf(id));
                 } catch (NumberFormatException e) {
                     // id is an actual Path instead of a row id, hence use the original uri as it is.
                     contentUri = uri;


### PR DESCRIPTION
CL: https://www.fabric.io/dimagi/android/apps/org.commcare.lts/issues/5c00cbb4f8b88c2963f67e8b/sessions/5C56BF64035200011BD90A6E255DDF81_DNE_0_v2?

Uses Environment.DIRECTORY_DOWNLOADS instead of hardcoding the downloads path. 

This is Inspired from: https://github.com/flutter/plugins/pull/1089 . I have not been able to repro the issue on my devices to be able to verify this. 