### PR TITLE
Shows custom App Version Tag in About CommCare

### DIFF
--- a/app/src/org/commcare/AppUtils.java
+++ b/app/src/org/commcare/AppUtils.java
@@ -2,6 +2,7 @@ package org.commcare;
 
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.text.TextUtils;
 
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.global.models.ApplicationRecord;
@@ -164,6 +165,12 @@ public class AppUtils {
         if (p != null) {
             profileVersion = String.valueOf(p.getVersion());
         }
+
+        String appVersionTag = HiddenPreferences.getAppVersionTag();
+        if (!TextUtils.isEmpty(appVersionTag)) {
+            profileVersion += " (" + appVersionTag + ")";
+        }
+
         String buildDate = BuildConfig.BUILD_DATE;
         String buildNumber = BuildConfig.BUILD_NUMBER;
 

--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -1,6 +1,7 @@
 package org.commcare.preferences;
 
 import android.content.SharedPreferences;
+
 import androidx.preference.PreferenceManager;
 
 import androidx.annotation.Nullable;
@@ -58,6 +59,7 @@ public class HiddenPreferences {
     private final static String GPS_WIDGET_GOOD_ACCURACY = "cc-gps-widget-good-accuracy";
     private final static String GPS_WIDGET_ACCEPTABLE_ACCURACY = "cc-gps-widget-acceptable-accuracy";
     private final static String GPS_WIDGET_TIMEOUT_SECS = "cc-gps-widget-timeout-secs";
+    private static final String APP_VERSION_TAG = "cc-app-version-tag";
     private final static String LOG_ENTITY_DETAIL = "cc-log-entity-detail-enabled";
     public static final String DUMP_FOLDER_PATH = "dump-folder-path";
     private final static String RESIZING_METHOD = "cc-resize-images";
@@ -306,6 +308,11 @@ public class HiddenPreferences {
         CommCareApplication.instance().getCurrentApp().getAppPreferences()
                 .edit()
                 .putInt(LATEST_APP_VERSION, appVersion).apply();
+    }
+
+    public static String getAppVersionTag() {
+        return CommCareApplication.instance().getCurrentApp().getAppPreferences()
+                .getString(APP_VERSION_TAG, "");
     }
 
     public static int getLatestAppVersion() {


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/ICDS-1236

This PR adds an app version tag (`cc-app-version-tag`) defined as a custom app property to the "About CommCare" dialog. 

Product Note: Apps can now define `cc-app-version-tag` as a custom property in app settings to tag a particular app version. This version then become visible in "About CommCare" dialog along with the app version. 