### PR TITLE
Correct error handling for Indexed Fixture atrribute lookup

### DIFF
--- a/app/src/org/commcare/engine/cases/AndroidIndexedFixtureInstanceTreeElement.java
+++ b/app/src/org/commcare/engine/cases/AndroidIndexedFixtureInstanceTreeElement.java
@@ -80,6 +80,7 @@ public class AndroidIndexedFixtureInstanceTreeElement extends IndexedFixtureInst
                     String newMessage = "Deserialization failed for indexed fixture root atrribute wrapper: " + e.getMessage();
                     throw new RuntimeException(newMessage);
                 }
+                throw e;
             }
         }
         return attributes;


### PR DESCRIPTION
Rethrows any exception caught during deserialization for indexed fixtures atrributes