### PR TITLE
Stop users from using app when forced update is required

### DIFF
--- a/app/src/org/commcare/heartbeat/UpdatePromptHelper.java
+++ b/app/src/org/commcare/heartbeat/UpdatePromptHelper.java
@@ -30,21 +30,21 @@ public class UpdatePromptHelper {
     public static boolean promptForUpdateIfNeeded(Activity context) {
         try {
             CommCareSessionService currentSession = CommCareApplication.instance().getSession();
-            if (!currentSession.apkUpdatePromptWasShown()) {
-                UpdateToPrompt apkUpdate = getCurrentUpdateToPrompt(UpdateToPrompt.Type.APK_UPDATE);
-                if (apkUpdate != null && apkUpdate.shouldShowOnThisLogin()) {
-                    Intent i = new Intent(context, PromptApkUpdateActivity.class);
-                    context.startActivity(i);
-                    return true;
-                }
+            UpdateToPrompt apkUpdate = getCurrentUpdateToPrompt(UpdateToPrompt.Type.APK_UPDATE);
+            if (apkUpdate != null &&
+                    ((apkUpdate.shouldShowOnThisLogin() && !currentSession.apkUpdatePromptWasShown()) ||
+                            apkUpdate.isForced())) {
+                Intent i = new Intent(context, PromptApkUpdateActivity.class);
+                context.startActivity(i);
+                return true;
             }
-            if (!currentSession.cczUpdatePromptWasShown()) {
-                UpdateToPrompt cczUpdate = getCurrentUpdateToPrompt(UpdateToPrompt.Type.CCZ_UPDATE);
-                if (cczUpdate != null && cczUpdate.shouldShowOnThisLogin()) {
-                    Intent i = new Intent(context, PromptCczUpdateActivity.class);
-                    context.startActivity(i);
-                    return true;
-                }
+            UpdateToPrompt cczUpdate = getCurrentUpdateToPrompt(UpdateToPrompt.Type.CCZ_UPDATE);
+            if (cczUpdate != null &&
+                    ((cczUpdate.shouldShowOnThisLogin() && !currentSession.cczUpdatePromptWasShown()) ||
+                            cczUpdate.isForced())) {
+                Intent i = new Intent(context, PromptCczUpdateActivity.class);
+                context.startActivity(i);
+                return true;
             }
         } catch (SessionUnavailableException e) {
             // Means we just performed an update and have therefore expired the session


### PR DESCRIPTION
From what I understood, using [this doc](https://confluence.dimagi.com/pages/viewpage.action?spaceKey=ICDS&title=Prompted+Updates), a **FORCED** update should restrict users from using CommCare at all until they update the app. 
Unfortunately, the above flow wasn't happening because of this check `if (!currentSession.apkUpdatePromptWasShown())` which says that if prompt is shown for the current session, then it won't be shown again until user logs out explicitly. So after seeing the popup, if a user kills the app and opens it again, he/she will be able to use the app without any problem. (which is exact opposite of what FORCED update guarantees.) 

There is one catch though, once the prompt is shown, there is no way for a user to get out of it without updating(like not even logout and use some other app).