### PR TITLE
Remove recovery activity from backstack on launching app manager

### DIFF
--- a/app/src/org/commcare/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/activities/RecoveryActivity.java
@@ -295,6 +295,7 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
         Intent i = new Intent(this, AppManagerActivity.class);
         i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(i);
+        finish();
     }
 
     public void stopLoading() {


### PR DESCRIPTION
[CL](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.lts/issues/c408f602f2c30690c1acda371a4421c1?time=last-ninety-days&sessionId=5F2D51F401D90001244F4B21917F612D_DNE_3_v2)

````
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int org.commcare.CommCareApp.getAppResourceState()' on a null object reference
       at org.commcare.activities.RecoveryActivity.isAppCorrupt(RecoveryActivity.java:236)
       at org.commcare.activities.RecoveryActivity.onBackPressed(RecoveryActivity.java:242)
````

Repro -
1. Delete app files from file system
2. launch CommCare
3. Login which should auto-direct to Recovery
4. Make Recovery fail by turning off internet
5. Go to App manager and uninstall the single CommCare app installed 
6. Press back to Recovery again
7. Press back to observe the crash

The PR just finishes the recovery on launching the app manager so that in case of any app seating changes, pressing back from App Manager in this case should let `Dispatch` recalculate the next step for the user. 