### PR TITLE
NPE fix on cancelling form submission task

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -362,7 +362,10 @@ public class CommCareApplication extends MultiDexApplication {
 
     protected void cancelWorkManagerTasks() {
         // Cancel form Submissions for this user
-        WorkManager.getInstance(this).cancelUniqueWork(FormSubmissionHelper.getFormSubmissionRequestName());
+        if (currentApp != null) {
+            WorkManager.getInstance(this).cancelUniqueWork(
+                    FormSubmissionHelper.getFormSubmissionRequestName(currentApp.getUniqueId()));
+        }
     }
 
     /**
@@ -805,7 +808,7 @@ public class CommCareApplication extends MultiDexApplication {
                         .build();
 
         WorkManager.getInstance(this).enqueueUniquePeriodicWork(
-                FormSubmissionHelper.getFormSubmissionRequestName(),
+                FormSubmissionHelper.getFormSubmissionRequestName(getCurrentApp().getUniqueId()),
                 ExistingPeriodicWorkPolicy.KEEP,
                 formSubmissionRequest
         );

--- a/app/src/org/commcare/sync/FormSubmissionHelper.java
+++ b/app/src/org/commcare/sync/FormSubmissionHelper.java
@@ -538,8 +538,7 @@ public class FormSubmissionHelper implements DataSubmissionListener {
                 context.getString(R.string.PostURL));
     }
 
-    public static String getFormSubmissionRequestName() {
-        String appId = CommCareApplication.instance().getCurrentApp().getUniqueId();
+    public static String getFormSubmissionRequestName(String appId) {
         String currentUserId = CommCareApplication.instance().getCurrentUserId();
         return FORM_SUBMISSION_REQUEST_NAME + "_" + appId + "_" + currentUserId;
     }


### PR DESCRIPTION
[Crash](https://console.firebase.google.com/u/1/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/68ab24bd83e103289e3734a6e8b11dba?time=last-thirty-days&sessionId=5ED64C7800EE000159C6F256D22B44CD_DNE_0_v2)

This happens when somehow the onClick event gets fired after a particular app has been uninstalled. I was able to repro it by rapidly clicking on uninstall after the uninstall dialogue closes for an application. 

This PR adds null safety around cancelling tasks while not compromising with the app being `null` when we schedule a form submission worker. 