### PR TITLE
[HOTFIX][2.47.3] Check for task cancellation before making a form upload attempt

### DIFF
--- a/app/src/org/commcare/tasks/ProcessAndSendTask.java
+++ b/app/src/org/commcare/tasks/ProcessAndSendTask.java
@@ -317,6 +317,12 @@ public abstract class ProcessAndSendTask<R> extends CommCareTask<FormRecord, Lon
                         int attemptsMade = 0;
                         logSubmissionAttempt(record);
                         while (attemptsMade < SUBMISSION_ATTEMPTS) {
+
+                            if (isCancelled()) {
+                                Logger.log(LogTypes.TYPE_USER, "Cancelling submission due to a manual stop. " + (i - 1) + " forms succesfully sent.");
+                                throw new TaskCancelledException();
+                            }
+
                             results[i] = FormUploadUtil.sendInstance(i, folder,
                                     new SecretKeySpec(record.getAesKey(), "AES"), url, this, user);
                             if (results[i] == FormUploadResult.FULL_SUCCESS) {


### PR DESCRIPTION
On a poor network connection, there can be a gap of 2 mins when the request timeout and another attempt is made. So it only seems fair that we check for task cancellation in between the upload attempts.