### PR TITLE
Bumps max update attempts to 10

### DIFF
--- a/app/src/org/commcare/logging/analytics/UpdateStats.java
+++ b/app/src/org/commcare/logging/analytics/UpdateStats.java
@@ -21,7 +21,7 @@ public class UpdateStats implements InstallStatsLogger, Serializable {
     private static final String TOP_LEVEL_STATS_KEY = "top-level-update-exceptions";
     private static final String UPGRADE_STATS_KEY = "upgrade_table_stats";
     private static final long TWO_WEEKS_IN_MS = 1000 * 60 * 60 * 24 * 24;
-    private static final int ATTEMPTS_UNTIL_UPDATE_STALE = 5;
+    private static final int ATTEMPTS_UNTIL_UPDATE_STALE = 10;
 
     private final Hashtable<String, InstallAttempts<String>> resourceInstallStats;
     private long startInstallTime;


### PR DESCRIPTION
looking at update resets [events](https://console.firebase.google.com/project/commcare-a57e4/analytics/app/android:org.commcare.dalvik/events/~2Freport~2Fcommon_commcare_event%3Ft%3D1589964381694&fpn%3D768065119425&swu%3D1&sgu%3D1&sus%3Dupgraded&params%3D_u..pageSize%253D25%2526_u.dateOption%253Dlast30Days%2526_r..eventId%253Dcommon_commcare_event&cs%3Dapp.m.events.detail&r%3Ddefault&g%3D1), it seems like in last 30 days around 81k users (who updated to 2.48) encountered 3,859,016 update resets due to maxing out the current limit of 5 attempts per update trial. 