### PR TITLE
Disable retries on getting rate limited on individual resource requests

### DIFF
--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -5,6 +5,7 @@ import androidx.core.util.Pair;
 import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
 import org.commcare.engine.resource.installers.LocalStorageUnavailableException;
+import org.commcare.network.RateLimitedException;
 import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceInstaller;
@@ -143,6 +144,8 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
         } catch (IOException e) {
             e.printStackTrace();
             throw new UnreliableSourceException(r, e.getMessage());
+        } catch (RateLimitedException e) {
+            throw new UnresolvedResourceException(r, "Our servers are unavailable at this time. Please try again later", true);
         }
     }
 

--- a/app/src/org/commcare/engine/references/JavaHttpReference.java
+++ b/app/src/org/commcare/engine/references/JavaHttpReference.java
@@ -3,8 +3,10 @@ package org.commcare.engine.references;
 import org.commcare.interfaces.CommcareRequestEndpoints;
 import org.commcare.network.CommcareRequestGenerator;
 import org.commcare.network.HttpUtils;
+import org.commcare.network.RateLimitedException;
 import org.javarosa.core.reference.ReleasedOnTimeSupportedReference;
 import org.javarosa.core.reference.Reference;
+import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 
 import java.io.IOException;
@@ -58,6 +60,8 @@ public class JavaHttpReference implements Reference, ReleasedOnTimeSupportedRefe
         } else {
             if (response.code() == 406) {
                 throw new IOException(HttpUtils.parseUserVisibleError(response));
+            } else if (response.code() == 503) {
+                throw new RateLimitedException();
             }
             throw new IOException(Localization.get("install.fail.error", Integer.toString(response.code())));
         }

--- a/app/src/org/commcare/network/RateLimitedException.java
+++ b/app/src/org/commcare/network/RateLimitedException.java
@@ -1,0 +1,4 @@
+package org.commcare.network;
+
+public class RateLimitedException extends RuntimeException {
+}


### PR DESCRIPTION
Today when we ecounter a 503 during a resource request during update, we still end up [retrying 4 times](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/resources/model/ResourceTable.java#L607) for the same request. 

Getting this in 2.48 to get this fixed sooner for ICDS. 