### PR TITLE
Add idling resource to avoid AppNotIdleExceptions

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/CommCareInstrumentationTestApplication.java
+++ b/app/instrumentation-tests/src/org/commcare/CommCareInstrumentationTestApplication.java
@@ -1,16 +1,69 @@
 package org.commcare;
 
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import org.commcare.tasks.AsyncRestoreHelper;
 import org.commcare.tasks.DataPullTask;
 
-public class CommCareInstrumentationTestApplication extends CommCareApplication {
+public class CommCareInstrumentationTestApplication extends CommCareApplication implements Application.ActivityLifecycleCallbacks {
+
+    /**
+     * We only wanna store the activity that's currently on top of the screen.
+     */
+    private Activity currentActivity;
+
     @Override
     public void onCreate() {
         super.onCreate();
+        registerActivityLifecycleCallbacks(this);
     }
 
     @Override
     public AsyncRestoreHelper getAsyncRestoreHelper(DataPullTask task) {
         return new AsyncRestoreHelperMock(task);
     }
+
+    @Override
+    public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {
+
+    }
+
+    @Override
+    public void onActivityStarted(@NonNull Activity activity) {
+
+    }
+
+    @Override
+    public void onActivityResumed(@NonNull Activity activity) {
+        currentActivity = activity;
+    }
+
+    @Override
+    public void onActivityPaused(@NonNull Activity activity) {
+
+    }
+
+    @Override
+    public void onActivityStopped(@NonNull Activity activity) {
+
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {
+
+    }
+
+    @Override
+    public void onActivityDestroyed(@NonNull Activity activity) {
+
+    }
+
+    public Activity getCurrentActivity() {
+        return currentActivity;
+    }
+    
+
 }

--- a/app/instrumentation-tests/src/org/commcare/androidTests/AsyncRestoreTest.java
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/AsyncRestoreTest.java
@@ -5,7 +5,7 @@ import androidx.test.espresso.IdlingRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import org.commcare.AsyncRestoreHelperMock;
-import org.commcare.utils.CommCareIdlingResource;
+import org.commcare.utils.ProgressIdlingResource;
 import org.commcare.utils.HQApi;
 import org.commcare.utils.InstrumentationUtility;
 import org.junit.After;
@@ -49,7 +49,7 @@ public class AsyncRestoreTest extends BaseTest {
         assertFalse(AsyncRestoreHelperMock.isServerProgressReportingStarted());
 
         // Register commcareidling resource before login
-        CommCareIdlingResource idlingResource = new CommCareIdlingResource();
+        ProgressIdlingResource idlingResource = new ProgressIdlingResource();
         IdlingRegistry.getInstance().register(idlingResource);
 
         // Login into the app
@@ -75,7 +75,7 @@ public class AsyncRestoreTest extends BaseTest {
         installAppAndClearCache();
 
         // Register commcareidling resource before login
-        CommCareIdlingResource idlingResource = new CommCareIdlingResource();
+        ProgressIdlingResource idlingResource = new ProgressIdlingResource();
         IdlingRegistry.getInstance().register(idlingResource);
 
         // Login into the app

--- a/app/instrumentation-tests/src/org/commcare/androidTests/AsyncRestoreTest.java
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/AsyncRestoreTest.java
@@ -1,9 +1,11 @@
 package org.commcare.androidTests;
 
 import android.content.Intent;
+import androidx.test.espresso.IdlingRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import org.commcare.AsyncRestoreHelperMock;
+import org.commcare.utils.CommCareIdlingResource;
 import org.commcare.utils.HQApi;
 import org.commcare.utils.InstrumentationUtility;
 import org.junit.After;
@@ -46,12 +48,19 @@ public class AsyncRestoreTest extends BaseTest {
         assertFalse(AsyncRestoreHelperMock.isRetryCalled());
         assertFalse(AsyncRestoreHelperMock.isServerProgressReportingStarted());
 
+        // Register commcareidling resource before login
+        CommCareIdlingResource idlingResource = new CommCareIdlingResource();
+        IdlingRegistry.getInstance().register(idlingResource);
+
         // Login into the app
         InstrumentationUtility.login("many.cases1", "123");
 
         // Confirm Async Restore is done.
         assertTrue(AsyncRestoreHelperMock.isRetryCalled());
         assertTrue(AsyncRestoreHelperMock.isServerProgressReportingStarted());
+
+        // Unregister idling resource
+        IdlingRegistry.getInstance().unregister(idlingResource);
     }
 
     @Test
@@ -64,6 +73,10 @@ public class AsyncRestoreTest extends BaseTest {
         HQApi.removeUserFromGroup(userId, groupId);
 
         installAppAndClearCache();
+
+        // Register commcareidling resource before login
+        CommCareIdlingResource idlingResource = new CommCareIdlingResource();
+        IdlingRegistry.getInstance().register(idlingResource);
 
         // Login into the app
         InstrumentationUtility.login("many.cases2", "123");
@@ -82,6 +95,9 @@ public class AsyncRestoreTest extends BaseTest {
         // Confirm AsyncRestore happened after sync
         assertTrue(AsyncRestoreHelperMock.isRetryCalled());
         assertTrue(AsyncRestoreHelperMock.isServerProgressReportingStarted());
+
+        // Unregister idling resource
+        IdlingRegistry.getInstance().unregister(idlingResource);
     }
 
     private void installAppAndClearCache() {

--- a/app/instrumentation-tests/src/org/commcare/utils/CommCareIdlingResource.kt
+++ b/app/instrumentation-tests/src/org/commcare/utils/CommCareIdlingResource.kt
@@ -1,0 +1,55 @@
+package org.commcare.utils
+
+import android.os.Handler
+import android.os.Looper
+import androidx.test.espresso.IdlingResource
+import androidx.test.platform.app.InstrumentationRegistry
+import org.commcare.CommCareInstrumentationTestApplication
+import org.commcare.activities.CommCareActivity
+
+/**
+ * An implementation of idling resource useful for monitoring idleness of progress dialogs.
+ *
+ * It has an additional idleness constraint that the progress dialog must not be shown for a set
+ * period of time before we declare the resource idle.
+ *
+ * Useful for cases where we make multiple network calls in succession where each response triggers
+ * another request until loading is complete.
+ * So the app will be like Not-Idle(Progress bar showing) -> Idle(Progress bar closed) -> Not-Idle -> Idle...
+ * And we don't want to report idle when this happens.
+ */
+class CommCareIdlingResource: IdlingResource {
+
+    companion object {
+        const val timeoutMs = 1000L
+    }
+
+    lateinit var resourceCallback: IdlingResource.ResourceCallback
+    var isIdle = false
+    val handler = Handler(Looper.getMainLooper())
+
+    override fun getName(): String {
+        return CommCareIdlingResource::class.java.name
+    }
+
+    override fun isIdleNow(): Boolean {
+        val activity = getCommCareActivity() ?: return true
+        if (!(activity.currentProgressDialog != null && activity.currentProgressDialog.isAdded)) {
+            handler.postDelayed({
+                isIdle = true
+                resourceCallback.onTransitionToIdle()
+            }, timeoutMs)
+        }
+        return isIdle
+    }
+
+    override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback) {
+        this.resourceCallback = callback
+    }
+
+    private fun getCommCareActivity(): CommCareActivity<*>? {
+        val application = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+                as CommCareInstrumentationTestApplication
+        return application.currentActivity as? CommCareActivity<*>
+    }
+}

--- a/app/instrumentation-tests/src/org/commcare/utils/ProgressIdlingResource.kt
+++ b/app/instrumentation-tests/src/org/commcare/utils/ProgressIdlingResource.kt
@@ -18,7 +18,7 @@ import org.commcare.activities.CommCareActivity
  * So the app will be like Not-Idle(Progress bar showing) -> Idle(Progress bar closed) -> Not-Idle -> Idle...
  * And we don't want to report idle when this happens.
  */
-class CommCareIdlingResource: IdlingResource {
+class ProgressIdlingResource: IdlingResource {
 
     companion object {
         const val timeoutMs = 1000L
@@ -29,7 +29,7 @@ class CommCareIdlingResource: IdlingResource {
     val handler = Handler(Looper.getMainLooper())
 
     override fun getName(): String {
-        return CommCareIdlingResource::class.java.name
+        return ProgressIdlingResource::class.java.name
     }
 
     override fun isIdleNow(): Boolean {


### PR DESCRIPTION
The tests are sometimes failing with `AppNotIdleException`. This PR will add an idling resource to make tests more robust.