### PR TITLE
Determines Install Authority based on Profile Reference

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -567,6 +567,10 @@ notification.install.invalid.title=A part of your application is invalid.
 notification.install.invalid.detail=CommCare found an issue with the '${0}' resource:
 notification.install.invalid.action=${0}
 
+notification.install.invalid.reference.title=Bad resource location in the application
+notification.install.invalid.reference.detail=Invalid resource location found in the application.
+notification.install.invalid.reference.action=${0}
+
 notification.install.missing.withmessage.title=Part of your app is not valid
 notification.install.missing.withmessage.detail=One of your app's resources (${0}) is not valid and must be fixed before it can be installed.
 notification.install.missing.withmessage.action=Installation error: ${0}

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -10,12 +10,14 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
+
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.core.content.ContextCompat;
+
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -462,7 +464,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
             ResourceEngineTask<CommCareSetupActivity> task =
                     new ResourceEngineTask<CommCareSetupActivity>(ccApp,
-                            DIALOG_INSTALL_PROGRESS, shouldSleep, determineAuthorityForInstall(), false) {
+                            DIALOG_INSTALL_PROGRESS, shouldSleep, false) {
 
                         @Override
                         protected void deliverResult(CommCareSetupActivity receiver,
@@ -506,6 +508,9 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             case InvalidResource:
                 receiver.failInvalidResource(resourceEngineTask.getInvalidResourceException(), result);
                 break;
+            case InvalidReference:
+                receiver.failInvalidReference(resourceEngineTask.getInvalidReferenceException(), result);
+                break;
             case IncompatibleReqs:
                 receiver.failBadReqs(resourceEngineTask.getVersionRequired(),
                         resourceEngineTask.getVersionAvailable(), resourceEngineTask.isMajorIsProblem());
@@ -535,14 +540,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 receiver.failUnknown(AppInstallStatus.UnknownFailure);
                 break;
         }
-    }
-
-    private int determineAuthorityForInstall() {
-        // Note that this is an imperfect way to determine the resource authority; we should
-        // really be looking at the nature of the reference that is being used itself (i.e. is it
-        // a file reference or a URL)
-        return lastInstallMode == INSTALL_MODE_OFFLINE ?
-                Resource.RESOURCE_AUTHORITY_LOCAL : Resource.RESOURCE_AUTHORITY_REMOTE;
     }
 
     public static CommCareApp getCommCareApp() {
@@ -755,6 +752,11 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     @Override
     public void failInvalidResource(InvalidResourceException e, AppInstallStatus statusMissing) {
         fail(NotificationMessageFactory.message(statusMissing, new String[]{null, e.resourceName, e.getMessage()}), true);
+    }
+
+    @Override
+    public void failInvalidReference(InvalidReferenceException e, AppInstallStatus status) {
+        fail(NotificationMessageFactory.message(status, new String[]{null, null, e.getMessage()}), true);
     }
 
     @Override

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -33,6 +33,7 @@ public enum AppInstallStatus implements MessageTag {
     MissingResources("notification.install.missing"),
     MissingResourcesWithMessage("notification.install.missing.withmessage"),
     InvalidResource("notification.install.invalid"),
+    InvalidReference("notification.install.invalid.reference"),
     IncompatibleReqs("notification.install.badreqs"),
     UnknownFailure("notification.install.unknown"),
     NoLocalStorage("notification.install.nolocal"),

--- a/app/src/org/commcare/engine/resource/installers/SingleAppInstallation.java
+++ b/app/src/org/commcare/engine/resource/installers/SingleAppInstallation.java
@@ -3,7 +3,6 @@ package org.commcare.engine.resource.installers;
 import org.commcare.CommCareApp;
 import org.commcare.activities.CommCareSetupActivity;
 import org.commcare.engine.resource.AppInstallStatus;
-import org.commcare.resources.model.Resource;
 import org.commcare.tasks.ResourceEngineTask;
 
 import static org.commcare.activities.CommCareSetupActivity.handleAppInstallResult;
@@ -26,7 +25,7 @@ public class SingleAppInstallation {
         CommCareApp app = CommCareSetupActivity.getCommCareApp();
 
         ResourceEngineTask<CommCareSetupActivity> task =
-                new ResourceEngineTask<CommCareSetupActivity>(app, dialogId, false, Resource.RESOURCE_AUTHORITY_LOCAL, false) {
+                new ResourceEngineTask<CommCareSetupActivity>(app, dialogId, false, false) {
                     @Override
                     protected void deliverResult(CommCareSetupActivity receiver,
                                                  AppInstallStatus result) {

--- a/app/src/org/commcare/recovery/measures/ExecuteRecoveryMeasuresActivity.java
+++ b/app/src/org/commcare/recovery/measures/ExecuteRecoveryMeasuresActivity.java
@@ -21,6 +21,7 @@ import org.commcare.tasks.UnZipTaskListener;
 import org.commcare.utils.StringUtils;
 import org.commcare.views.ManagedUi;
 import org.commcare.views.UiElement;
+import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.services.locale.Localization;
 
 import java.io.File;
@@ -149,12 +150,17 @@ public class ExecuteRecoveryMeasuresActivity extends CommCareActivity<ExecuteRec
 
     @Override
     public void failMissingResource(UnresolvedResourceException ure, AppInstallStatus status) {
-        mPresenter.appInstallExecutionFailed(status, "missing resource");
+        mPresenter.appInstallExecutionFailed(status, ure.getMessage());
     }
 
     @Override
     public void failInvalidResource(InvalidResourceException e, AppInstallStatus status) {
-        mPresenter.appInstallExecutionFailed(status, "invalid resource");
+        mPresenter.appInstallExecutionFailed(status, e.getMessage());
+    }
+
+    @Override
+    public void failInvalidReference(InvalidReferenceException e, AppInstallStatus status) {
+        mPresenter.appInstallExecutionFailed(status, e.getMessage());
     }
 
     @Override

--- a/app/src/org/commcare/recovery/measures/ExecuteRecoveryMeasuresPresenter.java
+++ b/app/src/org/commcare/recovery/measures/ExecuteRecoveryMeasuresPresenter.java
@@ -25,7 +25,6 @@ import org.commcare.engine.resource.ResourceInstallUtils;
 import org.commcare.interfaces.BasePresenterContract;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.preferences.HiddenPreferences;
-import org.commcare.resources.model.Resource;
 import org.commcare.tasks.InstallStagedUpdateTask;
 import org.commcare.tasks.ResourceEngineTask;
 import org.commcare.tasks.ResultAndError;
@@ -200,13 +199,13 @@ public class ExecuteRecoveryMeasuresPresenter implements BasePresenterContract, 
         updateStatus(StringUtils.getStringRobust(mActivity, R.string.recovery_measure_ccz_scan_in_progress));
     }
 
-    private void reinstallApp(String profileRef, int authority) {
+    private void reinstallApp(String profileRef) {
         CommCareApp currentApp = CommCareApplication.instance().getCurrentApp();
         ResourceEngineTask<ExecuteRecoveryMeasuresActivity> task
                 = new sResourceEngineTask(
                 currentApp,
                 REINSTALL_TASK_ID,
-                false, authority,
+                false,
                 true);
         task.connect(mActivity);
         task.execute(profileRef);
@@ -310,7 +309,7 @@ public class ExecuteRecoveryMeasuresPresenter implements BasePresenterContract, 
     }
 
     private void doOnlineAppInstall() {
-        reinstallApp(getProfileReference(), Resource.RESOURCE_AUTHORITY_REMOTE);
+        reinstallApp(getProfileReference());
     }
 
     private void showOfflineInstallActivity() {
@@ -319,7 +318,7 @@ public class ExecuteRecoveryMeasuresPresenter implements BasePresenterContract, 
     }
 
     public void doOfflineAppInstall(String profileRef) {
-        reinstallApp(profileRef, Resource.RESOURCE_AUTHORITY_LOCAL);
+        reinstallApp(profileRef);
     }
 
     public boolean shouldAllowBackPress() {
@@ -568,8 +567,8 @@ public class ExecuteRecoveryMeasuresPresenter implements BasePresenterContract, 
 
 
     static class sResourceEngineTask extends ResourceEngineTask<ExecuteRecoveryMeasuresActivity> {
-        sResourceEngineTask(CommCareApp currentApp, int taskId, boolean shouldSleep, int authority, boolean reinstall) {
-            super(currentApp, taskId, shouldSleep, authority, reinstall);
+        sResourceEngineTask(CommCareApp currentApp, int taskId, boolean shouldSleep, boolean reinstall) {
+            super(currentApp, taskId, shouldSleep, reinstall);
         }
 
         @Override

--- a/app/src/org/commcare/tasks/ResourceEngineListener.java
+++ b/app/src/org/commcare/tasks/ResourceEngineListener.java
@@ -3,6 +3,7 @@ package org.commcare.tasks;
 import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.resources.model.InvalidResourceException;
 import org.commcare.resources.model.UnresolvedResourceException;
+import org.javarosa.core.reference.InvalidReferenceException;
 
 public interface ResourceEngineListener {
     void reportSuccess(boolean b);
@@ -10,6 +11,8 @@ public interface ResourceEngineListener {
     void failMissingResource(UnresolvedResourceException ure, AppInstallStatus statusmissing);
 
     void failInvalidResource(InvalidResourceException e, AppInstallStatus statusmissing);
+
+    void failInvalidReference(InvalidReferenceException e, AppInstallStatus status);
 
     void failBadReqs(String vReq, String vAvail, boolean majorIsProblem);
 

--- a/app/src/org/commcare/tasks/ResourceEngineTask.java
+++ b/app/src/org/commcare/tasks/ResourceEngineTask.java
@@ -7,6 +7,7 @@ import org.commcare.core.network.CaptivePortalRedirectException;
 import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.engine.resource.ResourceInstallUtils;
 import org.commcare.engine.resource.installers.LocalStorageUnavailableException;
+import org.commcare.modern.reference.JavaHttpReference;
 import org.commcare.resources.ResourceManager;
 import org.commcare.resources.model.InvalidResourceException;
 import org.commcare.resources.model.Resource;
@@ -16,6 +17,9 @@ import org.commcare.resources.model.UnresolvedResourceException;
 import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidCommCarePlatform;
+import org.javarosa.core.reference.InvalidReferenceException;
+import org.javarosa.core.reference.Reference;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.Logger;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 
@@ -39,6 +43,7 @@ public abstract class ResourceEngineTask<R>
 
     private UnresolvedResourceException missingResourceException = null;
     private InvalidResourceException invalidResourceException = null;
+    private InvalidReferenceException invalidReferenceException = null;
     private int phase = -1;
     // This boolean is set from CommCareSetupActivity -- If we are in keep
     // trying mode for installation, we want to sleep in between attempts to
@@ -55,11 +60,10 @@ public abstract class ResourceEngineTask<R>
 
     private int authorityForInstall;
 
-    public ResourceEngineTask(CommCareApp app, int taskId, boolean shouldSleep, int authority, boolean reinstall) {
+    public ResourceEngineTask(CommCareApp app, int taskId, boolean shouldSleep, boolean reinstall) {
         this.app = app;
         this.taskId = taskId;
         this.shouldSleep = shouldSleep;
-        this.authorityForInstall = authority;
         this.reinstall = reinstall;
         TAG = ResourceEngineTask.class.getSimpleName();
     }
@@ -67,6 +71,14 @@ public abstract class ResourceEngineTask<R>
     @Override
     protected AppInstallStatus doTaskBackground(String... profileRefs) {
         String profileRef = profileRefs[0];
+
+        try {
+            authorityForInstall = deriveAuthorityFromReference(profileRef);
+        } catch (InvalidReferenceException e) {
+            invalidReferenceException = e;
+            return AppInstallStatus.InvalidReference;
+        }
+
         ResourceInstallUtils.recordUpdateAttemptTime(app);
 
         app.setupSandbox();
@@ -134,6 +146,12 @@ public abstract class ResourceEngineTask<R>
                     "Unknown error ocurred during install|");
             return AppInstallStatus.UnknownFailure;
         }
+    }
+
+    private int deriveAuthorityFromReference(String profileRef) throws InvalidReferenceException {
+        Reference reference = ReferenceManager.instance().DeriveReference(profileRef);
+        return  reference instanceof JavaHttpReference || reference instanceof org.commcare.engine.references.JavaHttpReference ?
+                Resource.RESOURCE_AUTHORITY_REMOTE : Resource.RESOURCE_AUTHORITY_LOCAL;
     }
 
     @Override
@@ -225,6 +243,10 @@ public abstract class ResourceEngineTask<R>
 
     public InvalidResourceException getInvalidResourceException() {
         return invalidResourceException;
+    }
+
+    public InvalidReferenceException getInvalidReferenceException() {
+        return invalidReferenceException;
     }
 
     public String getVersionAvailable() {

--- a/app/src/org/commcare/tasks/ResourceEngineTask.java
+++ b/app/src/org/commcare/tasks/ResourceEngineTask.java
@@ -4,10 +4,10 @@ import android.os.SystemClock;
 
 import org.commcare.CommCareApp;
 import org.commcare.core.network.CaptivePortalRedirectException;
+import org.commcare.engine.references.JavaHttpReference;
 import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.engine.resource.ResourceInstallUtils;
 import org.commcare.engine.resource.installers.LocalStorageUnavailableException;
-import org.commcare.modern.reference.JavaHttpReference;
 import org.commcare.resources.ResourceManager;
 import org.commcare.resources.model.InvalidResourceException;
 import org.commcare.resources.model.Resource;
@@ -150,8 +150,7 @@ public abstract class ResourceEngineTask<R>
 
     private int deriveAuthorityFromReference(String profileRef) throws InvalidReferenceException {
         Reference reference = ReferenceManager.instance().DeriveReference(profileRef);
-        return  reference instanceof JavaHttpReference || reference instanceof org.commcare.engine.references.JavaHttpReference ?
-                Resource.RESOURCE_AUTHORITY_REMOTE : Resource.RESOURCE_AUTHORITY_LOCAL;
+        return reference instanceof JavaHttpReference ? Resource.RESOURCE_AUTHORITY_REMOTE : Resource.RESOURCE_AUTHORITY_LOCAL;
     }
 
     @Override

--- a/app/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
+++ b/app/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
@@ -9,7 +9,6 @@ import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.android.mocks.CommCareTaskConnectorFake;
 import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.models.database.user.DemoUserBuilder;
-import org.commcare.resources.model.Resource;
 import org.commcare.tasks.ResourceEngineTask;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
@@ -85,7 +84,7 @@ public class TestAppInstaller {
 
         CommCareApp app = new CommCareTestApp(new CommCareApp(newRecord));
         ResourceEngineTask<Object> task =
-                new ResourceEngineTask<Object>(app, -1, false, Resource.RESOURCE_AUTHORITY_LOCAL, false) {
+                new ResourceEngineTask<Object>(app, -1, false, false) {
                     @Override
                     protected void deliverResult(Object receiver,
                                                  AppInstallStatus result) {


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/ICDS-1483
Sentry: https://sentry.io/organizations/dimagi/issues/1216666539/?project=1545828

 I don’t have a repro for this issue yet it seems like because of some edge case in state maintenance during install, a case might arise where mobile can incorrectly treat the local location as the remote location and make a request to invalid remote resource locations by infering the http url from the relative local location path for the media. 

For Example,  Mobile seems to be making a request to the url - 
http://cas.commcarehq.org/a/icds-cas/apps/download/c5a8d19d2ebd4ab299444720947f9923/commcare/english/audio/data/bp2/care_of_home.mp3

for a resource which is defined as below in `media_suite.xml` - 
````
  <media path="../../commcare/english/audio/data/bp2">
    <resource descriptor="Audio File: care_of_home.mp3" id="media-83228d97c69702184b810ec77fe0078b-care_of_home.mp3" version="31289">
      <location authority="local">./commcare/english/audio/data/bp2/care_of_home.mp3</location>
      <location authority="remote">https://cas.commcarehq.org/hq/multimedia/file/CommCareAudio/9b467ed90843bc07e36f1d1ea9142537/care_of_home.mp3</location>
    </resource>
  </media> 
````

This PR changes the authority resolution code to be based directly on the profileReference getting used for installation instead of the state set by `lastInstallMethod` . 