### PR TITLE
Permit tls 1.2 on Android 19

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,6 +99,8 @@ dependencies {
     implementation 'com.google.android.play:core:1.7.2'
     implementation 'android.arch.lifecycle:common-java8:1.1.0'
 
+    //Robust TLS 1.2 ciphers on Android 9-19
+    implementation "org.conscrypt:conscrypt-android:2.4.0"
 }
 
 ext {

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -98,6 +98,7 @@ import org.commcare.utils.PendingCalcs;
 import org.commcare.utils.SessionActivityRegistration;
 import org.commcare.utils.SessionStateUninitException;
 import org.commcare.utils.SessionUnavailableException;
+import org.conscrypt.Conscrypt;
 import org.javarosa.core.model.User;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.RootTranslator;
@@ -108,6 +109,7 @@ import org.javarosa.core.util.PropertyUtils;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 import java.io.File;
+import java.security.Security;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -239,6 +241,10 @@ public class CommCareApplication extends MultiDexApplication {
     }
 
     private void initTls12IfNeeded() {
+        if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 20) {
+            Security.insertProviderAt(Conscrypt.newProvider(), 1);
+        }
+
         if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 22) {
             CommCareNetworkServiceGenerator.customizeRetrofitSetup(new ForceTLS12BuilderConfig());
         }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -67,7 +67,9 @@ import org.commcare.modern.database.Table;
 import org.commcare.modern.util.PerformanceTuningUtil;
 import org.commcare.network.DataPullRequester;
 import org.commcare.network.DataPullResponseFactory;
+import org.commcare.network.ForceTLS12BuilderConfig;
 import org.commcare.network.HttpUtils;
+import org.commcare.network.Tls12SocketFactory;
 import org.commcare.preferences.DevSessionRestorer;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.preferences.HiddenPreferences;
@@ -206,6 +208,8 @@ public class CommCareApplication extends MultiDexApplication {
         // improperly, so the second https request in a short time period will flop)
         System.setProperty("http.keepAlive", "false");
 
+        initTls12IfNeeded();
+
         Thread.setDefaultUncaughtExceptionHandler(new CommCareExceptionHandler(Thread.getDefaultUncaughtExceptionHandler(), this));
 
         SQLiteDatabase.loadLibs(this);
@@ -232,6 +236,12 @@ public class CommCareApplication extends MultiDexApplication {
         }
 
         LocalePreferences.saveDeviceLocale(Locale.getDefault());
+    }
+
+    private void initTls12IfNeeded() {
+        if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 22) {
+            CommCareNetworkServiceGenerator.customizeRetrofitSetup(new ForceTLS12BuilderConfig());
+        }
     }
 
     protected void turnOnStrictMode() {

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -240,8 +240,12 @@ public class CommCareApplication extends MultiDexApplication {
         LocalePreferences.saveDeviceLocale(Locale.getDefault());
     }
 
+    public static boolean isRoboUnitTest() {
+        return "robolectric".equals(Build.FINGERPRINT);
+    }
+
     private void initTls12IfNeeded() {
-        if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 20) {
+        if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 20 && !isRoboUnitTest()) {
             Security.insertProviderAt(Conscrypt.newProvider(), 1);
         }
 

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -240,12 +240,12 @@ public class CommCareApplication extends MultiDexApplication {
         LocalePreferences.saveDeviceLocale(Locale.getDefault());
     }
 
-    public static boolean isRoboUnitTest() {
-        return "robolectric".equals(Build.FINGERPRINT);
+    public boolean useConscryptSecurity() {
+        return Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 20;
     }
 
     private void initTls12IfNeeded() {
-        if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 20 && !isRoboUnitTest()) {
+        if (useConscryptSecurity()) {
             Security.insertProviderAt(Conscrypt.newProvider(), 1);
         }
 

--- a/app/src/org/commcare/network/ForceTLS12BuilderConfig.java
+++ b/app/src/org/commcare/network/ForceTLS12BuilderConfig.java
@@ -1,0 +1,38 @@
+package org.commcare.network;
+
+import org.commcare.core.network.HttpBuilderConfig;
+import org.javarosa.core.services.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.net.ssl.SSLContext;
+
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+import okhttp3.TlsVersion;
+
+public class ForceTLS12BuilderConfig implements HttpBuilderConfig {
+    @Override
+    public OkHttpClient.Builder performCustomConfig(OkHttpClient.Builder client) {
+        try {
+            SSLContext sc = SSLContext.getInstance("TLSv1.2");
+            sc.init(null, null, null);
+            client.sslSocketFactory(new Tls12SocketFactory(sc.getSocketFactory()));
+
+            ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                    .tlsVersions(TlsVersion.TLS_1_2)
+                    .build();
+
+            List<ConnectionSpec> specs = new ArrayList<>();
+            specs.add(cs);
+            specs.add(ConnectionSpec.COMPATIBLE_TLS);
+            specs.add(ConnectionSpec.CLEARTEXT);
+
+            client.connectionSpecs(specs);
+        } catch (Exception exc) {
+            Logger.exception("Network.OkHttpTLSCompat", exc);
+        }
+        return client;
+    }
+}

--- a/app/src/org/commcare/network/Tls12SocketFactory.java
+++ b/app/src/org/commcare/network/Tls12SocketFactory.java
@@ -1,0 +1,69 @@
+package org.commcare.network;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Enables TLS v1.2 when creating SSLSockets.
+ * <p/>
+ * For some reason, android supports TLS v1.2 from API 16, but enables it by
+ * default only from API 20.
+ * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+ * @see SSLSocketFactory
+ */
+public class Tls12SocketFactory extends SSLSocketFactory {
+    private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
+
+    final SSLSocketFactory delegate;
+
+    public Tls12SocketFactory(SSLSocketFactory base) {
+        this.delegate = base;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return patch(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return patch(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket patch(Socket s) {
+        if (s instanceof SSLSocket) {
+            ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+        }
+        return s;
+    }
+}

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -77,6 +77,12 @@ public class CommCareTestApplication extends CommCareApplication implements Test
     }
 
     @Override
+    public boolean useConscryptSecurity() {
+        return false;
+    }
+
+
+    @Override
     protected void turnOnStrictMode() {
         StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
                 .detectLeakedSqlLiteObjects()

--- a/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertTrue;
 
 // Using sdk 19 to get past NsdManager because of a bug in robolectric that causes NsdManager
 // to get initialized with a null context resulting in a NPE
-@Config(application = CommCareTestApplication.class, sdk = 18)
+@Config(application = CommCareTestApplication.class, sdk = 20)
 @RunWith(CommCareTestRunner.class)
 public class CommCareSetupActivityTest {
 

--- a/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertTrue;
 
 // Using sdk 19 to get past NsdManager because of a bug in robolectric that causes NsdManager
 // to get initialized with a null context resulting in a NPE
-@Config(application = CommCareTestApplication.class, sdk = 20)
+@Config(application = CommCareTestApplication.class, sdk = 18)
 @RunWith(CommCareTestRunner.class)
 public class CommCareSetupActivityTest {
 


### PR DESCRIPTION
For older versions of Android, allow force-enabling TLS 1.2 support

cross-request: https://github.com/dimagi/commcare-core/pull/896