### PR TITLE
Makes xforminstaller accounts for  form id changes during update

### DIFF
--- a/app/src/org/commcare/android/database/app/models/FormDefRecord.java
+++ b/app/src/org/commcare/android/database/app/models/FormDefRecord.java
@@ -31,6 +31,7 @@ public class FormDefRecord extends Persisted {
     // these are null unless you enter something and aren't currently used
     public static final String META_MODEL_VERSION = "modelVersion";
     public static final String META_UI_VERSION = "uiVersion";
+    public static final String META_RESOURCE_VERSION = "resourceVersion";
 
     @Persisting(1)
     @MetaField(META_DISPLAY_NAME)
@@ -56,26 +57,33 @@ public class FormDefRecord extends Persisted {
     @MetaField(META_UI_VERSION)
     private int mUiVersion = -1;
 
+    // Corresponding resource version for this Form Record
+    @Persisting(value = 7, nullable = true)
+    @MetaField(META_RESOURCE_VERSION)
+    private int mResourceVersion = -1;
+
+
     //    Serialization Only!
     public FormDefRecord() {
     }
 
-    public FormDefRecord(String displayName, String jrFormId, String formFilePath, String formMediaPath) {
+    public FormDefRecord(String displayName, String jrFormId, String formFilePath, String formMediaPath, int resourceVersion) {
         checkFilePath(formFilePath);
         mDisplayName = displayName;
         mJrFormId = jrFormId;
         mFormFilePath = formFilePath;
         mFormMediaPath = formMediaPath;
+        mResourceVersion = resourceVersion;
     }
 
-    // Only for DB Migration
-    public FormDefRecord(Cursor cursor) {
-        mDisplayName = cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_NAME));
-        mJrFormId = cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_FORM_ID));
-        mModelVersion = cursor.getInt(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.MODEL_VERSION));
-        mUiVersion = cursor.getInt(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.UI_VERSION));
-        mFormMediaPath = cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH));
-        mFormFilePath = cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH));
+    // For migration from FormDefRecordV12
+    public FormDefRecord(FormDefRecordV12 oldFormDefRecord) {
+        mDisplayName = oldFormDefRecord.getDisplayName();
+        mJrFormId = oldFormDefRecord.getJrFormId();
+        mFormFilePath = oldFormDefRecord.getFilePath();
+        mFormMediaPath = oldFormDefRecord.getMediaPath();
+        mModelVersion = oldFormDefRecord.getModelVersion();
+        mUiVersion = oldFormDefRecord.getUiVersion();
     }
 
     public static Vector<Integer> getFormDefIdsByJrFormId(SqlStorage<FormDefRecord> formDefRecordStorage, String jrFormId) {
@@ -111,7 +119,7 @@ public class FormDefRecord extends Persisted {
         return recordId;
     }
 
-    private String getMediaPath(String formFilePath) {
+    private static String getMediaPath(String formFilePath) {
         String pathNoExtension = formFilePath.substring(0, formFilePath.lastIndexOf("."));
         return pathNoExtension + "-media";
     }
@@ -122,7 +130,7 @@ public class FormDefRecord extends Persisted {
     }
 
 
-    public void updateFilePath(SqlStorage<FormDefRecord> formDefRecordStorage, String newFilePath) {
+    private void updateFilePath(SqlStorage<FormDefRecord> formDefRecordStorage, String newFilePath) {
         checkFilePath(newFilePath);
         File newFormFile = new File(newFilePath);
         try {
@@ -143,7 +151,7 @@ public class FormDefRecord extends Persisted {
         formDefRecordStorage.write(this);
     }
 
-    private void checkFilePath(String formFilePath) {
+    private static void checkFilePath(String formFilePath) {
         if (StringUtils.isEmpty(formFilePath)) {
             throw new IllegalArgumentException("formFilePath can't by null or empty");
         }
@@ -161,19 +169,15 @@ public class FormDefRecord extends Persisted {
         return mFormMediaPath;
     }
 
-    public String getJrFormId() {
-        return mJrFormId;
-    }
-
-    public String getDisplayname() {
+    public String getDisplayName() {
         return mDisplayName;
-    }
-
-    public Integer getModelVersion() {
-        return mModelVersion;
     }
 
     public Integer getUiVersion() {
         return mUiVersion;
+    }
+
+    public int getResourceVersion() {
+        return mResourceVersion;
     }
 }

--- a/app/src/org/commcare/android/database/app/models/FormDefRecordV12.java
+++ b/app/src/org/commcare/android/database/app/models/FormDefRecordV12.java
@@ -24,7 +24,12 @@ import static org.commcare.android.database.app.models.FormDefRecord.META_JR_FOR
 import static org.commcare.android.database.app.models.FormDefRecord.META_MODEL_VERSION;
 import static org.commcare.android.database.app.models.FormDefRecord.META_UI_VERSION;
 
-// Model for Form Def Record pre App DB v13
+/**
+ * Represents the version of a FormDefRecord that exists on any devices running a pre-2.47
+ * version of CommCare, which was deprecated in app db version 13. This class is used to read a
+ * FormDefRecord that exists in such a database, in order to run a db upgrade.
+ *
+ */
 @Table(FormDefRecord.STORAGE_KEY)
 public class FormDefRecordV12  extends Persisted {
 

--- a/app/src/org/commcare/android/database/app/models/FormDefRecordV12.java
+++ b/app/src/org/commcare/android/database/app/models/FormDefRecordV12.java
@@ -1,0 +1,150 @@
+package org.commcare.android.database.app.models;
+
+import android.database.Cursor;
+import android.database.SQLException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.commcare.android.storage.framework.Persisted;
+import org.commcare.models.database.SqlStorage;
+import org.commcare.models.framework.Persisting;
+import org.commcare.modern.database.Table;
+import org.commcare.modern.models.MetaField;
+import org.commcare.provider.FormsProviderAPI;
+import org.commcare.util.LogTypes;
+import org.commcare.utils.FileUtil;
+import org.javarosa.core.services.Logger;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.commcare.android.database.app.models.FormDefRecord.META_DISPLAY_NAME;
+import static org.commcare.android.database.app.models.FormDefRecord.META_FORM_FILE_PATH;
+import static org.commcare.android.database.app.models.FormDefRecord.META_FORM_MEDIA_PATH;
+import static org.commcare.android.database.app.models.FormDefRecord.META_JR_FORM_ID;
+import static org.commcare.android.database.app.models.FormDefRecord.META_MODEL_VERSION;
+import static org.commcare.android.database.app.models.FormDefRecord.META_UI_VERSION;
+
+// Model for Form Def Record pre App DB v13
+@Table(FormDefRecord.STORAGE_KEY)
+public class FormDefRecordV12  extends Persisted {
+
+    @Persisting(1)
+    @MetaField(META_DISPLAY_NAME)
+    private String mDisplayName;
+
+    @Persisting(2)
+    @MetaField(META_JR_FORM_ID)
+    private String mJrFormId;
+
+    @Persisting(3)
+    @MetaField(META_FORM_FILE_PATH)
+    private String mFormFilePath;
+
+    @Persisting(4)
+    @MetaField(META_FORM_MEDIA_PATH)
+    private String mFormMediaPath;
+
+    @Persisting(value = 5, nullable = true)
+    @MetaField(META_MODEL_VERSION)
+    private int mModelVersion = -1;
+
+    @Persisting(value = 6, nullable = true)
+    @MetaField(META_UI_VERSION)
+    private int mUiVersion = -1;
+
+    // Serialization Only!
+    public FormDefRecordV12() {
+    }
+
+    // Only for DB Migration
+    public FormDefRecordV12(Cursor cursor) {
+        mDisplayName = cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_NAME));
+        mJrFormId = cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_FORM_ID));
+        mModelVersion = cursor.getInt(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.MODEL_VERSION));
+        mUiVersion = cursor.getInt(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.UI_VERSION));
+        mFormMediaPath = cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH));
+        mFormFilePath = cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH));
+    }
+
+    public void updateFilePath(SqlStorage<FormDefRecordV12> formDefRecordStorage, String newFilePath) {
+        checkFilePath(newFilePath);
+        File newFormFile = new File(newFilePath);
+        try {
+            if (new File(mFormFilePath).getCanonicalPath().equals(newFormFile.getCanonicalPath())) {
+                // Files are the same, so we may have just copied over something we had already
+            } else {
+                // New file name. This probably won't ever happen, though.
+                FileUtil.deleteFileOrDir(mFormFilePath);
+            }
+        } catch (IOException ioe) {
+            //we only get here if we couldn't canonicalize, in which case we can't risk deleting the old file
+            //so don't do anything.
+        }
+
+        // Set new values now
+        mFormFilePath = newFilePath;
+        mFormMediaPath = getMediaPath(newFilePath);
+        formDefRecordStorage.write(this);
+    }
+
+    private static void checkFilePath(String formFilePath) {
+        if (StringUtils.isEmpty(formFilePath)) {
+            throw new IllegalArgumentException("formFilePath can't by null or empty");
+        }
+    }
+
+
+    public int save(SqlStorage<FormDefRecordV12> formDefRecordStorage) {
+        // if we don't have a path to the file, the rest are irrelevant.
+        // it should fail anyway because you can't have a null file path.
+        if (StringUtils.isEmpty(mFormFilePath)) {
+            Logger.log(LogTypes.SOFT_ASSERT, "Empty value for mFormFilePath while saving FormDefRecord");
+        }
+
+        // Make sure that the necessary fields are all set
+        File form = new File(mFormFilePath);
+        if (StringUtils.isEmpty(mDisplayName)) {
+            mDisplayName = form.getName();
+        }
+
+        if (StringUtils.isEmpty(mFormMediaPath)) {
+            mFormMediaPath = getMediaPath(mFormFilePath);
+        }
+
+        formDefRecordStorage.write(this);
+
+        if (recordId == -1) {
+            throw new SQLException("Failed to save the FormDefRecord " + toString());
+        }
+        return recordId;
+    }
+
+    private static String getMediaPath(String formFilePath) {
+        String pathNoExtension = formFilePath.substring(0, formFilePath.lastIndexOf("."));
+        return pathNoExtension + "-media";
+    }
+
+    public String getFilePath() {
+        return mFormFilePath;
+    }
+
+    public String getMediaPath() {
+        return mFormMediaPath;
+    }
+
+    public String getDisplayName() {
+        return mDisplayName;
+    }
+
+    public Integer getUiVersion() {
+        return mUiVersion;
+    }
+
+    public String getJrFormId() {
+        return mJrFormId;
+    }
+
+    public int getModelVersion() {
+        return mModelVersion;
+    }
+}

--- a/app/src/org/commcare/android/database/app/models/FormDefRecordV12.java
+++ b/app/src/org/commcare/android/database/app/models/FormDefRecordV12.java
@@ -17,13 +17,6 @@ import org.javarosa.core.services.Logger;
 import java.io.File;
 import java.io.IOException;
 
-import static org.commcare.android.database.app.models.FormDefRecord.META_DISPLAY_NAME;
-import static org.commcare.android.database.app.models.FormDefRecord.META_FORM_FILE_PATH;
-import static org.commcare.android.database.app.models.FormDefRecord.META_FORM_MEDIA_PATH;
-import static org.commcare.android.database.app.models.FormDefRecord.META_JR_FORM_ID;
-import static org.commcare.android.database.app.models.FormDefRecord.META_MODEL_VERSION;
-import static org.commcare.android.database.app.models.FormDefRecord.META_UI_VERSION;
-
 /**
  * Represents the version of a FormDefRecord that exists on any devices running a pre-2.47
  * version of CommCare, which was deprecated in app db version 13. This class is used to read a
@@ -32,6 +25,14 @@ import static org.commcare.android.database.app.models.FormDefRecord.META_UI_VER
  */
 @Table(FormDefRecord.STORAGE_KEY)
 public class FormDefRecordV12  extends Persisted {
+
+    private static final String META_DISPLAY_NAME = "displayName";
+    private static final String META_JR_FORM_ID = "jrFormId";
+    private static final String META_FORM_FILE_PATH = "formFilePath";
+    private static final String META_FORM_MEDIA_PATH = "formMediaPath";
+    private static final String META_MODEL_VERSION = "modelVersion";
+    private static final String META_UI_VERSION = "uiVersion";
+
 
     @Persisting(1)
     @MetaField(META_DISPLAY_NAME)

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -80,22 +80,24 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     // Returns whether the associated formdefRecord is the one with highest form def resource version for our namespace
     private boolean isLatestFormRecord(AndroidCommCarePlatform platform) {
         if (formDefId != -1) {
-            Vector<Integer> formsForOurNamespace = FormDefRecord.getFormDefIdsByJrFormId(platform.getFormDefStorage(), namespace);
-            if (formsForOurNamespace.size() == 1) {
-                return true;
-            } else if (formsForOurNamespace.size() > 1) {
-                int maxFormResourceVersion = -1;
-                for (int i = 0; i < formsForOurNamespace.size(); i++) {
-                    FormDefRecord formDefRecordItem = platform.getFormDefStorage().read(formsForOurNamespace.get(i));
-                    if (formDefRecordItem.getResourceVersion() > maxFormResourceVersion) {
-                        maxFormResourceVersion = formDefRecordItem.getResourceVersion();
-                    }
-                }
-                FormDefRecord currentFormDefRecord = platform.getFormDefStorage().read(formDefId);
-                return maxFormResourceVersion == currentFormDefRecord.getResourceVersion();
-            }
+            return getLatestFormDefId(platform) == formDefId;
         }
         return false;
+    }
+
+    // Returns the formId of the formDefRecord with highest form def resource version for our namespace
+    private int getLatestFormDefId(AndroidCommCarePlatform platform) {
+        Vector<Integer> formsForOurNamespace = FormDefRecord.getFormDefIdsByJrFormId(platform.getFormDefStorage(), namespace);
+        int maxFormResourceVersion = -1;
+        int latestFormId = -1;
+        for (int i = 0; i < formsForOurNamespace.size(); i++) {
+            FormDefRecord formDefRecordItem = platform.getFormDefStorage().read(formsForOurNamespace.get(i));
+            if (formDefRecordItem.getResourceVersion() >= maxFormResourceVersion) {
+                maxFormResourceVersion = formDefRecordItem.getResourceVersion();
+                latestFormId = formDefRecordItem.getID();
+            }
+        }
+        return latestFormId;
     }
 
     @Override

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -183,6 +183,14 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
+    public boolean uninstall(Resource r, AndroidCommCarePlatform platform) throws UnresolvedResourceException {
+        if (formDefId != -1) {
+            platform.getFormDefStorage().remove(formDefId);
+        }
+        return super.uninstall(r, platform);
+    }
+
+    @Override
     public boolean verifyInstallation(Resource r,
                                       Vector<MissingMediaException> problems,
                                       CommCarePlatform platform) {

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -113,12 +113,13 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
         if (formDefId != -1) {
             FormDefRecord formDefRecord = platform.getFormDefStorage().read(formDefId);
             if (formDefRecord.getResourceVersion() == r.getVersion()) {
-                // This form def record belongs to an old version which is not part of current version since
-                // otherwise it's resource version would have got bumped to the resource
-                // version of new resource in the update.
+//                // This form def record belongs to an old version which is not part of current version since
+//                // otherwise it's resource version would have got bumped to the resource
+//                // version of new resource in the update.
                 platform.getFormDefStorage().remove(formDefId);
+                return super.uninstall(r, platform);
             }
-            return super.uninstall(r, platform);
+            return true;
         }
         return false;
     }

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -97,7 +97,7 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
             if (existingforms != null && existingforms.size() > 0) {
                 formDefId = existingforms.get(0);
             } else {
-                Logger.log(LogTypes.SOFT_ASSERT, "Form with schema " + formDef.getMainInstance().schema + " not present during the update");
+                throw new UnresolvedResourceException(r, "Form with schema " + formDef.getMainInstance().schema + " not present during the update");
             }
 
             if (existingforms.size() > 1) {

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -71,8 +71,31 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
         super.initialize(platform, isUpgrade);
-        platform.registerXmlns(namespace, formDefId);
+        if (isLatestFormRecord(platform)) {
+            platform.registerXmlns(namespace, formDefId);
+        }
         return true;
+    }
+
+    // Returns whether the associated formdefRecord is the one with highest form def resource version for our namespace
+    private boolean isLatestFormRecord(AndroidCommCarePlatform platform) {
+        if (formDefId != -1) {
+            Vector<Integer> formsForOurNamespace = FormDefRecord.getFormDefIdsByJrFormId(platform.getFormDefStorage(), namespace);
+            if (formsForOurNamespace.size() == 1) {
+                return true;
+            } else if (formsForOurNamespace.size() > 1) {
+                int maxFormResourceVersion = -1;
+                for (int i = 0; i < formsForOurNamespace.size(); i++) {
+                    FormDefRecord formDefRecordItem = platform.getFormDefStorage().read(formsForOurNamespace.get(i));
+                    if (formDefRecordItem.getResourceVersion() > maxFormResourceVersion) {
+                        maxFormResourceVersion = formDefRecordItem.getResourceVersion();
+                    }
+                }
+                FormDefRecord currentFormDefRecord = platform.getFormDefStorage().read(formDefId);
+                return maxFormResourceVersion == currentFormDefRecord.getResourceVersion();
+            }
+        }
+        return false;
     }
 
     @Override

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -183,14 +183,6 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean uninstall(Resource r, AndroidCommCarePlatform platform) throws UnresolvedResourceException {
-        if (formDefId != -1) {
-            platform.getFormDefStorage().remove(formDefId);
-        }
-        return super.uninstall(r, platform);
-    }
-
-    @Override
     public boolean verifyInstallation(Resource r,
                                       Vector<MissingMediaException> problems,
                                       CommCarePlatform platform) {

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -91,21 +91,20 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
         }
 
         Vector<Integer> existingforms = FormDefRecord.getFormDefIdsByJrFormId(platform.getFormDefStorage(), formDef.getMainInstance().schema);
-        if (existingforms != null && existingforms.size() > 0) {
-            //we already have one form. Hopefully this is during an upgrade...
-            if (!upgrade) {
-                //Hm, error out?
-                Logger.log(LogTypes.SOFT_ASSERT, "Form with schema " + formDef.getMainInstance().schema + " already present during the install");
-            }
 
-            //So we know there's another form here. We should wait until it's time for
-            //the upgrade and replace the pointer to here.
-            formDefId = existingforms.get(0);
+        if (upgrade) {
+            // We already have a resource with same resource id
+            if (existingforms != null && existingforms.size() > 0) {
+                formDefId = existingforms.get(0);
+            } else {
+                Logger.log(LogTypes.SOFT_ASSERT, "Form with schema " + formDef.getMainInstance().schema + " not present during the update");
+            }
 
             if (existingforms.size() > 1) {
                 Logger.log(LogTypes.SOFT_ASSERT, "More than one Form with schema " + formDef.getMainInstance().schema + "present during the install");
             }
         } else {
+            // It's either a fresh install or form id has changed from last version. Create a new record.
             FormDefRecord formDefRecord = new FormDefRecord("NAME", formDef.getMainInstance().schema, local.getLocalURI(), GlobalConstants.MEDIA_REF);
             formDefId = formDefRecord.save(platform.getFormDefStorage());
         }

--- a/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/app/AppDatabaseUpgrader.java
@@ -10,8 +10,10 @@ import net.sqlcipher.database.SQLiteDatabase;
 
 import org.apache.commons.lang3.StringUtils;
 import org.commcare.android.database.app.models.FormDefRecord;
+import org.commcare.android.database.app.models.FormDefRecordV12;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.app.models.UserKeyRecordV1;
+import org.commcare.android.database.user.models.ACase;
 import org.commcare.android.resource.installers.XFormAndroidInstaller;
 import org.commcare.android.resource.installers.XFormAndroidInstallerV1;
 import org.commcare.android.storage.framework.Persisted;
@@ -120,9 +122,16 @@ class AppDatabaseUpgrader {
             }
         }
 
+        if (oldVersion == 12) {
+            if (upgradeTwelveThirteen(db)) {
+                oldVersion = 13;
+            }
+        }
+
         //NOTE: If metadata changes are made to the Resource model, they need to be
         //managed by changing the TwoThree updater to maintain that metadata.
     }
+
 
     private boolean upgradeOneTwo(SQLiteDatabase db) {
         db.beginTransaction();
@@ -297,11 +306,11 @@ class AppDatabaseUpgrader {
     private boolean upgradeTenEleven(SQLiteDatabase db) {
         db.beginTransaction();
         try {
-            SqlStorage<FormDefRecord> formDefRecordStorage = new SqlStorage<>(
+            SqlStorage<FormDefRecordV12> formDefRecordStorage = new SqlStorage<>(
                     FormDefRecord.STORAGE_KEY,
-                    FormDefRecord.class,
+                    FormDefRecordV12.class,
                     new ConcreteAndroidDbHelper(context, db));
-            for (FormDefRecord formDefRecord : formDefRecordStorage) {
+            for (FormDefRecordV12 formDefRecord : formDefRecordStorage) {
                 String filePath = formDefRecord.getFilePath();
                 File formFile = new File(filePath);
 
@@ -333,18 +342,49 @@ class AppDatabaseUpgrader {
         }
     }
 
+
+    private boolean upgradeTwelveThirteen(SQLiteDatabase db) {
+        db.beginTransaction();
+        try {
+            db.execSQL(DbUtil.addColumnToTable(
+                    FormDefRecord.STORAGE_KEY,
+                    FormDefRecord.META_RESOURCE_VERSION,
+                    "INTEGER"));
+
+            SqlStorage<FormDefRecordV12> oldFormDefRecordStorage = new SqlStorage<>(
+                    FormDefRecord.STORAGE_KEY,
+                    FormDefRecordV12.class,
+                    new ConcreteAndroidDbHelper(context, db));
+
+            SqlStorage<FormDefRecord> formDefRecordStorage = new SqlStorage<>(
+                    FormDefRecord.STORAGE_KEY,
+                    FormDefRecord.class,
+                    new ConcreteAndroidDbHelper(context, db));
+
+            for (FormDefRecordV12 oldFormDefRecord : oldFormDefRecordStorage) {
+                FormDefRecord formDefRecord = new FormDefRecord(oldFormDefRecord);
+                formDefRecordStorage.update(oldFormDefRecord.getID(), formDefRecord);
+            }
+
+            db.setTransactionSuccessful();
+            return true;
+        } finally {
+            db.endTransaction();
+        }
+    }
+
     // migrate formProvider entries to db
     private void migrateFormProvider(SQLiteDatabase db) {
         Cursor cursor = null;
         try {
             cursor = context.getContentResolver().query(FormsProviderAPI.FormsColumns.CONTENT_URI, null, null, null, null);
             if (cursor != null && cursor.getCount() > 0) {
-                SqlStorage<FormDefRecord> formDefRecordStorage = new SqlStorage<>(
+                SqlStorage<FormDefRecordV12> formDefRecordStorage = new SqlStorage<>(
                         FormDefRecord.STORAGE_KEY,
-                        FormDefRecord.class,
+                        FormDefRecordV12.class,
                         new ConcreteAndroidDbHelper(context, db));
                 while (cursor.moveToNext()) {
-                    FormDefRecord formDefRecord = new FormDefRecord(cursor);
+                    FormDefRecordV12 formDefRecord = new FormDefRecordV12(cursor);
                     formDefRecord.save(formDefRecordStorage);
                 }
             }

--- a/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
+++ b/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
@@ -39,8 +39,9 @@ public class DatabaseAppOpenHelper extends SQLiteOpenHelper {
      * V.10 - No Change, Added because of incomplete resource table migration for v8 to v9
      * V.11 - No Change, Corrects FormDef references if corrupt (because of an earlier bug)
      * V.12 - Add RecoveryMeasure table
+     * V.13 - Add resource version for Form Def Record
      */
-    private static final int DB_VERSION_APP = 12;
+    private static final int DB_VERSION_APP = 13;
 
     private static final String DB_LOCATOR_PREF_APP = "database_app_";
 

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -165,7 +165,7 @@ public class SaveToDiskTask extends
             if (recordName == null) {
                 FormDefRecord formDefRecord = FormDefRecord.getFormDef(
                         CommCareApplication.instance().getAppStorage(FormDefRecord.class), mFormDefId);
-                recordName = formDefRecord.getDisplayname();
+                recordName = formDefRecord.getDisplayName();
             }
         }
 

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -317,6 +317,9 @@ public class FormStorageTest {
             // Added in 2.45
             , "org.commcare.recovery.measures.RecoveryMeasure"
             , "org.javarosa.xpath.expr.CacheableExprState"
+
+            // Added in 2.47
+            , "org.commcare.android.database.app.models.FormDefRecordV12"
     );
 
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/ICDS-343

#### Problem

In case of an update containing an existing form with changed resource id, during staging the update table to replace master, we end up giving it the `formid` for the existing entry for existing form with same namespace in `FormDefStorage`. This existing form's xml file gets removed when we uninstall this existing form. Though since the new form is still linked to old form's path,  it results in the "Error Reading XForm" error on opening that form. 

#### Solution

Instead of linking the form resource in update to the existing master form, we wanna treat it as a completely new resource and hence give it a new row in FormDef Storage. So Irrespective of the fact that a form already exists with the same namespace, we add a new form def row (hence new `formid` ) in the FormDefStorag whenver `upgrade` is set to false i.e. we have a new resource id for that form. Also during uninstall of old resource no longer in the update, we remove the form def row for the existing form so that we don't end up with 2 forms with same namespace. 