### PR TITLE
Adds set alarm permission

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -29,6 +29,9 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <!-- used to create an alarm from a custom callout -->
+    <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+
     <uses-feature
         android:name="android.hardware.telephony"
         android:required="false"/>
@@ -297,7 +300,7 @@
         </activity>
         <activity android:name="org.commcare.activities.InstallFromListActivity">
         </activity>
-        
+
         <uses-library
             android:name="com.google.android.maps"
             android:required="false"/>


### PR DESCRIPTION
Today in case an application wishes to set an alarm using a custom callout, they get an error because of this permission not being requested by the application. Since `SET_ALARM` is of [normal](https://developer.android.com/guide/topics/permissions/overview#normal_permissions) protection level, these permissions are auto granted without user approval.