### PR TITLE
[2.48.10 hotfix] Update retry time overflow fix

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -439,5 +439,9 @@
 
         <meta-data android:name="android.content.APP_RESTRICTIONS"
             android:resource="@xml/app_restrictions" />
+
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="false" />
     </application>
 </manifest>

--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -287,11 +287,11 @@ public class AndroidResourceManager extends ResourceManager {
      * @param numberOfRestarts used as the exponent for the delay calculation
      * @return delay in MS, which grows exponentially over the number of restarts.
      */
-    private long exponentionalRetryDelay(int numberOfRestarts) {
+    private static long exponentionalRetryDelay(int numberOfRestarts) {
         final Double base = 10 * (1.78);
         final long thirtySeconds = 30 * 1000;
-        long exponentialDelay = thirtySeconds + (long)Math.pow(base, numberOfRestarts);
-        return Math.min(exponentialDelay, MAX_UPDATE_RETRY_DELAY_IN_MS);
+        long exponentialDelay = numberOfRestarts < 6 ? thirtySeconds + (long)Math.pow(base, numberOfRestarts) : MAX_UPDATE_RETRY_DELAY_IN_MS;
+        return exponentialDelay;
     }
 
     @Override


### PR DESCRIPTION
Issue: In case `numberOfRestarts` become greater than 15, the long value 17.8^16 overflows and become negative causing the updates to be retried continuously without any delay.

Affects CommCare 2.48.[8-9], prior to this we were resetting the update on every 5 trials causing `numberOfRestarts` to not become greater than 5 ever. 

Also ports https://github.com/dimagi/commcare-android/pull/2219 in 2.48 to fix the debug builds. 

Product Note: Fixes an issue with CommCare 2.48.8 and CommCare 2.48.9 LTS where updates gets retries continuously without any delay. 
