### PR TITLE
Restore error handling 

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -120,6 +120,10 @@ sync.fail.bad.network=Couldn't contact server. Please make sure an internet conn
 sync.fail.server.error=The server encountered an error processing your data. Please try again later. If the problem persists, contact CommCare Support.
 sync.fail.rate.limited.server.error=Our servers are unavailable at this time. Please try again later.
 sync.fail.unknown=An unexpected issue occurred during sync. Please try to sync again.
+sync.fail.cancelled=Sync was cancelled. Please retry.
+sync.fail.encryption.failure=You were logged out during sync. Login again and retry sync.
+sync.fail.session.expire=Failed to set up data encryption. Login again and retry sync.
+sync.fail.recovery.failure=There was an error trying to recover from a bad local state. Please try again later. If the problem persists, contact help desk.
 sync.fail.unsent=Having issues communicating with the server to send forms. Will try again later.
 sync.fail.individual=1 or more forms failed to send due to individual problems. See quarantined forms for details.
 
@@ -528,6 +532,22 @@ notification.restore.storagefull.action=Check the amount of space available on y
 notification.restore.unknown.title=Unknown Error during Restore
 notification.restore.unknown.detail=CommCare had trouble dealing with something that happened when you tried to log in 
 notification.restore.unknown.action=Try to log in again. If you receive this message again, force close the application from the Manage Applications menu on the phone. If the error persists, contact CommCare Support.
+
+notification.restore.cancelled.title= Sync cancelled
+notification.restore.cancelled.detail=Sync was cancelled by user
+notification.restore.cancelled.action=Please try to sync again if required
+
+notification.restore.session.expire.title=Session expired
+notification.restore.session.expire.detail=You were logged out during sync
+notification.restore.session.expire.action=Please Login again and retry.
+
+notification.restore.encryption.error.title=Encryption error during Sync
+notification.restore.encryption.error.detail=Failed to set up data encryption
+notification.restore.encryption.error.action=Please Login again and retry. Contact help desk if you receive this message again.
+
+notification.restore.recovery.error.title=Sync Recovery Failed
+notification.restore.recovery.error.detail=There was an error trying to recover from a bad local state.
+notification.restore.recovery.error.action=Please retry and contact help desk if the error persists.
 
 notification.restore.baddata.title=Bad Server Response
 notification.restore.baddata.detail=CommCare had trouble processing the network response. Please try again.

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -249,7 +249,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     private static void disableWorkForLastSeatedApp() {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(CommCareApplication.instance());
         String lastSeatedId = prefs.getString(KEY_LAST_APP, "");
-        if(!lastSeatedId.isEmpty()) {
+        if (!lastSeatedId.isEmpty()) {
             WorkManager.getInstance(CommCareApplication.instance()).cancelAllWorkByTag(lastSeatedId);
         }
     }
@@ -666,6 +666,18 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
             case UNKNOWN_FAILURE:
                 raiseLoginMessageWithInfo(StockMessages.Restore_Unknown, resultAndErrorMessage.errorMessage, true);
                 break;
+            case CANCELLED:
+                raiseLoginMessage(StockMessages.Cancelled, true);
+                break;
+            case ENCRYPTION_FAILURE:
+                raiseLoginMessageWithInfo(StockMessages.Encryption_Error, resultAndErrorMessage.errorMessage, true);
+                break;
+            case SESSION_EXPIRE:
+                raiseLoginMessage(StockMessages.Session_Expire, true);
+                break;
+            case RECOVERY_FAILURE:
+                raiseLoginMessageWithInfo(StockMessages.Recovery_Error, resultAndErrorMessage.errorMessage, true);
+                break;
             case ACTIONABLE_FAILURE:
                 raiseLoginMessageWithInfo(StockMessages.Restore_Unknown, resultAndErrorMessage.errorMessage, true);
                 break;
@@ -700,7 +712,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
                 return;
             }
             Bundle appRestrictions = restrictionsManager.getApplicationRestrictions();
-            if (appRestrictions!=null && appRestrictions.containsKey("username") &&
+            if (appRestrictions != null && appRestrictions.containsKey("username") &&
                     appRestrictions.containsKey("password")) {
                 uiController.setUsername(appRestrictions.getString("username"));
                 uiController.setPasswordOrPin(appRestrictions.getString("password"));

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -93,7 +93,9 @@ public class StandardHomeActivity
                                 NotificationMessageFactory.StockMessages.Sync_NoConnections,
                                 AIRPLANE_MODE_CATEGORY));
             }
-            FirebaseAnalyticsUtil.reportSyncFailure(
+
+            FirebaseAnalyticsUtil.reportSyncResult(
+                    false,
                     AnalyticsParamValue.SYNC_TRIGGER_USER,
                     AnalyticsParamValue.SYNC_MODE_SEND_FORMS,
                     AnalyticsParamValue.SYNC_FAIL_NO_CONNECTION);

--- a/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
+++ b/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
@@ -141,11 +141,10 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
 
         String syncModeParam = formsToSend ? AnalyticsParamValue.SYNC_MODE_SEND_FORMS : AnalyticsParamValue.SYNC_MODE_JUST_PULL_DATA;
 
-        if (result == DataPullTask.PullTaskResult.DOWNLOAD_SUCCESS) {
-            FirebaseAnalyticsUtil.reportSyncSuccess(syncTriggerParam, syncModeParam);
-        } else {
-            FirebaseAnalyticsUtil.reportSyncFailure(syncTriggerParam, syncModeParam, result.analyticsFailureReasonParam);
-        }
+        FirebaseAnalyticsUtil.reportSyncResult(result == DataPullTask.PullTaskResult.DOWNLOAD_SUCCESS,
+                syncTriggerParam,
+                syncModeParam,
+                result.analyticsFailureReasonParam);
     }
 
     @Override

--- a/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
+++ b/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
@@ -25,6 +25,7 @@ import org.commcare.tasks.ResultAndError;
 import org.commcare.utils.SyncDetailCalculations;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.StandardAlertDialog;
+import org.commcare.views.notifications.NotificationMessageFactory;
 import org.javarosa.core.services.locale.Localization;
 
 import androidx.annotation.AnimRes;
@@ -124,6 +125,18 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
                 break;
             case UNKNOWN_FAILURE:
                 updateUiAfterDataPullOrSend(Localization.get("sync.fail.unknown"), FAIL);
+                break;
+            case CANCELLED:
+                updateUiAfterDataPullOrSend(Localization.get("sync.fail.cancelled"), FAIL);
+                break;
+            case ENCRYPTION_FAILURE:
+                updateUiAfterDataPullOrSend(Localization.get("sync.fail.encryption.failure"), FAIL);
+                break;
+            case SESSION_EXPIRE:
+                updateUiAfterDataPullOrSend(Localization.get("sync.fail.session.expire"), FAIL);
+                break;
+            case RECOVERY_FAILURE:
+                updateUiAfterDataPullOrSend(Localization.get("sync.fail.recovery.failure"), FAIL);
                 break;
             case ACTIONABLE_FAILURE:
                 updateUiAfterDataPullOrSend(resultAndError.errorMessage, FAIL);

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -42,6 +42,7 @@ public class AnalyticsParamValue {
     public static final String SYNC_FAIL_NO_CONNECTION = "no_connection";
     public static final String SYNC_FAIL_AUTH = "auth_failure";
     public static final String SYNC_FAIL_EMPTY_URL = "empty_url";
+    public static final String SYNC_FAIL_RETRY_NEEDED = "retry_needed";
     public static final String SYNC_FAIL_BAD_DATA = "bad_data";
     public static final String SYNC_FAIL_SERVER_ERROR = "server_error";
     public static final String SYNC_FAIL_RATE_LIMITED_SERVER_ERROR = "rate_limited_server_error";
@@ -52,6 +53,7 @@ public class AnalyticsParamValue {
     public static final String SYNC_FAIL_ACTIONABLE = "actionable_failure";
     public static final String SYNC_FAIL_AUTH_OVER_HTTP = "auth_over_http";
     public static final String SYNC_FAIL_CAPTIVE_PORTAL = "captive_portal";
+    public static final String SYNC_SUCCESS = "success";
 
     // Param values for feature usage
     public static final String FEATURE_SET_PIN = "set_pin";

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -49,6 +49,10 @@ public class AnalyticsParamValue {
     public static final String SYNC_FAIL_UNREACHABLE_HOST = "unreachable_host";
     public static final String SYNC_FAIL_CONNECTION_TIMEOUT = "connection_timeout";
     public static final String SYNC_FAIL_UNKNOWN = "unknown_failure";
+    public static final String SYNC_FAIL_CANCELLED = "cancelled";
+    public static final String SYNC_FAIL_ENCRYPTION = "encryption_failure";
+    public static final String SYNC_FAIL_SESSION_EXPIRE = "session_expire";
+    public static final String SYNC_FAIL_RECOVERY = "recovery_failure";
     public static final String SYNC_FAIL_STORAGE_FULL = "storage_full";
     public static final String SYNC_FAIL_ACTIONABLE = "actionable_failure";
     public static final String SYNC_FAIL_AUTH_OVER_HTTP = "auth_over_http";

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -189,18 +189,10 @@ public class FirebaseAnalyticsUtil {
                 new String[]{direction, navMethod, detailUiState});
     }
 
-    public static void reportSyncSuccess(String trigger, String syncMode) {
+    public static void reportSyncResult(boolean result, String trigger, String syncMode, String failureReason) {
         Bundle b = new Bundle();
         b.putString(FirebaseAnalytics.Param.SOURCE, trigger);
-        b.putLong(FirebaseAnalytics.Param.SUCCESS, 1);
-        b.putString(FirebaseAnalytics.Param.METHOD, syncMode);
-        reportEvent(CCAnalyticsEvent.SYNC_ATTEMPT, b);
-    }
-
-    public static void reportSyncFailure(String trigger, String syncMode, String failureReason) {
-        Bundle b = new Bundle();
-        b.putString(FirebaseAnalytics.Param.SOURCE, trigger);
-        b.putLong(FirebaseAnalytics.Param.SUCCESS, 0);
+        b.putLong(FirebaseAnalytics.Param.SUCCESS, result ? 1 : 0);
         b.putString(FirebaseAnalytics.Param.METHOD, syncMode);
         b.putString(CCAnalyticsParam.REASON, failureReason);
         reportEvent(CCAnalyticsEvent.SYNC_ATTEMPT, b);

--- a/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
+++ b/app/src/org/commcare/logic/ArchivedFormRemoteRestore.java
@@ -70,6 +70,17 @@ public class ArchivedFormRemoteRestore {
                     case UNKNOWN_FAILURE:
                         Toast.makeText(receiver, "Failure retrieving or processing data, please try again later...", Toast.LENGTH_LONG).show();
                         break;
+                    case CANCELLED:
+                        Toast.makeText(receiver, Localization.get("sync.fail.cancelled"), Toast.LENGTH_LONG).show();
+                        break;
+                    case ENCRYPTION_FAILURE:
+                        Toast.makeText(receiver, Localization.get("sync.fail.encryption.failure"), Toast.LENGTH_LONG).show();
+                        break;
+                    case SESSION_EXPIRE:
+                        Toast.makeText(receiver, Localization.get("sync.fail.session.expire"), Toast.LENGTH_LONG).show();
+                        break;
+                    case RECOVERY_FAILURE:
+                        Toast.makeText(receiver, Localization.get("sync.fail.recovery.failure"), Toast.LENGTH_LONG).show();
                     case ACTIONABLE_FAILURE:
                         Toast.makeText(receiver, statusAndErrorMessage.errorMessage, Toast.LENGTH_LONG).show();
                         break;

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -652,8 +652,8 @@ public abstract class DataPullTask<R>
     }
 
     public enum PullTaskResult {
-        DOWNLOAD_SUCCESS(null),
-        RETRY_NEEDED(null),
+        DOWNLOAD_SUCCESS(AnalyticsParamValue.SYNC_SUCCESS),
+        RETRY_NEEDED(AnalyticsParamValue.SYNC_FAIL_RETRY_NEEDED),
         EMPTY_URL(AnalyticsParamValue.SYNC_FAIL_EMPTY_URL),
         AUTH_FAILED(AnalyticsParamValue.SYNC_FAIL_AUTH),
         BAD_DATA(AnalyticsParamValue.SYNC_FAIL_BAD_DATA),

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -132,7 +132,7 @@ public abstract class DataPullTask<R>
     protected ResultAndError<PullTaskResult> doTaskBackground(Void... params) {
         if (!CommCareSessionService.sessionAliveLock.tryLock()) {
             // Don't try to sync if logging out is occurring
-            return new ResultAndError<>(PullTaskResult.UNKNOWN_FAILURE,
+            return new ResultAndError<>(PullTaskResult.SESSION_EXPIRE,
                     "Cannot sync while a logout is in process");
         }
         try {
@@ -156,7 +156,7 @@ public abstract class DataPullTask<R>
         byte[] wrappedEncryptionKey = getEncryptionKey();
         if (wrappedEncryptionKey == null) {
             this.publishProgress(PROGRESS_DONE);
-            return new ResultAndError<>(PullTaskResult.UNKNOWN_FAILURE,
+            return new ResultAndError<>(PullTaskResult.ENCRYPTION_FAILURE,
                     "Unable to get or generate encryption key");
         }
 
@@ -240,7 +240,7 @@ public abstract class DataPullTask<R>
             }
 
             if (isCancelled()) {
-                return new ResultAndError<>(PullTaskResult.UNKNOWN_FAILURE);
+                return new ResultAndError<>(PullTaskResult.CANCELLED);
             }
         }
 
@@ -342,7 +342,7 @@ public abstract class DataPullTask<R>
 
         if (isCancelled()) {
             // About to enter data commit phase; last chance to finish early if cancelled.
-            return new ResultAndError<>(PullTaskResult.UNKNOWN_FAILURE);
+            return new ResultAndError<>(PullTaskResult.CANCELLED);
         }
 
         this.publishProgress(PROGRESS_DOWNLOADING_COMPLETE, 0);
@@ -423,7 +423,7 @@ public abstract class DataPullTask<R>
         } else if (returnCode == PROGRESS_RECOVERY_FAIL_SAFE || returnCode == PROGRESS_RECOVERY_FAIL_BAD) {
             wipeLoginIfItOccurred();
             this.publishProgress(PROGRESS_DONE);
-            return new ResultAndError<>(PullTaskResult.UNKNOWN_FAILURE, failureReason);
+            return new ResultAndError<>(PullTaskResult.RECOVERY_FAILURE, failureReason);
         } else {
             throw new UnknownSyncError();
         }
@@ -659,6 +659,10 @@ public abstract class DataPullTask<R>
         BAD_DATA(AnalyticsParamValue.SYNC_FAIL_BAD_DATA),
         BAD_DATA_REQUIRES_INTERVENTION(AnalyticsParamValue.SYNC_FAIL_BAD_DATA),
         UNKNOWN_FAILURE(AnalyticsParamValue.SYNC_FAIL_UNKNOWN),
+        CANCELLED(AnalyticsParamValue.SYNC_FAIL_CANCELLED),
+        ENCRYPTION_FAILURE(AnalyticsParamValue.SYNC_FAIL_ENCRYPTION),
+        SESSION_EXPIRE(AnalyticsParamValue.SYNC_FAIL_SESSION_EXPIRE),
+        RECOVERY_FAILURE(AnalyticsParamValue.SYNC_FAIL_RECOVERY),
         ACTIONABLE_FAILURE(AnalyticsParamValue.SYNC_FAIL_ACTIONABLE),
         UNREACHABLE_HOST(AnalyticsParamValue.SYNC_FAIL_UNREACHABLE_HOST),
         CONNECTION_TIMEOUT(AnalyticsParamValue.SYNC_FAIL_CONNECTION_TIMEOUT),

--- a/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
+++ b/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
@@ -107,6 +107,14 @@ public class NotificationMessageFactory {
          */
         Restore_Unknown("notification.restore.unknown"),
 
+        Cancelled("notification.restore.cancelled"),
+
+        Encryption_Error("notification.restore.encryption.error"),
+
+        Session_Expire("notification.restore.session.expire"),
+
+        Recovery_Error("notification.restore.recovery.error"),
+
         Auth_Over_HTTP("auth.over.http"),
 
         /**

--- a/app/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
@@ -41,7 +41,7 @@ public class DataPullTaskTest {
     public void dataPullWithMissingRemoteKeyRecordTest() {
         TestAppInstaller.installApp(APP_BASE + "profile.ccpr");
         runDataPull(200, GOOD_RESTORE);
-        Assert.assertEquals(DataPullTask.PullTaskResult.UNKNOWN_FAILURE, dataPullResult.data);
+        Assert.assertEquals(DataPullTask.PullTaskResult.ENCRYPTION_FAILURE, dataPullResult.data);
         Assert.assertEquals("Unable to get or generate encryption key", dataPullResult.errorMessage);
     }
 
@@ -83,7 +83,7 @@ public class DataPullTaskTest {
     public void dataPullRecoverFailTest() {
         installLoginAndUseLocalKeys();
         runDataPull(new Integer[]{412, 500}, new String[]{GOOD_RESTORE, GOOD_RESTORE});
-        Assert.assertEquals(DataPullTask.PullTaskResult.UNKNOWN_FAILURE, dataPullResult.data);
+        Assert.assertEquals(DataPullTask.PullTaskResult.RECOVERY_FAILURE, dataPullResult.data);
     }
 
     @Test
@@ -106,14 +106,14 @@ public class DataPullTaskTest {
     public void dataPullRecoverFailLoginNeededTest() {
         installWithUserAndUseLocalKeys();
         runDataPull(new Integer[]{412, 500}, new String[]{GOOD_RESTORE, GOOD_RESTORE});
-        Assert.assertEquals(DataPullTask.PullTaskResult.UNKNOWN_FAILURE, dataPullResult.data);
+        Assert.assertEquals(DataPullTask.PullTaskResult.RECOVERY_FAILURE, dataPullResult.data);
     }
 
     @Test
     public void dataPullBadRecoverPayloadTest() {
         installLoginAndUseLocalKeys();
         runDataPull(new Integer[]{412, 200}, new String[]{GOOD_RESTORE, BAD_RESTORE_XML});
-        Assert.assertEquals(DataPullTask.PullTaskResult.UNKNOWN_FAILURE, dataPullResult.data);
+        Assert.assertEquals(DataPullTask.PullTaskResult.RECOVERY_FAILURE, dataPullResult.data);
     }
 
     @Test


### PR DESCRIPTION
Seeing a large # of unknown failures into Analytics so breaking these down further into `CANCELLED`, `ENCRYPTION_FAILURE`,`SESSION_EXPIRE` and `RECOVERY_FAILURE`  to get more visibility. 