### PR TITLE
Use flexible font size for label and list widgets

### DIFF
--- a/app/src/org/commcare/views/widgets/LabelWidget.java
+++ b/app/src/org/commcare/views/widgets/LabelWidget.java
@@ -38,7 +38,6 @@ import java.util.Vector;
 public class LabelWidget extends QuestionWidget {
     private static final String TAG = LabelWidget.class.getSimpleName();
     private static final int RANDOM_BUTTON_ID = 4853487;
-    private final static int TEXTSIZE = 21;
 
     private LinearLayout questionLayout;
 
@@ -122,7 +121,7 @@ public class LabelWidget extends QuestionWidget {
                 // button because it aligns horizontally, and we want the label on top
                 label = new TextView(getContext());
                 setChoiceText(label, mItems.get(i));
-                label.setTextSize(TypedValue.COMPLEX_UNIT_DIP, TEXTSIZE);
+                label.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mQuestionFontSize);
 
                 // answer layout holds the label text/image on top and the radio button on bottom
                 LinearLayout answer = new LinearLayout(getContext());
@@ -191,7 +190,7 @@ public class LabelWidget extends QuestionWidget {
         // Add the text view. Textview always exists, regardless of whether there's text.
         mQuestionText = new TextView(getContext());
         setQuestionText(mQuestionText, mPrompt);
-        mQuestionText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, TEXTSIZE);
+        mQuestionText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mQuestionFontSize);
         mQuestionText.setTypeface(null, Typeface.BOLD);
         mQuestionText.setPadding(0, 0, 0, 7);
         mQuestionText.setId(RANDOM_BUTTON_ID); // assign random id

--- a/app/src/org/commcare/views/widgets/ListMultiWidget.java
+++ b/app/src/org/commcare/views/widgets/ListMultiWidget.java
@@ -48,7 +48,6 @@ public class ListMultiWidget extends QuestionWidget {
 
     private final int buttonIdBase;
     private final static int CHECKBOX_ID = 100;
-    private final static int TEXTSIZE = 21;
 
     // Holds the entire question and answers. It is a horizontally aligned linear layout
     private LinearLayout questionLayout;
@@ -176,7 +175,7 @@ public class ListMultiWidget extends QuestionWidget {
                 // button because it aligns horizontally, and we want the label on top
                 TextView label = new TextView(getContext());
                 setChoiceText(label, mItems.get(i));
-                label.setTextSize(TypedValue.COMPLEX_UNIT_DIP, TEXTSIZE);
+                label.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mQuestionFontSize);
                 if (!displayLabel) {
                     label.setVisibility(View.GONE);
                 }
@@ -280,7 +279,7 @@ public class ListMultiWidget extends QuestionWidget {
         // Add the text view. Textview always exists, regardless of whether there's text.
         TextView questionText = new TextView(getContext());
         setQuestionText(questionText, mPrompt);
-        questionText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, TEXTSIZE);
+        questionText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mQuestionFontSize);
         questionText.setTypeface(null, Typeface.BOLD);
         questionText.setPadding(0, 0, 0, 7);
         questionText.setId(buttonIdBase); // assign random id

--- a/app/src/org/commcare/views/widgets/ListWidget.java
+++ b/app/src/org/commcare/views/widgets/ListWidget.java
@@ -47,7 +47,6 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
     private static final String TAG = ListWidget.class.getSimpleName();
 
     private final int buttonIdBase;
-    private final static int TEXTSIZE = 21;
 
     // Holds the entire question and answers. It is a horizontally aligned linear layout
     private LinearLayout questionLayout;
@@ -155,7 +154,7 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
                 // button because it aligns horizontally, and we want the label on top
                 TextView label = new TextView(getContext());
                 setChoiceText(label, mItems.get(i));
-                label.setTextSize(TypedValue.COMPLEX_UNIT_DIP, TEXTSIZE);
+                label.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mQuestionFontSize);
                 if (!displayLabel) {
                     label.setVisibility(View.GONE);
                 }
@@ -271,7 +270,7 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
         // Add the text view. Textview always exists, regardless of whether there's text.
         TextView questionText = new TextView(getContext());
         setQuestionText(questionText, mPrompt);
-        questionText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, TEXTSIZE);
+        questionText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mQuestionFontSize);
         questionText.setTypeface(null, Typeface.BOLD);
         questionText.setPadding(0, 0, 0, 7);
         questionText.setId(buttonIdBase); // assign random id


### PR DESCRIPTION
Fixes a bug where changing the form-fonts from the form-entry-preferences, won't have any effects on the texts of these widgets. 