### PR TITLE
Clear focus from views to avoid form jumps on adding/removing views

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -753,7 +753,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                 shouldRemoveFromView.add(i);
             }
 
-            // Finally if we have not changes this widget last, make sure that
+            // Finally if this is not the last widget user changed, make sure that
             // this widget is not in focus since it results in some absurd form
             // jumping issues.
             if (i != indexOfLastChangedWidget) {

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -39,6 +39,7 @@ import org.commcare.views.dialogs.PaneledChoiceDialog;
 import org.commcare.views.media.AudioController;
 import org.commcare.views.widgets.IntentWidget;
 import org.commcare.views.widgets.QuestionWidget;
+import org.commcare.views.widgets.StringWidget;
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
@@ -750,6 +751,13 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                 // If there is no equivalent prompt in the list of new prompts, then this prompt is
                 // no longer relevant in the new view, so it should get removed
                 shouldRemoveFromView.add(i);
+            }
+
+            // Finally if we have not changes this widget last, make sure that
+            // this widget is not in focus since it results in some absurd form
+            // jumping issues.
+            if (i != indexOfLastChangedWidget) {
+                oldWidgets.get(i).clearFocus();
             }
         }
         // Remove "atomically" to not mess up iterations


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/MOB-107
Also fixes: https://dimagi-dev.atlassian.net/browse/MOB-10 

Issue:
When after editing a editText, user shifts to a non editText field (like RadioButton), the last changed editText don't clear foucs by itself. This results into abrupt form jumps to this last focused EditText when soft keyboard gets hidden or if we add/remove any views from the Question List.


Solution:
Ensure that we remove focus from all views but the last changed one while updating Form Relevancies. 