### PR TITLE
Fixes form submission in practice mode

### DIFF
--- a/app/src/org/commcare/network/CommcareRequestGenerator.java
+++ b/app/src/org/commcare/network/CommcareRequestGenerator.java
@@ -199,6 +199,7 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
 
         if (User.TYPE_DEMO.equals(userType)) {
             params.put(SUBMIT_MODE, SUBMIT_MODE_DEMO);
+            params.put(AUTH_REQUEST_TYPE, AUTH_REQUEST_TYPE_NO_AUTH);
         }
 
         requester = CommCareApplication.instance().buildHttpRequester(


### PR DESCRIPTION
Looks like practice mode form submission has been broken for a while (since retrofit migration). On submitting any data in practice mode we get 401 from server since we are no longer putting `params.put(AUTH_REQUEST_TYPE, AUTH_REQUEST_TYPE_NO_AUTH);` in the form submission request. 

I am not sure if it's worth a hotfix so just PRing to master. 

Product Note: Fixes form submission in practice mode. 