### PR TITLE
Stops Images from getting shown in Gallery

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -347,12 +347,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
     }
 
-    public void saveImageWidgetAnswer(ContentValues values) {
-        Uri imageURI =
-                getContentResolver().insert(Images.Media.EXTERNAL_CONTENT_URI, values);
-        Log.i(TAG, "Inserting image returned uri = " + imageURI);
-
-        uiController.questionsView.setBinaryData(imageURI, mFormController);
+    public void saveImageWidgetAnswer(String imagePath) {
+        uiController.questionsView.setBinaryData(imagePath, mFormController);
         saveAnswersForCurrentScreen(FormEntryConstants.DO_NOT_EVALUATE_CONSTRAINTS);
         uiController.refreshView();
     }

--- a/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
+++ b/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
@@ -141,7 +141,7 @@ public class ImageCaptureProcessing {
         File originalImage = ImageWidget.getTempFileForImageCapture();
         try {
             File unscaledFinalImage = moveAndScaleImage(originalImage, isImage, instanceFolder, activity);
-            activity.saveImageWidgetAnswer(buildImageFileContentValues(unscaledFinalImage));
+            activity.saveImageWidgetAnswer(unscaledFinalImage.getAbsolutePath());
             return true;
         } catch (IOException e) {
             e.printStackTrace();
@@ -213,7 +213,7 @@ public class ImageCaptureProcessing {
         if (originalImage.exists()) {
             try {
                 File unscaledFinalImage = moveAndScaleImage(originalImage, true, instanceFolder, activity);
-                activity.saveImageWidgetAnswer(buildImageFileContentValues(unscaledFinalImage));
+                activity.saveImageWidgetAnswer(unscaledFinalImage.getAbsolutePath());
             } catch (IOException e) {
                 e.printStackTrace();
                 Toast.makeText(activity, Localization.get("image.selection.not.saved"), Toast.LENGTH_LONG).show();
@@ -227,17 +227,6 @@ public class ImageCaptureProcessing {
 
     private static void showInvalidImageMessage(FormEntryActivity activity) {
         Toast.makeText(activity, Localization.get("invalid.image.selection"), Toast.LENGTH_LONG).show();
-    }
-
-    private static ContentValues buildImageFileContentValues(File unscaledFinalImage) {
-        // Add the new image to the Media content provider so that the viewing is fast in Android 2.0+
-        ContentValues values = new ContentValues(6);
-        values.put(Media.TITLE, unscaledFinalImage.getName());
-        values.put(Media.DISPLAY_NAME, unscaledFinalImage.getName());
-        values.put(Media.DATE_TAKEN, System.currentTimeMillis());
-        values.put(Media.MIME_TYPE, "image/jpeg");
-        values.put(Media.DATA, unscaledFinalImage.getAbsolutePath());
-        return values;
     }
 
     public static void processImageFromBroadcast(FormEntryActivity activity, String instanceFolder) {

--- a/app/src/org/commcare/views/widgets/ImageWidget.java
+++ b/app/src/org/commcare/views/widgets/ImageWidget.java
@@ -300,17 +300,15 @@ public class ImageWidget extends QuestionWidget {
     }
 
     @Override
-    public void setBinaryData(Object binaryuri) {
+    public void setBinaryData(Object binaryPath) {
         // you are replacing an answer. delete the previous image using the
         // content provider.
         if (mBinaryName != null) {
             deleteMedia();
         }
-        String binaryPath = UrlUtils.getPathFromUri((Uri)binaryuri, getContext());
 
-        File f = new File(binaryPath);
+        File f = new File(binaryPath.toString());
         mBinaryName = f.getName();
-        Log.i(t, "Setting current answer to " + f.getName());
     }
 
     @Override

--- a/app/src/org/commcare/views/widgets/ImageWidget.java
+++ b/app/src/org/commcare/views/widgets/ImageWidget.java
@@ -271,12 +271,6 @@ public class ImageWidget extends QuestionWidget {
         }
         // clean up variables
         mBinaryName = null;
-
-        //TODO: possibly switch back to this implementation, but causes NullPointerException right now
-        /*
-        int del = MediaUtils.deleteImageFileFromMediaProvider(mInstanceFolder + File.separator + mBinaryName);
-        Log.i(t, "Deleted " + del + " rows from media content provider");
-        mBinaryName = null;*/
     }
 
     @Override


### PR DESCRIPTION
2 changes

- Removes the image publishing to MediaStore for CommCare Images
- Don't delete Gallery copies of the images

Jira: https://dimagi-dev.atlassian.net/browse/MOB-14 
Jira: https://dimagi-dev.atlassian.net/browse/MOB-72

Product Note:
- Fixes a bug where Internal CommCare copy of the image will start showing up in Gallery
- Fixes a bug where deleting or replacing the image from CommCare will result in the image getting deleted from Gallery