### PR TITLE
Don't retry form submissions when rate limited

### DIFF
--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -326,6 +326,9 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                                 // A processing failure indicates that there there is no point in
                                 // trying that submission again immediately
                                 break;
+                            } else if (results[i] == FormUploadResult.RATE_LIMITED) {
+                                // Don't keep retrying, the server is rate limiting submissions
+                                break;
                             } else {
                                 attemptsMade++;
                             }

--- a/app/src/org/commcare/utils/FormUploadResult.java
+++ b/app/src/org/commcare/utils/FormUploadResult.java
@@ -52,7 +52,14 @@ public enum FormUploadResult {
      */
     PROGRESS_LOGGED_OUT(8),
 
-    PROGRESS_SDCARD_REMOVED(9);
+    PROGRESS_SDCARD_REMOVED(9),
+
+    /**
+     * The server can't couldn't handle the submission due to load, we
+     * shouldn't keep retrying it
+     */
+    RATE_LIMITED(10)
+    ;
 
     private final int orderVal;
     private String errorMessage;

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -212,6 +212,8 @@ public class FormUploadUtil {
             return processActionableFaiure(response);
         } else if (responseCode == 422) {
             return handleProcessingFailure(response.errorBody().byteStream());
+        } else if (responseCode == 503) {
+            return FormUploadResult.RATE_LIMITED;
         } else {
             return FormUploadResult.FAILURE;
         }


### PR DESCRIPTION
Currently when receiving a 503 from the server, the phone immediately tries again a few times. This updates the send task to short circuit back instead to cease further attempts to submit the forms automatically.

This is high priority as our rate limiting is currently getting hit with even higher submission counts after each form due to the automated retry.