### PR TITLE
Fixes localization error message

### DIFF
--- a/app/src/org/commcare/utils/CommCareExceptionHandler.java
+++ b/app/src/org/commcare/utils/CommCareExceptionHandler.java
@@ -73,7 +73,7 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
             Intent i = new Intent(ctx, CrashWarningActivity.class);
             i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            i.putExtra(WARNING_MESSAGE_KEY, ex.getMessage());
+            i.putExtra(WARNING_MESSAGE_KEY, getMessageForLocalizationException(ex));
             ctx.startActivity(i);
             return true;
         } else if (causedBySessionUnavailableException(ex)) {
@@ -81,6 +81,16 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
             return true;
         }
         return false;
+    }
+
+    private String getMessageForLocalizationException(Throwable ex) {
+        if (ex == null) {
+            return "";
+        } else if (ex instanceof NoLocalizedTextException) {
+            return ex.getMessage();
+        } else {
+            return getMessageForLocalizationException(ex.getCause());
+        }
     }
 
     private static boolean causedByLocalizationException(Throwable ex) {


### PR DESCRIPTION
In cases where the nolocatization exception is not the primary exception, the localization error gets hidden by the primary exception leaving user with a non concrete error message.  

Example Exception for which this PR fixes the error message - 

````
java.lang.RuntimeException: An error occurred while executing doInBackground()
        at android.os.AsyncTask$3.done(AsyncTask.java:353)
        at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
        at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
        at java.util.concurrent.FutureTask.run(FutureTask.java:271)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
        at java.lang.Thread.run(Thread.java:764)
     Caused by: org.javarosa.core.util.NoLocalizedTextException: The Localizer could not find a definition for ID: due_list_case_tile_mother_name in the 'kha' locale.
at org.javarosa.core.services.locale.Localizer.getText(Localizer.java:328)
        at org.javarosa.core.services.locale.Localization.get(Localization.java:21)
        at org.javarosa.core.services.locale.Localization.get(Localization.java:11)
````

