### PR TITLE
Fix sync condition being default

### DIFF
--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -439,7 +439,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
             long updateReleasedOnTime = HiddenPreferences.geReleasedOnTimeForOngoingAppDownload();
             return lastSyncTime < updateReleasedOnTime;
         }
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
The new "Require Sync" feature logic was accidentally turned 'on' by default, this reverts it back to being off unless dictated otherwise