### PR TITLE
Fix audio button clipping on small devices

### DIFF
--- a/app/res/layout/audio_prototype.xml
+++ b/app/res/layout/audio_prototype.xml
@@ -30,7 +30,7 @@
             android:layout_marginEnd="10dp" />
 
         <TextView
-            android:layout_width="250dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/grey"
             android:id="@+id/recording_text"/>


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/QA-1919
With small devices, the `250dp` width of `textView` would push the audio button to the left of the screen(outside of parent `LinearLayout`) causing it to be clipped.