### PR TITLE
Ensure new file path for media file exists before renaming

### DIFF
--- a/app/src/org/commcare/android/resource/installers/FileSystemUtils.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemUtils.java
@@ -1,6 +1,7 @@
 package org.commcare.android.resource.installers;
 
 import org.commcare.util.LogTypes;
+import org.commcare.utils.FileUtil;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.Logger;
@@ -54,6 +55,7 @@ public class FileSystemUtils {
             }
         }
 
+        FileUtil.ensureFilePathExists(newFile);
         boolean success = oldFile.renameTo(newFile);
 
         if (success && oldFile.exists()) {


### PR DESCRIPTION
While updating a media file when a media resource file path changes folder structure, the update fails because of failure in moving the file to the new folder structure since we don't ensure that fold structure exists beforehand. 

Full Context [here](https://dimagi-dev.atlassian.net/browse/ICDS-578?focusedCommentId=21834&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21834)


This issue happens only for media files that existed in the old version. For ex. in version 1 say we have a media file with path a/b/mf.png and in version 2, we updated it's path to a/c/mf.png.  Mobile fails in updating a resource to this new path `a/c/mf.png` since it doesn't create the folder `c` before copying that file to the new path. It only happens while updating an existing resource since our `install` code takes care of [creating this folder structure](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java#L153) but `update` doesn't. So if we have a entirely new media file (with new resource id) with a filepath `a/c/mf2.png` it will create that path successfully.