### PR TITLE
Restore search on getting back to the Case list

### DIFF
--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -830,6 +830,10 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         adapter.registerDataSetObserver(this.mListStateObserver);
         containerFragment.setData(adapter);
 
+        if (entitySelectSearchUI != null) {
+            entitySelectSearchUI.restoreSearchString();
+        }
+
         // Pre-select entity if one was provided in original intent
         if (!resuming && !mNoDetailMode && inAwesomeMode && this.getIntent().hasExtra(EXTRA_ENTITY_KEY)) {
             TreeReference entity = selectDatum.getEntityFromID(evalContext(),

--- a/app/src/org/commcare/activities/EntitySelectSearchUI.java
+++ b/app/src/org/commcare/activities/EntitySelectSearchUI.java
@@ -94,6 +94,7 @@ class EntitySelectSearchUI implements TextWatcher {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
                 searchMenuItem.expandActionView();
             }
+            filterString = lastQueryString;
             searchView.setQuery(lastQueryString, false);
             if (activity.getAdapter() != null) {
                 activity.getAdapter().filterByString(lastQueryString);


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/MOB-73

Tries to restore the search after setting the adapter.

@ctsims It seems a bit urgent for REACH so getting it in 2.45 for next LTS release even though QA test run is complete. 

Product Note: Fixes a bug causing search results to not be retained on returning back to the case list. 