### PR TITLE
Removes default flags for RefreshToLatestBuildReceiver

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -350,9 +350,7 @@
             </intent-filter>
         </receiver>
 
-        <receiver android:name="org.commcare.provider.RefreshToLatestBuildReceiver"
-            android:enabled="true"
-            android:exported="true" >
+        <receiver android:name="org.commcare.provider.RefreshToLatestBuildReceiver">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.api.action.RefreshToLatestBuildAction"/>
                 <category android:name="android.intent.category.DEFAULT"/>


### PR DESCRIPTION
It's really a no-op since both `enabled` and `exported` takes the removed values by default. 