### PR TITLE
fix update completion indicator in case of background update

### DIFF
--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -188,8 +188,9 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
 
         // Update Stats are only maintained in case of an unsuccessful update,
         // so check whether we have a ready to install update instead
-        if (lastUpdateResult == null && ResourceInstallUtils.isUpdateReadyToInstall()) {
-            lastUpdateResult = new ResultAndError<>(AppInstallStatus.UpdateStaged);
+        if (lastUpdateResult == null) {
+            lastUpdateResult = ResourceInstallUtils.isUpdateReadyToInstall() ? new ResultAndError<>(AppInstallStatus.UpdateStaged)
+                    : new ResultAndError<>(AppInstallStatus.UnknownFailure);
         }
         return lastUpdateResult;
     }

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -177,17 +177,21 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
                                 data.getInt(UpdateWorker.Progress_Total, -1));
                     } else {
                         // Worker getting fired when not running imply completion of worker
-                        ResultAndError<AppInstallStatus> lastUpdateResult = getlastStageUpdateResult();
-                        if (lastUpdateResult != null) {
-                            handleTaskCompletion(getlastStageUpdateResult());
-                        }
+                        handleTaskCompletion(getlastStageUpdateResult());
                     }
                 });
     }
 
     private ResultAndError<AppInstallStatus> getlastStageUpdateResult() {
         UpdateStats updateStats = UpdateStats.loadUpdateStats(CommCareApplication.instance().getCurrentApp());
-        return updateStats.getLastStageUpdateResult();
+        ResultAndError<AppInstallStatus> lastUpdateResult = updateStats.getLastStageUpdateResult();
+
+        // Update Stats are only maintained in case of an unsuccessful update,
+        // so check whether we have a ready to install update instead
+        if (lastUpdateResult == null && ResourceInstallUtils.isUpdateReadyToInstall()) {
+            lastUpdateResult = new ResultAndError<>(AppInstallStatus.UpdateStaged);
+        }
+        return lastUpdateResult;
     }
 
     @Override
@@ -413,7 +417,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
 
     public void stopUpdateCheck() {
 
-        if(isAutoUpdateInProgress()){
+        if (isAutoUpdateInProgress()) {
             UpdateHelper.cancelUpdateWorker();
         }
 


### PR DESCRIPTION
Issue: When user opens up the Update check while a background update is in progress, the update UI fails to transition to update "ready to install" state because of incorrect check on updateStats in case of a success