### PR TITLE
Remove kujaku network change receiver

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -459,5 +459,8 @@
             android:name="firebase_crashlytics_collection_enabled"
             android:value="false" />
 
+        <receiver android:name="io.ona.kujaku.receivers.KujakuNetworkChangeReceiver"
+            tools:node="remove"/>
+
     </application>
 </manifest>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -459,6 +459,11 @@
             android:name="firebase_crashlytics_collection_enabled"
             android:value="false" />
 
+        <!-- With App Bundles, we're seeing a number of MissingLibraryExceptions
+            which is coming from `MapboxOfflineDownloaderService` in Kujaku library.
+            One way to start this service is by using this network change receiver.
+            So removing this entry from the manifest file.
+         -->
         <receiver android:name="io.ona.kujaku.receivers.KujakuNetworkChangeReceiver"
             tools:node="remove"/>
 


### PR DESCRIPTION
[Crash Fix](https://console.firebase.google.com/u/1/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/12e997a8b50eb71f33ec03df4925332a)
This receiver `KujakuNetworkChangeReceiver` starts  `MapboxOfflineDownloaderService` which is giving a lot of crashes. So removing it from here.  