### PR TITLE
Deregisters forms on uninstall

### DIFF
--- a/app/src/org/commcare/android/database/app/models/FormDefRecord.java
+++ b/app/src/org/commcare/android/database/app/models/FormDefRecord.java
@@ -195,4 +195,8 @@ public class FormDefRecord extends Persisted {
     public int getResourceVersion() {
         return mResourceVersion;
     }
+
+    public String getJrFormId() {
+        return mJrFormId;
+    }
 }

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -131,6 +131,7 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
 //                // This form def record belongs to an old version which is not part of current version since
 //                // otherwise it's resource version would have got bumped to the resource
 //                // version of new resource in the update.
+                platform.deregisterForm(formDefRecord.getJrFormId(), formDefId);
                 platform.getFormDefStorage().remove(formDefId);
                 return super.uninstall(r, platform);
             }

--- a/app/src/org/commcare/utils/AndroidCommCarePlatform.java
+++ b/app/src/org/commcare/utils/AndroidCommCarePlatform.java
@@ -48,6 +48,14 @@ public class AndroidCommCarePlatform extends CommCarePlatform {
         xmlnstable.put(xmlns, formDefId);
     }
 
+    // remove the form from xmlnstable if the form with formDefId is registered agains xmlns
+    public void deregisterForm(String xmlns, Integer formDefId) {
+        int existingFormId = xmlnstable.get(xmlns);
+        if (existingFormId == formDefId) {
+            xmlnstable.remove(xmlns);
+        }
+    }
+
     public Set<String> getInstalledForms() {
         return xmlnstable.keySet();
     }


### PR DESCRIPTION
In Continuation to: https://github.com/dimagi/commcare-android/pull/2186

We remove the formDefRecords today from DB while uninstalling a form but don't really remove the particular formid <-> namespace mapping. This causes the code change in the PR above to fail [here](https://github.com/dimagi/commcare-android/blob/commcare_2.47/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java#L82) as there can be form ids which exists in platform but their respective reports have been deleted. 