### PR TITLE
Always format Decimal Widget as English 

### DIFF
--- a/app/src/org/commcare/views/widgets/DecimalWidget.java
+++ b/app/src/org/commcare/views/widgets/DecimalWidget.java
@@ -29,6 +29,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 
 import java.text.NumberFormat;
+import java.util.Locale;
 
 /**
  * A widget that restricts values to floating point numbers.
@@ -60,7 +61,7 @@ public class DecimalWidget extends StringWidget {
             d = (Double)getCurrentAnswer().getValue();
         }
 
-        NumberFormat nf = NumberFormat.getNumberInstance();
+        NumberFormat nf = NumberFormat.getNumberInstance(Locale.ENGLISH);
         nf.setMaximumFractionDigits(15);
         nf.setMaximumIntegerDigits(15);
         nf.setGroupingUsed(false);

--- a/app/src/org/commcare/views/widgets/DecimalWidget.java
+++ b/app/src/org/commcare/views/widgets/DecimalWidget.java
@@ -61,14 +61,7 @@ public class DecimalWidget extends StringWidget {
             d = (Double)getCurrentAnswer().getValue();
         }
 
-        NumberFormat nf = NumberFormat.getNumberInstance(Locale.ENGLISH);
-        nf.setMaximumFractionDigits(15);
-        nf.setMaximumIntegerDigits(15);
-        nf.setGroupingUsed(false);
         if (d != null) {
-            Double dAnswer = (Double)getCurrentAnswer().getValue();
-            String dString = nf.format(dAnswer);
-            d = Double.parseDouble(dString.replace(',', '.'));
             mAnswer.setText(d.toString());
         }
 

--- a/app/src/org/commcare/views/widgets/DecimalWidget.java
+++ b/app/src/org/commcare/views/widgets/DecimalWidget.java
@@ -68,8 +68,8 @@ public class DecimalWidget extends StringWidget {
         if (d != null) {
             Double dAnswer = (Double)getCurrentAnswer().getValue();
             String dString = nf.format(dAnswer);
-            d = Double.parseDouble(dString.replace(',', '.'));
-            mAnswer.setText(d.toString());
+            dString = dString.replace(',', '.');
+            mAnswer.setText(dString);
         }
 
         // disable if read only

--- a/app/src/org/commcare/views/widgets/DecimalWidget.java
+++ b/app/src/org/commcare/views/widgets/DecimalWidget.java
@@ -61,7 +61,14 @@ public class DecimalWidget extends StringWidget {
             d = (Double)getCurrentAnswer().getValue();
         }
 
+        NumberFormat nf = NumberFormat.getNumberInstance(Locale.ENGLISH);
+        nf.setMaximumFractionDigits(15);
+        nf.setMaximumIntegerDigits(15);
+        nf.setGroupingUsed(false);
         if (d != null) {
+            Double dAnswer = (Double)getCurrentAnswer().getValue();
+            String dString = nf.format(dAnswer);
+            d = Double.parseDouble(dString.replace(',', '.'));
             mAnswer.setText(d.toString());
         }
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/QA-186

When we format numbers in Arabic, they get converted to Arabic numbers which then throws an error on getting parsed as double. 

This PR sets the language to english for formatting the decimals. Moreover, it also removes the ew-conversion from formatted string to Double to avoid showing decimals in scientific/exponential notation.