### PR TITLE
null adapter check in menu to avoid NPE

### DIFF
--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -557,19 +557,21 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
 
-        MenuItem quarantine = menu.findItem(MENU_SUBMIT_QUARANTINE_REPORT);
-        if (quarantine != null) {
-            quarantine.setVisible(FormRecordFilter.Limbo.equals(adapter.getFilter()));
-        }
+        if (adapter != null) {
+            MenuItem quarantine = menu.findItem(MENU_SUBMIT_QUARANTINE_REPORT);
+            if (quarantine != null) {
+                quarantine.setVisible(FormRecordFilter.Limbo.equals(adapter.getFilter()));
+            }
 
-        MenuItem downloadFormsFromServer = menu.findItem(DOWNLOAD_FORMS_FROM_SERVER);
-        if (downloadFormsFromServer != null) {
-            downloadFormsFromServer.setVisible(!FormRecordFilter.Incomplete.equals(adapter.getFilter()));
-        }
+            MenuItem downloadFormsFromServer = menu.findItem(DOWNLOAD_FORMS_FROM_SERVER);
+            if (downloadFormsFromServer != null) {
+                downloadFormsFromServer.setVisible(!FormRecordFilter.Incomplete.equals(adapter.getFilter()));
+            }
 
-        MenuItem downloadFormsFromFile = menu.findItem(DOWNLOAD_FORMS_FROM_FILE);
-        if (downloadFormsFromFile != null) {
-            downloadFormsFromFile.setVisible(!FormRecordFilter.Incomplete.equals(adapter.getFilter()));
+            MenuItem downloadFormsFromFile = menu.findItem(DOWNLOAD_FORMS_FROM_FILE);
+            if (downloadFormsFromFile != null) {
+                downloadFormsFromFile.setVisible(!FormRecordFilter.Incomplete.equals(adapter.getFilter()));
+            }
         }
 
         return menu.hasVisibleItems();


### PR DESCRIPTION
[Crashlytics](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.lts/issues/e3110befb09bd58913f9cff4b716f036?time=last-thirty-days&sessionId=5F04A74D038C00010B02783790F45A2E_DNE_0_v2)

Not sure why adapter is `null` in `onPrepareOptionsMenu`. Looks like `onPrepareOptionsMenu` might be getting called out of order but not sure how. I think it's better to show an empty menu which user can possibly correct by going back in menu in these rare cases rather than crashing the app so just putting a null check to solve this. 