### PR TITLE
[Hotfix] Update resets

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -544,6 +544,10 @@ notification.install.badcert.title=Bad Certificate
 notification.install.badcert.detail=The certificate you received from the server was invalid. This can be casued by many things, but is often do to a mis-set clock on your phone.
 notification.install.badcert.action=This is often due to your phone's internal clock being incorrect.
 
+notification.install.cancel.title=Update Cancelled
+notification.install.cancel.detail=An app update event was cancelled before it completed.
+notification.install.cancel.action=Please restart the update in order to update your app.
+
 notification.install.badreqs.title=Incompatible CommCare Version for Install
 notification.install.badreqs.detail=${0}
 notification.install.badreqs.action=${0}

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -587,6 +587,10 @@ notification.install.no.connection.title=No internet connection
 notification.install.no.connection.detail=Install failed because your device is not connected to Wi-Fi currently
 notification.install.no.connection.action=Go to your device settings to check the current status of your Wi-Fi connection. If a connection is unavailable at this time, you may try offline install.
 
+notification.install.network.failure.title=Bad internet connection
+notification.install.network.failure.detail=Install failed because of bad internet
+notification.install.network.failure.action=Your internet connection is not good at the moment. Please try again after some time.
+
 notification.logger.submitted.title=Device Logs Submitted
 notification.logger.submitted.detail=Your devices logs have been successfully submitted
 

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -591,6 +591,10 @@ notification.install.network.failure.title=Bad internet connection
 notification.install.network.failure.detail=Install failed because of bad internet
 notification.install.network.failure.action=Your internet connection is not good at the moment. Please try again after some time.
 
+notification.install.rate.limited.title=Servers are busy
+notification.install.rate.limited.detail=Install failed because of servers being busy at the moment.
+notification.install.rate.limited.action=Our servers are unavailable at this time. Please try again later
+
 notification.logger.submitted.title=Device Logs Submitted
 notification.logger.submitted.detail=Your devices logs have been successfully submitted
 

--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -145,7 +145,9 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
             e.printStackTrace();
             throw new UnreliableSourceException(r, e.getMessage());
         } catch (RateLimitedException e) {
-            throw new UnresolvedResourceException(r, "Our servers are unavailable at this time. Please try again later", true);
+            UnresolvedResourceException mURE = new UnresolvedResourceException(r, "Our servers are unavailable at this time. Please try again later", true);
+            mURE.initCause(e);
+            throw mURE;
         }
     }
 

--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -23,13 +23,8 @@ import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.AndroidResourceInstallerFactory;
 import org.commcare.utils.SessionUnavailableException;
-import org.javarosa.core.reference.ReleasedOnTimeSupportedReference;
-import org.javarosa.core.reference.Reference;
 import org.javarosa.core.services.Logger;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
-
-import java.text.ParseException;
-import java.util.Date;
 
 import static org.commcare.google.services.analytics.AnalyticsParamValue.UPDATE_RESET_REASON_CORRUPT;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.UPDATE_RESET_REASON_NEWER_VERSION_AVAILABLE;
@@ -215,7 +210,7 @@ public class AndroidResourceManager extends ResourceManager {
     public void processUpdateFailure(AppInstallStatus result,
                                      Context ctx,
                                      boolean isAutoUpdate) {
-        updateStats.registerUpdateException(new Exception(result.toString()));
+        updateStats.registerUpdateFailure(result);
         FirebaseAnalyticsUtil.reportStageUpdateAttemptFailure(result.toString());
 
         if (!result.canReusePartialUpdateTable()) {

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -34,6 +34,7 @@ public enum AppInstallStatus implements MessageTag {
     UnknownFailure("notification.install.unknown"),
     NoLocalStorage("notification.install.nolocal"),
     NoConnection("notification.install.no.connection"),
+    NetworkFailure("notification.install.network.failure"),
     BadCertificate("notification.install.badcert"),
 
     /**

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -35,6 +35,7 @@ public enum AppInstallStatus implements MessageTag {
     NoLocalStorage("notification.install.nolocal"),
     NoConnection("notification.install.no.connection"),
     NetworkFailure("notification.install.network.failure"),
+    RateLimited("notification.install.rate.limited"),
     BadCertificate("notification.install.badcert"),
 
     /**

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -26,6 +26,9 @@ public enum AppInstallStatus implements MessageTag {
      */
     UpToDate("notification.install.uptodate"),
 
+    // Update cancelled by user
+    Cancelled("notification.install.cancel"),
+
     // Error states shared by both app installation and updating:
     MissingResources("notification.install.missing"),
     MissingResourcesWithMessage("notification.install.missing.withmessage"),
@@ -68,5 +71,14 @@ public enum AppInstallStatus implements MessageTag {
     @Override
     public String getCategory() {
         return "install_update";
+    }
+
+    // whether to include in the counter for update reset
+    public boolean causeUpdateReset() {
+        return !(this == Cancelled ||
+                this == BadCertificate ||
+                this == NoConnection ||
+                this == RateLimited ||
+                this == NetworkFailure);
     }
 }

--- a/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
+++ b/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.engine.resource.installers.SingleAppInstallation;
+import org.commcare.network.RateLimitedException;
 import org.commcare.preferences.ServerUrls;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.preferences.MainConfigurablePreferences;
@@ -132,6 +133,10 @@ public class ResourceInstallUtils {
                     "A resource couldn't be found, almost certainly due to the network|" +
                             exception.getMessage());
             return AppInstallStatus.NetworkFailure;
+        }
+
+        if(exception.getCause() instanceof RateLimitedException){
+            return AppInstallStatus.RateLimited;
         }
 
         if (exception.isMessageUseful()) {

--- a/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
+++ b/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
@@ -11,6 +11,7 @@ import org.commcare.preferences.MainConfigurablePreferences;
 import org.commcare.resources.ResourceManager;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
+import org.commcare.resources.model.UnreliableSourceException;
 import org.commcare.resources.model.UnresolvedResourceException;
 import org.commcare.suite.model.Profile;
 import org.commcare.util.CommCarePlatform;
@@ -126,9 +127,13 @@ public class ResourceInstallUtils {
             return AppInstallStatus.BadCertificate;
         }
 
-        Logger.log(LogTypes.TYPE_WARNING_NETWORK,
-                "A resource couldn't be found, almost certainly due to the network|" +
-                        exception.getMessage());
+        if(exception instanceof UnreliableSourceException) {
+            Logger.log(LogTypes.TYPE_WARNING_NETWORK,
+                    "A resource couldn't be found, almost certainly due to the network|" +
+                            exception.getMessage());
+            return AppInstallStatus.NetworkFailure;
+        }
+
         if (exception.isMessageUseful()) {
             return AppInstallStatus.MissingResourcesWithMessage;
         } else {

--- a/app/src/org/commcare/tasks/UpdateTask.java
+++ b/app/src/org/commcare/tasks/UpdateTask.java
@@ -116,7 +116,7 @@ public class UpdateTask
         } catch (InvalidResourceException e) {
             ResourceInstallUtils.logInstallError(e,
                     "Structure error ocurred during install|");
-            return new ResultAndError<>(AppInstallStatus.UnknownFailure, buildCombinedErrorMessage(e.resourceName, e.getMessage()));
+            return new ResultAndError<>(AppInstallStatus.InvalidResource, buildCombinedErrorMessage(e.resourceName, e.getMessage()));
         } catch (LocalStorageUnavailableException e) {
             ResourceInstallUtils.logInstallError(e,
                     "Couldn't install file to local storage|");


### PR DESCRIPTION
* Segregrates update failures to selectively increment update reset counter 
* corrects a bug where `InvalidResourceException` was incorrectly getting logged as `AppInstallStatus.UnknownFailure`

Release Note: Tunes update bheaviour to be more intelligent in resuming update downloads from failures