### PR TITLE
Add option to re-run failing espresso tests

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -14,7 +14,7 @@ def appendData(command, dataUrl):
     var = "file=@{}".format(dataUrl)
     return command + " " + json.dumps(var)
 
-def buildTestCommand(appToken, testToken):
+def buildTestCommand(appToken, testToken, classes=None):
     test = {}
     if "BROWSERSTACK_DEVICES" in os.environ:
         list = os.environ["BROWSERSTACK_DEVICES"]
@@ -27,7 +27,67 @@ def buildTestCommand(appToken, testToken):
     test["deviceLogs"] = True
     test["testSuite"] = testToken
     test["networkLogs"] = True
+
+    if classes:
+        test["class"] = classes
+
     return json.dumps(json.dumps(test))
+
+def isSuccessfulBuild(buildId):
+    resultCommand = 'curl -u "{}:{}" -X GET "https://api-cloud.browserstack.com/app-automate/espresso/v2/builds/{}"'.format(userName, password, buildId)
+    result = subprocess.Popen(shlex.split(resultCommand), stdout=PIPE, stderr=None, shell=False)
+    status = json.loads(result.communicate()[0])["status"]
+
+    while status == "running":
+        print("Waiting for tests on browserstack to complete")
+        time.sleep(120)
+        result = subprocess.Popen(shlex.split(resultCommand), stdout=PIPE, stderr=None, shell=False)
+        status = json.loads(result.communicate()[0])["status"]
+
+    return status
+
+
+def testResult(buildId):
+    status = isSuccessfulBuild(buildId)
+
+    # if test succeeded then we can simply return from here.
+    if (status == "passed"):
+        return
+
+    # Otherwise run the failing test one more time.
+
+    # Get the sessionID from test result
+    resultCommand = 'curl -u "{}:{}" -X GET "https://api-cloud.browserstack.com/app-automate/espresso/v2/builds/{}"'.format(userName, password, buildId)
+    result = subprocess.Popen(shlex.split(resultCommand), stdout=PIPE, stderr=None, shell=False)
+    sessionId = json.loads(result.communicate()[0])["devices"][0]["sessions"][0]["id"]
+
+    # Gather the sessionDetails
+    testDetailsCommand = 'curl -u "{}:{}" -X GET "https://api-cloud.browserstack.com/app-automate/espresso/v2/builds/{}/sessions/{}"'.format(userName, password, buildId, sessionId)
+    testDetailsResult = subprocess.Popen(shlex.split(testDetailsCommand), stdout=PIPE, stderr=None, shell=False)
+    testcases = json.loads(testDetailsResult.communicate()[0])["testcases"]["data"]
+
+    # Create an array of failing classes.
+    classes = []
+    for testcase in testcases:
+        methods = testcase["testcases"]
+        for method in methods:
+            if (method["status"] != "passed"):
+                classes.append("org.commcare.androidTests." + testcase["class"])
+                break
+
+    # Now that we know all the test-classes that are failing, we can re-run those.
+
+    runConfig = buildTestCommand(appToken, testToken, classes)
+    runCmd = 'curl -X POST "{}" -d \ {} -H "Content-Type: application/json" -u "{}:{}"'.format(espressoUrl, runConfig, userName, password)
+    output = subprocess.Popen(shlex.split(runCmd), stdout=PIPE, stderr=None, shell=False).communicate()
+    buildId = json.loads(output[0])["build_id"]
+
+    status = isSuccessfulBuild(buildId)
+
+    if (status != "passed"):
+        print("Instrumentation Tests Failed. Visit browserstack dashboard for more details.")
+        sys.exit(-1)
+
 
 if __name__ == "__main__":
 
@@ -65,18 +125,4 @@ if __name__ == "__main__":
     buildId = json.loads(output[0])["build_id"]
 
     # Get the result of the test build
-
-    resultCommand = 'curl -u "{}:{}" -X GET "https://api-cloud.browserstack.com/app-automate/espresso/builds/{}"'.format(userName, password, buildId)
-
-    result = subprocess.Popen(shlex.split(resultCommand), stdout=PIPE, stderr=None, shell=False)
-    status = json.loads(result.communicate()[0])["status"]
-
-    while status == "running":
-        print("Waiting for tests on browserstack to complete")
-        time.sleep(60)
-        result = subprocess.Popen(shlex.split(resultCommand), stdout=PIPE, stderr=None, shell=False)
-        status = json.loads(result.communicate()[0])["status"]
-
-    if (status == "failed" or status == "error"):
-        print("Instrumentation Tests Failed. Visit browserstack dashboard for more details.")
-        sys.exit(-1)
+    testResult(buildId)

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -76,6 +76,7 @@ def testResult(buildId):
                 break
 
     # Now that we know all the test-classes that are failing, we can re-run those.
+    print("Failing test classes :: ", classes)
 
     runConfig = buildTestCommand(appToken, testToken, classes)
     runCmd = 'curl -X POST "{}" -d \ {} -H "Content-Type: application/json" -u "{}:{}"'.format(espressoUrl, runConfig, userName, password)
@@ -86,6 +87,7 @@ def testResult(buildId):
 
     if (status != "passed"):
         print("Instrumentation Tests Failed. Visit browserstack dashboard for more details.")
+        print("https://app-automate.browserstack.com/dashboard/v2/builds/{}".format(buildId))
         sys.exit(-1)
 
 


### PR DESCRIPTION
Using this change, we'll now be able to re-run only the failing test classes on browserstack one more time before marking the build as success/failure.