### PR TITLE
Hide menu options when required permissions are missing

### DIFF
--- a/app/src/org/commcare/fragments/InstallPermissionsFragment.java
+++ b/app/src/org/commcare/fragments/InstallPermissionsFragment.java
@@ -1,8 +1,12 @@
 package org.commcare.fragments;
 
 import android.os.Bundle;
+
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
@@ -25,6 +29,12 @@ import org.javarosa.core.services.locale.Localization;
  */
 public class InstallPermissionsFragment extends Fragment {
     private int attemptCount = 0;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -52,5 +62,11 @@ public class InstallPermissionsFragment extends Fragment {
             deniedDetails.setText(Localization.get("install.perms.denied.message",
                     new String[]{attemptCount + ""}));
         }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
+        menu.clear();
     }
 }


### PR DESCRIPTION
Removes the options menu completely when we show the missing permissions fragment. 
The options menu allows for offline installation, which would crash if user has declined storage permissions. 
[StackTrace](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/5ce2e2aaf8b88c2963706428?time=last-seven-days&sessionId=5EB902A003300001382B6A5755CEF623_DNE_0_v2)