### PR TITLE
Improve Sync Request hashing performance

### DIFF
--- a/app/src/org/commcare/network/CommcareRequestGenerator.java
+++ b/app/src/org/commcare/network/CommcareRequestGenerator.java
@@ -8,6 +8,7 @@ import org.commcare.cases.util.CaseDBUtils;
 import org.commcare.core.network.AuthInfo;
 import org.commcare.core.network.HTTPMethod;
 import org.commcare.core.network.ModernHttpRequester;
+import org.commcare.engine.cases.CaseUtils;
 import org.commcare.interfaces.CommcareRequestEndpoints;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.modern.util.Pair;
@@ -183,7 +184,8 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
             // For integration tests, use fake hash to trigger 412 recovery on this sync
             return fakeHash;
         } else {
-            return CaseDBUtils.computeCaseDbHash(CommCareApplication.instance().getUserStorage(ACase.STORAGE_KEY, ACase.class));
+            return CaseUtils.computeCaseDbHash(
+                    CommCareApplication.instance().getUserStorage(ACase.STORAGE_KEY, ACase.class));
         }
     }
 

--- a/app/unit-tests/src/org/commcare/android/tests/processing/ProcessingTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/ProcessingTest.java
@@ -5,6 +5,8 @@ import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestUtils;
 import org.commcare.cases.model.Case;
 import org.commcare.android.database.user.models.ACase;
+import org.commcare.cases.util.CaseDBUtils;
+import org.commcare.engine.cases.CaseUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,5 +55,24 @@ public class ProcessingTest {
         TestUtils.processResourceTransaction("/inputs/case_change_type.xml");
         Case c2 = TestUtils.getCaseStorage().getRecordForValue(ACase.INDEX_CASE_ID, "test_case_id");
         assertEquals("Changed Type", "changed_unit_test", c2.getTypeId());
+    }
+
+    @Test
+    public void testHashingParity() {
+        assertHashesEqual();
+        TestUtils.processResourceTransaction("/inputs/case_create.xml");
+        assertHashesEqual();
+        TestUtils.processResourceTransaction("/inputs/case_update.xml");
+        assertHashesEqual();
+        TestUtils.processResourceTransaction("/inputs/case_create_and_index.xml");
+        assertHashesEqual();
+    }
+
+    private void assertHashesEqual() {
+        String rawCalcHash = CaseDBUtils.computeCaseDbHash(TestUtils.getCaseStorage());
+
+        String fastCalcHash = CaseUtils.computeCaseDbHash(TestUtils.getCaseStorage());
+
+        assertEquals("fasthash incorrect", rawCalcHash, fastCalcHash);
     }
 }


### PR DESCRIPTION
Significantly improves how fast we generate the state hash token for syncs (at least 100% faster with 54k cases, probably faster on slower devices) by using the metadata index coverage method rather than reading the case records raw.

Found this while investigating performance issues identified by Jessica on isth-production

cross-request: https://github.com/dimagi/commcare-core/pull/852