### PR TITLE
Updates to Robolectric 4.3,  Gradle 5 , AGP 3.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,8 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 import com.android.builder.core.DefaultManifestParser
 
+import java.util.function.BooleanSupplier
+
 ////////////
 // README //
 ////////////
@@ -36,9 +38,8 @@ configurations {
 dependencies {
 
     testImplementation 'junit:junit:4.12'
-    testImplementation('org.robolectric:robolectric:3.2.2')
-    testImplementation 'org.robolectric:shadows-multidex:3.2.2'
-    testImplementation 'org.robolectric:shadows-core:3.2.2'
+    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'org.robolectric:shadows-multidex:4.3'
     testImplementation 'org.json:json:20140107'
     testImplementation project(path: ':commcare-core', configuration: 'testsAsJar')
 
@@ -357,7 +358,12 @@ android {
             // next to play store version
 
             // grab commcare version from manifest
-            def manifestParser = new DefaultManifestParser(android.sourceSets.main.manifest.srcFile)
+            def manifestParser = new DefaultManifestParser(android.sourceSets.main.manifest.srcFile, new BooleanSupplier() {
+                @Override
+                boolean getAsBoolean() {
+                    return true
+                }
+            }, null)
             def ccVersion = manifestParser.getVersionName()
             // convert numbers to words to use in app id
             def ccVersionSafe = numbersToLetters(ccVersion)
@@ -453,6 +459,9 @@ android {
             systemProperty 'robolectric.logging.enable', true
             systemProperty 'robolectric.logging', 'stdout'
         }
+        unitTests {
+            includeAndroidResources = true
+        }
     }
 }
 
@@ -478,12 +487,14 @@ downloadCCApp {
 }
 
 // dynamic check at task execution time
-downloadCCApp << {
-    if (ccAppId.equals("")) {
-        throw new InvalidUserDataException("Please provide cc_app_id property (CommCare App ID) to be packaged with apk")
-    }
-    if (ccDomain.equals("")) {
-        throw new InvalidUserDataException("Please provide cc_domain property (CommCare App Domain) to be packaged with apk")
+downloadCCApp {
+    doLast {
+        if (ccAppId.equals("")) {
+            throw new InvalidUserDataException("Please provide cc_app_id property (CommCare App ID) to be packaged with apk")
+        }
+        if (ccDomain.equals("")) {
+            throw new InvalidUserDataException("Please provide cc_domain property (CommCare App Domain) to be packaged with apk")
+        }
     }
 }
 
@@ -506,12 +517,14 @@ downloadRestoreFile {
 }
 
 // dynamic check at task execution time
-downloadRestoreFile << {
-    if (consumerAppUsername.equals("")) {
-        throw new InvalidUserDataException("Please provide username for restore to be packaged with apk")
-    }
-    if (consumerAppPassword.equals("")) {
-        throw new InvalidUserDataException("Please provide password for restore to be packaged with apk")
+downloadRestoreFile {
+    doLast {
+        if (consumerAppUsername.equals("")) {
+            throw new InvalidUserDataException("Please provide username for restore to be packaged with apk")
+        }
+        if (consumerAppPassword.equals("")) {
+            throw new InvalidUserDataException("Please provide password for restore to be packaged with apk")
+        }
     }
 }
 

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -177,14 +177,7 @@ public class CommCareApplication extends MultiDexApplication {
     public void onCreate() {
         super.onCreate();
 
-//        if (BuildConfig.DEBUG) {
-//            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-//                    .detectLeakedSqlLiteObjects()
-//                    .detectLeakedClosableObjects()
-//                    .penaltyLog()
-//                    .penaltyDeath()
-//                    .build());
-//        }
+        turnOnStrictMode();
 
         CommCareApplication.app = this;
         CrashUtil.init(this);
@@ -229,6 +222,17 @@ public class CommCareApplication extends MultiDexApplication {
         }
 
         LocalePreferences.saveDeviceLocale(Locale.getDefault());
+    }
+
+    protected void turnOnStrictMode() {
+        if (BuildConfig.DEBUG) {
+            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+                    .detectLeakedSqlLiteObjects()
+                    .detectLeakedClosableObjects()
+                    .penaltyLog()
+                    .penaltyDeath()
+                    .build());
+        }
     }
 
     @Override

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -177,14 +177,14 @@ public class CommCareApplication extends MultiDexApplication {
     public void onCreate() {
         super.onCreate();
 
-        if (BuildConfig.DEBUG) {
-            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-                    .detectLeakedSqlLiteObjects()
-                    .detectLeakedClosableObjects()
-                    .penaltyLog()
-                    .penaltyDeath()
-                    .build());
-        }
+//        if (BuildConfig.DEBUG) {
+//            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+//                    .detectLeakedSqlLiteObjects()
+//                    .detectLeakedClosableObjects()
+//                    .penaltyLog()
+//                    .penaltyDeath()
+//                    .build());
+//        }
 
         CommCareApplication.app = this;
         CrashUtil.init(this);

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -683,7 +683,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
                 return;
             }
             Bundle appRestrictions = restrictionsManager.getApplicationRestrictions();
-            if (appRestrictions.containsKey("username") &&
+            if (appRestrictions!=null && appRestrictions.containsKey("username") &&
                     appRestrictions.containsKey("password")) {
                 uiController.setUsername(appRestrictions.getString("username"));
                 uiController.setPasswordOrPin(appRestrictions.getString("password"));

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -129,9 +129,14 @@ public class CommCareTestApplication extends CommCareApplication implements Test
      */
     private static void initFactoryClassList() {
         if (factoryClassNames.isEmpty()) {
-            String baseODK = BuildConfig.BUILD_DIR + "/intermediates/javac/commcareDebug/compileCommcareDebugJavaWithJavac/classes/";
+            String[] baseODK = new String[]{BuildConfig.BUILD_DIR + "/intermediates/javac/commcareDebug/compileCommcareDebugJavaWithJavac/classes/"
+                        , BuildConfig.BUILD_DIR + "/intermediates/javac/commcareDebug/classes/"};
             String baseCC = BuildConfig.PROJECT_DIR + "/../../commcare-core/build/classes/java/main/";
-            addExternalizableClassesFromDir(baseODK.replace("/", File.separator), factoryClassNames);
+
+
+            for(String variant : baseODK) {
+                addExternalizableClassesFromDir(variant.replace("/", File.separator), factoryClassNames);
+            }
             addExternalizableClassesFromDir(baseCC.replace("/", File.separator), factoryClassNames);
         }
     }

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -10,7 +10,6 @@ import org.commcare.android.util.TestUtils;
 import org.commcare.core.encryption.CryptUtil;
 import org.commcare.core.interfaces.HttpResponseProcessor;
 import org.commcare.core.network.AuthInfo;
-import org.commcare.core.network.CommCareNetworkServiceGenerator;
 import org.commcare.core.network.HTTPMethod;
 import org.commcare.core.network.ModernHttpRequester;
 import org.commcare.dalvik.BuildConfig;
@@ -21,11 +20,8 @@ import org.commcare.models.database.AndroidPrototypeFactorySetup;
 import org.commcare.models.database.HybridFileBackedSqlStorage;
 import org.commcare.models.database.HybridFileBackedSqlStorageMock;
 import org.commcare.models.encryption.ByteEncrypter;
-import org.commcare.modern.util.Pair;
 import org.commcare.network.DataPullRequester;
-import org.commcare.network.HttpUtils;
 import org.commcare.network.LocalReferencePullResponseFactory;
-import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.services.CommCareSessionService;
 import org.commcare.utils.AndroidCacheDirSetup;
 import org.javarosa.core.model.User;
@@ -37,7 +33,7 @@ import org.junit.Assert;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestLifecycleApplication;
-import org.robolectric.util.ServiceController;
+import org.robolectric.android.controller.ServiceController;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -46,8 +42,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-
-import javax.annotation.Nullable;
 
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
@@ -125,7 +119,7 @@ public class CommCareTestApplication extends CommCareApplication implements Test
      */
     private static void initFactoryClassList() {
         if (factoryClassNames.isEmpty()) {
-            String baseODK = BuildConfig.BUILD_DIR + "/intermediates/classes/commcare/debug/";
+            String baseODK = BuildConfig.BUILD_DIR + "/intermediates/javac/commcareDebug/compileCommcareDebugJavaWithJavac/classes/";
             String baseCC = BuildConfig.PROJECT_DIR + "/../../commcare-core/build/classes/java/main/";
             addExternalizableClassesFromDir(baseODK.replace("/", File.separator), factoryClassNames);
             addExternalizableClassesFromDir(baseCC.replace("/", File.separator), factoryClassNames);
@@ -196,7 +190,7 @@ public class CommCareTestApplication extends CommCareApplication implements Test
                 new Intent(RuntimeEnvironment.application, CommCareSessionService.class);
         ServiceController<CommCareSessionService> serviceController =
                 Robolectric.buildService(CommCareSessionService.class, startIntent);
-        serviceController.attach()
+        serviceController
                 .create()
                 .startCommand(0, 1);
         return serviceController.get();

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -76,7 +76,11 @@ public class CommCareTestApplication extends CommCareApplication implements Test
 
     @Override
     protected void turnOnStrictMode() {
-        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().build());
+        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+                .detectLeakedSqlLiteObjects()
+                .detectLeakedClosableObjects()
+                .penaltyLog()
+                .build());
     }
 
     @Override

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -2,6 +2,7 @@ package org.commcare;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.StrictMode;
 import android.util.Log;
 
 import org.commcare.android.database.app.models.UserKeyRecord;
@@ -71,6 +72,11 @@ public class CommCareTestApplication extends CommCareApplication implements Test
             asyncExceptions.add(ex);
             Assert.fail(ex.getMessage());
         });
+    }
+
+    @Override
+    protected void turnOnStrictMode() {
+        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().build());
     }
 
     @Override

--- a/app/unit-tests/src/org/commcare/android/CommCareTestRunner.java
+++ b/app/unit-tests/src/org/commcare/android/CommCareTestRunner.java
@@ -4,10 +4,13 @@ import android.app.Application;
 import android.os.Environment;
 
 import org.jetbrains.annotations.NotNull;
+import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.robolectric.DefaultTestLifecycle;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestLifecycle;
+import org.robolectric.TestLifecycleApplication;
 import org.robolectric.annotation.Config;
 import org.robolectric.internal.bytecode.InstrumentationConfiguration;
 import org.robolectric.manifest.AndroidManifest;
@@ -26,8 +29,8 @@ public class CommCareTestRunner extends RobolectricTestRunner {
     }
 
     @Override
-    public InstrumentationConfiguration createClassLoaderConfig(Config config) {
-        InstrumentationConfiguration.Builder builder = InstrumentationConfiguration.newBuilder().withConfig(config);
+    public InstrumentationConfiguration createClassLoaderConfig(final FrameworkMethod method) {
+        InstrumentationConfiguration.Builder builder = new InstrumentationConfiguration.Builder(super.createClassLoaderConfig(method));
         builder.addInstrumentedPackage("net.sqlcipher.database.SQLiteDatabase");
         builder.addInstrumentedPackage("org.commcare.models.encryption");
         return builder.build();
@@ -40,10 +43,12 @@ public class CommCareTestRunner extends RobolectricTestRunner {
     }
 
     public static class CommCareTestLifeCycle extends DefaultTestLifecycle {
-        @Override
-        public Application createApplication(Method method, AndroidManifest appManifest, Config config) {
-            ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);
-            return super.createApplication(method, appManifest, config);
+
+        @Override public void prepareTest(final Object test) {
+            if (RuntimeEnvironment.application instanceof TestLifecycleApplication) {
+                ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);
+                super.prepareTest(test);
+            }
         }
     }
 }

--- a/app/unit-tests/src/org/commcare/android/shadows/CommCareShadowLog.java
+++ b/app/unit-tests/src/org/commcare/android/shadows/CommCareShadowLog.java
@@ -33,80 +33,86 @@ public class CommCareShadowLog extends ShadowLog {
     }
 
     @Implementation
-    public static void e(String tag, String msg) {
-        e(tag, msg, null);
+    public static int e(String tag, String msg) {
+        return e(tag, msg, null);
     }
 
     @Implementation
-    public static void e(String tag, String msg, Throwable throwable) {
+    public static int e(String tag, String msg, Throwable throwable) {
         if (shouldShowTag(tag)) {
             ShadowLog.e(tag, msg, throwable);
         }
+        return 0;
     }
 
     @Implementation
-    public static void d(String tag, String msg) {
-        d(tag, msg, null);
+    public static int d(String tag, String msg) {
+        return d(tag, msg, null);
     }
 
     @Implementation
-    public static void d(String tag, String msg, Throwable throwable) {
+    public static int d(String tag, String msg, Throwable throwable) {
         if (shouldShowTag(tag)) {
             ShadowLog.d(tag, msg, throwable);
         }
+        return 0;
     }
 
     @Implementation
-    public static void i(String tag, String msg) {
-        i(tag, msg, null);
+    public static int i(String tag, String msg) {
+        return i(tag, msg, null);
     }
 
     @Implementation
-    public static void i(String tag, String msg, Throwable throwable) {
+    public static int i(String tag, String msg, Throwable throwable) {
         if (shouldShowTag(tag)) {
             ShadowLog.i(tag, msg, throwable);
         }
+        return 0;
     }
 
     @Implementation
-    public static void v(String tag, String msg) {
-        v(tag, msg, null);
+    public static int v(String tag, String msg) {
+        return v(tag, msg, null);
     }
 
     @Implementation
-    public static void v(String tag, String msg, Throwable throwable) {
+    public static int v(String tag, String msg, Throwable throwable) {
         if (shouldShowTag(tag)) {
             ShadowLog.v(tag, msg, throwable);
         }
+        return 0;
     }
 
     @Implementation
-    public static void w(String tag, String msg) {
-        w(tag, msg, null);
+    public static int w(String tag, String msg) {
+        return w(tag, msg, null);
     }
 
     @Implementation
-    public static void w(String tag, Throwable throwable) {
-        w(tag, null, throwable);
+    public static int w(String tag, Throwable throwable) {
+        return w(tag, null, throwable);
     }
 
 
     @Implementation
-    public static void w(String tag, String msg, Throwable throwable) {
+    public static int w(String tag, String msg, Throwable throwable) {
         if (shouldShowTag(tag)) {
             ShadowLog.w(tag, msg, throwable);
         }
+        return 0;
     }
 
     @Implementation
-    public static void wtf(String tag, String msg) {
-        wtf(tag, msg, null);
+    public static int wtf(String tag, String msg) {
+        return wtf(tag, msg, null);
     }
 
     @Implementation
-    public static void wtf(String tag, String msg, Throwable throwable) {
+    public static int wtf(String tag, String msg, Throwable throwable) {
         if (shouldShowTag(tag)) {
             ShadowLog.wtf(tag, msg, throwable);
         }
+        return 0;
     }
 }

--- a/app/unit-tests/src/org/commcare/android/shadows/ShadowAsyncTaskNoExecutor.java
+++ b/app/unit-tests/src/org/commcare/android/shadows/ShadowAsyncTaskNoExecutor.java
@@ -4,11 +4,12 @@ import android.os.AsyncTask;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowAsyncTask;
+import org.robolectric.shadows.ShadowLegacyAsyncTask;
 
 import java.util.concurrent.Executor;
 
 @Implements(AsyncTask.class)
-public class ShadowAsyncTaskNoExecutor extends ShadowAsyncTask {
+public class ShadowAsyncTaskNoExecutor extends ShadowLegacyAsyncTask {
 
     /**
      * Because robolectric doesn't handle executeOnExecutor very well

--- a/app/unit-tests/src/org/commcare/android/tests/DemoUserRestoreTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/DemoUserRestoreTest.java
@@ -46,8 +46,8 @@ public class DemoUserRestoreTest {
         Intent loginActivityIntent =
                 new Intent(RuntimeEnvironment.application, LoginActivity.class);
         LoginActivity loginActivity =
-                Robolectric.buildActivity(LoginActivity.class)
-                        .withIntent(loginActivityIntent).setup().get();
+                Robolectric.buildActivity(LoginActivity.class, loginActivityIntent)
+                        .setup().get();
         ShadowActivity shadowActivity = Shadows.shadowOf(loginActivity);
         shadowActivity.clickMenuItem(LoginActivity.MENU_DEMO);
     }
@@ -57,8 +57,8 @@ public class DemoUserRestoreTest {
                 new Intent(RuntimeEnvironment.application, StandardHomeActivity.class);
         homeActivityIntent.putExtra(DispatchActivity.START_FROM_LOGIN, true);
         StandardHomeActivity homeActivity =
-                Robolectric.buildActivity(StandardHomeActivity.class)
-                        .withIntent(homeActivityIntent).setup().get();
+                Robolectric.buildActivity(StandardHomeActivity.class, homeActivityIntent)
+                        .setup().get();
         return Shadows.shadowOf(homeActivity);
     }
 

--- a/app/unit-tests/src/org/commcare/android/tests/GraphTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/GraphTest.java
@@ -1,5 +1,6 @@
 package org.commcare.android.tests;
 
+import org.commcare.CommCareTestApplication;
 import org.commcare.core.graph.suite.Graph;
 
 import org.commcare.core.graph.suite.XYSeries;
@@ -21,7 +22,7 @@ import org.robolectric.annotation.Config;
 import java.util.Vector;
 
 
-@Config(application = CommCareApplication.class)
+@Config(application = CommCareTestApplication.class)
 @RunWith(CommCareTestRunner.class)
 public class GraphTest extends XPathEvalTest {
 

--- a/app/unit-tests/src/org/commcare/android/tests/ImageInflationTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/ImageInflationTest.java
@@ -4,6 +4,7 @@ import android.graphics.Bitmap;
 import android.util.DisplayMetrics;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.utils.MediaUtil;
 import org.junit.Assert;
@@ -12,7 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-@Config(application = CommCareApplication.class)
+@Config(application = CommCareTestApplication.class)
 @RunWith(CommCareTestRunner.class)
 public class ImageInflationTest {
 

--- a/app/unit-tests/src/org/commcare/android/tests/IndexSpanningIteratorTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/IndexSpanningIteratorTest.java
@@ -1,6 +1,7 @@
 package org.commcare.android.tests;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.mocks.ExtendedTestCursor;
 import org.commcare.models.database.IndexSpanningIterator;
@@ -13,7 +14,7 @@ import java.util.Vector;
 
 import static junit.framework.Assert.assertEquals;
 
-@Config(application = CommCareApplication.class)
+@Config(application = CommCareTestApplication.class)
 @RunWith(CommCareTestRunner.class)
 public class IndexSpanningIteratorTest {
 

--- a/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertTrue;
 
 // Using sdk 19 to get past NsdManager because of a bug in robolectric that causes NsdManager
 // to get initialized with a null context resulting in a NPE
-@Config(application = CommCareTestApplication.class, sdk = 19)
+@Config(application = CommCareTestApplication.class, sdk = 18)
 @RunWith(CommCareTestRunner.class)
 public class CommCareSetupActivityTest {
 

--- a/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
@@ -29,9 +29,13 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Phillip Mates (pmates@dimagi.com)
  */
-@Config(application = CommCareTestApplication.class)
+
+// Using sdk 19 to get past NsdManager because of a bug in robolectric that causes NsdManager
+// to get initialized with a null context resulting in a NPE
+@Config(application = CommCareTestApplication.class, sdk = 19)
 @RunWith(CommCareTestRunner.class)
 public class CommCareSetupActivityTest {
+
 
     /**
      * Test that trying to install an app with an invalid suite file results in
@@ -41,6 +45,7 @@ public class CommCareSetupActivityTest {
     @Test
     public void invalidAppInstall() {
         String invalidUpdateReference = "jr://resource/commcare-apps/update_tests/invalid_suite_update/profile.ccpr";
+
 
         // start the setup activity
         Intent setupIntent =

--- a/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
@@ -47,8 +47,8 @@ public class CommCareSetupActivityTest {
                 new Intent(RuntimeEnvironment.application, CommCareSetupActivity.class);
 
         CommCareSetupActivity setupActivity =
-                Robolectric.buildActivity(CommCareSetupActivity.class)
-                        .withIntent(setupIntent).setup().get();
+                Robolectric.buildActivity(CommCareSetupActivity.class, setupIntent)
+                        .setup().get();
 
         // click the 'offline install' menu item
         ShadowActivity shadowActivity = Shadows.shadowOf(setupActivity);

--- a/app/unit-tests/src/org/commcare/android/tests/activities/FormRecordListActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/FormRecordListActivityTest.java
@@ -58,8 +58,8 @@ public class FormRecordListActivityTest {
         ShadowActivity homeActivityShadow = prepSavedFormsActivity(savedFormsIntent);
 
         FormRecordListActivity savedFormsActivity =
-                Robolectric.buildActivity(FormRecordListActivity.class)
-                        .withIntent(savedFormsIntent).create().start()
+                Robolectric.buildActivity(FormRecordListActivity.class, savedFormsIntent)
+                        .create().start()
                         .resume().get();
 
         // wait for saved forms to load
@@ -76,7 +76,7 @@ public class FormRecordListActivityTest {
         StandardHomeActivity homeActivity =
                 Robolectric.buildActivity(StandardHomeActivity.class).create().get();
         ShadowActivity homeActivityShadow = Shadows.shadowOf(homeActivity);
-        homeActivityShadow.startActivityForResult(savedFormsIntent,
+        homeActivity.startActivityForResult(savedFormsIntent,
                 StandardHomeActivity.GET_INCOMPLETE_FORM);
 
         // Call this to remove activity from stack, so we can access future activities...
@@ -107,8 +107,7 @@ public class FormRecordListActivityTest {
                 formRecordShadow.getResultIntent());
         ShadowActivity.IntentForResult formEntryIntent =
                 homeActivityShadow.getNextStartedActivityForResult();
-        Robolectric.buildActivity(FormEntryActivity.class)
-                        .withIntent(formEntryIntent.intent)
+        Robolectric.buildActivity(FormEntryActivity.class, formEntryIntent.intent)
                         .create().start().resume().get();
 
         Robolectric.flushBackgroundThreadScheduler();

--- a/app/unit-tests/src/org/commcare/android/tests/activities/PostRequestActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/PostRequestActivityTest.java
@@ -91,7 +91,7 @@ public class PostRequestActivityTest {
             postLaunchIntent.putExtra(PostRequestActivity.PARAMS_KEY,
                     new HashMap<String, String>());
         }
-        return Robolectric.buildActivity(PostRequestActivity.class).withIntent(postLaunchIntent)
+        return Robolectric.buildActivity(PostRequestActivity.class, postLaunchIntent)
                 .create().start().resume().get();
     }
 
@@ -203,7 +203,7 @@ public class PostRequestActivityTest {
         assertEquals("321", postUrlParams.get("selected_case_id"));
 
         PostRequestActivity postRequestActivity =
-                Robolectric.buildActivity(PostRequestActivity.class).withIntent(postActivityIntent)
+                Robolectric.buildActivity(PostRequestActivity.class, postActivityIntent)
                         .create().start().resume().get();
 
         assertTrue(postRequestActivity.isFinishing());

--- a/app/unit-tests/src/org/commcare/android/tests/activities/QueryRequestActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/QueryRequestActivityTest.java
@@ -26,9 +26,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowToast;
-import org.robolectric.util.ActivityController;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -55,8 +55,8 @@ public class QueryRequestActivityTest {
         Intent queryActivityIntent =
                 new Intent(RuntimeEnvironment.application, QueryRequestActivity.class);
         QueryRequestActivity queryRequestActivity =
-                Robolectric.buildActivity(QueryRequestActivity.class)
-                        .withIntent(queryActivityIntent).setup().get();
+                Robolectric.buildActivity(QueryRequestActivity.class, queryActivityIntent)
+                        .setup().get();
 
         assertEquals(Activity.RESULT_CANCELED,
                 Shadows.shadowOf(queryRequestActivity).getResultCode());
@@ -80,8 +80,8 @@ public class QueryRequestActivityTest {
         Intent queryActivityIntent =
                 new Intent(RuntimeEnvironment.application, QueryRequestActivity.class);
         QueryRequestActivity queryRequestActivity =
-                Robolectric.buildActivity(QueryRequestActivity.class)
-                        .withIntent(queryActivityIntent).setup().get();
+                Robolectric.buildActivity(QueryRequestActivity.class, queryActivityIntent)
+                        .setup().get();
 
         LinearLayout promptsLayout =
                 queryRequestActivity.findViewById(R.id.query_prompts);
@@ -116,8 +116,7 @@ public class QueryRequestActivityTest {
                 new Intent(RuntimeEnvironment.application, QueryRequestActivity.class);
 
         ActivityController<QueryRequestActivity> controller =
-                Robolectric.buildActivity(QueryRequestActivity.class)
-                        .withIntent(queryActivityIntent).setup();
+                Robolectric.buildActivity(QueryRequestActivity.class, queryActivityIntent).setup();
         QueryRequestActivity queryRequestActivity = controller.get();
 
         LinearLayout promptsLayout =
@@ -141,8 +140,8 @@ public class QueryRequestActivityTest {
         controller.saveInstanceState(savedInstanceState);
 
         // start new activity with serialized app state
-        queryRequestActivity = Robolectric.buildActivity(QueryRequestActivity.class)
-                .withIntent(queryActivityIntent).setup(savedInstanceState).get();
+        queryRequestActivity = Robolectric.buildActivity(QueryRequestActivity.class, queryActivityIntent)
+                .setup(savedInstanceState).get();
 
         // check that the error message is still there
         errorMessage = queryRequestActivity.findViewById(R.id.error_message);
@@ -162,8 +161,8 @@ public class QueryRequestActivityTest {
                 new Intent(RuntimeEnvironment.application, QueryRequestActivity.class);
 
         ActivityController<QueryRequestActivity> controller =
-                Robolectric.buildActivity(QueryRequestActivity.class)
-                        .withIntent(queryActivityIntent).create().start().resume();
+                Robolectric.buildActivity(QueryRequestActivity.class, queryActivityIntent)
+                        .create().start().resume();
         QueryRequestActivity queryRequestActivity = controller.get();
 
         LinearLayout promptsLayout =
@@ -176,8 +175,8 @@ public class QueryRequestActivityTest {
         controller.saveInstanceState(savedInstanceState);
 
         // start new activity with serialized app state
-        queryRequestActivity = Robolectric.buildActivity(QueryRequestActivity.class)
-                .withIntent(queryActivityIntent).setup(savedInstanceState).get();
+        queryRequestActivity = Robolectric.buildActivity(QueryRequestActivity.class, queryActivityIntent)
+                .setup(savedInstanceState).get();
 
         // check that the query prompts are filled out still
         promptsLayout = queryRequestActivity.findViewById(R.id.query_prompts);
@@ -207,8 +206,8 @@ public class QueryRequestActivityTest {
                 new Intent(RuntimeEnvironment.application, QueryRequestActivity.class);
 
         ActivityController<QueryRequestActivity> controller =
-                Robolectric.buildActivity(QueryRequestActivity.class)
-                        .withIntent(queryActivityIntent).setup();
+                Robolectric.buildActivity(QueryRequestActivity.class, queryActivityIntent)
+                        .setup();
         QueryRequestActivity queryRequestActivity = controller.get();
 
         LinearLayout promptsLayout =

--- a/app/unit-tests/src/org/commcare/android/tests/activities/UpdateActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/UpdateActivityTest.java
@@ -34,7 +34,10 @@ import static org.junit.Assert.assertNull;
  *
  * @author Phillip Mates (pmates@dimagi.com)
  */
-@Config(application = CommCareTestApplication.class)
+
+// Using sdk 19 to get past NsdManager because of a bug in robolectric that causes NsdManager
+// to get initialized with a null context resulting in a NPE
+@Config(application = CommCareTestApplication.class, sdk = 19)
 @RunWith(CommCareTestRunner.class)
 public class UpdateActivityTest {
     @Before

--- a/app/unit-tests/src/org/commcare/android/tests/activities/UpdateActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/UpdateActivityTest.java
@@ -58,8 +58,8 @@ public class UpdateActivityTest {
                 new Intent(RuntimeEnvironment.application, UpdateActivity.class);
 
         UpdateActivity updateActivity =
-                Robolectric.buildActivity(UpdateActivity.class)
-                        .withIntent(updateActivityIntent).setup().get();
+                Robolectric.buildActivity(UpdateActivity.class, updateActivityIntent)
+                        .setup().get();
 
         // click the 'offline install' menu item
         ShadowActivity shadowActivity = Shadows.shadowOf(updateActivity);

--- a/app/unit-tests/src/org/commcare/android/tests/activities/UpdateActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/UpdateActivityTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertNull;
 
 // Using sdk 19 to get past NsdManager because of a bug in robolectric that causes NsdManager
 // to get initialized with a null context resulting in a NPE
-@Config(application = CommCareTestApplication.class, sdk = 19)
+@Config(application = CommCareTestApplication.class, sdk = 18)
 @RunWith(CommCareTestRunner.class)
 public class UpdateActivityTest {
     @Before

--- a/app/unit-tests/src/org/commcare/android/tests/formentry/FormIntentTests.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formentry/FormIntentTests.java
@@ -60,7 +60,7 @@ public class FormIntentTests {
     private void navigateFormStructure(Intent formEntryIntent) {
         // launch form entry
         FormEntryActivity formEntryActivity =
-                Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
+                Robolectric.buildActivity(FormEntryActivity.class, formEntryIntent)
                         .create().start().resume().get();
 
         ImageButton nextButton = formEntryActivity.findViewById(R.id.nav_btn_next);

--- a/app/unit-tests/src/org/commcare/android/tests/formentry/IntentCalloutTests.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formentry/IntentCalloutTests.java
@@ -63,7 +63,7 @@ public class IntentCalloutTests {
     private FormEntryActivity navigateFormStructure(Intent formEntryIntent) {
         // launch form entry
         FormEntryActivity formEntryActivity =
-                Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
+                Robolectric.buildActivity(FormEntryActivity.class, formEntryIntent)
                         .create().start().resume().get();
         StringNumberWidget favoriteNumber = (StringNumberWidget)formEntryActivity.getODKView().getWidgets().get(0);
         favoriteNumber.setAnswer("1234567890");
@@ -78,7 +78,7 @@ public class IntentCalloutTests {
                 ActivityLaunchUtils.buildHomeActivityForFormEntryLaunch("m0-f1");
         Intent formEntryIntent = shadowActivity.getNextStartedActivity();
         FormEntryActivity formEntryActivity =
-                Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
+                Robolectric.buildActivity(FormEntryActivity.class, formEntryIntent)
                         .create().start().resume().get();
         IntentWidget phoneCallWidget = (IntentWidget) formEntryActivity.getODKView().getWidgets().get(0);
         Intent intent = phoneCallWidget.getIntentCallout().generate(FormEntryActivity.mFormController.getFormEntryController().getModel().getForm().getEvaluationContext());
@@ -92,7 +92,7 @@ public class IntentCalloutTests {
                 ActivityLaunchUtils.buildHomeActivityForFormEntryLaunch("m0-f2");
         Intent formEntryIntent = shadowActivity.getNextStartedActivity();
         FormEntryActivity formEntryActivity =
-                Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
+                Robolectric.buildActivity(FormEntryActivity.class, formEntryIntent)
                         .create().start().resume().get();
         IntentWidget phoneCallWidget = (IntentWidget) formEntryActivity.getODKView().getWidgets().get(0);
         Intent intent = phoneCallWidget.getIntentCallout().generate(FormEntryActivity.mFormController.getFormEntryController().getModel().getForm().getEvaluationContext());
@@ -106,7 +106,7 @@ public class IntentCalloutTests {
                 ActivityLaunchUtils.buildHomeActivityForFormEntryLaunch("m0-f3");
         Intent formEntryIntent = shadowActivity.getNextStartedActivity();
         FormEntryActivity formEntryActivity =
-                Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
+                Robolectric.buildActivity(FormEntryActivity.class, formEntryIntent)
                         .create().start().resume().get();
         IntentWidget phoneCallWidget = (IntentWidget) formEntryActivity.getODKView().getWidgets().get(0);
         Intent intent = phoneCallWidget.getIntentCallout().generate(FormEntryActivity.mFormController.getFormEntryController().getModel().getForm().getEvaluationContext());

--- a/app/unit-tests/src/org/commcare/android/tests/formnav/CalendarLocaleTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formnav/CalendarLocaleTest.java
@@ -58,7 +58,7 @@ public class CalendarLocaleTest {
     private void navigateCalendarForm(Intent formEntryIntent) {
         // launch form entry
         FormEntryActivity formEntryActivity =
-                Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
+                Robolectric.buildActivity(FormEntryActivity.class, formEntryIntent)
                         .create().start().resume().get();
 
         ImageButton nextButton = formEntryActivity.findViewById(R.id.nav_btn_next);

--- a/app/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
@@ -74,7 +74,7 @@ public class EndOfFormTest {
     private static ShadowActivity navigateFormEntry(Intent formEntryIntent) {
         // launch form entry
         FormEntryActivity formEntryActivity =
-                Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
+                Robolectric.buildActivity(FormEntryActivity.class, formEntryIntent)
                         .create().start().resume().get();
 
 

--- a/app/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
@@ -134,7 +134,7 @@ public class FormRecordProcessingTest {
     private ShadowActivity navigateFormEntry(Intent formEntryIntent) {
         // launch form entry
         FormEntryActivity formEntryActivity =
-                Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
+                Robolectric.buildActivity(FormEntryActivity.class, formEntryIntent)
                         .create().start().resume().get();
 
         // enter an answer for the question

--- a/app/unit-tests/src/org/commcare/android/tests/processing/ProcessingTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/ProcessingTest.java
@@ -1,6 +1,7 @@
 package org.commcare.android.tests.processing;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestUtils;
 import org.commcare.cases.model.Case;
@@ -17,7 +18,7 @@ import static junit.framework.Assert.assertEquals;
 /**
  * @author ctsims
  */
-@Config(application = CommCareApplication.class)
+@Config(application = CommCareTestApplication.class)
 @RunWith(CommCareTestRunner.class)
 public class ProcessingTest {
 

--- a/app/unit-tests/src/org/commcare/android/tests/processing/XFormUpdateInfoTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/XFormUpdateInfoTest.java
@@ -81,7 +81,7 @@ public class XFormUpdateInfoTest {
     private ShadowActivity navigateFormEntry(Intent formEntryIntent) {
         // launch form entry
         FormEntryActivity formEntryActivity =
-                Robolectric.buildActivity(FormEntryActivity.class).withIntent(formEntryIntent)
+                Robolectric.buildActivity(FormEntryActivity.class, formEntryIntent)
                         .create().start().resume().get();
         formEntryActivity.findViewById(R.id.nav_btn_finish).performClick();
 

--- a/app/unit-tests/src/org/commcare/android/tests/queries/CaseDbQueryTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/queries/CaseDbQueryTest.java
@@ -1,6 +1,7 @@
 package org.commcare.android.tests.queries;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestUtils;
 import org.commcare.cases.query.QueryContext;
@@ -37,7 +38,7 @@ import static junit.framework.Assert.assertEquals;
  *
  * @author ctsims
  */
-@Config(application = CommCareApplication.class)
+@Config(application = CommCareTestApplication.class)
 @RunWith(CommCareTestRunner.class)
 public class CaseDbQueryTest {
 

--- a/app/unit-tests/src/org/commcare/android/tests/queries/ExpressionCacheTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/queries/ExpressionCacheTest.java
@@ -1,6 +1,7 @@
 package org.commcare.android.tests.queries;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestUtils;
 import org.commcare.cases.instance.CaseChildElement;
@@ -23,7 +24,7 @@ import org.robolectric.annotation.Config;
  * Created by amstone326 on 2/2/18.
  */
 
-@Config(application = CommCareApplication.class)
+@Config(application = CommCareTestApplication.class)
 @RunWith(CommCareTestRunner.class)
 public class ExpressionCacheTest {
 

--- a/app/unit-tests/src/org/commcare/android/tests/queries/LedgerDbQueryTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/queries/LedgerDbQueryTest.java
@@ -1,6 +1,7 @@
 package org.commcare.android.tests.queries;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestUtils;
 import org.commcare.test.utilities.CaseTestUtils;
@@ -20,7 +21,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Phillip Mates (pmates@dimagi.com)
  */
-@Config(application = CommCareApplication.class)
+@Config(application = CommCareTestApplication.class)
 @RunWith(CommCareTestRunner.class)
 public class LedgerDbQueryTest {
 

--- a/app/unit-tests/src/org/commcare/android/util/CaseLoadUtils.java
+++ b/app/unit-tests/src/org/commcare/android/util/CaseLoadUtils.java
@@ -41,8 +41,8 @@ public class CaseLoadUtils {
         Assert.assertEquals(EntitySelectActivity.class.getName(), intentActivityName);
 
         // start the entity select activity
-        return Robolectric.buildActivity(EntitySelectActivity.class)
-                .withIntent(entitySelectIntent).setup().get();
+        return Robolectric.buildActivity(EntitySelectActivity.class, entitySelectIntent)
+                .setup().get();
     }
 
 }

--- a/app/unit-tests/src/org/commcare/recovery/measures/RecoveryMeasuresTest.java
+++ b/app/unit-tests/src/org/commcare/recovery/measures/RecoveryMeasuresTest.java
@@ -18,9 +18,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
-import org.robolectric.util.ActivityController;
 
 import java.util.List;
 
@@ -147,7 +147,7 @@ public class RecoveryMeasuresTest {
 
         // launch home activty
         StandardHomeActivity homeActivity =
-                Robolectric.buildActivity(StandardHomeActivity.class).withIntent(homeActivityIntent)
+                Robolectric.buildActivity(StandardHomeActivity.class, homeActivityIntent)
                         .create().start().resume().get();
         ShadowActivity shadowHomeActivity = Shadows.shadowOf(homeActivity);
 

--- a/app/unit-tests/src/org/commcare/utils/FormCacheEligibilityTester.java
+++ b/app/unit-tests/src/org/commcare/utils/FormCacheEligibilityTester.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.ArrayList;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareTestApplication;
 import org.commcare.android.CommCareTestRunner;
 import org.commcare.android.util.TestUtils;
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -40,7 +41,7 @@ import org.robolectric.annotation.Config;
  *      contents directly into the directory you just created.
  *   3. Run this test file, and observe the output to sys.out.
  */
-@Config(application = CommCareApplication.class)
+@Config(application = CommCareTestApplication.class)
 @RunWith(CommCareTestRunner.class)
 public class FormCacheEligibilityTester {
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.3.31'
     repositories {
         google()
         mavenCentral()
@@ -9,9 +9,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath 'com.google.gms:google-services:3.2.0'
-        classpath 'io.fabric.tools:gradle:1.24.4'
+        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.google.gms:google-services:4.3.0'
+        classpath 'io.fabric.tools:gradle:1.25.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,4 @@ org.gradle.parallel=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:configuration_on_demand
 org.gradle.configureondemand=false
 
-
-# We are doing this in order to get around this robolectirc bug -
-# https://github.com/robolectric/robolectric/issues/3157 and should
-# remove this line when this is fixed
-android.enableAapt2=false
+android.enableUnitTestBinaryResources=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Aug 20 17:03:14 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Robolectric Changes - 

* Turn off Strict mode death penalty in `CommCareTestApplication` and change all tests to build with `CommCareTestApplication` instead of `CommCareApplication`.  Otherwise various tests gets killed with message `StrictMode VmPolicy violation with POLICY_DEATH; shutting down.` because of leaked cursor/sqlite DB objects

* Run Tests  testing functions iincluding a call to NsdManager on sdk 18. There is a bug  on sdk 21 with robolectric that causes a NPE when accessing NsdManager functions

* API Changes for 4.3


cross-request: https://github.com/dimagi/commcare-core/pull/868