### PR TITLE
Change scaleDownFactor to make sure we don't load large image in imageView

### DIFF
--- a/app/src/org/commcare/utils/MediaUtil.java
+++ b/app/src/org/commcare/utils/MediaUtil.java
@@ -414,7 +414,7 @@ public class MediaUtil {
         double widthScaleDownFactor =  (double)boundingWidth / originalWidth;
         // Choosing the larger of the scale down factors, so that the image still fills the entire
         // container
-        double dominantScaleDownFactor = Math.max(widthScaleDownFactor, heightScaleDownFactor);
+        double dominantScaleDownFactor = Math.min(widthScaleDownFactor, heightScaleDownFactor);
 
         int widthImposedByContainer = (int)Math.round(originalWidth * dominantScaleDownFactor);
         int heightImposedByContainer = (int)Math.round(originalHeight * dominantScaleDownFactor);


### PR DESCRIPTION
In some cases the scaleDownFactor for a really large image comes out to be 1, so the bitmap is not scaled down at all and loading that bitmap in imageview crashes the app. 
This PR will fix it.