### PR TITLE
Use current form index to check constraints

### DIFF
--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -295,8 +295,7 @@ public class SaveToDiskTask extends
         int event;
         while ((event = formController.getEvent(currentFormIndex)) != FormEntryController.EVENT_END_OF_FORM) {
             if (event == FormEntryController.EVENT_QUESTION) {
-                int saveStatus =
-                        FormEntryActivity.mFormController.checkCurrentQuestionConstraint();
+                int saveStatus = formController.checkCurrentQuestionConstraint(currentFormIndex);
                 if (markCompleted &&
                         (saveStatus == FormEntryController.ANSWER_REQUIRED_BUT_EMPTY ||
                                 saveStatus == FormEntryController.ANSWER_CONSTRAINT_VIOLATED)) {


### PR DESCRIPTION
cross-request: https://github.com/dimagi/commcare-core/pull/908
A fix for this issue: https://dimagi-dev.atlassian.net/browse/QA-1354 caused by [this PR](https://github.com/dimagi/commcare-android/pull/2238). We've changed the SaveToDisk task to use a separate form index to loop over all the questions while saving them. But one of the internal [method call](https://github.com/dimagi/commcare-core/pull/908/files#diff-df805588fd3f80aa4ffb8036e891165aL171) was still using the static formIndex variable in FormModel which was out of bounds causing an NPE. 