### PR TITLE
Specify ndk version to fix CI builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -206,7 +206,8 @@ static def getDate() {
 
 android {
     compileSdkVersion 29
-
+    // only required to get past a AGP 4.0 bug and should be removed when we update to AGP 4.1+
+    ndkVersion "21.3.6528147"
     lintOptions {
         abortOnError false
         disable 'MissingTranslation'


### PR DESCRIPTION
Jenkins builds are failing from yesterday with the error - `No version of NDK matched the requested version 21.0.6113669. Versions available locally: 21.3.6528147` because of a bug in AGP 4.0 which doesn't download the required ndk version by default. 