### PR TITLE
Show downloaded app update info in case of no internet

### DIFF
--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -196,9 +196,15 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
 
         NSDDiscoveryTools.registerForNsdServices(this, this);
 
-        if (!ConnectivityStatus.isNetworkAvailable(this) && offlineUpdateRef == null) {
-            uiController.noConnectivityUiState();
-            return;
+        if (!ConnectivityStatus.isNetworkAvailable(this)) {
+            // If we've already downloaded an update but the network isn't available, show the update to user.
+            if (ResourceInstallUtils.isUpdateReadyToInstall()) {
+                uiController.unappliedUpdateAvailableUiState();
+                return;
+            } else if (offlineUpdateRef == null) {
+                uiController.noConnectivityUiState();
+                return;
+            }
         }
 
         if (isAutoUpdateInProgress()) {


### PR DESCRIPTION
In case an app update is already downloaded and user enters app update screen but doesn't have internet connectivity, we'll show the information of already downloaded update. 