### PR TITLE
Fix mismatched attachments while editing a saved form 

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -703,7 +703,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         saveDataToDisk(FormEntryConstants.EXIT, false, null, true);
     }
 
-    private void updateFormMediaToDisk() {
+    protected void updateFormMediaToDisk() {
         // Works only when we are editing a saved form.
         FormRecord formRecord = FormRecord.getFormRecord(formRecordStorage, FormEntryInstanceState.mFormRecordPath);
         if (formRecord == null) {

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -352,7 +352,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     public void saveImageWidgetAnswer(String imagePath) {
         uiController.questionsView.setBinaryData(imagePath, mFormController);
         saveAnswersForCurrentScreen(FormEntryConstants.DO_NOT_EVALUATE_CONSTRAINTS);
-        updateFormMediaToDisk();
+        onExternalAttachmentUpdated();
         uiController.refreshView();
     }
 
@@ -371,7 +371,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             uiController.questionsView.setBinaryData(media, mFormController);
         }
         saveAnswersForCurrentScreen(FormEntryConstants.DO_NOT_EVALUATE_CONSTRAINTS);
-        updateFormMediaToDisk();
+        onExternalAttachmentUpdated();
         uiController.refreshView();
     }
 
@@ -703,8 +703,11 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         saveDataToDisk(FormEntryConstants.EXIT, false, null, true);
     }
 
-    protected void updateFormMediaToDisk() {
-        // Works only when we are editing a saved form.
+    /**
+     * Attempts to update the form in the disk when user changes the attachment.
+     * NOTE:- This fixes the mismatch in attachments while trying to update attachments in a saved form.
+     */
+    protected void onExternalAttachmentUpdated() {
         FormRecord formRecord = FormRecord.getFormRecord(formRecordStorage, FormEntryInstanceState.mFormRecordPath);
         if (formRecord == null) {
             return;

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -352,6 +352,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     public void saveImageWidgetAnswer(String imagePath) {
         uiController.questionsView.setBinaryData(imagePath, mFormController);
         saveAnswersForCurrentScreen(FormEntryConstants.DO_NOT_EVALUATE_CONSTRAINTS);
+        updateFormMediaToDisk();
         uiController.refreshView();
     }
 
@@ -370,6 +371,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             uiController.questionsView.setBinaryData(media, mFormController);
         }
         saveAnswersForCurrentScreen(FormEntryConstants.DO_NOT_EVALUATE_CONSTRAINTS);
+        updateFormMediaToDisk();
         uiController.refreshView();
     }
 
@@ -699,6 +701,18 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
     private void saveIncompleteFormToDisk() {
         saveDataToDisk(FormEntryConstants.EXIT, false, null, true);
+    }
+
+    private void updateFormMediaToDisk() {
+        // Works only when we are editing a saved form.
+        FormRecord formRecord = FormRecord.getFormRecord(formRecordStorage, FormEntryInstanceState.mFormRecordPath);
+        if (formRecord == null) {
+            return;
+        }
+        String formStatus = formRecord.getStatus();
+        if (FormRecord.STATUS_INCOMPLETE.equals(formStatus)) {
+            saveDataToDisk(false, false, null, true);
+        }
     }
 
     private void showSaveErrorAndExit() {

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -43,7 +43,6 @@ import org.commcare.views.widgets.QuestionWidget;
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
-import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.InvalidData;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
@@ -717,8 +716,6 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                 FormRelevancyUpdating.getOldSelectChoicesForEachWidget(oldWidgets);
         ArrayList<String> oldQuestionTexts =
                 FormRelevancyUpdating.getOldQuestionTextsForEachWidget(oldWidgets);
-        ArrayList<IAnswerData> oldAnswers =
-                FormRelevancyUpdating.getOldAnswersForEachWidget(oldWidgets);
 
         activity.saveAnswersForCurrentScreen(FormEntryConstants.DO_NOT_EVALUATE_CONSTRAINTS);
 
@@ -745,9 +742,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
             if (oldWidgets.get(i) instanceof ImageWidget) {
                 // If there was change(in particular image-remove) in an image widget,
                 // only then update the form to disk.
-                if (oldAnswers.get(i) != null && oldWidgets.get(i).getAnswer() == null) {
-                    activity.onExternalAttachmentUpdated();
-                }
+                activity.onExternalAttachmentUpdated();
             }
 
             FormEntryPrompt oldPrompt = oldWidgets.get(i).getPrompt();

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -43,6 +43,7 @@ import org.commcare.views.widgets.QuestionWidget;
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.InvalidData;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
@@ -716,6 +717,8 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                 FormRelevancyUpdating.getOldSelectChoicesForEachWidget(oldWidgets);
         ArrayList<String> oldQuestionTexts =
                 FormRelevancyUpdating.getOldQuestionTextsForEachWidget(oldWidgets);
+        ArrayList<IAnswerData> oldAnswers =
+                FormRelevancyUpdating.getOldAnswersForEachWidget(oldWidgets);
 
         activity.saveAnswersForCurrentScreen(FormEntryConstants.DO_NOT_EVALUATE_CONSTRAINTS);
 
@@ -739,9 +742,12 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                 continue;
             }
 
-            //If there was change(in particular image-remove) in an image widget, then update the form
             if (oldWidgets.get(i) instanceof ImageWidget) {
-                activity.updateFormMediaToDisk();
+                // If there was change(in particular image-remove) in an image widget,
+                // only then update the form to disk.
+                if (oldAnswers.get(i) != null && oldWidgets.get(i).getAnswer() == null) {
+                    activity.onExternalAttachmentUpdated();
+                }
             }
 
             FormEntryPrompt oldPrompt = oldWidgets.get(i).getPrompt();

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -37,6 +37,7 @@ import org.commcare.views.dialogs.DialogChoiceItem;
 import org.commcare.views.dialogs.HorizontalPaneledChoiceDialog;
 import org.commcare.views.dialogs.PaneledChoiceDialog;
 import org.commcare.views.media.AudioController;
+import org.commcare.views.widgets.ImageWidget;
 import org.commcare.views.widgets.IntentWidget;
 import org.commcare.views.widgets.QuestionWidget;
 import org.javarosa.core.model.Constants;
@@ -737,6 +738,12 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                 shouldRemoveFromView.add(i);
                 continue;
             }
+
+            //If there was change(in particular image-remove) in an image widget, then update the form
+            if (oldWidgets.get(i) instanceof ImageWidget) {
+                activity.updateFormMediaToDisk();
+            }
+
             FormEntryPrompt oldPrompt = oldWidgets.get(i).getPrompt();
             String priorQuestionTextForThisWidget = oldQuestionTexts.get(i);
             Vector<SelectChoice> priorSelectChoicesForThisWidget = oldSelectChoices.get(i);

--- a/app/src/org/commcare/activities/components/FormRelevancyUpdating.java
+++ b/app/src/org/commcare/activities/components/FormRelevancyUpdating.java
@@ -38,18 +38,6 @@ public class FormRelevancyUpdating {
     }
 
     /**
-     * @return A list of answers for each widget in the list of old widgets, with the
-     * original order preserved
-     */
-    public static ArrayList<IAnswerData> getOldAnswersForEachWidget(ArrayList<QuestionWidget> oldWidgets) {
-        ArrayList<IAnswerData> answerList = new ArrayList<>();
-        for (QuestionWidget qw : oldWidgets) {
-            answerList.add(qw.getPrompt().getAnswerValue());
-        }
-        return answerList;
-    }
-
-    /**
      * @param newValidPrompts  All of the prompts that should be in the new view
      * @param oldPrompt        The prompt from the prior view for which we are seeking a match in the
      *                         list of new prompts

--- a/app/src/org/commcare/activities/components/FormRelevancyUpdating.java
+++ b/app/src/org/commcare/activities/components/FormRelevancyUpdating.java
@@ -2,6 +2,7 @@ package org.commcare.activities.components;
 
 import org.commcare.views.widgets.QuestionWidget;
 import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 
 import java.util.ArrayList;
@@ -34,6 +35,18 @@ public class FormRelevancyUpdating {
             questionTextList.add(qw.getPrompt().getQuestionText());
         }
         return questionTextList;
+    }
+
+    /**
+     * @return A list of answers for each widget in the list of old widgets, with the
+     * original order preserved
+     */
+    public static ArrayList<IAnswerData> getOldAnswersForEachWidget(ArrayList<QuestionWidget> oldWidgets) {
+        ArrayList<IAnswerData> answerList = new ArrayList<>();
+        for (QuestionWidget qw : oldWidgets) {
+            answerList.add(qw.getPrompt().getAnswerValue());
+        }
+        return answerList;
     }
 
     /**

--- a/app/src/org/commcare/views/widgets/ImageWidget.java
+++ b/app/src/org/commcare/views/widgets/ImageWidget.java
@@ -157,6 +157,7 @@ public class ImageWidget extends QuestionWidget {
                 !mPrompt.isReadOnly());
         mDiscardButton.setOnClickListener(v -> {
             deleteMedia();
+            widgetEntryChanged();
         });
         mDiscardButton.setVisibility(View.GONE);
 


### PR DESCRIPTION
Fix for: https://dimagi-dev.atlassian.net/browse/SAAS-10659

We will now save the form to disk as soon as there is a change in widgets containing attachments. 