### PR TITLE
Initialize TLS1.2 before adding the isrg cert

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -217,8 +217,8 @@ public class CommCareApplication extends MultiDexApplication {
         // improperly, so the second https request in a short time period will flop)
         System.setProperty("http.keepAlive", "false");
 
-        attachISRGCert();
         initTls12IfNeeded();
+        attachISRGCert();
 
         Thread.setDefaultUncaughtExceptionHandler(new CommCareExceptionHandler(Thread.getDefaultUncaughtExceptionHandler(), this));
 


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/QA-2137

https://github.com/dimagi/commcare-android/pull/2409 broke the HTTP requests on Android 4 because I was initializing TLS 2 after adding the ISRG cert. (Took me like 2 days to figure this one line change :( , though happy that our new hotfix QA process caught it)