### PR TITLE
Lazy Media fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation 'androidx.work:work-testing:2.4.0'
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2"
     testImplementation "io.mockk:mockk:1.10.0"
     testImplementation 'org.json:json:20140107'
     testImplementation project(path: ':commcare-core', configuration: 'testsAsJar')

--- a/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
+++ b/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
@@ -1,6 +1,5 @@
 package org.commcare.mediadownload
 
-import android.util.Log
 import androidx.annotation.WorkerThread
 import androidx.work.*
 import kotlinx.coroutines.*
@@ -11,12 +10,11 @@ import org.commcare.engine.resource.AndroidResourceUtils
 import org.commcare.engine.resource.AppInstallStatus
 import org.commcare.engine.resource.ResourceInstallUtils
 import org.commcare.engine.resource.installers.LocalStorageUnavailableException
-import org.commcare.preferences.HiddenPreferences
-import org.commcare.resources.model.*
 import org.commcare.network.RequestStats
+import org.commcare.preferences.HiddenPreferences
 import org.commcare.resources.ResourceInstallContext
+import org.commcare.resources.model.*
 import org.commcare.tasks.ResultAndError
-import org.commcare.util.LogTypes
 import org.commcare.utils.AndroidCommCarePlatform
 import org.commcare.utils.FileUtil
 import org.commcare.utils.StringUtils
@@ -24,7 +22,6 @@ import org.commcare.views.dialogs.PinnedNotificationWithProgress
 import org.commcare.views.notifications.NotificationMessage
 import org.commcare.views.notifications.NotificationMessageFactory
 import org.javarosa.core.services.Logger
-import java.lang.Exception
 import java.util.concurrent.TimeUnit
 
 // Contains helper functions to download lazy or missing media resources
@@ -229,12 +226,9 @@ object MissingMediaDownloadHelper : TableStateListener {
                 ResultAndError(AppInstallStatus.Installed)
             } else {
                 platform.globalResourceTable.recoverResource(it, platform, ResourceInstallUtils.getProfileReference(), ResourceInstallContext(source))
-                Log.w("shubham", "cp")
                 ResultAndError(AppInstallStatus.Installed)
             }
         } catch (e: Exception) {
-            Log.w("shubham", "cp1")
-            e.printStackTrace()
             handleRecoverResourceFailure(e)
         } finally {
             withContext(Dispatchers.Main) {

--- a/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
+++ b/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
@@ -158,9 +158,6 @@ object MissingMediaDownloadHelper : TableStateListener {
     @JvmStatic
     fun requestMediaDownload(mediaUri: String, defaultDispatcher: CoroutineDispatcher,
                              missingMediaDownloadListener: MissingMediaDownloadListener) {
-        // We want the foreground downloads to take priority, so cancel any ongoing background download
-        WorkManager.getInstance(CommCareApplication.instance()).cancelUniqueWork(getMissingMediaDownloadRequestName())
-
         jobs.add(
                 CoroutineScope(defaultDispatcher).launch {
                     var result: MissingMediaDownloadResult = MissingMediaDownloadResult.Error("Unknown Error")

--- a/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
+++ b/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
@@ -158,6 +158,9 @@ object MissingMediaDownloadHelper : TableStateListener {
     @JvmStatic
     fun requestMediaDownload(mediaUri: String, defaultDispatcher: CoroutineDispatcher,
                              missingMediaDownloadListener: MissingMediaDownloadListener) {
+        // We want the foreground downloads to take priority, so cancel any ongoing background download
+        WorkManager.getInstance(CommCareApplication.instance()).cancelUniqueWork(getMissingMediaDownloadRequestName())
+
         jobs.add(
                 CoroutineScope(defaultDispatcher).launch {
                     var result: MissingMediaDownloadResult = MissingMediaDownloadResult.Error("Unknown Error")

--- a/app/src/org/commcare/views/media/MediaLayout.java
+++ b/app/src/org/commcare/views/media/MediaLayout.java
@@ -211,6 +211,7 @@ public class MediaLayout extends ConstraintLayout {
                 videoButton.setImageResource(mediaPresent ? android.R.drawable.ic_media_play : R.drawable.update_download_icon);
                 AndroidUtil.showToast(getContext(), R.string.media_download_completed);
                 videoButton.setVisibility(VISIBLE);
+                videoButton.invalidate();
             } else if (result instanceof MissingMediaDownloadResult.InProgress) {
                 AndroidUtil.showToast(getContext(), R.string.media_download_in_progress);
             } else {

--- a/app/src/org/commcare/views/media/MediaLayout.java
+++ b/app/src/org/commcare/views/media/MediaLayout.java
@@ -379,7 +379,7 @@ public class MediaLayout extends ConstraintLayout {
                     progressBar.setVisibility(GONE);
                     downloadIcon.setVisibility(VISIBLE);
                     downloadIcon.setEnabled(true);
-                    missingMediaStatus.setText(StringUtils.getStringRobust(getContext(), R.string.media_download_failed));
+                    missingMediaStatus.setText(result.getMessage());
                 }
             });
         });

--- a/app/src/org/commcare/views/media/MediaLayout.java
+++ b/app/src/org/commcare/views/media/MediaLayout.java
@@ -211,7 +211,6 @@ public class MediaLayout extends ConstraintLayout {
                 videoButton.setImageResource(mediaPresent ? android.R.drawable.ic_media_play : R.drawable.update_download_icon);
                 AndroidUtil.showToast(getContext(), R.string.media_download_completed);
                 videoButton.setVisibility(VISIBLE);
-                videoButton.invalidate();
             } else if (result instanceof MissingMediaDownloadResult.InProgress) {
                 AndroidUtil.showToast(getContext(), R.string.media_download_in_progress);
             } else {

--- a/app/unit-tests/src/org/commcare/mediadownload/LazyMediaDownloadTest.kt
+++ b/app/unit-tests/src/org/commcare/mediadownload/LazyMediaDownloadTest.kt
@@ -17,11 +17,13 @@ import org.commcare.android.util.UpdateUtils
 import org.commcare.engine.resource.AppInstallStatus
 import org.commcare.network.RequestStats
 import org.commcare.resources.model.InstallRequestSource
+import org.commcare.rules.MainCoroutineRule
 import org.commcare.utils.FileUtil
 import org.commcare.utils.TimeProvider
 import org.hamcrest.CoreMatchers
 import org.junit.Assert.*
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -32,6 +34,10 @@ import java.util.*
 class LazyMediaDownloadTest {
 
     private lateinit var context: Context
+
+    @get:Rule
+    var mainCoroutineRule = MainCoroutineRule()
+
 
     companion object {
         const val REF_BASE_DIR = "jr://resource/commcare-apps/update_tests/"
@@ -70,7 +76,7 @@ class LazyMediaDownloadTest {
     }
 
     @Test
-    fun testLazyMediaDownloadInForeground() {
+    fun testLazyMediaDownloadInForeground() = mainCoroutineRule.runBlockingTest {
         updateToAnAppWithLazyMedia()
         assertFalse(FileUtil.referenceFileExists(LAZY_MEDIA_REF))
         MissingMediaDownloadHelper.requestMediaDownload(LAZY_MEDIA_REF, Dispatchers.Main, object : MissingMediaDownloadListener {

--- a/app/unit-tests/src/org/commcare/rules/MainCoroutineRule.kt
+++ b/app/unit-tests/src/org/commcare/rules/MainCoroutineRule.kt
@@ -1,0 +1,29 @@
+package org.commcare.rules
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class MainCoroutineRule(val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description?) {
+        super.starting(description)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    fun runBlockingTest(block: suspend () -> Unit) =
+            this.testDispatcher.runBlockingTest {
+                block()
+            }
+}


### PR DESCRIPTION
* https://dimagi-dev.atlassian.net/browse/QA-1906 - was happening because of a NPE on `mResourceInProgressListener` which was getting set to null on a background thread and later on accessed on UI thread without null check. 

* https://dimagi-dev.atlassian.net/browse/QA-1915 - Error message correction


* Earlier the `recoverResource` which gets fired by both background worker and the foreground download was invoking the UI thread to notify the listener. This logic is now moved to the `downloadResource` which is invoked by foreground download process only to avoid the background worker suspending because of unavailablity of the main thread. 
