### PR TITLE
Disable minify, proguard for debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -424,9 +424,8 @@ android {
             def odkProviderStr = "org.commcare.dalvik.debug.provider.odk"
             manifestPlaceholders = [odkProvider: odkProviderStr]
 
-            minifyEnabled true
+            minifyEnabled false
             debuggable true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
 
             // used in test suite to build the prototype factory; otherwise unneeded
             buildConfigField "String", "CC_AUTHORITY", "\"${applicationId}\""


### PR DESCRIPTION
Trying to Speed up the debug builds locally. 