### PR TITLE
Avoid progress numerator shooting beyond denominator For Async Restore

### DIFF
--- a/app/src/org/commcare/tasks/AsyncRestoreHelper.java
+++ b/app/src/org/commcare/tasks/AsyncRestoreHelper.java
@@ -117,12 +117,18 @@ public class AsyncRestoreHelper {
         reportServerProgressTimer.schedule(new TimerTask() {
             @Override
             public void run() {
-                if (lastReportedServerProgressValue == serverProgressCompletedSoFar) {
+                if ((lastReportedServerProgressValue == serverProgressCompletedSoFar) ||
+                        (lastReportedServerProgressValue == serverProgressTotal)) {
                     reportServerProgressTimer.cancel();
                     reportServerProgressTimer.purge();
                     return;
                 }
-                syncTask.reportServerProgress(++lastReportedServerProgressValue, serverProgressTotal);
+                // sometimes due to invald data from HQ, mobile gets in a state where the lastReportedServerProgressValue
+                // overshoots the serverProgressTotal and cause the progress bar to be increased in a fashion similar to
+                // 10/10 , 11/11, 12/12 and so on. We wanna avoid that behaviour by using a "less than" check below.
+                if (lastReportedServerProgressValue < serverProgressTotal) {
+                    syncTask.reportServerProgress(++lastReportedServerProgressValue, serverProgressTotal);
+                }
             }
         }, 0, intervalAllottedPerProgressUnit);
     }


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/MOB-113

@ctsims I am not really sure how I can reproduce this behaviour to test this out so just adding additional checks that I think would restrict this issue to happen in future. 