### PR TITLE
Fixes form load crash in case of an pending update

### DIFF
--- a/app/src/org/commcare/activities/components/FormEntryInstanceState.java
+++ b/app/src/org/commcare/activities/components/FormEntryInstanceState.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Pair;
 
+import org.commcare.CommCareApplication;
 import org.commcare.activities.FormEntryActivity;
 import org.commcare.android.database.app.models.FormDefRecord;
 import org.commcare.android.database.user.models.FormRecord;
@@ -62,7 +63,9 @@ public class FormEntryInstanceState {
                 !FormRecord.STATUS_UNSTARTED.equals(formStatus) &&
                         !FormRecord.STATUS_INCOMPLETE.equals(formStatus);
 
-        int formDefId = FormDefRecord.getLatestFormDefId(formDefRecordStorage, formRecord.getXmlns());
+        int formDefId = CommCareApplication.instance()
+                .getCommCarePlatform()
+                .getFormDefId(formRecord.getXmlns());
         if (formDefId == -1) {
             String error = "No XForm definition defined for this form with namespace " + formRecord.getXmlns();
             Logger.log(LogTypes.SOFT_ASSERT, error);

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -78,7 +78,7 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
         if (platform.getFormDefId(namespace) == -1) {
             platform.registerXmlns(namespace, formDefId);
         } else {
-            // Only overwrite a form if the resourceVersion of the new form is higher
+            // Only overwrites the existing form if the resourceVersion of the new form is higher than the existing one
             FormDefRecord existingForm = FormDefRecord.getFormDef(platform.getFormDefStorage(), platform.getFormDefId(namespace));
             FormDefRecord newForm = FormDefRecord.getFormDef(platform.getFormDefStorage(), formDefId);
             if (newForm.getResourceVersion() > existingForm.getResourceVersion()) {

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -74,19 +74,21 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
             IOException, InvalidReferenceException, InvalidStructureException,
             XmlPullParserException, UnfullfilledRequirementsException {
         super.initialize(platform, isUpgrade);
-        if (isLatestFormRecord(platform)) {
+
+        if (platform.getFormDefId(namespace) == -1) {
             platform.registerXmlns(namespace, formDefId);
+        } else {
+            // Only overwrite a form if the resourceVersion of the new form is higher
+            FormDefRecord existingForm = FormDefRecord.getFormDef(platform.getFormDefStorage(), platform.getFormDefId(namespace));
+            FormDefRecord newForm = FormDefRecord.getFormDef(platform.getFormDefStorage(), formDefId);
+            if (newForm.getResourceVersion() > existingForm.getResourceVersion()) {
+                platform.registerXmlns(namespace, formDefId);
+            }
         }
+
         return true;
     }
 
-    // Returns whether the associated formdefRecord is the one with highest form def resource version for our namespace
-    private boolean isLatestFormRecord(AndroidCommCarePlatform platform) {
-        if (formDefId != -1) {
-            return getLatestFormDefId(platform.getFormDefStorage(), namespace) == formDefId;
-        }
-        return false;
-    }
 
     @Override
     protected int customInstall(Resource r, Reference local, boolean upgrade, AndroidCommCarePlatform platform) throws IOException, UnresolvedResourceException {

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -81,7 +81,7 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
             // Only overwrites the existing form if the resourceVersion of the new form is higher than the existing one
             FormDefRecord existingForm = FormDefRecord.getFormDef(platform.getFormDefStorage(), platform.getFormDefId(namespace));
             FormDefRecord newForm = FormDefRecord.getFormDef(platform.getFormDefStorage(), formDefId);
-            if (newForm.getResourceVersion() > existingForm.getResourceVersion()) {
+            if (newForm.getResourceVersion() >= existingForm.getResourceVersion()) {
                 platform.registerXmlns(namespace, formDefId);
             }
         }


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/ICDS-1264

Issue Repro:

- Install an App and login
- Initiate an update , though don't install it
- Kill CC (to force app re-initialization)
- Open CC again
- Go to a form that's part of the update
- CC Crashes

Explaination: The crash happens when there is an update in progress or there is an update downloaded that’s not been installed and user tries to open a form that’s been updated in the pending update. When a form is installed as part of update, it [creates formDefRecords](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java#L107) into user storage. When an app which has a pending update gets initialized, we loop through forms to find the [latestFormId](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java#L86) for the particular namespace. [This code](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/database/app/models/FormDefRecord.java#L161) was also looping through the forms that were part of the update causing getLatestFormDefId to return the formId of the updated form which in turn caused the right xform to not be mapped to namespace ever because of the check [here](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java#L77). When user opens a form that's part of a pending update, this causes a lookup for formId -1 into sql causing a crash. It's worth to note that this issue fixes itself once the pending update has been installed.

Solution:  Instead of looking throgh the formDefRecords to decide whether to register a namespace or not this PR always registers a namespace if it doesn't exist and only overwrites in case the resource version of the new form is greater than the existing form. 