### PR TITLE
Fix npe in unregistering app updates

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -1302,7 +1302,9 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
     @Override
     protected void onDestroy() {
-        appUpdateController.unregister();
+        if (appUpdateController != null) {
+            appUpdateController.unregister();
+        }
         super.onDestroy();
     }
 


### PR DESCRIPTION
I've seen 2 crashes on crashlytics and from sumologic [1](https://service.us2.sumologic.com/ui/#/search/ce17f220_6a8c_062e_5598_416eb545edd5), [2](https://service.us2.sumologic.com/ui/#/search/7aa27bba_7953_601f_2556_79456624ef41) it seems like whenever there is a crash in some other place, this code also crashes. I've also been able to locally repro it by throwing a Runtime exception.