### PR TITLE
Navigate form to failed question when form finishes

### DIFF
--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -299,6 +299,7 @@ public class SaveToDiskTask extends
                 if (markCompleted &&
                         (saveStatus == FormEntryController.ANSWER_REQUIRED_BUT_EMPTY ||
                                 saveStatus == FormEntryController.ANSWER_CONSTRAINT_VIOLATED)) {
+                    formController.jumpToIndex(currentFormIndex);
                     return true;
                 }
             }


### PR DESCRIPTION
Fixes side-effect caused by this PR: https://github.com/dimagi/commcare-android/pull/2238. 
When finish button is clicked, and one of the previous questions had a validation error, the form wouldn't go to that failed question, instead it would stay there giving a feeling that the finish button isn't working at all.  

More details here: https://dimagi-dev.atlassian.net/browse/SAAS-11042