### PR TITLE
[2.48.9] Removes writes for update install stats

### DIFF
--- a/app/src/org/commcare/logging/analytics/UpdateStats.java
+++ b/app/src/org/commcare/logging/analytics/UpdateStats.java
@@ -135,33 +135,13 @@ public class UpdateStats implements InstallStatsLogger, Serializable {
 
     @Override
     public void recordResourceInstallSuccess(String resourceName) {
-        InstallAttempts<String> attempts =
-                resourceInstallStats.get(resourceName);
-        if (attempts == null) {
-            attempts = new InstallAttempts<>(resourceName);
-            resourceInstallStats.put(resourceName, attempts);
-        }
-        attempts.registerSuccesfulInstall();
+        // Do nothing
     }
 
     @Override
     public void recordResourceInstallFailure(String resourceName,
                                              Exception errorMsg) {
-        InstallAttempts<String> attempts =
-                resourceInstallStats.get(resourceName);
-        if (attempts == null) {
-            attempts = new InstallAttempts<>(resourceName);
-            resourceInstallStats.put(resourceName, attempts);
-        }
-        String stackTrace = getStackTraceString(errorMsg);
-        attempts.addFailure(stackTrace);
-    }
-
-    private static String getStackTraceString(Exception e) {
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        e.printStackTrace(pw);
-        return sw.toString();
+        // Do nothing
     }
 
     @Override


### PR DESCRIPTION
removing the writes as well since deserializing a big UpdateStats object can also degrade performance a lot. 