### PR TITLE
Return empty string as answer instead of OK for a label

### DIFF
--- a/app/src/org/commcare/views/widgets/TriggerWidget.java
+++ b/app/src/org/commcare/views/widgets/TriggerWidget.java
@@ -118,7 +118,7 @@ public class TriggerWidget extends QuestionWidget {
     @Override
     public IAnswerData getAnswer() {
         if (!mInteractive) {
-            return new StringData(mOK);
+            return new StringData("");
         }
         String s = mStringAnswer.getText().toString();
         if (s == null || s.equals("")) {


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/MOB-140

This PR will return an empty string as answer to a label question instead of "OK" text.