### PR TITLE
Fix crash in print activity

### DIFF
--- a/app/res/values/themes.xml
+++ b/app/res/values/themes.xml
@@ -126,7 +126,7 @@
     <style name="TextAppearance.Custom.WindowTitle.Menu" parent="TextAppearance.Custom.WindowTitle">
     </style>
 
-    <style name="Theme.Dialog.NoTitle" parent="@android:style/Theme.Holo.Light.Dialog">
+    <style name="Theme.Dialog.NoTitle" parent="Theme.AppCompat.Light.Dialog">
         <item name="windowNoTitle">true</item>
     </style>
 


### PR DESCRIPTION

Stacktrace: 
```
Caused by: java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.
        at androidx.appcompat.app.AppCompatDelegateImpl.createSubDecor(AppCompatDelegateImpl.java:843)
        at androidx.appcompat.app.AppCompatDelegateImpl.ensureSubDecor(AppCompatDelegateImpl.java:806)
        at androidx.appcompat.app.AppCompatDelegateImpl.setContentView(AppCompatDelegateImpl.java:693)
        at androidx.appcompat.app.AppCompatActivity.setContentView(AppCompatActivity.java:170)
        at org.commcare.print.TemplatePrinterActivity.onCreate(TemplatePrinterActivity.java:74)
        at android.app.Activity.performCreate(Activity.java:7893)
        at android.app.Activity.performCreate(Activity.java:7880)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1307)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3283)
```

