### PR TITLE
Use right username to validate if an update is blocked before login

### DIFF
--- a/app/src/org/commcare/AppUtils.java
+++ b/app/src/org/commcare/AppUtils.java
@@ -97,7 +97,7 @@ public class AppUtils {
      * it shouldn't be used lightly.
      */
     public static void clearUserData() {
-        wipeSandboxForUser(CommCareApplication.instance().getSession().getLoggedInUser().getUsername());
+        wipeSandboxForUser(getLoggedInUserName());
         CommCareApplication.instance().getCurrentApp().getAppPreferences().edit()
                 .putString(HiddenPreferences.LAST_LOGGED_IN_USER, null).apply();
         CommCareApplication.instance().closeUserSession();
@@ -183,5 +183,9 @@ public class AppUtils {
     public static boolean notOnLatestCCVersion() {
         return new ApkVersion(ReportingUtils.getCommCareVersionString()).compareTo(
                 new ApkVersion(HiddenPreferences.getLatestCommcareVersion())) < 0;
+    }
+
+    public static String getLoggedInUserName() {
+        return CommCareApplication.instance().getSession().getLoggedInUser().getUsername();
     }
 }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -187,7 +187,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
             DevSessionRestorer.tryAutoLoginPasswordSave(uiController.getEnteredPasswordOrPin(), false);
         }
 
-        if (ResourceInstallUtils.isUpdateReadyToInstall() && !UpdateActivity.isUpdateBlockedOnSync()) {
+        if (ResourceInstallUtils.isUpdateReadyToInstall() && !UpdateActivity.isUpdateBlockedOnSync(uiController.getEnteredUsername())) {
             // install update, which triggers login upon completion
             installPendingUpdate();
         } else {

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -428,14 +428,18 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
         uiController.applyingUpdateUiState();
     }
 
-
     public static boolean isUpdateBlockedOnSync() {
+        return isUpdateBlockedOnSync(ReportingUtils.getUser());
+    }
+
+    // Returns whether a sync is required in order to take an app update
+    public static boolean isUpdateBlockedOnSync(String username) {
         if (HiddenPreferences.shouldBypassPreUpdateSync()) {
             return false;
         }
 
         if (ResourceInstallUtils.isUpdateReadyToInstall() && HiddenPreferences.preUpdateSyncNeeded()) {
-            long lastSyncTime = SyncDetailCalculations.getLastSyncTime();
+            long lastSyncTime = SyncDetailCalculations.getLastSyncTime(username);
             long updateReleasedOnTime = HiddenPreferences.geReleasedOnTimeForOngoingAppDownload();
             return lastSyncTime < updateReleasedOnTime;
         }

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.widget.TextView;
 
+import org.commcare.AppUtils;
 import org.commcare.CommCareApplication;
 import org.commcare.activities.StandardHomeActivity;
 import org.commcare.adapters.HomeCardDisplayData;
@@ -19,7 +20,6 @@ import org.commcare.preferences.HiddenPreferences;
 import org.commcare.util.LogTypes;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
-import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.joda.time.LocalDate;
 
@@ -118,8 +118,12 @@ public class SyncDetailCalculations {
     }
 
     public static long getLastSyncTime() {
+        return getLastSyncTime(AppUtils.getLoggedInUserName());
+    }
+
+    public static long getLastSyncTime(String username) {
         SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        return prefs.getLong(getLastSyncKey(ReportingUtils.getUser()), 0);
+        return prefs.getLong(getLastSyncKey(username), 0);
     }
 
     public static String getLastSyncKey(String username) {


### PR DESCRIPTION
The previous sync calculation was looking for a logged in username which is empty in case of a pre-login update check. This was causing the last sync time to always be 0 (< updateReleaseTime) and was thus resulting in the update install not getting triggered for a ready update even if the user has synced after the update release time. 