### PR TITLE
Fixes XForm Uninstall

### DIFF
--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -130,13 +130,14 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
                 if (formDefRecord.getResourceVersion() == r.getVersion()) { // check if the record corresponds to the same resource we are uninstalling
                     platform.deregisterForm(formDefRecord.getJrFormId(), formDefId);
                     platform.getFormDefStorage().remove(formDefId);
+                    return super.uninstall(r, platform);
                 }
             } catch (NoSuchElementException e) {
                 // no form with the formDefId exists somehow so just log the failure
                 Logger.log(LogTypes.TYPE_MAINTENANCE,
                         "No form record with id " + formDefId + " was found while uninstalling the resource");
             }
-            return super.uninstall(r, platform);
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1904

It's a regression of https://github.com/dimagi/commcare-android/pull/2297/files where I am calling `super.uninstall` at a wrong place as we should only remove the associlated XForm files when we remove the corresponding form def entry from the DB. 

