### PR TITLE
[2.49.5 hotfix] Fix Update Resumptions

### DIFF
--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -192,7 +192,7 @@ public class AndroidResourceManager extends ResourceManager {
         updateStats.registerUpdateFailure(result);
         FirebaseAnalyticsUtil.reportStageUpdateAttemptFailure(result.toString());
 
-        if (!result.canReusePartialUpdateTable()) {
+        if (result.shouldDiscardPartialUpdateTable()) {
             clearUpgrade();
             FirebaseAnalyticsUtil.reportUpdateReset(UPDATE_RESET_REASON_CORRUPT);
         }

--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -193,22 +193,22 @@ public class AndroidResourceManager extends ResourceManager {
         FirebaseAnalyticsUtil.reportStageUpdateAttemptFailure(result.toString());
 
         if (result.shouldDiscardPartialUpdateTable()) {
+            Logger.log(LogTypes.TYPE_CC_UPDATE, "Clearing update due to error: " + result);
             clearUpgrade();
             FirebaseAnalyticsUtil.reportUpdateReset(UPDATE_RESET_REASON_CORRUPT);
+        } else {
+            saveUpdateOrGiveUp();
         }
-
-        saveUpdateOrGiveUp();
     }
 
     private void saveUpdateOrGiveUp() {
         if (updateStats.isUpgradeStale()) {
-            Logger.log(LogTypes.TYPE_RESOURCES,
+            Logger.log(LogTypes.TYPE_CC_UPDATE,
                     "Update was stale, stopped trying to download update. Update Stats: " + updateStats.toString());
 
             FirebaseAnalyticsUtil.reportUpdateReset(updateStats.hasUpdateTrialsMaxedOut() ?
                     UPDATE_RESET_REASON_OVERSHOOT_TRIALS : UPDATE_RESET_REASON_TIMEOUT);
 
-            UpdateStats.clearPersistedStats(app);
             clearUpgrade();
         } else {
             UpdateStats.saveStatsPersistently(app, updateStats);
@@ -218,6 +218,7 @@ public class AndroidResourceManager extends ResourceManager {
     @Override
     public void clearUpgrade() {
         super.clearUpgrade();
+        updateStats.resetStats(app);
         HiddenPreferences.setReleasedOnTimeForOngoingAppDownload((AndroidCommCarePlatform)platform, 0);
         HiddenPreferences.setPreUpdateSyncNeeded(PrefValues.NO);
     }

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -75,8 +75,7 @@ public enum AppInstallStatus implements MessageTag {
 
     public boolean shouldRetryUpdate() {
         return (this == NetworkFailure ||
-                this == NoConnection ||
-                this == RateLimited);
+                this == NoConnection);
     }
 
     @Override

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -74,7 +74,9 @@ public enum AppInstallStatus implements MessageTag {
     }
 
     public boolean shouldRetryUpdate() {
-        return (this == MissingResources || this == MissingResourcesWithMessage || this == NoConnection);
+        return (this == NetworkFailure ||
+                this == NoConnection ||
+                this == RateLimited);
     }
 
     @Override

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -62,8 +62,11 @@ public enum AppInstallStatus implements MessageTag {
         return root;
     }
 
-    public boolean canReusePartialUpdateTable() {
-        return (this == UnknownFailure || this == NoLocalStorage);
+    public boolean shouldDiscardPartialUpdateTable() {
+        return this == MissingResources ||
+                this == MissingResourcesWithMessage ||
+                this == InvalidResource ||
+                this == IncompatibleReqs;
     }
 
     public boolean isUpdateInCompletedState() {

--- a/app/src/org/commcare/logging/analytics/UpdateStats.java
+++ b/app/src/org/commcare/logging/analytics/UpdateStats.java
@@ -60,7 +60,7 @@ public class UpdateStats implements Serializable {
     /**
      * Wipe stats associated with upgrade table from app preferences.
      */
-    public static void clearPersistedStats(CommCareApp app) {
+    private static void clearPersistedStats(CommCareApp app) {
         PrefStats.clearPersistedStats(app, UPGRADE_STATS_KEY);
     }
 


### PR DESCRIPTION
- Corrects update resumptions to only reset table with specific install codes
- Corrects auto update retries to retry on network failures 
- Clears updateStats anytime we clear upgrade