### PR TITLE
Show PromptAPK activity for version mismatch error

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -760,15 +760,10 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     @Override
     public void failBadReqs(String versionRequired, String versionAvailable, boolean majorIsProblem) {
         String versionMismatch = Localization.get("install.version.mismatch", new String[]{versionRequired, versionAvailable});
-
-        String error;
-        if (majorIsProblem) {
-            error = Localization.get("install.major.mismatch");
-        } else {
-            error = Localization.get("install.minor.mismatch");
-        }
-
-        fail(NotificationMessageFactory.message(AppInstallStatus.IncompatibleReqs, new String[]{null, versionMismatch, error}), true);
+        Intent intent = new Intent(this, PromptApkUpdateActivity.class);
+        intent.putExtra(PromptApkUpdateActivity.REQUIRED_VERSION, versionRequired);
+        intent.putExtra(PromptApkUpdateActivity.CUSTOM_PROMPT_TITLE, versionMismatch);
+        startActivity(intent);
     }
 
     @Override

--- a/app/src/org/commcare/activities/PromptActivity.java
+++ b/app/src/org/commcare/activities/PromptActivity.java
@@ -26,6 +26,7 @@ public abstract class PromptActivity extends CommCareActivity {
     protected static final int DO_AN_UPDATE = 1;
 
     public static String FROM_RECOVERY_MEASURE = "from-recovery-measure";
+    public static final String REQUIRED_VERSION = "required-version";
 
     protected PromptItem toPrompt;
 
@@ -44,7 +45,8 @@ public abstract class PromptActivity extends CommCareActivity {
 
         refreshPromptIfNull();
         if (savedInstanceState == null &&
-                !getIntent().getBooleanExtra(FROM_RECOVERY_MEASURE, false)) {
+                !getIntent().getBooleanExtra(FROM_RECOVERY_MEASURE, false) &&
+                getIntent().getStringExtra(REQUIRED_VERSION) == null) {
             // on initial activity load only
             toPrompt.incrementTimesSeen();
         }

--- a/app/src/org/commcare/activities/PromptApkUpdateActivity.java
+++ b/app/src/org/commcare/activities/PromptApkUpdateActivity.java
@@ -16,9 +16,7 @@ import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.commcare.heartbeat.UpdatePromptHelper;
 import org.commcare.heartbeat.UpdateToPrompt;
-import org.commcare.preferences.HiddenPreferences;
 import org.commcare.util.LogTypes;
-import org.commcare.utils.ConnectivityStatus;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.views.dialogs.StandardAlertDialog;
 import org.commcare.views.notifications.NotificationMessage;
@@ -35,6 +33,8 @@ public class PromptApkUpdateActivity extends PromptActivity {
     private FlexibleAppUpdateController flexibleAppUpdateController;
     private AppUpdateController immediateAppUpdateController;
     private static final String APP_UPDATE_NOTIFICATION = "APP_UPDATE_NOTIFICATION";
+
+    public static final String CUSTOM_PROMPT_TITLE = "custom-prompt-title";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -136,7 +136,10 @@ public class PromptApkUpdateActivity extends PromptActivity {
 
     @Override
     void refreshPromptObject() {
-        if (getIntent().getBooleanExtra(FROM_RECOVERY_MEASURE, false)) {
+        if (getIntent().getStringExtra(REQUIRED_VERSION) != null) {
+            String requiredVersion = getIntent().getStringExtra(REQUIRED_VERSION);
+            toPrompt = new UpdateToPrompt(requiredVersion, "true", UpdateToPrompt.Type.APK_UPDATE);
+        } else if (getIntent().getBooleanExtra(FROM_RECOVERY_MEASURE, false)) {
             toPrompt = UpdateToPrompt.DUMMY_APK_PROMPT_FOR_RECOVERY_MEASURE;
         } else {
             toPrompt = UpdatePromptHelper.getCurrentUpdateToPrompt(UpdateToPrompt.Type.APK_UPDATE);
@@ -150,9 +153,14 @@ public class PromptApkUpdateActivity extends PromptActivity {
 
     @Override
     protected void setUpTypeSpecificUIComponents() {
-        promptTitle.setText(
-                Localization.get(inForceMode() ? "apk.update.required.title" : "apk.update.available.title",
-                        getCurrentClientName()));
+        String customText = getIntent().getStringExtra(CUSTOM_PROMPT_TITLE);
+        if (customText != null) {
+            promptTitle.setText(customText);
+        } else {
+            promptTitle.setText(
+                    Localization.get(inForceMode() ? "apk.update.required.title" : "apk.update.available.title",
+                            getCurrentClientName()));
+        }
         doLaterButton.setText(Localization.get("update.later.button.text"));
 
         actionButton.setText(Localization.get("apk.update.action", getCurrentClientName()));


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SAAS-10748

Using this change, for version mismatch errors, we'll now launch PromptAPKUpdateActivity. 

Product Note: For Version Mismatch errors, CommCare will now launch a new screen with details about the required version and buttons to launch PlayStore to update the app. 