### PR TITLE
Set latest CC version from Heartbeat response

### DIFF
--- a/app/src/org/commcare/heartbeat/HeartbeatRequester.java
+++ b/app/src/org/commcare/heartbeat/HeartbeatRequester.java
@@ -156,6 +156,7 @@ public class HeartbeatRequester extends GetAndParseActor {
                     if (latestVersionInfo.has("force")) {
                         forceString = latestVersionInfo.getString("force");
                     }
+                    HiddenPreferences.setLatestCommcareVersion(versionValue);
                     UpdateToPrompt updateToPrompt = new UpdateToPrompt(versionValue, forceString, updateType);
                     updateToPrompt.registerWithSystem();
                 }


### PR DESCRIPTION
This was only getting set currently from the Recovery measures response which is not active for most of the projects. Since we are now using this version info for the udpate prompt's In App Update feature, setting it from the heartbeat response as well so that we have this info set before we prompt for update. 