### PR TITLE
Optimize android instrumentation test time

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/androidTests/AppPreferenceSettingsTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/AppPreferenceSettingsTest.kt
@@ -10,12 +10,12 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import org.commcare.annotations.BrowserstackTests
 import org.commcare.dalvik.R
+import org.commcare.utils.CustomMatchers
 import org.commcare.utils.InstrumentationUtility
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.endsWith
@@ -94,7 +94,7 @@ class AppPreferenceSettingsTest: BaseTest() {
 
         //Create a dummy file selection intent
         val resultData = Intent()
-        val expectedIntent = hasAction(Intent.ACTION_GET_CONTENT)
+        val expectedIntent = CustomMatchers.withIntent(Intent.ACTION_GET_CONTENT, Intent.CATEGORY_OPENABLE, "file/*")
         val result = Instrumentation.ActivityResult(AppCompatActivity.RESULT_CANCELED, resultData)
         intending(expectedIntent).respondWith(result)
 

--- a/app/instrumentation-tests/src/org/commcare/androidTests/CaseSharingTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/CaseSharingTest.kt
@@ -13,15 +13,12 @@ import org.commcare.utils.doesNotExist
 import org.commcare.utils.isDisplayed
 import org.hamcrest.Matchers.endsWith
 import org.junit.Before
-import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.MethodSorters
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 @BrowserstackTests
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class CaseSharingTest: BaseTest() {
 
     companion object {
@@ -35,33 +32,21 @@ class CaseSharingTest: BaseTest() {
     }
 
     @Test
-    fun test_A_CaseCleanup() {
+    fun testCaseSharing() {
         InstrumentationUtility.login("case_sharing_1", "123")
-        InstrumentationUtility.openModule("Test Cleanup")
-        onView(withId(R.id.nav_btn_finish))
-                .perform(click())
-        InstrumentationUtility.openModule("Follow Up")
-        withText("First Case").doesNotExist()
-        withText("Second Case").doesNotExist()
-        InstrumentationUtility.gotoHome()
-        onView(withText("Sync with Server"))
-                .perform(click())
-    }
+        caseCleanup()
 
-    @Test
-    fun test_B_CaseCreation_withFirstUser() {
-        InstrumentationUtility.login("case_sharing_1", "123")
+        // Create case with first user
         createCase("First Case", "1")
 
         // validate that case was created
         InstrumentationUtility.openModule("Follow Up")
         withText("First Case").isDisplayed()
-        onView(withText("First Case"))
-                .perform(click())
-    }
 
-    @Test
-    fun test_C_CaseCreation_withSecondUser() {
+        // logout first user.
+        InstrumentationUtility.logout()
+
+        // Create case with second user.
         InstrumentationUtility.login("case_sharing_2", "123")
         createCase("Second Case", "2")
 
@@ -85,10 +70,11 @@ class CaseSharingTest: BaseTest() {
                 .perform(click())
         onView(withText("Sync with Server"))
                 .perform(click())
-    }
 
-    @Test
-    fun test_D_CloseCases_withFirstUser() {
+        // Logout second user
+        InstrumentationUtility.logout()
+
+        // Login with first user and close cases.
         InstrumentationUtility.login("case_sharing_1", "123")
         onView(withText("Sync with Server"))
                 .perform(click())
@@ -113,17 +99,30 @@ class CaseSharingTest: BaseTest() {
 
         onView(withText("Sync with Server"))
                 .perform(click())
-    }
 
-    @Test
-    fun validateCaseClosed() {
-        InstrumentationUtility.login("case_sharing_1", "123")
+        // logout first user.
+        InstrumentationUtility.logout()
+
+        // login with second user and validate that the cases are closed.
+        InstrumentationUtility.login("case_sharing_2", "123")
         onView(withText("Sync with Server"))
                 .perform(click())
 
         InstrumentationUtility.openModule("Follow Up")
         withText("First Case").doesNotExist()
         withText("Second Case").doesNotExist()
+    }
+
+    private fun caseCleanup() {
+        InstrumentationUtility.openModule("Test Cleanup")
+        onView(withId(R.id.nav_btn_finish))
+                .perform(click())
+        InstrumentationUtility.openModule("Follow Up")
+        withText("First Case").doesNotExist()
+        withText("Second Case").doesNotExist()
+        InstrumentationUtility.gotoHome()
+        onView(withText("Sync with Server"))
+                .perform(click())
     }
 
     private fun createCase(name: String, number: String) {

--- a/app/instrumentation-tests/src/org/commcare/androidTests/MenuTests.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/MenuTests.kt
@@ -24,7 +24,6 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
-@BrowserstackTests
 class MenuTests: BaseTest() {
 
     companion object {
@@ -55,6 +54,7 @@ class MenuTests: BaseTest() {
     }
 
     @Test
+    @BrowserstackTests
     fun testHomeScreenOptions() {
         InstrumentationUtility.openOptionsMenu()
         checkStringExists(homeMenuItems)
@@ -123,6 +123,7 @@ class MenuTests: BaseTest() {
     }
 
     @Test
+    @BrowserstackTests
     fun testAdvancedActions() {
         openAdvancedOption(0)
         onView(withText("Do you want to send, receive, or submit forms?"))
@@ -185,7 +186,7 @@ class MenuTests: BaseTest() {
         onView(withText("You are not connected the Internet. Please run this test again after connecting to Wi-Fi or mobile data."))
                 .check(matches(isDisplayed()))
         InstrumentationUtility.changeWifi(true)
-        InstrumentationUtility.gotoHome()
+        InstrumentationUtility.logout()
     }
 
     private fun openAdvancedOption(index: Int) {

--- a/app/instrumentation-tests/src/org/commcare/utils/CustomMatchers.kt
+++ b/app/instrumentation-tests/src/org/commcare/utils/CustomMatchers.kt
@@ -1,5 +1,6 @@
 package org.commcare.utils
 
+import android.content.Intent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ListView
@@ -10,6 +11,7 @@ import org.commcare.android.database.global.models.AppAvailableToInstall
 import org.hamcrest.BaseMatcher
 import org.hamcrest.Description
 import org.hamcrest.Matcher
+import org.hamcrest.Matchers
 import org.hamcrest.TypeSafeMatcher
 
 
@@ -121,6 +123,24 @@ object CustomMatchers {
             override fun describeTo(description: Description) {
                 description.appendText("with match textView fontSize with $expectedSize")
                 description.appendValue(expectedSize)
+            }
+        }
+    }
+
+    /**
+     * Creates a matcher that matches an intent with specified action, category and type.
+     */
+    fun withIntent(action: String, category: String, type: String): Matcher<Intent> {
+        return object : TypeSafeMatcher<Intent>() {
+            override fun describeTo(description: Description) {
+                description.appendText("has action: $action, category: $category and type: $type")
+            }
+
+            override fun matchesSafely(intent: Intent): Boolean {
+                val actionMatcher = Matchers.`is`(action).matches(intent.action)
+                val categoryMatcher = Matchers.hasItem(category).matches(intent.categories)
+                val typeMatcher = Matchers.`is`(type).matches(intent.type)
+                return actionMatcher && categoryMatcher && typeMatcher
             }
         }
     }

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -27,6 +27,9 @@ def buildTestCommand(appToken, testToken, classes=None):
     test["deviceLogs"] = True
     test["testSuite"] = testToken
     test["networkLogs"] = True
+    test["shards"] = {
+        "numberOfShards": 5
+    }
     test["annotation"] = ["org.commcare.annotations.BrowserstackTests"]
 
     if classes:

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -63,21 +63,31 @@ def testResult(buildId):
     # Get the sessionID from test result
     resultCommand = 'curl -u "{}:{}" -X GET "https://api-cloud.browserstack.com/app-automate/espresso/v2/builds/{}"'.format(userName, password, buildId)
     result = subprocess.Popen(shlex.split(resultCommand), stdout=PIPE, stderr=None, shell=False)
-    sessionId = json.loads(result.communicate()[0])["devices"][0]["sessions"][0]["id"]
+    sessions = json.loads(result.communicate()[0])["devices"][0]["sessions"]
 
-    # Gather the sessionDetails
-    testDetailsCommand = 'curl -u "{}:{}" -X GET "https://api-cloud.browserstack.com/app-automate/espresso/v2/builds/{}/sessions/{}"'.format(userName, password, buildId, sessionId)
-    testDetailsResult = subprocess.Popen(shlex.split(testDetailsCommand), stdout=PIPE, stderr=None, shell=False)
-    testcases = json.loads(testDetailsResult.communicate()[0])["testcases"]["data"]
+    # Loop over all the sessions and Create an array of failing classes.
 
-    # Create an array of failing classes.
     classes = []
-    for testcase in testcases:
-        methods = testcase["testcases"]
-        for method in methods:
-            if (method["status"] != "passed"):
-                classes.append("org.commcare.androidTests." + testcase["class"])
-                break
+    for session in sessions:
+        if (session["status"] == "passed"):
+            continue
+
+        sessionId = session["id"]
+
+        # Gather the sessionDetails
+        testDetailsCommand = 'curl -u "{}:{}" -X GET "https://api-cloud.browserstack.com/app-automate/espresso/v2/builds/{}/sessions/{}"'.format(userName, password, buildId, sessionId)
+        testDetailsResult = subprocess.Popen(shlex.split(testDetailsCommand), stdout=PIPE, stderr=None, shell=False)
+        testcases = json.loads(testDetailsResult.communicate()[0])["testcases"]["data"]
+
+        # Collect the failed classes
+        for testcase in testcases:
+            methods = testcase["testcases"]
+            for method in methods:
+                if (method["status"] != "passed"):
+                    failedClassName = "org.commcare.androidTests." + testcase["class"]
+                    if (failedClassName not in classes):
+                        classes.append(failedClassName)
+                    break
 
     # Now that we know all the test-classes that are failing, we can re-run those.
     print("Failing test classes :: ", classes)


### PR DESCRIPTION
Using auto shard strategy from this doc https://www.browserstack.com/docs/app-automate/espresso/test-sharding
Since we've a limit of 5 parallel tests, so I've configured the `numberOfShards` to 5. 