### PR TITLE
Use in-built audio widget as default to record audio

### DIFF
--- a/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
+++ b/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
@@ -42,6 +42,7 @@ public class CommCareAudioWidget extends AudioWidget
     private ImageButton mPlayButton;
     private TextView recordingNameText;
     private MediaPlayer player;
+    private static final String ACQUIRE_UPLOAD_FIELD = "acquire-or-upload";
 
     public CommCareAudioWidget(Context context, FormEntryPrompt prompt,
                                PendingCalloutInterface pic) {
@@ -79,6 +80,8 @@ public class CommCareAudioWidget extends AudioWidget
 
 
         mPlayButton.setOnClickListener(v -> playAudio());
+        boolean showFileChooser = ACQUIRE_UPLOAD_FIELD.equals(mPrompt.getAppearanceHint());
+        chooseButton.setVisibility(showFileChooser ? VISIBLE : GONE);
     }
 
     @Override

--- a/app/src/org/commcare/views/widgets/WidgetFactory.java
+++ b/app/src/org/commcare/views/widgets/WidgetFactory.java
@@ -59,10 +59,10 @@ public class WidgetFactory {
                 }
                 break;
             case Constants.CONTROL_AUDIO_CAPTURE:
-                if (appearance != null && appearance.contains("prototype")) {
-                    questionWidget = new CommCareAudioWidget(context, fep, pendingCalloutInterface);
-                } else {
+                if (appearance != null && appearance.contains("legacy")) {
                     questionWidget = new AudioWidget(context, fep, pendingCalloutInterface);
+                } else {
+                    questionWidget = new CommCareAudioWidget(context, fep, pendingCalloutInterface);
                 }
                 break;
             case Constants.CONTROL_VIDEO_CAPTURE:


### PR DESCRIPTION
Product Note:- The audio-record questions will now use CommCare's in-built audio widget by default. And the older UX can still be achieved using `legacy` appearance attribute. The new audio widget won't have the the option to choose audio from file system by default, but it can be achieved using `acquire-or-upload` appearance attribute