### PR TITLE
Fix "Choose point on Map" functionality

### DIFF
--- a/app/src/org/commcare/views/widgets/GeoPointWidget.java
+++ b/app/src/org/commcare/views/widgets/GeoPointWidget.java
@@ -51,7 +51,7 @@ public class GeoPointWidget extends QuestionWidget {
         if ("maps".equalsIgnoreCase(appearance)) {
             try {
                 // use google maps it exists on the device
-                Class.forName("com.google.android.maps.MapActivity");
+                Class.forName("com.google.android.gms.maps.MapView");
                 mUseMaps = true;
             } catch (ClassNotFoundException e) {
                 mUseMaps = false;


### PR DESCRIPTION
The feature that lets you see the map while geopoints resolve was broken because it was looking for the old v1 play services element to enable it rather than the new one.

NOTE: This bug is blocking a user workflow on COVID-19 response so I think we should hotfix back into 2.48