### PR TITLE
Improvements to Update Error handling

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -602,6 +602,14 @@ notification.install.no.connection.title=No internet connection
 notification.install.no.connection.detail=Install failed because your device is not connected to Wi-Fi currently
 notification.install.no.connection.action=Go to your device settings to check the current status of your Wi-Fi connection. If a connection is unavailable at this time, you may try offline install.
 
+notification.install.network.failure.title=Bad internet connection
+notification.install.network.failure.detail=Install failed because of bad internet
+notification.install.network.failure.action=Your internet connection is not good at the moment. Please try again after some time.
+
+notification.install.rate.limited.title=Servers are busy
+notification.install.rate.limited.detail=Install failed because of servers being busy at the moment.
+notification.install.rate.limited.action=Our servers are unavailable at this time. Please try again later
+
 notification.logger.submitted.title=Device Logs Submitted
 notification.logger.submitted.detail=Your devices logs have been successfully submitted
 

--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -149,7 +149,9 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
             e.printStackTrace();
             throw new UnreliableSourceException(r, e.getMessage());
         } catch (RateLimitedException e) {
-            throw new UnresolvedResourceException(r, "Our servers are unavailable at this time. Please try again later", true);
+            UnresolvedResourceException mURE = new UnresolvedResourceException(r, "Our servers are unavailable at this time. Please try again later", true);
+            mURE.initCause(e);
+            throw mURE;
         }
     }
 

--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -112,7 +112,11 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
                 throw new LocalStorageUnavailableException("Couldn't write to local reference " + localLocation + " for file system installation", localLocation);
             }
 
-            StreamsUtil.writeFromInputToOutputNew(inputFileStream, outputFileStream);
+            try {
+                StreamsUtil.writeFromInputToOutputNew(inputFileStream, outputFileStream);
+            } catch (StreamsUtil.OutputIOException e) {
+                throw new LocalStorageUnavailableException("Couldn't write incoming file to temp location for file system installation", tempFile.getAbsolutePath());
+            }
 
             renameFile(localReference.getLocalURI(), tempFile);
 

--- a/app/src/org/commcare/android/resource/installers/OfflineUserRestoreAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/OfflineUserRestoreAndroidInstaller.java
@@ -38,7 +38,8 @@ public class OfflineUserRestoreAndroidInstaller extends FileSystemInstaller {
         return true;
     }
 
-    private OfflineUserRestore initDemoUserRestore() throws UnfullfilledRequirementsException, InvalidStructureException, XmlPullParserException, IOException {
+    private OfflineUserRestore initDemoUserRestore() throws UnfullfilledRequirementsException, InvalidStructureException,
+            XmlPullParserException, IOException, InvalidReferenceException {
         return new OfflineUserRestore(localLocation);
     }
 
@@ -52,7 +53,7 @@ public class OfflineUserRestoreAndroidInstaller extends FileSystemInstaller {
             initDemoUserRestore();
         } catch (XmlPullParserException | InvalidStructureException e) {
             throw new InvalidResourceException(r.getDescriptor(), e.getMessage());
-        } catch (RuntimeException | UnfullfilledRequirementsException | IOException e) {
+        } catch (RuntimeException | UnfullfilledRequirementsException | IOException | InvalidReferenceException e) {
             throw new UnresolvedResourceException(r, e, e.getMessage(), true);
         }
 

--- a/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/ProfileAndroidInstaller.java
@@ -119,7 +119,7 @@ public class ProfileAndroidInstaller extends FileSystemInstaller {
         } catch (XmlPullParserException | InvalidReferenceException | IOException e) {
             e.printStackTrace();
         } catch (InvalidStructureException e) {
-            throw new UnresolvedResourceException(r, "Invalid content in the Profile Definition: " + e.getMessage(), true);
+            throw new InvalidResourceException(r.getDescriptor(), "Invalid content in the Profile Definition: " + e.getMessage());
         } finally {
             try {
                 if (inputStream != null) {

--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -9,6 +9,7 @@ import org.commcare.engine.extensions.IntentExtensionParser;
 import org.commcare.engine.extensions.PollSensorExtensionParser;
 import org.commcare.engine.extensions.XFormExtensionUtils;
 import org.commcare.models.database.SqlStorage;
+import org.commcare.resources.model.InvalidResourceException;
 import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
@@ -85,7 +86,6 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
                 platform.registerXmlns(namespace, formDefId);
             }
         }
-
         return true;
     }
 
@@ -97,12 +97,12 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
         try (InputStream inputStream = local.getStream()) {
             formDef = XFormExtensionUtils.getFormFromInputStream(inputStream);
         } catch (XFormParseException xfpe) {
-            throw new UnresolvedResourceException(r, xfpe.getMessage(), true);
+            throw new InvalidResourceException(r.getDescriptor(), xfpe.getMessage());
         }
 
         this.namespace = formDef.getInstance().schema;
         if (namespace == null) {
-            throw new UnresolvedResourceException(r, "Invalid XForm, no namespace defined", true);
+            throw new InvalidResourceException(r.getDescriptor(), "Invalid XForm, no namespace defined");
         }
 
         FormDefRecord formDefRecord = new FormDefRecord("NAME", formDef.getMainInstance().schema, local.getLocalURI(), GlobalConstants.MEDIA_REF, r.getVersion());

--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -180,10 +180,6 @@ public class AndroidResourceManager extends ResourceManager {
         }
     }
 
-    public void incrementUpdateAttempts() {
-        updateStats.registerStagingAttempt();
-    }
-
     /**
      * Log update failure that occurs while trying to install the staged update table
      */
@@ -206,7 +202,7 @@ public class AndroidResourceManager extends ResourceManager {
      * @param result       update attempt result
      */
     public void processUpdateFailure(AppInstallStatus result) {
-        updateStats.registerUpdateException(new Exception(result.toString()));
+        updateStats.registerUpdateFailure(result);
         FirebaseAnalyticsUtil.reportStageUpdateAttemptFailure(result.toString());
 
         if (!result.canReusePartialUpdateTable()) {

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -37,6 +37,8 @@ public enum AppInstallStatus implements MessageTag {
     UnknownFailure("notification.install.unknown"),
     NoLocalStorage("notification.install.nolocal"),
     NoConnection("notification.install.no.connection"),
+    NetworkFailure("notification.install.network.failure"),
+    RateLimited("notification.install.rate.limited"),
     BadCertificate("notification.install.badcert"),
 
 
@@ -75,5 +77,14 @@ public enum AppInstallStatus implements MessageTag {
     @Override
     public String getCategory() {
         return "install_update";
+    }
+
+    // whether to include in the counter for update reset
+    public boolean causeUpdateReset() {
+        return !(this == Cancelled ||
+                this == BadCertificate ||
+                this == NoConnection ||
+                this == RateLimited ||
+                this == NetworkFailure);
     }
 }

--- a/app/src/org/commcare/update/UpdateHelper.java
+++ b/app/src/org/commcare/update/UpdateHelper.java
@@ -89,7 +89,7 @@ public class UpdateHelper implements TableStateListener {
         } catch (InvalidResourceException e) {
             ResourceInstallUtils.logInstallError(e,
                     "Structure error ocurred during install|");
-            return new ResultAndError<>(AppInstallStatus.UnknownFailure, buildCombinedErrorMessage(e.resourceName, e.getMessage()));
+            return new ResultAndError<>(AppInstallStatus.InvalidResource, buildCombinedErrorMessage(e.resourceName, e.getMessage()));
         } catch (LocalStorageUnavailableException e) {
             ResourceInstallUtils.logInstallError(e,
                     "Couldn't install file to local storage|");
@@ -123,7 +123,6 @@ public class UpdateHelper implements TableStateListener {
 
     private void setupUpdate(String profileRef) {
         ResourceInstallUtils.recordUpdateAttemptTime(mApp);
-        mResourceManager.incrementUpdateAttempts();
         Logger.log(LogTypes.TYPE_RESOURCES,
                 "Beginning install attempt for profile " + profileRef);
 

--- a/app/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.java
@@ -92,7 +92,7 @@ public class AppUpdateTest {
 
         String profileRef = UpdateUtils.buildResourceRef(REF_BASE_DIR, "invalid_update", "profile.ccpr");
         UpdateUtils.installUpdate(profileRef,
-                AppInstallStatus.MissingResourcesWithMessage,
+                AppInstallStatus.InvalidResource,
                 AppInstallStatus.UnknownFailure);
 
         Profile p = CommCareApplication.instance().getCommCarePlatform().getCurrentProfile();
@@ -118,7 +118,7 @@ public class AppUpdateTest {
 
         String profileRef = UpdateUtils.buildResourceRef(REF_BASE_DIR, "valid_update_without_multimedia_present", "profile.ccpr");
         UpdateUtils.installUpdate(profileRef,
-                AppInstallStatus.MissingResources,
+                AppInstallStatus.MissingResourcesWithMessage,
                 AppInstallStatus.UnknownFailure);
 
         Profile p = CommCareApplication.instance().getCommCarePlatform().getCurrentProfile();


### PR DESCRIPTION
Port of https://github.com/dimagi/commcare-android/pull/2244 along with additional error handling -
* Tag parse errors as InvalidResourceException instead of URE
* indentify errors writing incoming resource to a file and throw a `LocalStorageUnavailableException`

cross-request: https://github.com/dimagi/commcare-core/pull/904