### PR TITLE
Add clear button to SelectOneAutoAdvanceWidget [WIP]

### DIFF
--- a/app/src/org/commcare/views/widgets/SelectOneAutoAdvanceWidget.java
+++ b/app/src/org/commcare/views/widgets/SelectOneAutoAdvanceWidget.java
@@ -4,9 +4,8 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
-import android.view.MotionEvent;
-import android.view.View;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.ImageView;
@@ -21,6 +20,7 @@ import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
+import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
 
@@ -42,6 +42,7 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
     private final AdvanceToNextListener listener;
 
     private final int buttonIdBase;
+    private Button clearButton;
 
     public SelectOneAutoAdvanceWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
@@ -122,7 +123,19 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
 
                 addView(thisParentLayout);
             }
+            addClearButton(context, s != null && !prompt.isReadOnly());
         }
+    }
+
+    private void addClearButton(Context context, boolean show) {
+        clearButton = (Button) LayoutInflater.from(context).inflate(R.layout.blue_outlined_button, this, false);
+        clearButton.setText(Localization.get("button.clear.title"));
+        clearButton.setVisibility(show ? VISIBLE : GONE);
+        clearButton.setOnClickListener(view -> {
+            clearAnswer();
+            widgetEntryChanged();
+        });
+        addView(clearButton);
     }
 
     @Override
@@ -130,9 +143,10 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
         for (RadioButton button : this.buttons) {
             if (button.isChecked()) {
                 button.setChecked(false);
-                return;
+                break;
             }
         }
+        clearButton.setVisibility(GONE);
     }
 
 
@@ -182,6 +196,7 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
                 button.setChecked(false);
             }
         }
+        clearButton.setVisibility(VISIBLE);
         widgetEntryChanged();
 
         listener.advance();

--- a/app/src/org/commcare/views/widgets/SelectOneAutoAdvanceWidget.java
+++ b/app/src/org/commcare/views/widgets/SelectOneAutoAdvanceWidget.java
@@ -5,7 +5,6 @@ import android.graphics.drawable.Drawable;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.ImageView;
@@ -20,7 +19,6 @@ import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
-import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
 
@@ -33,7 +31,7 @@ import java.util.Vector;
  *
  * @author Jeff Beorse (jeff@beorse.net)
  */
-public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnCheckedChangeListener {
+public class SelectOneAutoAdvanceWidget extends SelectQuestionWidget implements OnCheckedChangeListener {
 
     private final Vector<SelectChoice> mItems;
 
@@ -42,7 +40,6 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
     private final AdvanceToNextListener listener;
 
     private final int buttonIdBase;
-    private Button clearButton;
 
     public SelectOneAutoAdvanceWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
@@ -125,17 +122,6 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
             }
             addClearButton(context, s != null && !prompt.isReadOnly());
         }
-    }
-
-    private void addClearButton(Context context, boolean show) {
-        clearButton = (Button) LayoutInflater.from(context).inflate(R.layout.blue_outlined_button, this, false);
-        clearButton.setText(Localization.get("button.clear.title"));
-        clearButton.setVisibility(show ? VISIBLE : GONE);
-        clearButton.setOnClickListener(view -> {
-            clearAnswer();
-            widgetEntryChanged();
-        });
-        addView(clearButton);
     }
 
     @Override

--- a/app/src/org/commcare/views/widgets/SelectOneWidget.java
+++ b/app/src/org/commcare/views/widgets/SelectOneWidget.java
@@ -2,9 +2,7 @@ package org.commcare.views.widgets;
 
 import android.content.Context;
 import android.util.TypedValue;
-import android.view.LayoutInflater;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.ImageView;
@@ -16,7 +14,6 @@ import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
-import org.javarosa.core.services.locale.Localization;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
 
@@ -28,11 +25,10 @@ import java.util.Vector;
  * @author Carl Hartung (carlhartung@gmail.com)
  * @author Yaw Anokwa (yanokwa@gmail.com)
  */
-public class SelectOneWidget extends QuestionWidget implements OnCheckedChangeListener {
+public class SelectOneWidget extends SelectQuestionWidget implements OnCheckedChangeListener {
 
     private final Vector<SelectChoice> mItems;
     private final int buttonIdBase;
-    private Button clearButton;
 
     private final Vector<RadioButton> buttons;
 
@@ -106,17 +102,6 @@ public class SelectOneWidget extends QuestionWidget implements OnCheckedChangeLi
             }
             addClearButton(context, s != null && !prompt.isReadOnly());
         }
-    }
-
-    private void addClearButton(Context context, boolean show) {
-        clearButton = (Button) LayoutInflater.from(context).inflate(R.layout.blue_outlined_button, this, false);
-        clearButton.setText(Localization.get("button.clear.title"));
-        clearButton.setVisibility(show ? VISIBLE : GONE);
-        clearButton.setOnClickListener(view -> {
-            clearAnswer();
-            widgetEntryChanged();
-        });
-        addView(clearButton);
     }
 
     @Override

--- a/app/src/org/commcare/views/widgets/SelectQuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/SelectQuestionWidget.java
@@ -1,0 +1,36 @@
+package org.commcare.views.widgets;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.widget.Button;
+
+import org.commcare.dalvik.R;
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.form.api.FormEntryPrompt;
+
+/**
+ * @author $|-|!˅@M
+ */
+public abstract class SelectQuestionWidget extends QuestionWidget {
+
+    protected Button clearButton;
+
+    public SelectQuestionWidget(Context context, FormEntryPrompt p) {
+        super(context, p);
+    }
+
+    public SelectQuestionWidget(Context context, FormEntryPrompt p, boolean inCompactGroup) {
+        super(context, p, inCompactGroup);
+    }
+
+    protected void addClearButton(Context context, boolean show) {
+        clearButton = (Button) LayoutInflater.from(context).inflate(R.layout.blue_outlined_button, this, false);
+        clearButton.setText(Localization.get("button.clear.title"));
+        clearButton.setVisibility(show ? VISIBLE : GONE);
+        clearButton.setOnClickListener(view -> {
+            clearAnswer();
+            widgetEntryChanged();
+        });
+        addView(clearButton);
+    }
+}


### PR DESCRIPTION
I had only added clear button support to `SelectOneWidget` earlier. This PR will add clear button to the `SelectOneAutoAdvanceWidget` as well. 

![Screenshot_2020-09-17-15-27-43-703_org commcare dalvik debug](https://user-images.githubusercontent.com/29516995/93455944-a3b0b200-f8fa-11ea-8414-9af3091f406e.jpg)
