### PR TITLE
Corrects log setting values

### DIFF
--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -71,8 +71,8 @@ public class HiddenPreferences {
     public final static String MM_VALIDATED_FROM_HQ = "cc-content-valid";
     private static final String USER_DOMAIN_SUFFIX = "cc_user_domain";
     private final static String LOGS_ENABLED = "logenabled";
-    public final static String LOGS_ENABLED_YES = "yes";
-    public final static String LOGS_ENABLED_NO = "no";
+    public final static String LOGS_ENABLED_YES = "Enabled";
+    public final static String LOGS_ENABLED_NO = "Disabled";
     public final static String LOGS_ENABLED_ON_DEMAND = "on_demand";
     private final static String RELEASED_ON_TIME_FOR_ONGOING_APP_DOWNLOAD = "released-on-time-for-ongoing-app-download";
 


### PR DESCRIPTION
It seems like HQ have different log values [presets](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml#L32-L39), I had mistakenly [changed these values in 2.48 ](https://github.com/dimagi/commcare-android/pull/2141/files#diff-690b5590c3872f345d2740efb8cc41a5L62) on mobile which would have broke most log submissions on 2.48 on mobile. 