### PR TITLE
Handle Form resource Id changes during App Update

### DIFF
--- a/app/src/org/commcare/android/resource/installers/FileSystemUtils.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemUtils.java
@@ -31,6 +31,10 @@ public class FileSystemUtils {
         File newFile = new File(ReferenceManager.instance().DeriveReference(newLocation).getLocalURI());
         File oldFile = new File(ReferenceManager.instance().DeriveReference(oldLocation).getLocalURI());
 
+        if (oldFile.getAbsolutePath().contentEquals(newFile.getAbsolutePath())) {
+            return true;
+        }
+
         if (!oldFile.exists()) {
             //Nothing should be allowed to exist in the new location except for the incoming file
             //due to the staging rules. If there's a file there, it's this one.

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -91,7 +91,8 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
         }
 
         Vector<Integer> existingforms = FormDefRecord.getFormDefIdsByJrFormId(platform.getFormDefStorage(), formDef.getMainInstance().schema);
-        if (existingforms != null && existingforms.size() > 0) {
+        boolean formAlreadyExists = existingforms != null && existingforms.size() > 0;
+        if (formAlreadyExists) {
             //we already have one form. Hopefully this is during an upgrade...
             if (!upgrade) {
                 //Hm, error out?
@@ -110,7 +111,7 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
             formDefId = formDefRecord.save(platform.getFormDefStorage());
         }
 
-        return upgrade ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED;
+        return formAlreadyExists ? Resource.RESOURCE_STATUS_UPGRADE : Resource.RESOURCE_STATUS_INSTALLED;
     }
 
     public static void registerAndroidLevelFormParsers() {


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/ICDS-343

**Issue before this PR**

`upgrade` flag for `Resource.install` gets set based on the resource id match. If master table already has a resource with a given resource id, `upgrade` is set to true otherwise false.

For all update table resources who have a resource id match in master table and gets marked as `RESOURCE_STATUS_UPGRADE` during `install`, `Resource.upgrade` is called while applying the staged update. For a form resource `upgrade` is where we [update the filePath](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java#L125) for an existing form in the FormDef storage to point to the newer form. 

This updation of path doesn't happen when a form changes the resource id  currently since both the conditions that are required for `upgrade` to get called doesn't meet - 
1. Such resources doesn't get marked as `RESOURCE_STATUS_UPGRADE` but as `RESOURCE_STATUS_INSTALLED` in `Resource.install` as due to resource id being different `upgrade` is set to false in [install](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java#L113). 

2. No corresponding resource id match in master table which means `upgrade` [won't be called](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/resources/model/ResourceTable.java#L666) even if 1st condistion is met. 

To end the loop, we call `uninstall` for the master table resources who are no longer there in the update table. When a form changes the resource id, the old file path for the master form resource gets deleted [later](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/resources/model/ResourceTable.java#L723) during `uninstall` which results in the "Form Not found error" for such forms. 

**Solution**

In order to meet both conditions - 

1. Instead of using the upgrade flag to marke resources as `RESOURCE_STATUS_UPGRADE`, do it based on whether a form is already present with the given namespace.  (this is what this PR changes)

2. Call `upgrade` for all update resources marked as `RESOURCE_STATUS_UPGRADE` even if there is no resource id match in master for the update form resource (This is what the cross requested PR addresses)


cross-request: https://github.com/dimagi/commcare-core/pull/841
