### PR TITLE
Fixes in Offline Update Workflow

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -414,6 +414,5 @@
     <string name="recovery_measure_unzip_progress" cc:translatable="true">Processing CCZ File.. %1$s</string>
     <string name="reinstall_prompt_title" cc:translatable="true">Reinstall of %1$s is Required</string>
 
-    <string name="install_error_file_not_found">No file found for resource %1$s</string>
-
+    <string name="install_error_file_not_found" cc:translatable="true">No file found for resource %1$s</string>
 </resources>

--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -78,7 +78,7 @@ public class AndroidResourceManager extends ResourceManager {
 
             if (updateNotNewer(getMasterProfile())) {
                 Logger.log(LogTypes.TYPE_RESOURCES, "App Resources up to Date");
-                upgradeTable.clearUpgrade(platform);
+                clearUpgrade();
                 return AppInstallStatus.UpToDate;
             }
 
@@ -198,7 +198,7 @@ public class AndroidResourceManager extends ResourceManager {
         updateStats.registerUpdateException(new Exception(result.toString()));
 
         if (!result.canReusePartialUpdateTable()) {
-            upgradeTable.clearUpgrade(platform);
+            clearUpgrade();
         }
 
         retryUpdateOrGiveUp(ctx, isAutoUpdate);
@@ -215,7 +215,7 @@ public class AndroidResourceManager extends ResourceManager {
                 ResourceInstallUtils.recordAutoUpdateCompletion(app);
             }
 
-            upgradeTable.clearUpgrade(platform);
+            clearUpgrade();
         } else {
             Logger.log(LogTypes.TYPE_RESOURCES, "Retrying auto-update");
             UpdateStats.saveStatsPersistently(app, updateStats);

--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -59,37 +59,30 @@ public class AndroidResourceManager extends ResourceManager {
      * Download the latest profile; if it is new, download and stage the entire
      * update.
      *
-     * @param profileRef Reference that resolves to the profile file used to
-     *                   seed the update
+     * @param profileRef       Reference that resolves to the profile file used to
+     *                         seed the update
      * @param profileAuthority The authority from which the app resources for the update are
      *                         coming (local vs. remote)
      * @return UpdateStaged upon update download, UpToDate if no new update,
      * otherwise an error status.
      */
     public AppInstallStatus checkAndPrepareUpgradeResources(String profileRef, int profileAuthority)
-            throws UnfullfilledRequirementsException, UnresolvedResourceException {
+            throws UnfullfilledRequirementsException, UnresolvedResourceException, InstallCancelledException {
         synchronized (platform) {
             this.profileRef = profileRef;
-            try {
-                instantiateLatestUpgradeProfile(profileAuthority);
+            instantiateLatestUpgradeProfile(profileAuthority);
 
-                if (isUpgradeTableStaged()) {
-                    return AppInstallStatus.UpdateStaged;
-                }
-
-                if (updateNotNewer(getMasterProfile())) {
-                    Logger.log(LogTypes.TYPE_RESOURCES, "App Resources up to Date");
-                    upgradeTable.clearUpgrade(platform);
-                    return AppInstallStatus.UpToDate;
-                }
-
-                prepareUpgradeResources();
-            } catch (InstallCancelledException e) {
-                // The user cancelled the upgrade check process. The calling task
-                // should have caught and handled the cancellation
-                return AppInstallStatus.UnknownFailure;
+            if (isUpgradeTableStaged()) {
+                return AppInstallStatus.UpdateStaged;
             }
 
+            if (updateNotNewer(getMasterProfile())) {
+                Logger.log(LogTypes.TYPE_RESOURCES, "App Resources up to Date");
+                upgradeTable.clearUpgrade(platform);
+                return AppInstallStatus.UpToDate;
+            }
+
+            prepareUpgradeResources();
             return AppInstallStatus.UpdateStaged;
         }
     }

--- a/app/src/org/commcare/tasks/UpdateTask.java
+++ b/app/src/org/commcare/tasks/UpdateTask.java
@@ -316,4 +316,7 @@ public class UpdateTask
         return Pair.create(splitMessage[0].substring(2), splitMessage[1]);
     }
 
+    public void clearUpgrade() {
+        resourceManager.clearUpgrade();
+    }
 }


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/MOB-108

Issue1: When user stops the current update check, `taskIsCancelling` gets set to `true` which never gets reset to false even after the task is cancelled. So when user triggers an offline update the update task never gets triggered again because of the [check on taskIsCancelling](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/activities/UpdateActivity.java#L128).

Issue2: When user triggers an offline update without stopping the current check, the offline update never takes effect and the update check just continues fetching the resources online. This is because if there is an ongoing update check, we just[ connect to it](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/activities/UpdateActivity.java#L299) in order to avoid duplicate `UpdateTask` instances. 

Changes in this PR to solve these issues:

1. When user selects "Offline Update" from Options Menu, resets the `taskIsCancelling` flag if the `UpdateTask` instance has been cleared by now. 

2. When user selects "Offline Update" from Options Menu, cancels the ongoing update task to check for update. This makes it so that when user returns to the activity after selecting a ccz for offline update, the previous updateTask has been cancelled already making it safe for us to instantiate another updateTask with the offline reference. This step is protected by step 1 above where we only reset the `taskIsCancelling` flag when the `updateTask` has been cleared. 

Additional Changes this PR make:

3. When we are triggering an offline update, make sure that we clear the update table first before starting the update check. This is because failures in previous update check doesn't always clears the update table and there might be entries belonging to a different app version in the table. 

4. In cases when we call cancel the `UpdateTask`, `onPostExecute` doesn't get called which is where we handle update failures. To resolve this, now we also handle update failures in `doInBackground` itself by intercepting `InstallCancelledException` which is the exception we throw when we detect task cancellation. 

Product Note: Fixes a bug where offline update doesn't get triggered on selecting a ccz. 

cross-request: https://github.com/dimagi/commcare-core/pull/856



