### PR TITLE
Fix NPE while building question label with asterisk

### DIFF
--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -388,6 +388,8 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
         SpannableStringBuilder builder = new SpannableStringBuilder();
         if (prompt.getMarkdownText() != null) {
             builder.append(forceMarkdown(prompt.getMarkdownText()));
+        } else if (mPrompt.getLongText() == null) {
+            return null;
         } else {
             builder.append(mPrompt.getLongText());
         }


### PR DESCRIPTION
If there is a question without label, then `mPrompt.getLongText()` will return null and `builder.append(null);` will cause a NPE. 