### PR TITLE
Fix for login using PIN when no User exists for a UserKeyRecord

### DIFF
--- a/app/src/org/commcare/activities/DataPullController.java
+++ b/app/src/org/commcare/activities/DataPullController.java
@@ -18,7 +18,7 @@ public interface DataPullController {
         CCZ_DEMO
     }
 
-    void startDataPull(DataPullMode mode);
+    void startDataPull(DataPullMode mode, String password);
 
     void dataPullCompleted();
 

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -202,7 +202,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     }
 
     @Override
-    public void startDataPull(DataPullMode mode) {
+    public void startDataPull(DataPullMode mode, String password) {
         switch (mode) {
             case CONSUMER_APP:
                 formAndDataSyncer.performLocalRestore(this, getUniformUsername(),
@@ -215,8 +215,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
                 formAndDataSyncer.performDemoUserRestore(this, offlineUserRestore);
                 break;
             case NORMAL:
-                formAndDataSyncer.performOtaRestore(this, getUniformUsername(),
-                        uiController.getEnteredPasswordOrPin());
+                formAndDataSyncer.performOtaRestore(this, getUniformUsername(), password);
                 break;
         }
     }
@@ -598,7 +597,8 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         }
 
         // If local login was not successful
-        startDataPull(CommCareApplication.instance().isConsumerApp() ? DataPullMode.CONSUMER_APP : DataPullMode.NORMAL);
+        startDataPull(CommCareApplication.instance().isConsumerApp() ? DataPullMode.CONSUMER_APP : DataPullMode.NORMAL,
+                uiController.getEnteredPasswordOrPin());
     }
 
     @Override

--- a/app/src/org/commcare/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/tasks/ManageKeyRecordTask.java
@@ -150,7 +150,7 @@ public abstract class ManageKeyRecordTask<R extends DataPullController> extends 
 
     protected void keysReadyForSync(R receiver) {
         // TODO: we only wanna do this on the _first_ try. Not subsequent ones (IE: On return from startDataPull)
-        receiver.startDataPull(this.dataPullMode);
+        receiver.startDataPull(this.dataPullMode, password);
     }
 
     protected void keysLoginComplete(R receiver) {

--- a/app/unit-tests/src/org/commcare/activities/DataPullControllerMock.java
+++ b/app/unit-tests/src/org/commcare/activities/DataPullControllerMock.java
@@ -58,7 +58,7 @@ public class DataPullControllerMock implements DataPullController, CommCareTaskC
     }
 
     @Override
-    public void startDataPull(DataPullMode mode) {
+    public void startDataPull(DataPullMode mode, String password) {
 
     }
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SUPPORT-4456 (Issue 1)

Repro: 

1. Install App A, Login as user X and set Pin
2. Install App B, Login as same user X and set Pin
3. Uninstall App A (this deleted the User X DB)
4. Login using pin in App B
5. Login fails 

Issue happens because the `DataPullTask` always expects a `password` and [in cases when there is no user in DB for the UKR](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/tasks/ManageKeyRecordTask.java#L121) we were sending a pin as password to the `DataPullTask`
