### PR TITLE
Shows localized error for invalid case property length errors

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -431,5 +431,5 @@
     <string name="area_format" cc:translatable="true">%1s sq m</string>
     <string name="parse_coordinates_failure" cc:translatable="true">Could not parse input coordinates</string>
     <string name="location_provider_disabled" cc:translatable="true">Turn on your location to receive location updates</string>
-    <string name="invalid_case_property_length" cc:translatable="true">invalid %1s, value must be 255 characters or less</string>
+    <string name="invalid_case_property_length" cc:translatable="true">Invalid %1s, value must be 255 characters or less</string>
 </resources>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -431,4 +431,5 @@
     <string name="area_format" cc:translatable="true">%1s sq m</string>
     <string name="parse_coordinates_failure" cc:translatable="true">Could not parse input coordinates</string>
     <string name="location_provider_disabled" cc:translatable="true">Turn on your location to receive location updates</string>
+    <string name="invalid_case_property_length" cc:translatable="true">invalid %1s, value must be 255 characters or less</string>
 </resources>

--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -1,6 +1,7 @@
 package org.commcare.android.database.user.models;
 
 import android.database.SQLException;
+
 import androidx.annotation.StringDef;
 
 import net.sqlcipher.database.SQLiteDatabase;
@@ -8,6 +9,7 @@ import net.sqlcipher.database.SQLiteDatabase;
 import org.commcare.CommCareApplication;
 import org.commcare.android.logging.ForceCloseLogger;
 import org.commcare.android.storage.framework.Persisted;
+import org.commcare.dalvik.R;
 import org.commcare.models.AndroidSessionWrapper;
 import org.commcare.models.FormRecordProcessor;
 import org.commcare.models.database.SqlStorage;
@@ -19,9 +21,11 @@ import org.commcare.tasks.FormRecordCleanupTask;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.CrashUtil;
 import org.commcare.utils.StorageUtils;
+import org.commcare.utils.StringUtils;
 import org.commcare.views.notifications.NotificationMessage;
 import org.commcare.views.notifications.NotificationMessageFactory;
 import org.javarosa.core.services.Logger;
+import org.javarosa.xml.util.InvalidCasePropertyLengthException;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.xmlpull.v1.XmlPullParserException;
@@ -380,6 +384,13 @@ public class FormRecord extends Persisted implements EncryptedModel {
                 try {
                     new FormRecordProcessor(CommCareApplication.instance()).process(current);
                     userDb.setTransactionSuccessful();
+                } catch (InvalidCasePropertyLengthException e) {
+                    Logger.log(LogTypes.TYPE_ERROR_WORKFLOW, e.getMessage());
+                    throw new IllegalStateException(
+                            StringUtils.getStringRobust(
+                                    CommCareApplication.instance(),
+                                    R.string.invalid_case_property_length,
+                                    e.getCaseProperty()));
                 } catch (InvalidStructureException e) {
                     // Record will be wiped when form entry is exited
                     Logger.log(LogTypes.TYPE_ERROR_WORKFLOW, e.getMessage());

--- a/app/src/org/commcare/utils/StringUtils.java
+++ b/app/src/org/commcare/utils/StringUtils.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.collection.LruCache;
 import android.text.Spannable;
 
+import org.commcare.CommCareApplication;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
 

--- a/app/src/org/commcare/utils/StringUtils.java
+++ b/app/src/org/commcare/utils/StringUtils.java
@@ -3,16 +3,16 @@ package org.commcare.utils;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Build;
-import androidx.annotation.NonNull;
-import androidx.collection.LruCache;
 import android.text.Spannable;
 
-import org.commcare.CommCareApplication;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.text.Normalizer;
 import java.util.regex.Pattern;
+
+import androidx.annotation.NonNull;
+import androidx.collection.LruCache;
 
 /**
  * @author ctsims


### PR DESCRIPTION
This was flagged by the icds team that they want to localize these errors. 

cross-request: https://github.com/dimagi/commcare-core/pull/922

Product Note: Throws an error on saving a form with any of case_name, case_type, owner_id and external_id for a case is greater than 255 chars in length.