### PR TITLE
[HOTFIX] Revert "Turns Image scaling code path off"

### DIFF
--- a/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
+++ b/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
@@ -44,12 +44,6 @@ public class ImageCaptureProcessing {
         String finalFilePath = instanceFolder + imageFilename;
 
         boolean savedScaledImage = false;
-
-        // Turning off scaling for now, since current code never actually ends up using the
-        // final scaled image. We might wanna turn that later on again sometime so leaving the scaling
-        // code as it is
-        shouldScale = false;
-
         if (shouldScale) {
             ImageWidget currentWidget = (ImageWidget)formEntryActivity.getPendingWidget();
             if (currentWidget != null) {


### PR DESCRIPTION
Reverts #2019

Jira: https://dimagi-dev.atlassian.net/browse/MOB-103

Hotfixing https://github.com/dimagi/commcare-android/pull/2105

This was a misunderstanding on my part where I thought the scaled image doesn't get used at all. Though it looks like we are using the final scaled image later on. I got confused by not knowing the fact that we always display the original image on screen while the scaled image gets submitted to the server.

Product Note: Fixes a bug where CommCare 2.45 doesn't respect "Image Size" set for image capture questions.