### PR TITLE
Form Entry Menu Alignment Fix for RTL

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -446,7 +446,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     public boolean onCreateOptionsMenu(Menu menu) {
         if (CommCareApplication.instance().isConsumerApp()) {
             // Do not show options menu at all if this is a consumer app
-            return super.onPrepareOptionsMenu(menu);
+            return super.onCreateOptionsMenu(menu);
         }
 
         super.onCreateOptionsMenu(menu);

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -761,6 +761,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             saveAnswersForCurrentScreen(FormEntryConstants.DO_NOT_EVALUATE_CONSTRAINTS);
         }
         uiController.refreshView();
+        invalidateOptionsMenu();
     }
 
     @Override

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -442,6 +442,26 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         return wasAnswerSet;
     }
 
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        if (CommCareApplication.instance().isConsumerApp()) {
+            // Do not show options menu at all if this is a consumer app
+            return super.onPrepareOptionsMenu(menu);
+        }
+
+        super.onCreateOptionsMenu(menu);
+
+        menu.add(0, FormEntryConstants.MENU_SAVE, 0, StringUtils.getStringRobust(this, R.string.save_all_answers))
+                .setIcon(android.R.drawable.ic_menu_save);
+        menu.add(0, FormEntryConstants.MENU_HIERARCHY_VIEW, 0, StringUtils.getStringRobust(this, R.string.view_hierarchy))
+                .setIcon(R.drawable.ic_menu_goto);
+        menu.add(0, FormEntryConstants.MENU_LANGUAGES, 0, StringUtils.getStringRobust(this, R.string.change_language))
+                .setIcon(R.drawable.ic_menu_start_conversation);
+        menu.add(0, FormEntryConstants.MENU_PREFERENCES, 0, StringUtils.getStringRobust(this, R.string.form_entry_settings))
+                .setIcon(android.R.drawable.ic_menu_preferences);
+
+        return true;
+    }
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
@@ -449,29 +469,15 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             // Do not show options menu at all if this is a consumer app
             return super.onPrepareOptionsMenu(menu);
         }
+        super.onPrepareOptionsMenu(menu);
 
-        menu.removeItem(FormEntryConstants.MENU_LANGUAGES);
-        menu.removeItem(FormEntryConstants.MENU_HIERARCHY_VIEW);
-        menu.removeItem(FormEntryConstants.MENU_SAVE);
-        menu.removeItem(FormEntryConstants.MENU_PREFERENCES);
+        menu.findItem(FormEntryConstants.MENU_SAVE).setVisible(mIncompleteEnabled && !instanceIsReadOnly);
 
-        if (mIncompleteEnabled && !instanceIsReadOnly) {
-            menu.add(0, FormEntryConstants.MENU_SAVE, 0, StringUtils.getStringRobust(this, R.string.save_all_answers)).setIcon(
-                    android.R.drawable.ic_menu_save);
-        }
-        menu.add(0, FormEntryConstants.MENU_HIERARCHY_VIEW, 0, StringUtils.getStringRobust(this, R.string.view_hierarchy)).setIcon(
-                R.drawable.ic_menu_goto);
+        boolean hasMultipleLanguages = (!(mFormController == null ||
+                mFormController.getLanguages() == null || mFormController.getLanguages().length == 1));
+        menu.findItem(FormEntryConstants.MENU_LANGUAGES).setEnabled(hasMultipleLanguages);
 
-        boolean hasMultipleLanguages =
-                (!(mFormController == null || mFormController.getLanguages() == null || mFormController.getLanguages().length == 1));
-        menu.add(0, FormEntryConstants.MENU_LANGUAGES, 0, StringUtils.getStringRobust(this, R.string.change_language))
-                .setIcon(R.drawable.ic_menu_start_conversation)
-                .setEnabled(hasMultipleLanguages);
-
-        menu.add(0, FormEntryConstants.MENU_PREFERENCES, 0, StringUtils.getStringRobust(this, R.string.form_entry_settings)).setIcon(
-                android.R.drawable.ic_menu_preferences);
-
-        return super.onPrepareOptionsMenu(menu);
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/QA-171

In RTL, form entry menu was not getting aligned to the right on some devices. Moving the menu creation code to `onCreateOptionsMenu` from `onPrepareOptionsMenu` seems to fix the issue. 