### PR TITLE
Include aar libs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     }
 
     // this syntax doesn't work for compiling .aar files, so those have to be loaded manually
-    implementation fileTree(include: '*.jar',exclude: 'regexp-me.jar', dir: 'libs')
+    implementation fileTree(include: ['*.jar','*.aar'],exclude: 'regexp-me.jar', dir: 'libs')
     implementation(name: 'htmlspanner-custom', ext: 'aar')
     implementation(name: 'android-zebra-interface-1.1', ext: 'aar')
     implementation 'com.simprints:LibSimprints:1.0.12'


### PR DESCRIPTION
These files got mistakenly removed by me during gradle update last year were probably getting served through cache/ transitive dependencies till now. Adding them back to get past some build errors after cleaning my cache. 