### PR TITLE
sub-detail fixes

### DIFF
--- a/app/src/org/commcare/fragments/EntitySubnodeDetailFragment.java
+++ b/app/src/org/commcare/fragments/EntitySubnodeDetailFragment.java
@@ -22,6 +22,8 @@ import org.javarosa.core.model.instance.TreeReference;
 
 import java.util.List;
 
+import androidx.annotation.Nullable;
+
 /**
  * Created by jschweers on 8/26/2015.
  * <p/>
@@ -33,6 +35,12 @@ public class EntitySubnodeDetailFragment extends EntityDetailFragment implements
     private ListView listView;
 
     public EntitySubnodeDetailFragment() {
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
     }
 
     @Override
@@ -65,6 +73,8 @@ public class EntitySubnodeDetailFragment extends EntityDetailFragment implements
             headerLayout.removeAllViews();
             headerLayout.addView(headerView);
             headerLayout.setVisibility(View.VISIBLE);
+        } else if (adapter != null) {
+            listView.setAdapter((ListAdapter)adapter);
         }
 
         return rootView;

--- a/app/src/org/commcare/fragments/EntitySubnodeDetailFragment.java
+++ b/app/src/org/commcare/fragments/EntitySubnodeDetailFragment.java
@@ -2,6 +2,7 @@ package org.commcare.fragments;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -89,20 +90,22 @@ public class EntitySubnodeDetailFragment extends EntityDetailFragment implements
     public void deliverLoadResult(List<Entity<TreeReference>> entities,
                                   List<TreeReference> references,
                                   NodeEntityFactory factory, int focusTargetIndex) {
-        Bundle args = getArguments();
-        Detail detail = asw.getSession().getDetail(args.getString(DETAIL_ID));
-        final int thisIndex = args.getInt(CHILD_DETAIL_INDEX, -1);
-        final boolean detailCompound = thisIndex != -1;
-        if (detailCompound) {
-            detail = getChildDetailForDisplay(detail, thisIndex);
-        }
+        if(isVisible()) { // underlying session might have changed otherwise and can cause xpath eval errors
+            Bundle args = getArguments();
+            Detail detail = asw.getSession().getDetail(args.getString(DETAIL_ID));
+            final int thisIndex = args.getInt(CHILD_DETAIL_INDEX, -1);
+            final boolean detailCompound = thisIndex != -1;
+            if (detailCompound) {
+                detail = getChildDetailForDisplay(detail, thisIndex);
+            }
 
-        this.loader = null;
-        this.adapter = new EntitySubnodeDetailAdapter(getActivity(), detail, references,
-                entities, modifier, factory);
-        this.listView.setAdapter((ListAdapter)this.adapter);
-        if (focusTargetIndex != -1) {
-            listView.setSelection(focusTargetIndex);
+            this.loader = null;
+            this.adapter = new EntitySubnodeDetailAdapter(getActivity(), detail, references,
+                    entities, modifier, factory);
+            this.listView.setAdapter((ListAdapter)this.adapter);
+            if (focusTargetIndex != -1) {
+                listView.setSelection(focusTargetIndex);
+            }
         }
     }
 

--- a/app/src/org/commcare/views/TabbedDetailView.java
+++ b/app/src/org/commcare/views/TabbedDetailView.java
@@ -73,11 +73,9 @@ public class TabbedDetailView extends RelativeLayout {
 
         mMenu = root.findViewById(R.id.tabbed_detail_menu);
         mViewPager = root.findViewById(R.id.tabbed_detail_pager);
-        mViewPager.setId(AndroidUtil.generateViewId());
-
         mViewPageTabStrip = root.findViewById(R.id.pager_tab_strip);
 
-        mViewPager.setOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+        mViewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
 
             @Override
             public void onPageSelected(int position) {


### PR DESCRIPTION
- Retain `EntitySubnodeDetailFragment` to avoid reloading data on configuration changes
- Fixes [the crash](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/59ddfc4cbe077a4dcc1af280?time=last-thirty-days&sessionId=5F214311007C0001769F8DCE188D03F7_DNE_0_v2) : This crash happens when the user moves out of the sub detail fragment before the `EntityLoaderTask` completes resulting in the `deliverLoadResult` to operate on a changed session scope. The PR just discards the result of the `EntityLoaderTask` if fragment is not visible. 

