### PR TITLE
[no op] Removes syncPending 

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -700,7 +700,6 @@ public class CommCareApplication extends MultiDexApplication {
                         if (shouldAutoUpdate()) {
                             startAutoUpdate();
                         }
-                        syncPending = PendingCalcs.getPendingSyncStatus();
 
                         doReportMaintenance();
                         mBoundService.initHeartbeatLifecycle();
@@ -866,24 +865,12 @@ public class CommCareApplication extends MultiDexApplication {
         return getSession().getUserKeyRecord();
     }
 
-    private boolean syncPending = false;
-
-    public synchronized boolean isSyncPending(boolean clearFlag) {
+    public synchronized boolean isSyncPending() {
         if (areAutomatedActionsInvalid()) {
             return false;
         }
-        // We only set this to true occasionally, but in theory it could be set to false
-        // from other factors, so turn it off if it is.
-        if (!PendingCalcs.getPendingSyncStatus()) {
-            syncPending = false;
-        }
-        if (!syncPending) {
-            return false;
-        }
-        if (clearFlag) {
-            syncPending = false;
-        }
-        return true;
+
+        return PendingCalcs.getPendingSyncStatus();
     }
 
     public boolean isPostUpdateSyncNeeded() {

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -240,7 +240,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             return true;
         }
 
-        if (!CommCareApplication.instance().isSyncPending(false)) {
+        if (!CommCareApplication.instance().isSyncPending()) {
             // Trigger off a regular unsent task processor, unless we're about to sync (which will
             // then handle this in a blocking fashion)
             checkAndStartUnsentFormsTask(false, false);
@@ -1140,7 +1140,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
         } else if (UpdateActivity.isUpdateBlockedOnSync() && UpdateActivity.sBlockedUpdateWorkflowInProgress) {
             triggerSync(true);
             kickedOff = true;
-        } else if (CommCareApplication.instance().isSyncPending(false)) {
+        } else if (CommCareApplication.instance().isSyncPending()) {
             triggerSync(true);
             kickedOff = true;
         } else if (UpdatePromptHelper.promptForUpdateIfNeeded(this)) {


### PR DESCRIPTION
I didn't see any particular use case of maintaining this var `syncPending` and hence removing it to simplify some code. 