### PR TITLE
Show form-save-toast before finishing activity

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1143,10 +1143,12 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                     hasSaved = true;
                     break;
                 case SAVED_AND_EXIT:
-                    toastMessage = Localization.get("form.entry.complete.save.success");
                     hasSaved = true;
+                    if (!CommCareApplication.instance().isConsumerApp()) {
+                        Toast.makeText(this, Localization.get("form.entry.complete.save.success"), Toast.LENGTH_SHORT).show();
+                    }
                     finishReturnInstance();
-                    break;
+                    return;
                 case INVALID_ANSWER:
                     // an answer constraint was violated, so try to save the
                     // current question to trigger the constraint violation message


### PR DESCRIPTION
An attempt to fix [these crashes](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/5c58070df8b88c296399dd45?time=last-seven-days&sessionId=5EB9080901DB00014831E21091E943D1_DNE_0_v2): 
```
Fatal Exception: android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@ec645b0 is not valid; is your activity running?
       at android.view.ViewRootImpl.setView(ViewRootImpl.java:679)
       at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:342)
       at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:94)
       at android.widget.Toast$TN.handleShow(Toast.java:459)
       at android.widget.Toast$TN$2.handleMessage(Toast.java:342)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:154)
       at android.app.ActivityThread.main(ActivityThread.java:6291)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
```

It appears that in API 25, android's Toast had a bug which causes these BadTokenException and there is a [3rd party library](https://github.com/PureWriter/ToastCompat) that has the detailed explanation with the proper fix. 

It appears to me that showing the toast after finishing the activity is the main culprit here, so fixing that behaviour.  
PS: Though I tried running the app on Android 7.1 emulator but couldn't reproduce the error, even by showing the toast with a 5s delay after finishing activity. 