### PR TITLE
Save as Incomplete Navigation fix for external launch

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -803,11 +803,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     private void clearSessionAndExit(AndroidSessionWrapper currentState, boolean shouldWarnUser) {
         currentState.reset();
         if (wasExternal) {
-            if (shouldWarnUser) {
-                setResult(RESULT_CANCELED);
-            } else {
-                setResult(RESULT_OK);
-            }
+            setResult(RESULT_CANCELED);
             this.finish();
         }
         refreshUI();
@@ -1158,7 +1154,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     @Override
     public void handlePullTaskResult(ResultAndError<DataPullTask.PullTaskResult> resultAndError, boolean userTriggeredSync, boolean formsToSend, boolean usingRemoteKeyManagement) {
         super.handlePullTaskResult(resultAndError, userTriggeredSync, formsToSend, usingRemoteKeyManagement);
-            if (UpdateActivity.sBlockedUpdateWorkflowInProgress) {
+        if (UpdateActivity.sBlockedUpdateWorkflowInProgress) {
             Intent i = new Intent(getApplicationContext(), UpdateActivity.class);
             i.putExtra(UpdateActivity.KEY_PROCEED_AUTOMATICALLY, true);
 


### PR DESCRIPTION
On saving form as incomplete, we end up relaunching the sesssion instance again instead of returning back to the calling application. This can be really confusing if CC was called with a session stack pointing to a form, on saving that form as incomplete, a new intance of the same form gets relaunched automatically. I think the incomplete form save here should follow the same navigation pattern as when we save a complete form. 

Related to: https://dimagi-dev.atlassian.net/browse/MOB-138