### PR TITLE
Fix issue with mediacontroller visibility while navigation and scroll

### DIFF
--- a/app/src/org/commcare/views/media/CommCareMediaController.java
+++ b/app/src/org/commcare/views/media/CommCareMediaController.java
@@ -1,0 +1,53 @@
+package org.commcare.views.media;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.MediaController;
+
+/**
+ * Custom MediaController which provides a workaround to the issue where hide and show aren't working while adding it in the view hierarchy.
+ * Note: Use only when you're manually adding MediaController in the view hierarchy.
+ * Used here {@link MediaLayout}
+ * @author $|-|!˅@M
+ */
+public class CommCareMediaController extends MediaController {
+
+    // A mock to superclass' isShowing property.
+    // {@link https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/MediaController.java#96}
+    private boolean _isShowing = false;
+
+    public CommCareMediaController(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public CommCareMediaController(Context context, boolean useFastForward) {
+        super(context, useFastForward);
+    }
+
+    public CommCareMediaController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public boolean isShowing() {
+        return _isShowing;
+    }
+
+    @Override
+    public void show() {
+        super.show();
+        _isShowing = true;
+        ViewGroup parent = (ViewGroup) this.getParent();
+        parent.setVisibility(VISIBLE);
+    }
+
+    @Override
+    public void hide() {
+        super.hide();
+        _isShowing = false;
+        ViewGroup parent = (ViewGroup) this.getParent();
+        parent.setVisibility(View.GONE);
+    }
+}

--- a/app/src/org/commcare/views/media/CommCareVideoView.java
+++ b/app/src/org/commcare/views/media/CommCareVideoView.java
@@ -39,6 +39,10 @@ public class CommCareVideoView extends VideoView {
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
+        // Do not log events if the video is never played.
+        if (duration == 0) {
+            return;
+        }
         listener.onVideoDetached(duration);
     }
 

--- a/app/src/org/commcare/views/media/MediaLayout.java
+++ b/app/src/org/commcare/views/media/MediaLayout.java
@@ -18,7 +18,6 @@ import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
-import android.widget.MediaController;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -410,7 +409,7 @@ public class MediaLayout extends RelativeLayout {
                 //since clicking the video view to bring up controls has weird effects.
                 //since we shotgun grab the focus for the input widget.
 
-                final MediaController ctrl = new MediaController(this.getContext());
+                final CommCareMediaController ctrl = new CommCareMediaController(this.getContext());
 
                 CommCareVideoView videoView = new CommCareVideoView(this.getContext());
                 videoView.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
@@ -419,14 +418,15 @@ public class MediaLayout extends RelativeLayout {
                         //Since MediaController will create a default set of controls and put them in a window floating above your application(From AndroidDocs)
                         //It would never follow the parent view's animation or scroll.
                         //So, adding the MediaController to the view hierarchy here.
-                        //Side-effect: MediaController never hides now 😅.
-                        videoView.setMediaController(ctrl);
-                        ctrl.show();
                         FrameLayout frameLayout = (FrameLayout) ctrl.getParent();
                         ((ViewGroup) frameLayout.getParent()).removeView(frameLayout);
                         RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
                         params.addRule(ALIGN_BOTTOM, videoView.getId());
                         ((RelativeLayout) videoView.getParent()).addView(frameLayout, params);
+
+                        ctrl.setAnchorView(videoView);
+                        videoView.setMediaController(ctrl);
+                        ctrl.show();
                     }
                 });
                 videoView.setVideoPath(videoFilename);
@@ -436,7 +436,6 @@ public class MediaLayout extends RelativeLayout {
                         FirebaseAnalyticsUtil.reportInlineVideoPlayEvent(videoFilename, FileUtil.getDuration(videoFile), duration);
                     }
                 });
-                ctrl.setAnchorView(videoView);
 
                 //These surprisingly get re-jiggered as soon as the video is loaded, so we
                 //just want to give it the _max_ bounds, it'll pick the limiter and shrink


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/MOB-117
**Problem**: Since [The MediaController will create a default set of controls and put them in a window floating above your application.](https://developer.android.com/reference/android/widget/MediaController), the mediacontroller will not respect parent view's animation or scroll. 

**Solution**: Add the mediaController to the view hierarchy to force it always conforms parent view's animation and scroll. 

**Extra**: Prevent logging inline video events if the video is never played. 