### PR TITLE
Fix form jump issues with edittext

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -761,6 +761,11 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                 // no longer relevant in the new view, so it should get removed
                 shouldRemoveFromView.add(i);
             }
+            // Unfortunately editTexts don't lose focus by itself, so we need to remove focus
+            // from editText if it's not the last widget that user was interacting with.
+            if (i != indexOfLastChangedWidget) {
+                oldWidgets.get(i).removeFocus();
+            }
         }
         // Remove "atomically" to not mess up iterations
         questionsView.removeQuestionsFromIndex(shouldRemoveFromView);

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -41,6 +41,7 @@ import org.commcare.views.media.AudioController;
 import org.commcare.views.widgets.ImageWidget;
 import org.commcare.views.widgets.IntentWidget;
 import org.commcare.views.widgets.QuestionWidget;
+import org.commcare.views.widgets.StringWidget;
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
@@ -763,8 +764,8 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
             }
             // Unfortunately editTexts don't lose focus by itself, so we need to remove focus
             // from editText if it's not the last widget that user was interacting with.
-            if (i != indexOfLastChangedWidget) {
-                oldWidgets.get(i).removeFocus();
+            if (i != indexOfLastChangedWidget && oldWidgets.get(i) instanceof StringWidget) {
+                ((StringWidget) oldWidgets.get(i)).removeFocus();
             }
         }
         // Remove "atomically" to not mess up iterations

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -135,9 +135,6 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
     protected void acceptFocus() {
     }
 
-    public void removeFocus() {
-    }
-
     private void addHelpPlaceholder() {
         if (!mPrompt.hasHelp()) {
             return;

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -135,6 +135,9 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
     protected void acceptFocus() {
     }
 
+    public void removeFocus() {
+    }
+
     private void addHelpPlaceholder() {
         if (!mPrompt.hasHelp()) {
             return;

--- a/app/src/org/commcare/views/widgets/StringWidget.java
+++ b/app/src/org/commcare/views/widgets/StringWidget.java
@@ -217,7 +217,6 @@ public class StringWidget extends QuestionWidget implements OnClickListener, Tex
         mAnswer.performClick();
     }
 
-    @Override
     public void removeFocus() {
         mAnswer.clearFocus();
     }

--- a/app/src/org/commcare/views/widgets/StringWidget.java
+++ b/app/src/org/commcare/views/widgets/StringWidget.java
@@ -218,6 +218,11 @@ public class StringWidget extends QuestionWidget implements OnClickListener, Tex
     }
 
     @Override
+    public void removeFocus() {
+        mAnswer.clearFocus();
+    }
+
+    @Override
     public void afterTextChanged(Editable s) {
         widgetEntryChanged();
     }


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SAAS-11370

### Summary
While working in a question list, when a user enters some text in an edittext and then shifts to a non editText question (like RadioButton or DateWidget), then the last changed editText doesn't clear foucs by itself. 
This results into the screen jumping to this last focused EditText when any change is made to any other question. 

This PR will ask the QuestionWidget to remove focus if it's not the last widget user was interacting with. And only StringWidget will respond to the `removeFocus` call. 

### Product Note: 
Fixes a bug in the view hierarchy wherein making any change to a question in the questionList will cause the screen to scroll up to the first edittext that has focus.

