### PR TITLE
Defaults to a static version code for debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -250,7 +250,7 @@ android {
                 googlePlayMapsApiKey: "${project.ext.GOOGLE_PLAY_MAPS_API_KEY}"
         ]
 
-        versionCode computeVersionCode()
+        versionCode 1
 
         // when set, app won't show install screen and try to install
         // resources from assets folder
@@ -273,6 +273,14 @@ android {
         buildConfigField "String", "ENTITY_SELECT_AD_UNIT_ID", "\"\""
         buildConfigField "String", "MENU_LIST_AD_UNIT_ID", "\"\""
         buildConfigField "String", "MENU_GRID_AD_UNIT_ID", "\"\""
+    }
+
+    applicationVariants.all { variant ->
+        if (variant.buildType.name == "release") {
+            variant.outputs.each { output ->
+                output.versionCodeOverride = computeVersionCode()
+            }
+        }
     }
 
     compileOptions {


### PR DESCRIPTION
Defaults to a static version code and sets it from properties only for release builds. 

It seems like setting dynamic manifest properties can have downstream effects on build time. So moving the versionCode computation only for release builds. 