### PR TITLE
Not crash when a form record is not found in db during purge

### DIFF
--- a/app/src/org/commcare/tasks/PurgeStaleArchivedFormsTask.java
+++ b/app/src/org/commcare/tasks/PurgeStaleArchivedFormsTask.java
@@ -8,6 +8,7 @@ import org.commcare.util.LogTypes;
 import org.javarosa.core.services.Logger;
 import org.joda.time.DateTime;
 
+import java.util.NoSuchElementException;
 import java.util.Vector;
 
 /**
@@ -127,8 +128,13 @@ public class PurgeStaleArchivedFormsTask
                 new Object[]{FormRecord.STATUS_SAVED, currentAppId});
 
         for (int id : savedFormsForThisApp) {
-            String dateAsString =
-                    formStorage.getMetaDataFieldForRecord(id, FormRecord.META_LAST_MODIFIED);
+            String dateAsString;
+            try {
+                dateAsString = formStorage.getMetaDataFieldForRecord(id, FormRecord.META_LAST_MODIFIED);
+            } catch (NoSuchElementException e) {
+                continue;
+            }
+
             long timeSinceEpoch;
             try {
                 timeSinceEpoch = Long.valueOf(dateAsString);


### PR DESCRIPTION
[CL Link](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/5b655dc36007d59fcdc38c84?time=last-ninety-days&sessionId=5F0EED230214000118638CE9816680EA_DNE_0_v2)

```
Caused by java.util.NoSuchElementException: No record in table FORMRECORDS for ID 10
       at org.commcare.models.database.SqlStorage.getMetaDataFieldForRecord(SqlStorage.java:168)
       at org.commcare.tasks.PurgeStaleArchivedFormsTask.getSavedFormsToPurge(PurgeStaleArchivedFormsTask.java:131)
       at org.commcare.tasks.PurgeStaleArchivedFormsTask.performArchivedFormPurge(PurgeStaleArchivedFormsTask.java:84)
````

When there are a lot of submitted forms on device, it's possible for the user to delete a form from Saved forms list while [this loop](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/tasks/PurgeStaleArchivedFormsTask.java#L129) is in progress causing this crash to surface. Even though it does seem highly unlikely to happen, the issue occurrences are quite rare as well making it a possible hypothesis.  