### PR TITLE
Fix linking to external files

### DIFF
--- a/app/res/xml/provider_paths.xml
+++ b/app/res/xml/provider_paths.xml
@@ -2,4 +2,5 @@
 <paths>
     <external-files-path name="all_external_files" path="."/>
     <external-files-path name="external_temp" path="temp/external/"/>
+    <external-path name="external_files" path="." />
 </paths>

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -92,6 +92,7 @@ import org.commcare.utils.CrashUtil;
 import org.commcare.utils.DeviceIdentifier;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.GlobalConstants;
+import org.commcare.utils.MarkupUtil;
 import org.commcare.utils.MultipleAppsUtil;
 import org.commcare.utils.PendingCalcs;
 import org.commcare.utils.SessionActivityRegistration;
@@ -131,6 +132,7 @@ import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
+
 import io.noties.markwon.Markwon;
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin;
 import io.noties.markwon.ext.tables.TablePlugin;
@@ -1101,6 +1103,7 @@ public class CommCareApplication extends MultiDexApplication {
             markwon = Markwon.builder(CommCareApplication.instance())
                     .usePlugin(TablePlugin.create(CommCareApplication.instance()))
                     .usePlugin(StrikethroughPlugin.create())
+                    .usePlugin(MarkupUtil.getLinkResolverPlugin())
                     .build();
         }
         return markwon;

--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -667,7 +667,7 @@ public class FileUtil {
         }
     }
 
-    private static String getMimeType(String filePath) {
+    public static String getMimeType(String filePath) {
         String extension = MimeTypeMap.getFileExtensionFromUrl(filePath);
         String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
         return mimeType;


### PR DESCRIPTION
Jira Ticket:: https://dimagi-dev.atlassian.net/browse/SAAS-11757


I've added a custom plugin for handling clicks of markdown text. 

While testing it out on Android 10, I found that `ACTION_VIEW` intent won't show the images of external storage.(I modified the paths for the same `<external-path name="external_files" path="." />`). But it would simply show an error in the gallery app `File format isn't supported or file is corrupted`. 

 I created an app [here](https://www.commcarehq.org/a/srishti-1/apps/view/e75ca00a7e53385e292049d16c0fa1ac/form/936705e7ee9c4f5bbe77708a795f2b0a/source/#form/total_repeat_count) and only the first question shows the image correctly.