### PR TITLE
Avoid using 5 shards when number of tests are low

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -31,7 +31,8 @@ def buildTestCommand(appToken, testToken, classes=None):
 
     if classes:
         test["class"] = classes
-        test["shards"] = { "numberOfShards": 5 if (len(classes) > 5) else len(classes) }
+        classSize = len(classes)
+        test["shards"] = { "numberOfShards": 5 if (classSize > 5) else classSize }
     else:
         test["shards"] = { "numberOfShards": 5 }
 

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -27,13 +27,13 @@ def buildTestCommand(appToken, testToken, classes=None):
     test["deviceLogs"] = True
     test["testSuite"] = testToken
     test["networkLogs"] = True
-    test["shards"] = {
-        "numberOfShards": 5
-    }
     test["annotation"] = ["org.commcare.annotations.BrowserstackTests"]
 
     if classes:
         test["class"] = classes
+        test["shards"] = { "numberOfShards": 5 if (len(classes) > 5) else len(classes) }
+    else:
+        test["shards"] = { "numberOfShards": 5 }
 
     return json.dumps(json.dumps(test))
 


### PR DESCRIPTION
Fixes a false positive in test result when number of tests are lower than number of shards and browserstack simply errors out. 