### PR TITLE
Use a separate form index to loop over all questions while saving form

### DIFF
--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -20,6 +20,7 @@ import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
+import org.javarosa.form.api.FormController;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.model.xform.XFormSerializingVisitor;
 import org.javarosa.xform.util.XFormSerializer;
@@ -289,25 +290,21 @@ public class SaveToDiskTask extends
      * though, until all answers conform to their constraints/requirements.
      */
     private boolean hasInvalidAnswers(boolean markCompleted) {
-        FormIndex i = FormEntryActivity.mFormController.getFormIndex();
-        FormEntryActivity.mFormController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
-
+        FormController formController = FormEntryActivity.mFormController;
+        FormIndex currentFormIndex = FormIndex.createBeginningOfFormIndex();
         int event;
-        while ((event =
-                FormEntryActivity.mFormController.stepToNextEvent(FormEntryController.STEP_INTO_GROUP)) != FormEntryController.EVENT_END_OF_FORM) {
+        while ((event = formController.getEvent(currentFormIndex)) != FormEntryController.EVENT_END_OF_FORM) {
             if (event == FormEntryController.EVENT_QUESTION) {
                 int saveStatus =
                         FormEntryActivity.mFormController.checkCurrentQuestionConstraint();
                 if (markCompleted &&
                         (saveStatus == FormEntryController.ANSWER_REQUIRED_BUT_EMPTY ||
                                 saveStatus == FormEntryController.ANSWER_CONSTRAINT_VIOLATED)) {
-
                     return true;
                 }
             }
+            currentFormIndex = formController.getNextFormIndex(currentFormIndex, FormEntryController.STEP_INTO_GROUP, true);
         }
-
-        FormEntryActivity.mFormController.jumpToIndex(i);
         return false;
     }
 


### PR DESCRIPTION
The earlier code used to modify the currentFormIndex to loop over all the questions. But if at the same time, some other thread also wants to get hold of the current question in screen, it'll have to use the currentFormIndex which might give wrong value, if this thread has already modified it. And hence may produce NPE in worst cases.

Since, we've to loop over all the questions here, we don't really need to modify the currentFormIndex rather we can simply have another form index to get all the questions. And this will also make sure that the other threads who might be using the currentFormIndex at the same time don't get wrong values.