### PR TITLE
Orphan Progress dialog fix

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -7,11 +7,6 @@ import android.content.DialogInterface;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
-
-import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.fragment.app.FragmentManager;
-
 import android.text.Spannable;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -62,6 +57,9 @@ import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
 
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 
@@ -112,7 +110,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
      * so that the dialog can be shown when fragments have fully resumed.
      */
     private boolean triedBlockingWhilePaused;
-    private int taskIdForPendingDismissal = -1;
+    private int taskIdForPendingDismissal = UNDEFINED_TASK_ID;
 
     /**
      * Store the id of a task progress dialog so it can be disabled/enabled

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -620,6 +620,7 @@ public abstract class CommCareActivity<R> extends FragmentActivity
                 taskIdForPendingDismissal = taskId;
             } else {
                 progressDialog.dismiss();
+                getSupportFragmentManager().executePendingTransactions();
             }
         }
     }

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -62,21 +62,18 @@ import org.commcare.models.FormRecordProcessor;
 import org.commcare.models.ODKStorage;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.tasks.FormLoaderTask;
-import org.commcare.tasks.FormRecordCleanupTask;
 import org.commcare.tasks.SaveToDiskTask;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.Base64Wrapper;
 import org.commcare.utils.CompoundIntentList;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.GeoUtils;
-import org.commcare.utils.QuarantineUtil;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.utils.StringUtils;
 import org.commcare.views.QuestionsView;
 import org.commcare.views.ResizingImageView;
 import org.commcare.views.UserfacingErrorHandling;
 import org.commcare.views.dialogs.CustomProgressDialog;
-import org.commcare.views.media.MediaLayout;
 import org.commcare.views.widgets.BarcodeWidget;
 import org.commcare.views.widgets.ImageWidget;
 import org.commcare.views.widgets.IntentWidget;
@@ -980,7 +977,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 @Override
                 protected void deliverError(FormEntryActivity receiver, Exception e) {
                     receiver.setFormLoadFailure();
-                    receiver.dismissProgressDialog();
+                    receiver.dismissProgressDialogForTask(taskId);
 
                     if (e != null) {
                         UserfacingErrorHandling.createErrorDialog(receiver, e.getMessage(), FormEntryConstants.EXIT);
@@ -1281,7 +1278,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             //InstrumentationUtils.printCachedAndNotCachedExpressions(this.traceReporter, "CACHED AND NOT CACHED EXPRESSIONS:");
         }
 
-        dismissProgressDialog();
+        dismissCurrentProgressDialog();
         reportFormExitTime();
         finish();
     }

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -258,7 +258,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         if (purgeTask != null) {
             try {
                 purgeTask.unregisterTaskListener(this);
-                dismissProgressDialog();
+                dismissProgressDialogForTask(PurgeStaleArchivedFormsTask.PURGE_STALE_ARCHIVED_FORMS_TASK_ID);
             } catch (TaskListenerRegistrationException e) {
                 Log.e(TAG, "Attempting to unregister a not previously " +
                         "registered TaskListener.");
@@ -695,7 +695,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
      */
     @Override
     public void handleTaskCompletion(Void result) {
-        dismissProgressDialog();
+        dismissProgressDialogForTask(PurgeStaleArchivedFormsTask.PURGE_STALE_ARCHIVED_FORMS_TASK_ID);
 
         // reload form list to make sure purged forms aren't shown
         if (adapter != null) {
@@ -708,6 +708,6 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
      */
     @Override
     public void handleTaskCancellation() {
-        dismissProgressDialog();
+        dismissProgressDialogForTask(PurgeStaleArchivedFormsTask.PURGE_STALE_ARCHIVED_FORMS_TASK_ID);
     }
 }

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -300,7 +300,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
     @Override
     public void handleTaskCompletion(ResultAndError<AppInstallStatus> result) {
         if (CommCareApplication.instance().isConsumerApp()) {
-            dismissProgressDialog();
+            dismissProgressDialogForTask(DIALOG_CONSUMER_APP_UPGRADE);
         }
 
         if (result.data == AppInstallStatus.UpdateStaged) {

--- a/app/src/org/commcare/provider/ExternalApiReceiver.java
+++ b/app/src/org/commcare/provider/ExternalApiReceiver.java
@@ -11,8 +11,6 @@ import org.commcare.CommCareApplication;
 import org.commcare.activities.LoginMode;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.global.models.AndroidSharedKeyRecord;
-import org.commcare.android.database.user.models.FormRecord;
-import org.commcare.dalvik.R;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.encryption.ByteEncrypter;
 import org.commcare.preferences.ServerUrls;
@@ -23,14 +21,12 @@ import org.commcare.tasks.ResultAndError;
 import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.tasks.templates.CommCareTaskConnector;
 import org.commcare.utils.FormUploadResult;
-import org.commcare.utils.StorageUtils;
 import org.javarosa.core.model.User;
 import org.javarosa.core.services.locale.Localization;
 
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.util.NoSuchElementException;
-import java.util.Vector;
 
 /**
  * This broadcast receiver is the central point for incoming API calls from other apps.
@@ -70,7 +66,7 @@ public class ExternalApiReceiver extends BroadcastReceiver {
         }
 
         @Override
-        public void stopTaskTransition() {
+        public void stopTaskTransition(int taskId) {
         }
 
         @Override

--- a/app/src/org/commcare/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/tasks/templates/CommCareTask.java
@@ -72,7 +72,7 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
                 connector.stopBlockingForTask(getTaskId());
                 connector.taskCancelled();
                 handleCancellation(connector.getReceiver());
-                connector.stopTaskTransition();
+                connector.stopTaskTransition(taskId);
             }
         }
     }
@@ -92,7 +92,7 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
                 } else {
                     deliverResult(connector.getReceiver(), result);
                 }
-                connector.stopTaskTransition();
+                connector.stopTaskTransition(taskId);
             }
         }
     }

--- a/app/src/org/commcare/tasks/templates/CommCareTaskConnector.java
+++ b/app/src/org/commcare/tasks/templates/CommCareTaskConnector.java
@@ -44,8 +44,9 @@ public interface CommCareTaskConnector<R> {
      * Should be called at the end of onPreExecute or onCancelled for any
      * CommCareTask, indicating that we are ending a potential transition from
      * one task to another
+     * @param taskId
      */
-    void stopTaskTransition();
+    void stopTaskTransition(int taskId);
 
     void hideTaskCancelButton();
 }

--- a/app/src/org/commcare/views/dialogs/DialogController.java
+++ b/app/src/org/commcare/views/dialogs/DialogController.java
@@ -11,9 +11,15 @@ public interface DialogController {
     void showProgressDialog(int taskId);
 
     /**
+     * Should dismiss the dialog fragment belonging to given taskId
+     * @param taskId
+     */
+    void dismissProgressDialogForTask(int taskId);
+
+    /**
      * Should dismiss the current dialog fragment
      */
-    void dismissProgressDialog();
+    void dismissCurrentProgressDialog();
 
     /**
      * Return the dialog that is currently showing, or null

--- a/app/unit-tests/src/org/commcare/activities/DataPullControllerMock.java
+++ b/app/unit-tests/src/org/commcare/activities/DataPullControllerMock.java
@@ -48,7 +48,7 @@ public class DataPullControllerMock implements DataPullController, CommCareTaskC
     }
 
     @Override
-    public void stopTaskTransition() {
+    public void stopTaskTransition(int taskId) {
 
     }
 

--- a/app/unit-tests/src/org/commcare/android/mocks/CommCareTaskConnectorFake.java
+++ b/app/unit-tests/src/org/commcare/android/mocks/CommCareTaskConnectorFake.java
@@ -40,7 +40,7 @@ public class CommCareTaskConnectorFake<R> implements CommCareTaskConnector<R> {
     }
 
     @Override
-    public void stopTaskTransition() {
+    public void stopTaskTransition(int taskId) {
 
     }
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-1893

Because we were using `dialog.show` instead of `dialog.showNow`, it allowed Fragment manager to lazily execute on committed fragment transactions resulting in a state where `dismiss` was called even before the `show` transaction executes resulting in a hanging progress dialog as described in the JIRA linked above. 

This PR changes the `showProgressDialog` to use `dialog.showNow` and then make other supporting changes so that a task only dismisses the progress dialog generated by itself. This is done to avoid incorrect dialog cancellation in case of a task transition. For example in case of sync, if we don't use task specific dialog cancellation the `DataPullTask` new dialog gets cancelled by the concluding `ProcessAndSendTask` dismiss dialog call resulting in the pull task dialog to never gets visible. 

It is not clear to me why this issue is only surfacing now in 2.50. Nothing related seems to have changed in between 2.49 and 2.50 and the whole code path is same line to line. 
