### PR TITLE
Fix for RtL layouts with audio buttons

### DIFF
--- a/app/res/layout/small_audio_playback.xml
+++ b/app/res/layout/small_audio_playback.xml
@@ -1,26 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical">
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="55dp"
+    android:layout_height="55dp">
 
     <ImageButton
         android:id="@+id/play_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:layout_gravity="center"
         android:background="@null"
-        android:src="@drawable/audio_playback_selector"/>
+        android:src="@drawable/audio_playback_selector" />
 
     <ProgressBar
         android:id="@+id/circular_progress_bar"
         style="?android:attr/progressBarStyleHorizontal"
         android:layout_width="55dp"
         android:layout_height="55dp"
-        android:layout_centerInParent="true"
         android:max="500"
         android:progress="0"
         android:progressDrawable="@drawable/circular_progress"/>
 
-</RelativeLayout>
+</FrameLayout>

--- a/app/res/layout/small_audio_playback.xml
+++ b/app/res/layout/small_audio_playback.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="55dp"
-    android:layout_height="55dp">
+    android:layout_width="@dimen/audio_button_size"
+    android:layout_height="@dimen/audio_button_size">
 
     <ImageButton
         android:id="@+id/play_button"
@@ -15,8 +15,8 @@
     <ProgressBar
         android:id="@+id/circular_progress_bar"
         style="?android:attr/progressBarStyleHorizontal"
-        android:layout_width="55dp"
-        android:layout_height="55dp"
+        android:layout_width="@dimen/audio_button_size"
+        android:layout_height="@dimen/audio_button_size"
         android:max="500"
         android:progress="0"
         android:progressDrawable="@drawable/circular_progress"/>

--- a/app/res/layout/small_audio_playback.xml
+++ b/app/res/layout/small_audio_playback.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="@dimen/audio_button_size"
-    android:layout_height="@dimen/audio_button_size">
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
 
     <ImageButton
         android:id="@+id/play_button"

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -126,4 +126,7 @@
     <!-- Should be font medium SP x 4, roughly -->
     <dimen name="rectangle_button_height">60sp</dimen>
 
+    <!-- Audio button -->
+    <dimen name="audio_button_size">55dp</dimen>
+
 </resources>

--- a/app/src/org/commcare/views/media/AudioPlaybackButtonBase.java
+++ b/app/src/org/commcare/views/media/AudioPlaybackButtonBase.java
@@ -3,9 +3,12 @@ package org.commcare.views.media;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.FrameLayout;
 import android.widget.ImageButton;
+import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
 
@@ -16,7 +19,7 @@ import java.io.IOException;
 /**
  * @author Phillip Mates (pmates@dimagi.com)
  */
-public abstract class AudioPlaybackButtonBase extends RelativeLayout {
+public abstract class AudioPlaybackButtonBase extends FrameLayout {
 
     private final static String TAG = AudioPlaybackButtonBase.class.getSimpleName();
     /**
@@ -61,6 +64,7 @@ public abstract class AudioPlaybackButtonBase extends RelativeLayout {
     protected void setupView(Context context) {
         LayoutInflater vi = (LayoutInflater)context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         View view = vi.inflate(getLayout(), null);
+
         addView(view);
         setupButton();
     }

--- a/app/src/org/commcare/views/media/AudioPlaybackButtonBase.java
+++ b/app/src/org/commcare/views/media/AudioPlaybackButtonBase.java
@@ -3,13 +3,10 @@ package org.commcare.views.media;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
-import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 import android.widget.Toast;
 
 import org.commcare.dalvik.R;

--- a/app/src/org/commcare/views/media/MediaLayout.java
+++ b/app/src/org/commcare/views/media/MediaLayout.java
@@ -185,41 +185,47 @@ public class MediaLayout extends RelativeLayout {
         // Add the audioButton and videoButton (if applicable) and view
         // (containing text) to the relative layout.
         if (audioButton != null) {
-            audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-            textParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                 audioParams.addRule(RelativeLayout.ALIGN_PARENT_END);
                 textParams.addRule(RelativeLayout.START_OF, audioButton.getId());
+            } else {
+                audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                textParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
             }
             questionTextPane.addView(audioButton, audioParams);
 
             if (videoButton != null) {
-                videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
                 videoParams.addRule(RelativeLayout.BELOW, audioButton.getId());
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                     videoParams.addRule(RelativeLayout.ALIGN_PARENT_END);
+                } else {
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
                 }
                 questionTextPane.addView(videoButton, videoParams);
             }
         } else if (videoButton != null) {
-            videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-            textParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                 videoParams.addRule(RelativeLayout.ALIGN_PARENT_END);
                 textParams.addRule(RelativeLayout.START_OF, videoButton.getId());
+            } else {
+                videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                textParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
             }
             questionTextPane.addView(videoButton, videoParams);
         } else {
             //Audio and Video are both null, let text bleed to right
-            textParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                 textParams.addRule(RelativeLayout.ALIGN_PARENT_END);
+            } else {
+                textParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
             }
         }
         if (viewText.getVisibility() != GONE) {
-            textParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                 textParams.addRule(RelativeLayout.ALIGN_PARENT_START);
+            } else {
+                textParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+            }
             questionTextPane.addView(viewText, textParams);
         }
     }
@@ -312,11 +318,19 @@ public class MediaLayout extends RelativeLayout {
             if (viewText.getVisibility() == GONE) {
                 this.addView(questionTextPane, questionTextPaneParams);
                 if (audioButton != null) {
-                    mediaPaneParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                        mediaPaneParams.addRule(RelativeLayout.START_OF, audioButton.getId());
+                    } else {
+                        mediaPaneParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
+                    }
                     questionTextPane.addView(mediaPane, mediaPaneParams);
                 }
                 if (videoButton != null) {
-                    mediaPaneParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                        mediaPaneParams.addRule(RelativeLayout.START_OF, videoButton.getId());
+                    } else {
+                        mediaPaneParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
+                    }
                     questionTextPane.addView(mediaPane, mediaPaneParams);
                 }
             } else {


### PR DESCRIPTION
The AudioButton was not properly sizing itself in RtL previously on at least some devices, probably because our layout declaration was non-deterministic.

![image](https://user-images.githubusercontent.com/155066/52244742-f320a680-28ac-11e9-8c58-4e28a067498b.png)

Fixes so that the button has the same layout configuration as in LtR mode

![image](https://user-images.githubusercontent.com/155066/52244772-0df31b00-28ad-11e9-9839-a0936e4d0182.png)

For consistency: this is what the app currently (not with this PR's code) lays out for RtL audio buttons
![image](https://user-images.githubusercontent.com/155066/52245147-60810700-28ae-11e9-82b6-7cad3f7dd0c6.png)

I'm not really sure whether the placement of the round button in the box model is an issue, but it's consistent now.