### PR TITLE
[2.49.7 hotfix] Fix to current location for Maps Location Capture

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="retry_button_text">Retry</string>
     <string name="skipped_verification_warning">You did not validate multimedia resources for the app that was just
          installed! This app will not be visible to users on the log-in screen until multimedia is validated.</string>
-    <string name="skipped_verification_warning_2">You did not validate multimedia resources for this app! The app will 
+    <string name="skipped_verification_warning_2">You did not validate multimedia resources for this app! The app will
         not be visible to users on the log-in screen until multimedia is validated.</string>
     <string name="manager_instructions">Select an app to view its management options, or install a new app.</string>
     <string name="pre_multiple_apps_warning">Warning: The app you have installed is from an outdated build.
@@ -419,4 +419,5 @@
     <string name="area_format" cc:translatable="true">%1s sq m</string>
     <string name="parse_coordinates_failure" cc:translatable="true">Could not parse input coordinates</string>
     <string name="location_provider_disabled" cc:translatable="true">Turn on your location to receive location updates</string>
+    <string name="wait_for_location_fix"  cc:translatable="true">CommCare is still trying to get your location. Please wait or click Cancel to abort.</string>
 </resources>

--- a/app/src/org/commcare/activities/GeoPointMapActivity.java
+++ b/app/src/org/commcare/activities/GeoPointMapActivity.java
@@ -123,7 +123,7 @@ public class GeoPointMapActivity extends Activity
     }
 
     private void returnLocation() {
-        if (location != null &&
+        if (location == null ||
                 (location.getLatitude() == 0d && location.getLongitude() == 0d && location.getAccuracy() == 0d)) {
             // we do not have a location fix yet, show an error to the user
             Toast.makeText(

--- a/app/src/org/commcare/activities/GeoPointMapActivity.java
+++ b/app/src/org/commcare/activities/GeoPointMapActivity.java
@@ -14,6 +14,7 @@ import android.view.View;
 import android.view.Window;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.fasterxml.jackson.databind.type.MapType;
 import com.google.android.gms.maps.CameraUpdate;
@@ -26,11 +27,13 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 
+import org.commcare.CommCareApplication;
 import org.commcare.activities.components.FormEntryConstants;
 import org.commcare.dalvik.R;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.utils.GeoUtils;
 import org.commcare.utils.MapLayer;
+import org.commcare.utils.StringUtils;
 import org.commcare.views.widgets.GeoPointWidget;
 
 import java.text.DecimalFormat;
@@ -120,12 +123,20 @@ public class GeoPointMapActivity extends Activity
     }
 
     private void returnLocation() {
-        if (location != null) {
+        if (location != null &&
+                (location.getLatitude() == 0d && location.getLongitude() == 0d && location.getAccuracy() == 0d)) {
+            // we do not have a location fix yet, show an error to the user
+            Toast.makeText(
+                    this,
+                    StringUtils.getStringRobust(CommCareApplication.instance(), R.string.wait_for_location_fix),
+                    Toast.LENGTH_LONG).show();
+
+        } else {
             Intent i = new Intent();
             i.putExtra(FormEntryConstants.LOCATION_RESULT, GeoUtils.locationToString(location));
             setResult(RESULT_OK, i);
+            finish();
         }
-        finish();
     }
 
     private void loadMapView(Bundle savedInstanceState) {

--- a/app/src/org/commcare/activities/GeoPointMapActivity.java
+++ b/app/src/org/commcare/activities/GeoPointMapActivity.java
@@ -153,7 +153,8 @@ public class GeoPointMapActivity extends Activity
     public void onLocationChanged(Location location) {
         if (!inViewMode && !isManualSelectedLocation) {
             if (location != null &&
-                    (this.location == null || (location.getAccuracy() < this.location.getAccuracy()))) {
+                    (this.location == null || this.location.getAccuracy() == 0 ||
+                            (location.getAccuracy() < this.location.getAccuracy()))) {
                 this.location = location;
                 drawMarker();
             }


### PR DESCRIPTION
* Corrects the accuracy check to let the initial location fix go through 
* Don't allow 0,0,0,0 location to be recorded

Produce Notes: 
* Move the maps to user's initial location on start up in case no existing location is set
* Don't allow locatin with values "0.0 0.0 0.0 0.0" to be recorded as a valid location 