### PR TITLE
Assist Crash reports with device logs

### DIFF
--- a/app/src/org/commcare/logging/AndroidLogger.java
+++ b/app/src/org/commcare/logging/AndroidLogger.java
@@ -2,6 +2,7 @@ package org.commcare.logging;
 
 import org.commcare.android.javarosa.AndroidLogEntry;
 import org.commcare.models.database.SqlStorage;
+import org.commcare.utils.CrashUtil;
 import org.javarosa.core.api.ILogger;
 import org.javarosa.core.log.IFullLogSerializer;
 import org.javarosa.core.log.LogEntry;
@@ -31,6 +32,7 @@ public class AndroidLogger implements ILogger {
     @Override
     public void log(String type, String message, Date logDate) {
         storage.write(new AndroidLogEntry(type, message, logDate));
+        CrashUtil.log(message);
     }
 
     @Override


### PR DESCRIPTION
Crashlytics provide us a way to add logs to a particular crash report by adding the logs for the particular crash session to the crash report. Adding these device logs to crashlytics will help us in debugging some of the more trickier crashes. 