### PR TITLE
Reverts firebase-ads to 16.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,11 @@ dependencies {
     implementation 'net.sourceforge.htmlcleaner:htmlcleaner:2.16'
     implementation 'org.jsoup:jsoup:1.8.3'
     implementation 'com.google.firebase:firebase-core:17.4.2'
-    implementation 'com.google.firebase:firebase-ads:19.1.0'
+
+    // crashes on update - https://developers.google.com/admob/android/quick-start#update_your_androidmanifestxml
+    // We need to update consumer apps script to inject the right admob id to be able to update this
+    implementation 'com.google.firebase:firebase-ads:16.0.1'
+
     implementation 'com.carrotsearch:hppc:0.7.2'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'


### PR DESCRIPTION
The update was causing a crash on app startup [due to this](https://developers.google.com/admob/android/quick-start#update_your_androidmanifestxml). Just reverting it right now since it's not worth the time right now to invest in correcting the consumer apps deploy script. 