### PR TITLE
[2.50.3] Deletes Raw Folder on Form Completion + Free Disk space Analytics

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -96,6 +96,7 @@ import org.commcare.utils.PendingCalcs;
 import org.commcare.utils.SessionActivityRegistration;
 import org.commcare.utils.SessionStateUninitException;
 import org.commcare.utils.SessionUnavailableException;
+import org.commcare.views.widgets.CleanRawMedia;
 import org.conscrypt.Conscrypt;
 import org.javarosa.core.model.User;
 import org.javarosa.core.reference.ReferenceManager;
@@ -146,6 +147,7 @@ public class CommCareApplication extends MultiDexApplication {
     public static final int STATE_MIGRATION_FAILED = 16;
     public static final int STATE_MIGRATION_QUESTIONABLE = 32;
     private static final String DELETE_LOGS_REQUEST = "delete-logs-request";
+    private static final String CLEAN_RAW_MEDIA_REQUEST = "clean-raw-media-request";
     private static final long BACKOFF_DELAY_FOR_UPDATE_RETRY = 5 * 60 * 1000L; // 5 mins
     private static final long BACKOFF_DELAY_FOR_FORM_SUBMISSION_RETRY = 5 * 60 * 1000L; // 5 mins
     private static final long PERIODICITY_FOR_FORM_SUBMISSION_IN_HOURS = 1;
@@ -766,6 +768,7 @@ public class CommCareApplication extends MultiDexApplication {
                         }
 
                         purgeLogs();
+                        cleanRawMedia();
 
                     }
 
@@ -790,6 +793,12 @@ public class CommCareApplication extends MultiDexApplication {
         startService(new Intent(this, CommCareSessionService.class));
         bindService(new Intent(this, CommCareSessionService.class), mConnection, Context.BIND_AUTO_CREATE);
         sessionServiceIsBinding = true;
+    }
+
+    private void cleanRawMedia() {
+        OneTimeWorkRequest cleanRawMediaRequest = new OneTimeWorkRequest.Builder(CleanRawMedia.class).build();
+        WorkManager.getInstance(CommCareApplication.instance())
+                .enqueueUniqueWork(CLEAN_RAW_MEDIA_REQUEST, ExistingWorkPolicy.KEEP, cleanRawMediaRequest);
     }
 
     private void purgeLogs() {

--- a/app/src/org/commcare/DiskUtils.kt
+++ b/app/src/org/commcare/DiskUtils.kt
@@ -1,0 +1,19 @@
+package org.commcare
+
+import android.os.StatFs
+
+object DiskUtils {
+
+    /**
+     * Calculates and returns the amount of used disk space in bytes at the specified path.
+     *
+     * @param path Filesystem path at which to make the space calculations
+     * @return Amount of disk space used, in bytes
+     */
+     @JvmStatic
+     fun calculateFreeDiskSpaceInBytes(path: String?): Long {
+        val statFs = StatFs(path)
+        val blockSizeBytes = statFs.blockSize.toLong()
+        return blockSizeBytes * statFs.availableBlocks
+    }
+}

--- a/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
+++ b/app/src/org/commcare/activities/components/ImageCaptureProcessing.java
@@ -62,7 +62,7 @@ public class ImageCaptureProcessing {
         } else {
             // Otherwise, relocate the original image to a raw/ folder, so that we still have access
             // to the unmodified version
-            String rawDirPath = instanceFolder + "/raw";
+            String rawDirPath = getRawDirectoryPath(instanceFolder);
             File rawDir = new File(rawDirPath);
             if (!rawDir.exists()) {
                 rawDir.mkdir();
@@ -76,6 +76,11 @@ public class ImageCaptureProcessing {
             }
             return rawImageFile;
         }
+    }
+
+    // Returns path for the raw folder used to store the original images for a form
+    public static String getRawDirectoryPath(String instanceFolderPath){
+        return instanceFolderPath + "/raw";
     }
 
     /**

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
@@ -11,6 +11,7 @@ public class CCAnalyticsParam {
     static final String CC_APP_BUILD_PROFILE_ID = "cc_app_build_profile_id";
     static final String CCHQ_DOMAIN = "cchq_domain";
     static final String SERVER = "server";
+    static final String FREE_DISK = "free_disk";
 
     static final String ACTION_TYPE = "action_type";
     static final String DIRECTION = "direction";

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -2,11 +2,13 @@ package org.commcare.google.services.analytics;
 
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
 import android.text.TextUtils;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.commcare.CommCareApplication;
+import org.commcare.DiskUtils;
 import org.commcare.android.logging.ReportingUtils;
 import org.commcare.preferences.MainConfigurablePreferences;
 import org.commcare.suite.model.OfflineUserRestore;
@@ -80,6 +82,26 @@ public class FirebaseAnalyticsUtil {
         String serverName = ReportingUtils.getServerName();
         if (!TextUtils.isEmpty(serverName)) {
             analyticsInstance.setUserProperty(CCAnalyticsParam.SERVER, serverName);
+        }
+
+        String freeDiskBucket = getFreeDiskBucket();
+        if (!TextUtils.isEmpty(freeDiskBucket)) {
+            analyticsInstance.setUserProperty(CCAnalyticsParam.FREE_DISK, freeDiskBucket);
+        }
+    }
+
+    private static String getFreeDiskBucket() {
+        long freeDiskInMB = DiskUtils.calculateFreeDiskSpaceInBytes(Environment.getDataDirectory().getPath()) / 1000000;
+        if (freeDiskInMB > 1000) {
+            return "gt_1000";
+        } else if (freeDiskInMB > 500) {
+            return "lt_1000";
+        } else if (freeDiskInMB > 300) {
+            return "lt_500";
+        } else if (freeDiskInMB > 100) {
+            return "lt_300";
+        } else {
+            return "lt_100";
         }
     }
 

--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -48,6 +48,7 @@ public class HiddenPreferences {
     private final static String COMMCARE_UPDATE_CANCELLATION_COUNTER = "cc_update_cancellation_counter";
     private final static String DISABLE_RATE_LIMIT_POPUP = "disable-rate-limit-popup";
     private final static String LAZY_MEDIA_DOWNLOAD_COMPLETE = "lazy-media-download-complete";
+    private final static String RAW_MEDIA_CLEANUP_COMPLETE = "raw_media_cleanup_complete";
 
     // Preferences whose values are only ever set by being sent down from HQ via the profile file
     private final static String USE_MAPBOX_MAP = "cc-use-mapbox-map";
@@ -519,7 +520,6 @@ public class HiddenPreferences {
     }
 
     /**
-     *
      * @return whether the lazy media download has already completed successfully for this app version
      */
     public static boolean isLazyMediaDownloadComplete() {
@@ -534,5 +534,15 @@ public class HiddenPreferences {
 
     public static boolean allowRunOnRootedDevice() {
         return DeveloperPreferences.doesPropertyMatch(ALLOW_RUN_ON_ROOTED_DEVICE, PrefValues.YES, PrefValues.YES);
+    }
+
+    public static boolean isRawMediaCleanUpPending() {
+        return !CommCareApplication.instance().getCurrentApp().getAppPreferences()
+                .getBoolean(RAW_MEDIA_CLEANUP_COMPLETE, false);
+    }
+
+    public static void markRawMediaCleanUpComplete() {
+        CommCareApplication.instance().getCurrentApp().getAppPreferences()
+                .edit().putBoolean(RAW_MEDIA_CLEANUP_COMPLETE, true).apply();
     }
 }

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -4,6 +4,7 @@ import android.util.Log;
 
 import org.commcare.CommCareApplication;
 import org.commcare.activities.FormEntryActivity;
+import org.commcare.activities.components.ImageCaptureProcessing;
 import org.commcare.android.database.app.models.FormDefRecord;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.logging.ForceCloseLogger;
@@ -13,6 +14,7 @@ import org.commcare.models.database.SqlStorage;
 import org.commcare.models.encryption.EncryptionIO;
 import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.util.LogTypes;
+import org.commcare.utils.FileUtil;
 import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
@@ -228,7 +230,7 @@ public class SaveToDiskTask extends
 
             // delete the restore Xml file.
             if (!instanceXml.delete()) {
-                Log.e(TAG,
+                Logger.log(LogTypes.TYPE_MAINTENANCE,
                         "Error deleting " + instanceXml.getAbsolutePath()
                                 + " prior to renaming submission.xml");
                 return;
@@ -236,7 +238,13 @@ public class SaveToDiskTask extends
 
             // rename the submission.xml to be the instanceXml
             if (!submissionXml.renameTo(instanceXml)) {
-                Log.e(TAG, "Error renaming submission.xml to " + instanceXml.getAbsolutePath());
+                Logger.log(LogTypes.TYPE_MAINTENANCE,
+                        "Error renaming submission.xml to " + instanceXml.getAbsolutePath());
+            }
+
+            String rawDirPath = ImageCaptureProcessing.getRawDirectoryPath(instanceXml.getParent());
+            if(!FileUtil.deleteFileOrDir(rawDirPath)){
+                Logger.log(LogTypes.TYPE_MAINTENANCE, "Error deleting raw dir at path " + rawDirPath);
             }
         }
     }

--- a/app/src/org/commcare/utils/StorageUtils.java
+++ b/app/src/org/commcare/utils/StorageUtils.java
@@ -34,6 +34,18 @@ public class StorageUtils {
         return ids;
     }
 
+    @NonNull
+    public static Vector<Integer> getUnsentCompleteOrSavedFormIdsForCurrentApp(
+            SqlStorage<FormRecord> storage) {
+        String currentAppId =
+                CommCareApplication.instance().getCurrentApp().getAppRecord().getApplicationId();
+        Vector<Integer> ids = getUnsentOrUnprocessedFormIdsForCurrentApp(storage);
+        ids.addAll(storage.getIDsForValues(
+                new String[]{FormRecord.META_STATUS, FormRecord.META_APP_ID},
+                new Object[]{FormRecord.STATUS_SAVED, currentAppId}));
+        return ids;
+    }
+
     private static Vector<FormRecord> getUnsentOrUnprocessedFormRecordsForCurrentApp(
             SqlStorage<FormRecord> storage) {
 

--- a/app/src/org/commcare/views/widgets/CleanRawMedia.kt
+++ b/app/src/org/commcare/views/widgets/CleanRawMedia.kt
@@ -1,0 +1,42 @@
+package org.commcare.views.widgets
+
+import android.content.Context
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import org.commcare.CommCareApplication
+import org.commcare.activities.components.ImageCaptureProcessing
+import org.commcare.android.database.user.models.FormRecord
+import org.commcare.preferences.HiddenPreferences
+import org.commcare.utils.CrashUtil
+import org.commcare.utils.StorageUtils.getUnsentCompleteOrSavedFormIdsForCurrentApp
+import java.io.File
+
+class CleanRawMedia(appContext: Context, workerParams: WorkerParameters)
+    : Worker(appContext, workerParams) {
+
+    override fun doWork(): Result {
+        var success = true
+        if(HiddenPreferences.isRawMediaCleanUpPending()) {
+            val storage = CommCareApplication.instance().getUserStorage(FormRecord::class.java)
+            val recordsToRemove = getUnsentCompleteOrSavedFormIdsForCurrentApp(storage)
+            for (formId in recordsToRemove) {
+                try {
+                    val filePath = storage.getMetaDataFieldForRecord(formId, FormRecord.META_FILE_PATH)
+                    File(filePath).parent?.let {
+                        val rawDirPath = ImageCaptureProcessing.getRawDirectoryPath(it)
+                        File(rawDirPath).deleteRecursively()
+                    }
+                } catch (e: Exception) {
+                    CrashUtil.reportException(e)
+                    success = false
+                }
+            }
+        }
+        return if (success) {
+            HiddenPreferences.markRawMediaCleanUpComplete()
+            Result.success()
+        } else {
+            Result.failure()
+        }
+    }
+}

--- a/app/src/org/commcare/views/widgets/ImageWidget.java
+++ b/app/src/org/commcare/views/widgets/ImageWidget.java
@@ -190,7 +190,7 @@ public class ImageWidget extends QuestionWidget {
 
             // If there is an image in the raw folder, use that as the display image, since it is
             // better quality
-            File toDisplay = new File(mInstanceFolder + "/raw/" + mBinaryName);
+            File toDisplay = new File(ImageCaptureProcessing.getRawDirectoryPath(mInstanceFolder) + mBinaryName);
             if (!toDisplay.exists()) {
                 toDisplay = imageBeingSubmitted;
             }


### PR DESCRIPTION
Long term port for [LTS PR](https://github.com/dimagi/commcare-android/pull/2385)



Product Note: CommCare no longer retains original images for a form in order to save disk storage used by CommCare. Smaller sized compressed copies are still retained and shown to the user in "Saved Forms" instead of the original images. 