### PR TITLE
Add days since last sync param to sync requests

### DIFF
--- a/app/src/org/commcare/network/CommcareRequestGenerator.java
+++ b/app/src/org/commcare/network/CommcareRequestGenerator.java
@@ -11,6 +11,7 @@ import org.commcare.engine.cases.CaseUtils;
 import org.commcare.interfaces.CommcareRequestEndpoints;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.provider.DebugControlsReceiver;
+import org.commcare.utils.SyncDetailCalculations;
 import org.javarosa.core.model.User;
 import org.javarosa.core.model.utils.DateUtils;
 
@@ -106,6 +107,11 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
             }
             if (digest != null) {
                 params.put("state", "ccsh:" + digest);
+            }
+
+            int getDaysSinceSync = SyncDetailCalculations.getDaysSinceLastSync();
+            if(getDaysSinceSync != -1) {
+                params.put("days_since_last_sync", Integer.toString(getDaysSinceSync));
             }
         }
 

--- a/app/unit-tests/src/org/commcare/utils/DateUtilTest.java
+++ b/app/unit-tests/src/org/commcare/utils/DateUtilTest.java
@@ -1,0 +1,53 @@
+package org.commcare.utils;
+
+import org.joda.time.DateTime;
+import org.joda.time.Hours;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalDateTime;
+import org.joda.time.Minutes;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Date;
+
+/**
+ * Tests for various date calculations
+ *
+ * @author Clayton Sims (csims@dimagi.com)
+ */
+public class DateUtilTest {
+
+    @Test
+    public void testDateCalculations() {
+
+        //Test Identity Calculations
+        Date now = new Date();
+        LocalDateTime ldnow = new LocalDateTime(now);
+        DateTime dtnow = new DateTime(now);
+
+        Assert.assertEquals("Dates are incompatible (Date -> LocalDate)", now.getTime(), ldnow.toDate().getTime());
+        Assert.assertEquals("Dates are incompatible (Date -> DateTime)", now.getTime(), dtnow.toLocalDateTime().toDate().getTime());
+
+        DateTime elevenPm = new DateTime(2020, 10, 10, 23, 00, 00);
+
+        DateTime twoAmNd = elevenPm.plus(Hours.hours(4));
+
+        DateTime elevenThirtyPmNd = new DateTime(2020, 10, 11, 23, 30, 00);
+
+        DateTime elevenPmPlusThree = elevenPm.plus(Hours.hours(72));
+        DateTime elevenPmPlusThreeDaysThirtyMinutes = elevenPm.plus(Hours.hours(72).plus(Minutes.minutes(30).toStandardHours()));
+        DateTime elevenPmPlusThreeDaysOneHour = elevenPm.plus(Hours.hours(73));
+
+        Assert.assertEquals(1, SyncDetailCalculations.getDaysBetweenJavaDatetimes(elevenPm.toDate(), twoAmNd.toDate()));
+
+        Assert.assertEquals(0, SyncDetailCalculations.getDaysBetweenJavaDatetimes(twoAmNd.toDate(), elevenThirtyPmNd.toDate()));
+
+        Assert.assertEquals(3, SyncDetailCalculations.getDaysBetweenJavaDatetimes(elevenPm.toDate(), elevenPmPlusThree.toDate()));
+
+        Assert.assertEquals(3, SyncDetailCalculations.getDaysBetweenJavaDatetimes(elevenPm.toDate(), elevenPmPlusThreeDaysThirtyMinutes.toDate()));
+
+        Assert.assertEquals(4, SyncDetailCalculations.getDaysBetweenJavaDatetimes(elevenPm.toDate(), elevenPmPlusThreeDaysOneHour.toDate()));
+
+
+    }
+}


### PR DESCRIPTION
When performing a sync request, includes the integer days since the last day the device has synced to the URL parameters of the request, ie:
`/a/no-feature-flags/phone/restore/07a82c079ce340a8ae705ef3d66089f7/?device_id=353522096503145&user_id=ce3719da49ef4b4ea8740b2e617ae6b5&days_since_last_sync=34&state=ccsh:ba14c90a2370ecd5778cbdf5d81370ff&version=2.0&items=true&since=2605adb21c2b11eabf720a5180e0c5bc`

The intent here is to allow HQ to create different pooled priorities for rate limiting based on how far behind a user is in syncing data, as such the data needs to be available to the proxy with no downstream processing. 

@shubham1g5 I am thinking that it makes the most sense for me to hotfix this as 2.47.5 as well, otherwise it won't make it out to users fast enough to be usable. Do you have reservations about that based on the code?

@snopoke This is what we were discussing this morning. HQ can ignore all other cases other than `days_since_last_sync=0`, which should be simple pattern matching. Any objections to that?