### PR TITLE
Start Align Text in String widget to support for RTL

### DIFF
--- a/app/res/layout/edit_text_question_widget.xml
+++ b/app/res/layout/edit_text_question_widget.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <EditText xmlns:android="http://schemas.android.com/apk/res/android"
-          android:layout_width="match_parent"
-          android:layout_height="match_parent"
+          android:background="@drawable/edit_text_modern"
+          android:gravity="start"
           android:imeOptions="flagNoExtractUi"
+          android:layout_height="match_parent"
+          android:layout_width="match_parent"
+          android:paddingEnd="8dp"
           android:paddingLeft="8dp"
           android:paddingRight="8dp"
+          android:paddingStart="8dp"
           android:scrollHorizontally="false"
-          android:textCursorDrawable="@drawable/color_cursor"
-          android:background="@drawable/edit_text_modern"
-    android:paddingEnd="8dp"
-    android:paddingStart="8dp">
-
-</EditText>
+          android:textAlignment="viewStart"
+          android:textCursorDrawable="@drawable/color_cursor"/>

--- a/app/res/layout/edit_text_question_widget_compact.xml
+++ b/app/res/layout/edit_text_question_widget_compact.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <EditText xmlns:android="http://schemas.android.com/apk/res/android"
-          android:layout_width="@dimen/edit_text_question_widget_compact_width"
-          android:layout_height="match_parent"
-          android:layout_gravity="end|end"
-          android:gravity="end"
           android:background="@drawable/edit_text_modern"
+          android:gravity="start"
           android:imeOptions="flagNoExtractUi"
+          android:layout_gravity="end"
+          android:layout_height="match_parent"
+          android:layout_width="@dimen/edit_text_question_widget_compact_width"
+          android:paddingEnd="@dimen/edit_text_question_widget_padding_horizontal"
           android:paddingLeft="@dimen/edit_text_question_widget_padding_horizontal"
           android:paddingRight="@dimen/edit_text_question_widget_padding_horizontal"
-          android:textCursorDrawable="@drawable/color_cursor"
-    android:paddingStart="@dimen/edit_text_question_widget_padding_horizontal"
-    android:paddingEnd="@dimen/edit_text_question_widget_padding_horizontal" />
+          android:paddingStart="@dimen/edit_text_question_widget_padding_horizontal"
+          android:textAlignment="viewStart"
+          android:textCursorDrawable="@drawable/color_cursor"/>


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/QA-188

Lots of formatting diff below though the only meaningful change is addition of below 2 properties in both Edittexts - 

```
android:gravity="start"
android:textAlignment="viewStart"
```     