### PR TITLE
Fixes a crash on opening form that's part of a pending update on phone

### DIFF
--- a/app/src/org/commcare/activities/components/FormEntryInstanceState.java
+++ b/app/src/org/commcare/activities/components/FormEntryInstanceState.java
@@ -4,6 +4,8 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Pair;
 
+import org.commcare.CommCareApp;
+import org.commcare.CommCareApplication;
 import org.commcare.activities.FormEntryActivity;
 import org.commcare.android.database.app.models.FormDefRecord;
 import org.commcare.android.database.user.models.FormRecord;
@@ -62,7 +64,8 @@ public class FormEntryInstanceState {
                 !FormRecord.STATUS_UNSTARTED.equals(formStatus) &&
                         !FormRecord.STATUS_INCOMPLETE.equals(formStatus);
 
-        int formDefId = FormDefRecord.getLatestFormDefId(formDefRecordStorage, formRecord.getXmlns());
+        int appVersion = CommCareApplication.instance().getCurrentApp().getAppRecord().getVersionNumber();
+        int formDefId = FormDefRecord.getLatestFormDefId(appVersion, formDefRecordStorage, formRecord.getXmlns());
         if (formDefId == -1) {
             String error = "No XForm definition defined for this form with namespace " + formRecord.getXmlns();
             Logger.log(LogTypes.SOFT_ASSERT, error);

--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -2,7 +2,6 @@ package org.commcare.android.resource.installers;
 
 import android.support.v4.util.Pair;
 
-import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
 import org.commcare.engine.resource.installers.LocalStorageUnavailableException;
@@ -23,7 +22,6 @@ import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.Logger;
-import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
@@ -70,7 +68,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
     }
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
+    public boolean initialize(Resource r, AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
         Reference ref = ReferenceManager.instance().DeriveReference(localLocation);

--- a/app/src/org/commcare/android/resource/installers/LocaleAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/LocaleAndroidInstaller.java
@@ -36,10 +36,10 @@ public class LocaleAndroidInstaller extends FileSystemInstaller {
 
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
+    public boolean initialize(Resource r, AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
-        super.initialize(platform, isUpgrade);
+        super.initialize(r, platform, isUpgrade);
         Localization.registerLanguageReference(locale, localLocation);
         return true;
     }

--- a/app/src/org/commcare/android/resource/installers/MediaFileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/MediaFileAndroidInstaller.java
@@ -59,7 +59,7 @@ public class MediaFileAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
+    public boolean initialize(Resource r, AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
         return false;

--- a/app/src/org/commcare/android/resource/installers/OfflineUserRestoreAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/OfflineUserRestoreAndroidInstaller.java
@@ -30,7 +30,7 @@ public class OfflineUserRestoreAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
+    public boolean initialize(Resource r, AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
         platform.registerDemoUserRestore(initDemoUserRestore());

--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -49,7 +49,7 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
 
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
+    public boolean initialize(Resource r, AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
         InputStream inputStream = null;

--- a/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/SuiteAndroidInstaller.java
@@ -16,7 +16,6 @@ import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.DummyResourceTable;
 import org.commcare.utils.FileUtil;
-import org.commcare.utils.StringUtils;
 import org.commcare.xml.AndroidSuiteParser;
 import org.commcare.xml.SuiteParser;
 import org.javarosa.core.io.StreamsUtil;
@@ -27,7 +26,6 @@ import org.javarosa.core.services.Logger;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.javarosa.xpath.XPathException;
-import org.jsoup.helper.StringUtil;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -52,7 +50,7 @@ public class SuiteAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean initialize(final AndroidCommCarePlatform platform, boolean isUpgrade) throws
+    public boolean initialize(Resource r, final AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException, XmlPullParserException,
             UnfullfilledRequirementsException {
         InputStream inputStream = null;

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -8,7 +8,6 @@ import org.commcare.android.javarosa.PollSensorAction;
 import org.commcare.engine.extensions.IntentExtensionParser;
 import org.commcare.engine.extensions.PollSensorExtensionParser;
 import org.commcare.engine.extensions.XFormExtensionUtils;
-import org.commcare.models.database.SqlStorage;
 import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
@@ -70,20 +69,20 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
     }
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
+    public boolean initialize(Resource r, AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
-        super.initialize(platform, isUpgrade);
-        if (isLatestFormRecord(platform)) {
+        super.initialize(r, platform, isUpgrade);
+        if (isLatestFormRecord(r, platform)) {
             platform.registerXmlns(namespace, formDefId);
         }
         return true;
     }
 
     // Returns whether the associated formdefRecord is the one with highest form def resource version for our namespace
-    private boolean isLatestFormRecord(AndroidCommCarePlatform platform) {
+    private boolean isLatestFormRecord(Resource r, AndroidCommCarePlatform platform) {
         if (formDefId != -1) {
-            return getLatestFormDefId(platform.getFormDefStorage(), namespace) == formDefId;
+            return getLatestFormDefId(r.getVersion(), platform.getFormDefStorage(), namespace) == formDefId;
         }
         return false;
     }

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstallerV1.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstallerV1.java
@@ -27,7 +27,7 @@ public class XFormAndroidInstallerV1 extends FileSystemInstaller {
     }
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
+    public boolean initialize(Resource r, AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
         return false;

--- a/app/src/org/commcare/android/resource/installers/XFormUpdateInfoInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormUpdateInfoInstaller.java
@@ -1,5 +1,6 @@
 package org.commcare.android.resource.installers;
 
+import org.commcare.resources.model.Resource;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.xml.util.InvalidStructureException;
@@ -20,10 +21,10 @@ public class XFormUpdateInfoInstaller extends XFormAndroidInstaller {
     }
 
     @Override
-    public boolean initialize(AndroidCommCarePlatform platform, boolean isUpgrade) throws
+    public boolean initialize(Resource r, AndroidCommCarePlatform platform, boolean isUpgrade) throws
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
         platform.setUpdateInfoFormXmlns(namespace);
-        return super.initialize(platform, isUpgrade);
+        return super.initialize(r, platform, isUpgrade);
     }
 }

--- a/app/src/org/commcare/utils/DummyResourceTable.java
+++ b/app/src/org/commcare/utils/DummyResourceTable.java
@@ -83,7 +83,7 @@ public class DummyResourceTable extends ResourceTable {
                     }
 
                     @Override
-                    public boolean initialize(CommCarePlatform platform, boolean isUpgrade) throws
+                    public boolean initialize(Resource r, CommCarePlatform platform, boolean isUpgrade) throws
                             IOException, InvalidReferenceException, InvalidStructureException,
                             XmlPullParserException, UnfullfilledRequirementsException {
                         return true;


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/ICDS-1264

Issue Repro: 

- Install an App and login
- Initiate an update , though don't install it
- Kill CC (to force app re-initialization)
- Open CC again 
- Go to a form that's part of the update 
- CC Crashes

Explaination: The crash happens when there is an update in progress or there is an update downloaded that’s not been installed and user tries to open a form that’s been updated in the pending update. When a form is installed as part of update, it c[reates formDefRecords](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java#L107) into user storage. When an app which has a pending update gets initialized, we loop through forms to find the [latestFormId](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java#L86) for the particular namespace. [This code](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/database/app/models/FormDefRecord.java#L161) was also looping through the forms that were part of the update causing `getLatestFormDefId` to return the formId of the updated form which in turn caused the right xform to not be mapped to namespace ever because of the check [here](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java#L77).  When user opens a form that's part of a pending update, this causes a lookup for formId -1 into sql causing a crash. It's worth to note that this issue fixes itself once the pending update has been installed. 

Solution: This PR implements a resource version check in `getLatestFormDefId` to exclude any forms that has resource version greater than the resource version of the resource being initialized and thus excluding all the forms that are saved into DB because of the update. 

cross-request: https://github.com/dimagi/commcare-core/pull/880