### PR TITLE
Fix Sign Save

### DIFF
--- a/app/src/org/commcare/views/widgets/SignatureWidget.java
+++ b/app/src/org/commcare/views/widgets/SignatureWidget.java
@@ -201,15 +201,14 @@ public class SignatureWidget extends QuestionWidget {
 
 
     @Override
-    public void setBinaryData(Object binaryURI) {
+    public void setBinaryData(Object binaryPath) {
         // you are replacing an answer. delete the previous image using the
         // content provider.
         if (mBinaryName != null) {
             deleteMedia();
         }
 
-        String binaryPath = UrlUtils.getPathFromUri((Uri)binaryURI, getContext());
-        File f = new File(binaryPath);
+        File f = new File(binaryPath.toString());
         mBinaryName = f.getName();
         Log.i(t, "Setting current answer to " + f.getName());
     }


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/QA-436

CL: https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/5ccabef0f8b88c2963d337c5?time=last-thirty-days

Regression of https://github.com/dimagi/commcare-android/pull/2110/files#diff-7825926c6662bb8827ea6b48aae09b83R174

We are now calling `setBinaryPath` with the path of the image rathr than URI and since we didn't make this change in SignatureWidget and only for ImageWidget, the app was crashing. 

Can someone merge it on approving so that it gets available to QA for testing and also ping on Jira ticket so that QA can test it again. 