### PR TITLE
Fix mediaController visibility issue while navigating between questions

### DIFF
--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -25,6 +25,7 @@ import org.commcare.util.LogTypes;
 import org.commcare.utils.BlockingActionsManager;
 import org.commcare.utils.CompoundIntentList;
 import org.commcare.utils.MarkupUtil;
+import org.commcare.views.media.MediaLayout;
 import org.commcare.views.widgets.DateTimeWidget;
 import org.commcare.views.widgets.IntentWidget;
 import org.commcare.views.widgets.QuestionWidget;
@@ -422,6 +423,12 @@ public class QuestionsView extends ScrollView
     public void teardownView() {
         for (QuestionWidget widget : widgets) {
             widget.unsetListeners();
+            for (int i = 0; i < widget.getChildCount(); i++) {
+                View view = widget.getChildAt(i);
+                if (view instanceof MediaLayout) {
+                    ((MediaLayout) view).tearDown();
+                }
+            }
             widget.setOnCreateContextMenuListener(null);
         }
         wcListener = null;

--- a/app/src/org/commcare/views/media/MediaLayout.java
+++ b/app/src/org/commcare/views/media/MediaLayout.java
@@ -68,6 +68,7 @@ public class MediaLayout extends RelativeLayout {
     private AudioPlaybackButton audioButton;
     private ImageButton videoButton;
     private TextView missingImageText;
+    private MediaController ctrl;
 
     private MediaLayout(Context c) {
         super(c);
@@ -405,7 +406,7 @@ public class MediaLayout extends RelativeLayout {
                 //since clicking the video view to bring up controls has weird effects.
                 //since we shotgun grab the focus for the input widget.
 
-                final MediaController ctrl = new MediaController(this.getContext());
+                ctrl = new MediaController(this.getContext());
 
                 VideoView videoView = new VideoView(this.getContext());
                 videoView.setOnPreparedListener(mediaPlayer -> ctrl.show());
@@ -426,6 +427,12 @@ public class MediaLayout extends RelativeLayout {
             Log.e(TAG, "invalid video reference exception");
             ire.printStackTrace();
             return getMissingImageView("Invalid reference: " + ire.getReferenceString());
+        }
+    }
+
+    public void tearDown() {
+        if (ctrl != null) {
+            ctrl.setVisibility(GONE);
         }
     }
 


### PR DESCRIPTION
Problem: While navigating between questions, the MediaController would show for a tiny bit of a second after the video view is removed from the screen. 

Solution: While removing view from the screen, hide the visibility of MediaController. 