### PR TITLE
[HOTFIX] [commcare_2.47.2] Fixes saved forms reading issue when there are duplicate namespaces in Forms table

### DIFF
--- a/app/src/org/commcare/activities/components/FormEntryInstanceState.java
+++ b/app/src/org/commcare/activities/components/FormEntryInstanceState.java
@@ -60,22 +60,17 @@ public class FormEntryInstanceState {
         String formStatus = formRecord.getStatus();
         boolean isInstanceReadOnly =
                 !FormRecord.STATUS_UNSTARTED.equals(formStatus) &&
-                !FormRecord.STATUS_INCOMPLETE.equals(formStatus);
+                        !FormRecord.STATUS_INCOMPLETE.equals(formStatus);
 
-        Vector<FormDefRecord> formDefRecords =
-                FormDefRecord.getFormDefsByJrFormId(formDefRecordStorage, formRecord.getXmlns());
-        if (formDefRecords.size() == 1) {
-            FormDefRecord formDefRecord = formDefRecords.get(0);
-            instanceState.setFormDefPath(formDefRecord.getFilePath());
-            return new Pair<>(formDefRecord.getID(), isInstanceReadOnly);
-        } else if (formDefRecords.size() < 1) {
+        int formDefId = FormDefRecord.getLatestFormDefId(formDefRecordStorage, formRecord.getXmlns());
+        if (formDefId == -1) {
             String error = "No XForm definition defined for this form with namespace " + formRecord.getXmlns();
             Logger.log(LogTypes.SOFT_ASSERT, error);
             throw new FormEntryActivity.FormQueryException(error);
         } else {
-            String error = "More than one XForm definition present for this form with namespace " + formRecord.getXmlns();
-            Logger.log(LogTypes.SOFT_ASSERT, error);
-            throw new FormEntryActivity.FormQueryException(error);
+            FormDefRecord formDefRecord = FormDefRecord.getFormDef(formDefRecordStorage, formDefId);
+            instanceState.setFormDefPath(formDefRecord.getFilePath());
+            return new Pair<>(formDefRecord.getID(), isInstanceReadOnly);
         }
     }
 

--- a/app/src/org/commcare/android/database/app/models/FormDefRecord.java
+++ b/app/src/org/commcare/android/database/app/models/FormDefRecord.java
@@ -157,6 +157,21 @@ public class FormDefRecord extends Persisted {
         }
     }
 
+    // Returns the formId of the formDefRecord with highest form def resource version for our namespace
+    public static int getLatestFormDefId(SqlStorage<FormDefRecord> formDefStorage, String namespace) {
+        Vector<Integer> formsForOurNamespace = FormDefRecord.getFormDefIdsByJrFormId(formDefStorage, namespace);
+        int maxFormResourceVersion = -1;
+        int latestFormId = -1;
+        for (int i = 0; i < formsForOurNamespace.size(); i++) {
+            FormDefRecord formDefRecordItem = formDefStorage.read(formsForOurNamespace.get(i));
+            if (formDefRecordItem.getResourceVersion() >= maxFormResourceVersion) {
+                maxFormResourceVersion = formDefRecordItem.getResourceVersion();
+                latestFormId = formDefRecordItem.getID();
+            }
+        }
+        return latestFormId;
+    }
+
     public static FormDefRecord getFormDef(SqlStorage<FormDefRecord> formDefRecordStorage, int formId) {
         return formDefRecordStorage.read(formId);
     }

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -8,6 +8,7 @@ import org.commcare.android.javarosa.PollSensorAction;
 import org.commcare.engine.extensions.IntentExtensionParser;
 import org.commcare.engine.extensions.PollSensorExtensionParser;
 import org.commcare.engine.extensions.XFormExtensionUtils;
+import org.commcare.models.database.SqlStorage;
 import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
@@ -41,6 +42,8 @@ import java.io.InputStreamReader;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
+
+import static org.commcare.android.database.app.models.FormDefRecord.getLatestFormDefId;
 
 /**
  * @author ctsims
@@ -80,24 +83,9 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     // Returns whether the associated formdefRecord is the one with highest form def resource version for our namespace
     private boolean isLatestFormRecord(AndroidCommCarePlatform platform) {
         if (formDefId != -1) {
-            return getLatestFormDefId(platform) == formDefId;
+            return getLatestFormDefId(platform.getFormDefStorage(), namespace) == formDefId;
         }
         return false;
-    }
-
-    // Returns the formId of the formDefRecord with highest form def resource version for our namespace
-    private int getLatestFormDefId(AndroidCommCarePlatform platform) {
-        Vector<Integer> formsForOurNamespace = FormDefRecord.getFormDefIdsByJrFormId(platform.getFormDefStorage(), namespace);
-        int maxFormResourceVersion = -1;
-        int latestFormId = -1;
-        for (int i = 0; i < formsForOurNamespace.size(); i++) {
-            FormDefRecord formDefRecordItem = platform.getFormDefStorage().read(formsForOurNamespace.get(i));
-            if (formDefRecordItem.getResourceVersion() >= maxFormResourceVersion) {
-                maxFormResourceVersion = formDefRecordItem.getResourceVersion();
-                latestFormId = formDefRecordItem.getID();
-            }
-        }
-        return latestFormId;
     }
 
     @Override


### PR DESCRIPTION
Issue: https://forum.dimagi.com/t/incomplete-forms-error-more-than-one-xform-present/6705

The duplicate formid issue PR introduced a bug in reading saved/Incomplete forms by creating the possibility of more than one entries in Form Def table for a namespace. On reading such a saved form, we were erroring out with message "More than one XForm definition present for this form". I missed out on this code path earlier while implementing the fix costing this bug. 

