### PR TITLE
Enable network logs for instrumentation tests

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -25,6 +25,7 @@ def buildTestCommand(appToken, testToken):
     test["app"] = appToken
     test["deviceLogs"] = True
     test["testSuite"] = testToken
+    test["networkLogs"] = True
     return json.dumps(json.dumps(test))
 
 if __name__ == "__main__":


### PR DESCRIPTION
I'm seeing some network failures(in deviceLogs) in some of the tests of browserstack  `connect failed: ENETUNREACH (Network is unreachable)`
 This PR will enable network logs as well to give better insight on those failures. 