### PR TITLE
Bug fix: Saving a form as Incomplete more than once doesn't work

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -734,7 +734,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
 
         // A form save has already been triggered, ignore subsequent form saves
-        if (FormEntryActivity.mFormController.isFormSaveComplete()) {
+        if (FormEntryActivity.mFormController.isFormCompleteAndSaved()) {
             return;
         }
 

--- a/app/src/org/commcare/logic/AndroidFormController.java
+++ b/app/src/org/commcare/logic/AndroidFormController.java
@@ -16,7 +16,7 @@ public class AndroidFormController extends FormController implements PendingCall
     private FormIndex mPendingCalloutFormIndex = null;
     private boolean wasPendingCalloutCancelled;
     private FormIndex formIndexToReturnTo = null;
-    private boolean formSaveComplete = false;
+    private boolean formCompleteAndSaved = false;
 
     public AndroidFormController(FormEntryController fec, boolean readOnly) {
         super(fec, readOnly);
@@ -64,11 +64,11 @@ public class AndroidFormController extends FormController implements PendingCall
         this.formIndexToReturnTo = null;
     }
 
-    public boolean isFormSaveComplete() {
-        return formSaveComplete;
+    public boolean isFormCompleteAndSaved() {
+        return formCompleteAndSaved;
     }
 
-    public void markFormSaveProcessComplete(boolean formSaveComplete) {
-        this.formSaveComplete = formSaveComplete;
+    public void markCompleteFormAsSaved() {
+        this.formCompleteAndSaved = true;
     }
 }

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -123,7 +123,10 @@ public class SaveToDiskTask extends
             return new ResultAndError<>(SaveStatus.SAVE_ERROR, cleanedMessage);
         }
 
-        FormEntryActivity.mFormController.markFormSaveProcessComplete(true);
+        if (mMarkCompleted) {
+            FormEntryActivity.mFormController.markCompleteFormAsSaved();
+        }
+
         if (exitAfterSave) {
             FormRecord saved = CommCareApplication.instance().getCurrentSessionWrapper().getFormRecord();
             Logger.log(LogTypes.TYPE_FORM_ENTRY,


### PR DESCRIPTION
Jira:https://dimagi-dev.atlassian.net/browse/MOB-86

Issue: When we rolled out [this change](https://github.com/dimagi/commcare-android/pull/2041/files) to allow a form to only be saved once we didn't consider that we currently allow incomplete forms to be saved more than once through the "Save" options menu. 

Proposed Change: Only mark forms as "saved" for complete forms so that a incomplete form's save don't get stuck at [the check here](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/activities/FormEntryActivity.java#L737).

Product Note: Fixes a bug due to which saving a form as Incomplete more than once doesn't work