### PR TITLE
Quarantines form records on form processing failures

### DIFF
--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -476,7 +476,6 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     private void manuallyQuarantineRecord(FormRecord record) {
         this.formRecordProcessor.quarantineRecord(record, FormRecord.QuarantineReason_MANUAL);
         listView.post(adapter::notifyDataSetInvalidated);
-        record.logManualQuarantine();
     }
 
     private void createQuarantineReasonDialog(FormRecord record) {

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -294,14 +294,6 @@ public class FormRecord extends Persisted implements EncryptedModel {
         Logger.log(LogTypes.TYPE_FORM_DELETION, logMessage);
     }
 
-    public void logManualQuarantine() {
-        String logMessage = String.format(
-                "User manually quarantined form record with id %s and submission ordering number %s ",
-                getInstanceID(),
-                getSubmissionOrderingNumber());
-        Logger.log(LogTypes.TYPE_FORM_DELETION, logMessage);
-    }
-
     public static FormRecord getFormRecord(SqlStorage<FormRecord> formRecordStorage, int formRecordId) {
         return formRecordStorage.read(formRecordId);
     }

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -350,17 +350,13 @@ public class FormRecord extends Persisted implements EncryptedModel {
         try {
             current = updateAndWriteRecord();
         } catch (Exception e) {
-            // Something went wrong with all of the connections which should exist.
-            logPendingDeletion(TAG, "something went wrong trying to update the record for the current session");
-            AndroidSessionWrapper currentState = CommCareApplication.instance().getCurrentSessionWrapper();
-            FormRecordCleanupTask.wipeRecord(currentState);
-
             // Notify the server of this problem (since we aren't going to crash)
             ForceCloseLogger.reportExceptionInBg(e);
             CrashUtil.reportException(e);
-            raiseFormEntryError("An error occurred: " + e.getMessage() +
-                    " and your data could not be saved.", currentState);
-            return;
+            Logger.log(LogTypes.TYPE_FORM_ENTRY, e.getMessage());
+
+            // Record will be wiped when form entry is exited
+            throw new IllegalStateException(e.getMessage());
         }
 
         boolean complete = STATUS_COMPLETE.equals(status);
@@ -418,18 +414,6 @@ public class FormRecord extends Persisted implements EncryptedModel {
         } catch (UnfullfilledRequirementsException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    /**
-     * Throw and Log FormEntry-related errors
-     *
-     * @param loggerText   String sent to javarosa logger
-     * @param currentState session to be cleared
-     */
-    private void raiseFormEntryError(String loggerText, AndroidSessionWrapper currentState) {
-        Logger.log(LogTypes.TYPE_FORM_ENTRY, loggerText);
-        currentState.reset();
-        throw new RuntimeException(loggerText);
     }
 
     private static class InvalidStateException extends Exception {

--- a/app/src/org/commcare/sync/FormSubmissionHelper.java
+++ b/app/src/org/commcare/sync/FormSubmissionHelper.java
@@ -410,26 +410,12 @@ public class FormSubmissionHelper implements DataSubmissionListener {
                         FormRecord.QuarantineReason_RECORD_ERROR :
                         FormRecord.QuarantineReason_SERVER_PROCESSING_ERROR;
         record = mProcessor.quarantineRecord(record, reasonType, uploadResult.getErrorMessage());
-        logAndNotifyQuarantine(record);
         return record;
     }
 
     private FormRecord quarantineRecord(FormRecord record, String quarantineReasonType) {
         record = mProcessor.quarantineRecord(record, quarantineReasonType);
-        logAndNotifyQuarantine(record);
         return record;
-    }
-
-    private static void logAndNotifyQuarantine(FormRecord record) {
-        Logger.log(LogTypes.TYPE_ERROR_STORAGE,
-                String.format("Quarantining Form Record with id %s because: %s",
-                        record.getInstanceID(),
-                        QuarantineUtil.getQuarantineReasonDisplayString(record, true)));
-
-        NotificationMessage m = QuarantineUtil.getQuarantineNotificationMessage(record);
-        if (m != null) {
-            CommCareApplication.notificationManager().reportNotificationMessage(m, true);
-        }
     }
 
     private static void logSubmissionAttempt(FormRecord record) {


### PR DESCRIPTION
Earlier Form processing failures was resulting in the form getting saved on phone which used to get quarantined during form submission due to a 422 response to the submission. This PR changes this behaviour to delete such form records as soon as user "finish" the form. 

Product Note: Deletes any erroneous forms on form save by user rather than later quarantining them at the time of form submission. 