### PR TITLE
Enable cleartext support by default

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -63,6 +63,7 @@
         android:supportsRtl="true"
         android:label="@string/application_name"
         android:hardwareAccelerated="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/AppBaseTheme">
         <activity
             android:name="org.commcare.activities.DispatchActivity"


### PR DESCRIPTION
Problem: Starting with Android 9 (API level 28), cleartext support is disabled by default due to which on Android 9 devices, the installation using app code fails due to a security exception - "Cleartext communication to *** not permitted by network security policy."

Solution: Enable cleartext support by default in Manifest. 