### PR TITLE
Hacky fix for edittext focus issue

### DIFF
--- a/app/res/layout/edit_text_question_widget.xml
+++ b/app/res/layout/edit_text_question_widget.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<EditText xmlns:android="http://schemas.android.com/apk/res/android"
+<org.commcare.views.ClearFocusEditText xmlns:android="http://schemas.android.com/apk/res/android"
           android:gravity="start"
           android:imeOptions="flagNoExtractUi"
           android:layout_height="match_parent"

--- a/app/res/layout/edit_text_question_widget_compact.xml
+++ b/app/res/layout/edit_text_question_widget_compact.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<EditText xmlns:android="http://schemas.android.com/apk/res/android"
+<org.commcare.views.ClearFocusEditText xmlns:android="http://schemas.android.com/apk/res/android"
           android:gravity="start"
           android:imeOptions="flagNoExtractUi"
           android:layout_gravity="end"

--- a/app/src/org/commcare/views/ClearFocusEditText.java
+++ b/app/src/org/commcare/views/ClearFocusEditText.java
@@ -1,0 +1,63 @@
+package org.commcare.views;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.widget.EditText;
+
+import androidx.annotation.RequiresApi;
+
+/**
+ * @author $|-|!˅@M
+ */
+public class ClearFocusEditText extends EditText {
+
+    /**
+     * A boolean value to keep track of whether we explicitly want this editText to remove focus.
+     */
+    boolean shouldRemoveFocus = false;
+
+    public ClearFocusEditText(Context context) {
+        super(context);
+    }
+
+    public ClearFocusEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ClearFocusEditText(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    public ClearFocusEditText(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    public void acceptFocus() {
+        shouldRemoveFocus = false;
+    }
+
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            /*
+            this.clearFocus() works in Android 10, and it should've worked in all the android versions.
+            But in Android 6 it doesn't, clearFocus() internally propagates the clearFocus call up the parent hierarchy.
+            And when it does so, the framework tries to give focus to the first focusable view from the top automatically.
+             */
+            shouldRemoveFocus = true;
+            this.clearFocus();
+        }
+        return super.onKeyPreIme(keyCode, event);
+    }
+
+    @Override
+    public boolean isFocused() {
+        if (shouldRemoveFocus) {
+            return false;
+        }
+        return super.isFocused();
+    }
+}

--- a/app/src/org/commcare/views/widgets/StringWidget.java
+++ b/app/src/org/commcare/views/widgets/StringWidget.java
@@ -19,6 +19,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import org.commcare.dalvik.R;
+import org.commcare.views.ClearFocusEditText;
 import org.javarosa.core.model.condition.pivot.StringLengthRangeHint;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
 import org.javarosa.core.model.data.IAnswerData;
@@ -34,7 +35,7 @@ import org.javarosa.form.api.FormEntryPrompt;
 public class StringWidget extends QuestionWidget implements OnClickListener, TextWatcher {
 
     private boolean mReadOnly = false;
-    protected final EditText mAnswer;
+    protected final ClearFocusEditText mAnswer;
     protected boolean secret = false;
 
     public StringWidget(Context context, FormEntryPrompt prompt, boolean secret) {
@@ -43,9 +44,13 @@ public class StringWidget extends QuestionWidget implements OnClickListener, Tex
 
     public StringWidget(Context context, FormEntryPrompt prompt, boolean secret, boolean inCompactGroup) {
         super(context, prompt, inCompactGroup);
-        mAnswer = (EditText)LayoutInflater.from(getContext()).inflate(getAnswerLayout(), this, false);
+        mAnswer = (ClearFocusEditText)LayoutInflater.from(getContext()).inflate(getAnswerLayout(), this, false);
         mAnswer.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mAnswerFontSize);
         mAnswer.setOnClickListener(this);
+        mAnswer.setOnTouchListener((v, event) -> {
+            mAnswer.acceptFocus();
+            return false;
+        });
 
         mAnswer.addTextChangedListener(this);
 


### PR DESCRIPTION
More information here: https://dimagi-dev.atlassian.net/browse/SAAS-11370

Product Note: Fixes a bug in the view hierarchy where in making any change to a question in the questionList will cause the screen to scroll up to the first edittext that has focus. 