### PR TITLE
Fix for CommCare not getting filePath for Files selected from File Explorer 'Recent' option

### DIFF
--- a/app/src/org/commcare/utils/UriToFilePath.java
+++ b/app/src/org/commcare/utils/UriToFilePath.java
@@ -33,7 +33,7 @@ public class UriToFilePath {
      *
      * @param context The context.
      * @param uri     The Uri to query.
-     * @return Filepath string extracted from the Uri argument. Returns null if
+     * @return Filepath string extracted from the Uri argument. Returns the original uri if
      * filepath couldn't be succesfully extracted.
      */
     @SuppressLint("NewApi")

--- a/app/src/org/commcare/utils/UriToFilePath.java
+++ b/app/src/org/commcare/utils/UriToFilePath.java
@@ -39,7 +39,7 @@ public class UriToFilePath {
     @SuppressLint("NewApi")
     public static String getPathFromUri(final Context context, final Uri uri) throws NoDataColumnForUriException {
         final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
-
+        String filePath = null;
         if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
             if (isExternalStorageDocument(uri)) {
                 final String docId = DocumentsContract.getDocumentId(uri);
@@ -47,7 +47,7 @@ public class UriToFilePath {
                 final String type = split[0];
 
                 if ("primary".equalsIgnoreCase(type)) {
-                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                    filePath =  Environment.getExternalStorageDirectory() + "/" + split[1];
                 }
             } else if (isDownloadsDocument(uri)) {
                 final String id = DocumentsContract.getDocumentId(uri);
@@ -60,7 +60,7 @@ public class UriToFilePath {
                     contentUri = uri;
                 }
 
-                return getDataColumn(context, contentUri, null, null);
+                filePath = getDataColumn(context, contentUri, null, null);
             } else if (isMediaDocument(uri)) {
                 final String docId = DocumentsContract.getDocumentId(uri);
                 final String[] split = docId.split(":");
@@ -80,19 +80,22 @@ public class UriToFilePath {
                         split[1]
                 };
 
-                return getDataColumn(context, contentUri, selection, selectionArgs);
+                filePath = getDataColumn(context, contentUri, selection, selectionArgs);
             }
         } else if ("content".equalsIgnoreCase(uri.getScheme())) {
             // Return the remote address
             if (isGooglePhotosUri(uri)) {
                 return uri.getLastPathSegment();
             }
-            return getDataColumn(context, uri, null, null);
+            filePath =  getDataColumn(context, uri, null, null);
         } else if ("file".equalsIgnoreCase(uri.getScheme())) {
-            return uri.getPath();
+            filePath = uri.getPath();
         }
 
-        return null;
+        if(filePath == null){
+            filePath = uri.toString();
+        }
+        return filePath;
     }
 
     /**


### PR DESCRIPTION
Issue: Noticed that on a Lennovo phone, `getDataColumn` returns null for files selected from 'Recent' option in stock file provider. 

Proposed Change: if we are not able to get a non null filePath from a file provider uri, returns the original uri for further processing (making a internal copy of the file using uri which seems to be the best optionto protect against such failures). 

Product Note: Fixes an issue where CommCare won't be able to detect a file selected from Recent folder of Android File Explorer. 