### PR TITLE
Graceful Form Intent Interruption

### DIFF
--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -2,7 +2,6 @@ package org.commcare.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
-import androidx.fragment.app.FragmentActivity;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -20,6 +19,8 @@ import org.commcare.utils.CommCareLifecycleUtils;
 import org.commcare.utils.MultipleAppsUtil;
 import org.commcare.utils.SessionUnavailableException;
 import org.javarosa.core.services.locale.Localization;
+
+import androidx.fragment.app.FragmentActivity;
 
 /**
  * Dispatches install, login, and home screen activities.
@@ -318,13 +319,17 @@ public class DispatchActivity extends FragmentActivity {
     }
 
     private void handleExternalLaunch() {
-        String sessionRequest = this.getIntent().getStringExtra(SESSION_REQUEST);
-        SessionStateDescriptor ssd = new SessionStateDescriptor();
-        ssd.fromBundle(sessionRequest);
-        CommCareApplication.instance().getCurrentSessionWrapper().loadFromStateDescription(ssd);
-        Intent i = new Intent(this, StandardHomeActivity.class);
-        i.putExtra(WAS_EXTERNAL, true);
-        startActivityForResult(i, HOME_SCREEN);
+        //First off, make sure the incoming session is clear
+        CommCareApplication.instance().getSession().proceedWithSavedSessionIfNeeded(() -> {
+                    String sessionRequest = this.getIntent().getStringExtra(SESSION_REQUEST);
+                    SessionStateDescriptor ssd = new SessionStateDescriptor();
+                    ssd.fromBundle(sessionRequest);
+                    CommCareApplication.instance().getCurrentSessionWrapper().loadFromStateDescription(ssd);
+                    Intent i = new Intent(this, StandardHomeActivity.class);
+                    i.putExtra(WAS_EXTERNAL, true);
+                    startActivityForResult(i, HOME_SCREEN);
+        }
+        );
     }
 
     private void handleShortcutLaunch() {

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -153,10 +153,12 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
     private BroadcastReceiver mLocationServiceIssueReceiver;
 
-    // marked true if we are in the process of saving a form because the user
-    // database & key session are expiring. Being set causes savingComplete to
-    // broadcast a form saving intent.
-    private boolean savingFormOnKeySessionExpiration = false;
+    // This will be set if a unique action needs to be taken
+    // at the end of saving a form - like continuing a logout
+    // or proceeding unblocked
+    private Runnable customFormSaveCallback = null;
+    private boolean wasInterrupted = false;
+
     private FormEntryActivityUIController uiController;
     private SqlStorage<FormRecord> formRecordStorage;
 
@@ -220,9 +222,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     }
 
     @Override
-    public void formSaveCallback() {
+    public void formSaveCallback(Runnable listener) {
         // note that we have started saving the form
-        savingFormOnKeySessionExpiration = true;
+        customFormSaveCallback = listener;
 
         // Set flag that will allow us to restore this form when we log back in
         CommCareApplication.instance().getCurrentSessionWrapper().setCurrentStateAsInterrupted();
@@ -853,6 +855,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
     @Override
     public void onResumeSessionSafe() {
+        if(wasInterrupted) {
+
+        }
         if (!hasFormLoadBeenTriggered) {
             loadForm();
         }
@@ -1088,13 +1093,13 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     public void savingComplete(SaveToDiskTask.SaveStatus saveStatus, String errorMessage) {
         // Did we just save a form because the key session
         // (CommCareSessionService) is ending?
-        if (savingFormOnKeySessionExpiration) {
-            savingFormOnKeySessionExpiration = false;
+        if (customFormSaveCallback != null) {
+            Runnable toCall = customFormSaveCallback;
+            customFormSaveCallback = null;
+            wasInterrupted = true;
 
-            // Notify the key session that the form state has been saved (or at
-            // least attempted to be saved) so CommCareSessionService can
-            // continue closing down key pool and user database.
-            CommCareApplication.instance().expireUserSession();
+            toCall.run();
+            returnAsInterrupted();
         } else if (saveStatus != null) {
             String toastMessage = "";
             switch (saveStatus) {
@@ -1129,6 +1134,14 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             }
             uiController.refreshView();
         }
+    }
+
+    private void returnAsInterrupted() {
+        Intent formReturnIntent = new Intent();
+        formReturnIntent.putExtra(FormEntryConstants.WAS_INTERRUPTED, true);
+
+        setResult(RESULT_CANCELED, formReturnIntent);
+        finish();
     }
 
     /**

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -157,7 +157,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     // at the end of saving a form - like continuing a logout
     // or proceeding unblocked
     private Runnable customFormSaveCallback = null;
-    private boolean wasInterrupted = false;
 
     private FormEntryActivityUIController uiController;
     private SqlStorage<FormRecord> formRecordStorage;
@@ -855,9 +854,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
     @Override
     public void onResumeSessionSafe() {
-        if(wasInterrupted) {
-
-        }
         if (!hasFormLoadBeenTriggered) {
             loadForm();
         }
@@ -1096,7 +1092,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         if (customFormSaveCallback != null) {
             Runnable toCall = customFormSaveCallback;
             customFormSaveCallback = null;
-            wasInterrupted = true;
 
             toCall.run();
             returnAsInterrupted();

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -509,6 +509,10 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                     }
                     break;
                 case MODEL_RESULT:
+                    if(intent.getBooleanExtra(FormEntryConstants.WAS_INTERRUPTED, false)) {
+                        tryRestoringFormFromSessionExpiration();
+                        return;
+                    }
                     continueWithSessionNav = processReturnFromFormEntry(resultCode, intent);
                     if (!continueWithSessionNav) {
                         return;

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -439,7 +439,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
             long updateReleasedOnTime = HiddenPreferences.geReleasedOnTimeForOngoingAppDownload();
             return lastSyncTime < updateReleasedOnTime;
         }
-        return true;
+        return false;
     }
 
     @Override

--- a/app/src/org/commcare/activities/components/FormEntryConstants.java
+++ b/app/src/org/commcare/activities/components/FormEntryConstants.java
@@ -40,4 +40,5 @@ public class FormEntryConstants {
      * whether to redirect to archive view or sync the form.
      */
     public static final String IS_ARCHIVED_FORM = "is-archive-form";
+    public static final String WAS_INTERRUPTED = "form-entry-interrupted";
 }

--- a/app/src/org/commcare/interfaces/FormSaveCallback.java
+++ b/app/src/org/commcare/interfaces/FormSaveCallback.java
@@ -5,8 +5,8 @@ package org.commcare.interfaces;
  */
 public interface FormSaveCallback {
     /**
-     * Starts a task to save the current form being editted. Is expected to
-     * eventually call CommCareApplication.expireUserSession
+     * Starts a task to save the current form being edited. Will be expected to call the provided
+     * listener when saving is complete and the current session state is no longer volatile
      */
-    void formSaveCallback();
+    void formSaveCallback(Runnable callback);
 }

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -380,9 +380,6 @@ public class CommCareSessionService extends Service {
         synchronized (lock) {
             if (formSaver != null) {
                 formSaver.formSaveCallback(() -> {
-                    // Notify the key session that the form state has been saved (or at
-                    // least attempted to be saved) so CommCareSessionService can
-                    // continue closing down key pool and user database.
                     CommCareApplication.instance().expireUserSession();
                 });
             } else {

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -9,9 +9,9 @@ import android.content.SharedPreferences;
 import android.os.Binder;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
-import androidx.core.app.NotificationCompat;
 import android.text.format.DateFormat;
 import android.util.Log;
+import android.widget.Toast;
 
 import net.sqlcipher.database.SQLiteDatabase;
 
@@ -50,6 +50,8 @@ import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+
+import androidx.core.app.NotificationCompat;
 
 /**
  * The CommCare Session Service is a persistent service which maintains
@@ -371,14 +373,42 @@ public class CommCareSessionService extends Service {
         // maintenance timer will launch CommCareApplication.instance().expireUserSession
         logoutStartedAt = new Date().getTime();
 
+        // Note: Any other types of callbacks should be added to both this method
+        // and the non-close version
+
         // save form progress, if any
         synchronized (lock) {
             if (formSaver != null) {
-                formSaver.formSaveCallback();
+                formSaver.formSaveCallback(() -> {
+                    // Notify the key session that the form state has been saved (or at
+                    // least attempted to be saved) so CommCareSessionService can
+                    // continue closing down key pool and user database.
+                    CommCareApplication.instance().expireUserSession();
+                });
             } else {
                 CommCareApplication.instance().expireUserSession();
             }
         }
+    }
+
+    /**
+     * Calls the provided runnable ensuring that if there is currently an active
+     * form session being executed that it is interrupted and stored
+     *
+     */
+    public void proceedWithSavedSessionIfNeeded(Runnable callback)  {
+        // save form progress, if any
+        synchronized (lock) {
+            if (formSaver != null) {
+                Toast.makeText(CommCareApplication.instance(),
+                        "Suspending existing form entry session...", Toast.LENGTH_LONG).show();
+                formSaver.formSaveCallback(callback);
+                formSaver = null;
+                return;
+            }
+        }
+        //No forms to be saved, just run the callback immediately
+        callback.run();
     }
 
     /**

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -76,6 +76,7 @@ public class SaveToDiskTask extends
 
         if (headless) {
             this.taskId = -1;
+            this.setConnectionTimeout(0);
         } else {
             this.taskId = SAVING_TASK_ID;
         }

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -76,6 +76,8 @@ public class SaveToDiskTask extends
 
         if (headless) {
             this.taskId = -1;
+
+            //Don't block on the UI thread if there's no available screen to connect to
             this.setConnectionTimeout(0);
         } else {
             this.taskId = SAVING_TASK_ID;

--- a/app/src/org/commcare/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/tasks/templates/CommCareTask.java
@@ -27,6 +27,8 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
     //Wait for 2 seconds for something to reconnnect for now (very high)
     private static final int ALLOWABLE_CONNECTOR_ACQUISITION_DELAY = 2000;
 
+    private int connectionTimout = ALLOWABLE_CONNECTOR_ACQUISITION_DELAY;
+
     protected CommCareTask() {
         TAG = CommCareTask.class.getSimpleName();
     }
@@ -127,6 +129,15 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
         }
     }
 
+    /**
+     * Adjust the time that the task will wait for a connector before cancelling
+     * or proceeding (if headless)
+     *
+     */
+    protected void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimout = connectionTimeout;
+    }
+
     private CommCareTaskConnector<Receiver> getConnector() {
         return getConnector(true);
     }
@@ -136,7 +147,7 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
         //We wanna hold off on anything that requires the connector
         //until there is one present, up until some specified limit
         long requested = System.currentTimeMillis();
-        while (System.currentTimeMillis() - requested < ALLOWABLE_CONNECTOR_ACQUISITION_DELAY) {
+        while (System.currentTimeMillis() - requested < connectionTimout) {
             //See if we've gotten a connector
             synchronized (connectorLock) {
                 if (connector != null) {


### PR DESCRIPTION
Framework for addressing the issues from [MOB-138](https://dimagi-dev.atlassian.net/browse/MOB-138)

External session callouts manipulate the session stack in dangerous ways. This PR extends the "interrupt" mechanism built to capture form entry state when users are logged out due to their session expiring and makes it triggerable from the entry point for external session call-ins.

This should make it possible to safely end and resume a form entry session based on an external intent. It is a future piece of work to do the inverse (make it safe to load a form in CommCare when one is already in progress having been loaded from an intent)

Workflow example:
![form_resume](https://user-images.githubusercontent.com/155066/70113259-8db15980-1626-11ea-86ec-0fd033e3cb43.gif)
