### PR TITLE
Increase heap size to 1.5G for Test tasks 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -448,7 +448,7 @@ android {
 
     testOptions {
         unitTests.all {
-            maxHeapSize = "1536m"
+            maxHeapSize = "2048m"
 
             // Needed for robolectric tests to work with kxml for some bizarre reason
             jvmArgs '-noverify'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -448,7 +448,7 @@ android {
 
     testOptions {
         unitTests.all {
-            maxHeapSize = "2048m"
+            maxHeapSize = "1536m"
 
             // Needed for robolectric tests to work with kxml for some bizarre reason
             jvmArgs '-noverify'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -448,7 +448,7 @@ android {
 
     testOptions {
         unitTests.all {
-            maxHeapSize = "1024m"
+            maxHeapSize = "2048m"
 
             // Needed for robolectric tests to work with kxml for some bizarre reason
             jvmArgs '-noverify'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -448,6 +448,8 @@ android {
 
     testOptions {
         unitTests.all {
+            maxHeapSize = "1024m"
+
             // Needed for robolectric tests to work with kxml for some bizarre reason
             jvmArgs '-noverify'
             systemProperty 'robolectric.logging.enable', true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -448,7 +448,7 @@ android {
 
     testOptions {
         unitTests.all {
-            maxHeapSize = "3072m"
+            maxHeapSize = "4096m"
 
             // Needed for robolectric tests to work with kxml for some bizarre reason
             jvmArgs '-noverify'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -448,7 +448,7 @@ android {
 
     testOptions {
         unitTests.all {
-            maxHeapSize = "4096m"
+            maxHeapSize = "2000m"
 
             // Needed for robolectric tests to work with kxml for some bizarre reason
             jvmArgs '-noverify'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -448,7 +448,7 @@ android {
 
     testOptions {
         unitTests.all {
-            maxHeapSize = "2048m"
+            maxHeapSize = "3072m"
 
             // Needed for robolectric tests to work with kxml for some bizarre reason
             jvmArgs '-noverify'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -448,7 +448,7 @@ android {
 
     testOptions {
         unitTests.all {
-            maxHeapSize = "2000m"
+            maxHeapSize = "1024m"
 
             // Needed for robolectric tests to work with kxml for some bizarre reason
             jvmArgs '-noverify'

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.daemon=true
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:ErrorFile=/home/jenkins/error-logs/java_error%p.log
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.daemon=true
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx10248m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:ErrorFile=/home/jenkins/error-logs/java_error%p.log
+org.gradle.jvmargs=-Xmx1024m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:ErrorFile=/home/jenkins/error-logs/java_error%p.log
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.daemon=true
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3072m -XX:MaxPermSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.daemon=true
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx3072m -XX:MaxPermSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3072m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.daemon=true
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:ErrorFile=/home/jenkins/error-logs/java_error%p.log
+org.gradle.jvmargs=-Xmx10248m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:ErrorFile=/home/jenkins/error-logs/java_error%p.log
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Xmx1024m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryErro
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-org.gradle.parallel=true
+org.gradle.parallel=false
 
 # Enables new incubating mode that makes Gradle selective when configuring projects.
 # Only relevant projects are configured which results in faster builds for large multi-projects.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.daemon=true
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx3072m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
@@ -16,6 +16,8 @@ org.gradle.parallel=true
 # Only relevant projects are configured which results in faster builds for large multi-projects.
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:configuration_on_demand
 org.gradle.configureondemand=false
+
+org.gradle.caching=true
 
 
 # We are doing this in order to get around this robolectirc bug -


### PR DESCRIPTION
Jenkins is [erroring currently](https://jenkins.dimagi.com/job/commcare-android/461173/console) while running tests due to memory issues. Increasing the heap size for tests helps making things better. 

Also increases swap from 1G to 2G on Jenkins machine though it doesn't seem to have any positive affect. 

I have also disabled the debug builds from Jenkins since I never had to use them in last couple years. This does make the jobs success rate much better for now. 
 