### PR TITLE
Protect Form finish when activity is getting destroyed

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1002,12 +1002,13 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
      * Call when the user is ready to save and return the current form as complete
      */
     protected void triggerUserFormComplete() {
-
-        if (mFormController.isFormReadOnly()) {
-            finishReturnInstance(false);
-        } else {
-            int formRecordId = getIntent().getIntExtra(KEY_FORM_RECORD_ID, -1);
-            saveCompletedFormToDisk(instanceState.getDefaultFormTitle(formRecordId));
+        if(!isFinishing()) {
+            if (mFormController.isFormReadOnly()) {
+                finishReturnInstance(false);
+            } else {
+                int formRecordId = getIntent().getIntExtra(KEY_FORM_RECORD_ID, -1);
+                saveCompletedFormToDisk(instanceState.getDefaultFormTitle(formRecordId));
+            }
         }
     }
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/ICDS-525

CL: https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5b5b918a6007d59fcdfa7535?time=last-thirty-days

I was able to repro this issue on clicking Finish twice for a form who has another form linked to it via EOF navigation. I am not sure why it only happens when we have another form linked to current form. though what seems to be happening is "mFormController" becomes null when the activity is getting destoyed and if user clicks "Finish" around the same time it results in a NPE. 