### PR TITLE
Makes No. of Unsent Forms always visible

### DIFF
--- a/app/src/org/commcare/activities/HomeButtons.java
+++ b/app/src/org/commcare/activities/HomeButtons.java
@@ -114,12 +114,7 @@ public class HomeButtons {
 
     private static TextSetter getSyncButtonTextSetter(final StandardHomeActivity activity) {
         return (cardDisplayData, squareButtonViewHolder, context, notificationText) -> {
-            if (notificationText != null) {
-                squareButtonViewHolder.subTextView.setText(notificationText);
-                squareButtonViewHolder.subTextView.setTextColor(activity.getResources().getColor(cardDisplayData.subTextColor));
-            } else {
-                SyncDetailCalculations.updateSubText(activity, squareButtonViewHolder, cardDisplayData);
-            }
+            SyncDetailCalculations.updateSubText(activity, squareButtonViewHolder, cardDisplayData, notificationText);
             squareButtonViewHolder.subTextView.setBackgroundColor(activity.getResources().getColor(cardDisplayData.subTextBgColor));
             squareButtonViewHolder.textView.setTextColor(context.getResources().getColor(cardDisplayData.textColor));
             squareButtonViewHolder.textView.setText(cardDisplayData.text);

--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -67,6 +67,7 @@ public class HiddenPreferences {
     // last known filepath where ccz was installed from
     private static final String LAST_KNOWN_CCZ_LOCATION = "last_known_ccz_location";
 
+
     /**
      * @return How many seconds should a user session remain open before expiring?
      */
@@ -83,6 +84,9 @@ public class HiddenPreferences {
             return oneDayInSecs;
         }
     }
+
+    // Controls whether to show the number of unsent forms on Sync button when there are no unsent forms
+    private final static String SHOW_UNSENT_FORMS_WHEN_ZERO = "cc-show_unsent_forms_when_zero";
 
     /**
      * @return Accuracy needed for GPS auto-capture to stop polling during form entry
@@ -310,5 +314,10 @@ public class HiddenPreferences {
         String userId = CommCareApplication.instance().getSession().getLoggedInUser().getUniqueId();
         return CommCareApplication.instance().getCurrentApp().getAppPreferences()
                 .getLong(userId + "_" + LAST_UPLOAD_SYNC_ATTEMPT, 0);
+    }
+
+    public static boolean shouldShowUnsentFormsWhenZero() {
+        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        return properties.getString(SHOW_UNSENT_FORMS_WHEN_ZERO, PrefValues.NO).equals(PrefValues.YES);
     }
 }

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -31,18 +31,26 @@ public class SyncDetailCalculations {
 
     public static void updateSubText(final StandardHomeActivity activity,
                                      SquareButtonViewHolder squareButtonViewHolder,
-                                     HomeCardDisplayData cardDisplayData) {
+                                     HomeCardDisplayData cardDisplayData, String notificationText) {
 
         int numUnsentForms = getNumUnsentForms();
         Pair<Long, String> lastSyncTimeAndMessage = getLastSyncTimeAndMessage();
 
-        if (numUnsentForms > 0) {
-            Spannable syncIndicator = (activity.localize("home.unsent.forms.indicator",
-                    new String[]{String.valueOf(numUnsentForms)}));
-            squareButtonViewHolder.subTextView.setText(syncIndicator);
+        Spannable syncIndicator = (activity.localize("home.unsent.forms.indicator",
+                new String[]{String.valueOf(numUnsentForms)}));
+
+        String syncStatus;
+
+        if (notificationText != null) {
+            syncStatus = notificationText + "\n\n" + syncIndicator;
+        } else if (numUnsentForms == 0) {
+            syncStatus = lastSyncTimeAndMessage.second + "\n\n" + syncIndicator;
         } else {
-            squareButtonViewHolder.subTextView.setText(lastSyncTimeAndMessage.second);
+            syncStatus = syncIndicator.toString();
         }
+
+        squareButtonViewHolder.subTextView.setText(syncStatus);
+
         setSyncSubtextColor(
                 squareButtonViewHolder.subTextView, numUnsentForms, lastSyncTimeAndMessage.first,
                 activity.getResources().getColor(cardDisplayData.subTextColor),

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -14,6 +14,7 @@ import org.commcare.dalvik.R;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.modern.util.Pair;
+import org.commcare.preferences.HiddenPreferences;
 import org.javarosa.core.services.locale.Localization;
 
 import java.text.DateFormat;
@@ -44,7 +45,10 @@ public class SyncDetailCalculations {
         if (notificationText != null) {
             syncStatus = notificationText + "\n\n" + syncIndicator;
         } else if (numUnsentForms == 0) {
-            syncStatus = lastSyncTimeAndMessage.second + "\n\n" + syncIndicator;
+            syncStatus = lastSyncTimeAndMessage.second;
+            if (HiddenPreferences.shouldShowUnsentFormsWhenZero()) {
+                syncStatus += "\n\n" + syncIndicator;
+            }
         } else {
             syncStatus = syncIndicator.toString();
         }


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/ICDS-795

* Makes Unsent Forms Always Visible
* Adds a custom property "cc-show_unsent_forms_when_zero" to control whether to show unsent forms indicator when there are no unsent forms. 

<img src="https://user-images.githubusercontent.com/4679137/63189512-c0d4da80-c081-11e9-86b9-8e8f90e8b048.png" width="400" height="600">
<img src="https://user-images.githubusercontent.com/4679137/63189513-c0d4da80-c081-11e9-9d4b-0018dc7a6742.png" width="400" height="600">
<img src="https://user-images.githubusercontent.com/4679137/63189514-c16d7100-c081-11e9-8f0a-a97c56c49aa3.png" width="400" height="600">

Product Note: Makes No. of unsent forms always visible on the sync button. 


