### PR TITLE
Revert "menu list item now expands on whole screen"

### DIFF
--- a/app/res/layout/menu_list_item_modern.xml
+++ b/app/res/layout/menu_list_item_modern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<org.commcare.views.ShrinkingLinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -49,8 +49,7 @@
         android:id="@+id/row_txt"
         style="@style/ListContentWithoutBadge"
         android:layout_height="@dimen/list_text_height"
-        android:layout_width="0dp"
-        android:gravity="start"
+        android:layout_width="wrap_content"
         android:layout_weight="1"
         android:ellipsize="end"
         android:maxLines="2"/>
@@ -62,4 +61,4 @@
         android:layout_width="wrap_content"
         android:background="@color/transparent_background"/>
 
-</LinearLayout>
+</org.commcare.views.ShrinkingLinearLayout>


### PR DESCRIPTION
This reverts [commit](https://github.com/dimagi/commcare-android/commit/a25a990c620bf4325bbd19dadaf661403be03898#diff-b7391c239a63a97341bf79e75211e6da).

This was done to align the audio button in the menu list. Though I would assume ShrinkingLayout was intentional here. I missed it during RTL review and noticed only now. So wants to get it cross-checked if it's alright to remove ShrinkingLayout here. 

cc: @rristovic 