### PR TITLE
Hide save button when recorded sound is shown

### DIFF
--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -90,7 +90,7 @@ public class RecordingFragment extends DialogFragment {
 
     private void reloadSavedRecording() {
         recordAgain.setVisibility(View.VISIBLE);
-        saveRecording.setVisibility(View.VISIBLE);
+        saveRecording.setVisibility(View.GONE);
         recordingDuration.setVisibility(View.VISIBLE);
         toggleRecording.setBackgroundResource(R.drawable.play);
         toggleRecording.setOnClickListener(v -> playAudio());


### PR DESCRIPTION
This PR will remove the save button from the recording fragment, when it's loaded with a saved recording. 

 
![recording](https://user-images.githubusercontent.com/29516995/106558927-a418b500-654a-11eb-9a21-413924fb1ecd.gif)
