### PR TITLE
[2.48.9 LTS Hotifix] OOM protection for writing update stats

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -3,7 +3,7 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="org.commcare.dalvik"
           android:versionCode="106"
-          android:versionName="2.48.8">
+          android:versionName="2.48.9">
 
 
     <uses-permission android:name="android.permission.NFC"/>

--- a/app/src/org/commcare/logging/analytics/UpdateStats.java
+++ b/app/src/org/commcare/logging/analytics/UpdateStats.java
@@ -62,7 +62,7 @@ public class UpdateStats implements InstallStatsLogger, Serializable {
             PrefStats.saveStatsPersistently(app, UPGRADE_STATS_KEY, stats);
         } catch (OutOfMemoryError error) {
             Logger.log(LogTypes.TYPE_MAINTENANCE, "Top level OOM while writing update stats to pref");
-            stats.resetTopLevelExceptions();
+            stats.resetResourceInstallStats();
             try {
                 PrefStats.saveStatsPersistently(app, UPGRADE_STATS_KEY, stats);
             } catch (OutOfMemoryError outOfMemoryError) {
@@ -73,8 +73,8 @@ public class UpdateStats implements InstallStatsLogger, Serializable {
 
     }
 
-    private void resetTopLevelExceptions() {
-        resourceInstallStats.put(TOP_LEVEL_STATS_KEY, new InstallAttempts<>(TOP_LEVEL_STATS_KEY));
+    private void resetResourceInstallStats() {
+        resourceInstallStats.clear();
     }
 
     public void resetStats(CommCareApp app) {

--- a/app/src/org/commcare/logging/analytics/UpdateStats.java
+++ b/app/src/org/commcare/logging/analytics/UpdateStats.java
@@ -3,6 +3,8 @@ package org.commcare.logging.analytics;
 import org.commcare.CommCareApp;
 import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.resources.model.InstallStatsLogger;
+import org.commcare.util.LogTypes;
+import org.javarosa.core.services.Logger;
 
 import java.io.PrintWriter;
 import java.io.Serializable;
@@ -31,7 +33,7 @@ public class UpdateStats implements InstallStatsLogger, Serializable {
         startInstallTime = new Date().getTime();
         resourceInstallStats = new Hashtable<>();
         resourceInstallStats.put(TOP_LEVEL_STATS_KEY,
-                new InstallAttempts<String>(TOP_LEVEL_STATS_KEY));
+                new InstallAttempts<>(TOP_LEVEL_STATS_KEY));
     }
 
     /**
@@ -56,7 +58,23 @@ public class UpdateStats implements InstallStatsLogger, Serializable {
      */
     public static void saveStatsPersistently(CommCareApp app,
                                              UpdateStats stats) {
-        PrefStats.saveStatsPersistently(app, UPGRADE_STATS_KEY, stats);
+        try {
+            PrefStats.saveStatsPersistently(app, UPGRADE_STATS_KEY, stats);
+        } catch (OutOfMemoryError error) {
+            Logger.log(LogTypes.TYPE_MAINTENANCE, "Top level OOM while writing update stats to pref");
+            stats.resetTopLevelExceptions();
+            try {
+                PrefStats.saveStatsPersistently(app, UPGRADE_STATS_KEY, stats);
+            } catch (OutOfMemoryError outOfMemoryError) {
+                // very unlikely that this will happen, though just here as a precautionary measure
+                Logger.log(LogTypes.TYPE_MAINTENANCE, "Top - 1 level OOM while writing update stats to pref");
+            }
+        }
+
+    }
+
+    private void resetTopLevelExceptions() {
+        resourceInstallStats.put(TOP_LEVEL_STATS_KEY, new InstallAttempts<>(TOP_LEVEL_STATS_KEY));
     }
 
     public void resetStats(CommCareApp app) {


### PR DESCRIPTION
[Crash](https://console.firebase.google.com/u/1/project/commcare-a57e4/crashlytics/app/android:org.commcare.lts/issues/89eebf691ef96001ffe22811b8033bf6?time=last-thirty-days)

Because of the change we make in 2.48.8 that allows for update resets to happen based on selective errors, the network errors while updates keeps on accumulating in update stats resulting in an OOM crash. 