### PR TITLE
Fabric debug crash - The Crashlytics build ID is missing

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -439,5 +439,10 @@
 
         <meta-data android:name="android.content.APP_RESTRICTIONS"
             android:resource="@xml/app_restrictions" />
+
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="false" />
+
     </application>
 </manifest>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -440,6 +440,7 @@
         <meta-data android:name="android.content.APP_RESTRICTIONS"
             android:resource="@xml/app_restrictions" />
 
+        <!-- This is to disable fabric for debug builds properly - https://stackoverflow.com/a/49836972/3811963 -->
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"
             android:value="false" />


### PR DESCRIPTION
[updating fabric]( https://github.com/dimagi/commcare-android/pull/2214) broke the debug builds for me with a crash on application startup - 

`UnmetDependencyException: The Crashlytics build ID is missing.` 

This was only hapening on debug builds and not release due to fabric not properly shutting down fabric based on `ext.enableCrashlytics`

It seems like the [new recommended way](https://stackoverflow.com/a/49836972/3811963) to disable fabric for debug also needs to falsify `firebase_crashlytics_collection_enabled` flag  in manifest. I can confirm that this flag doesn't affect the release builds [here](https://www.fabric.io/dimagi/android/apps/org.commcare.dalvik/issues/f9ee3f15167a7f2bdefb6f49e9bcb97e/sessions/latest) . 