### PR TITLE
skip invalid case search prompts

### DIFF
--- a/app/src/org/commcare/activities/QueryRequestActivity.java
+++ b/app/src/org/commcare/activities/QueryRequestActivity.java
@@ -156,7 +156,7 @@ public class QueryRequestActivity
         }
     }
 
-    private boolean isPromptValid(QueryPrompt queryPrompt) {
+    private boolean isPromptSupported(QueryPrompt queryPrompt) {
         return queryPrompt.getInput() == null || queryPrompt.getInput().contentEquals(INPUT_TYPE_SELECT1);
     }
 

--- a/app/src/org/commcare/activities/QueryRequestActivity.java
+++ b/app/src/org/commcare/activities/QueryRequestActivity.java
@@ -100,7 +100,7 @@ public class QueryRequestActivity
             remoteQuerySessionManager =
                     RemoteQuerySessionManager.buildQuerySessionManager(sessionWrapper.getSession(),
                             sessionWrapper.getEvaluationContext());
-        } catch(XPathException xpe) {
+        } catch (XPathException xpe) {
             UserfacingErrorHandling.createErrorDialog(this, xpe.getMessage(), true);
             return;
         }
@@ -142,16 +142,22 @@ public class QueryRequestActivity
         View promptView = LayoutInflater.from(this).inflate(R.layout.query_prompt_layout, promptsLayout, false);
         setLabelText(promptView, queryPrompt.getDisplay());
         View inputView;
-        String input = queryPrompt.getInput();
-        if (input != null && input.contentEquals(INPUT_TYPE_SELECT1)) {
-            inputView = buildSpinnerView(promptView, queryPrompt);
-        } else {
-            inputView = buildEditTextView(promptView, queryPrompt, isLastPrompt);
-        }
-        setUpBarCodeScanButton(promptView, promptId, queryPrompt);
+        if (isPromptValid(queryPrompt)) {
+            String input = queryPrompt.getInput();
+            if (input != null && input.contentEquals(INPUT_TYPE_SELECT1)) {
+                inputView = buildSpinnerView(promptView, queryPrompt);
+            } else {
+                inputView = buildEditTextView(promptView, queryPrompt, isLastPrompt);
+            }
+            setUpBarCodeScanButton(promptView, promptId, queryPrompt);
 
-        promptsLayout.addView(promptView);
-        promptsBoxes.put(promptId, inputView);
+            promptsLayout.addView(promptView);
+            promptsBoxes.put(promptId, inputView);
+        }
+    }
+
+    private boolean isPromptValid(QueryPrompt queryPrompt) {
+        return queryPrompt.getInput() == null || queryPrompt.getInput().contentEquals(INPUT_TYPE_SELECT1);
     }
 
     private void setUpBarCodeScanButton(View promptView, String promptId, QueryPrompt queryPrompt) {

--- a/app/unit-tests/resources/commcare-apps/case_search_and_claim/suite.xml
+++ b/app/unit-tests/resources/commcare-apps/case_search_and_claim/suite.xml
@@ -308,6 +308,13 @@
             <sort ref="id"/>
           </itemset>
         </prompt>
+        <prompt key="invalid" input="foobar">
+          <display>
+            <text>
+              <locale id="query.district"/>
+            </text>
+          </display>
+        </prompt>
       </query>
       <datum id="case_id" nodeset="instance('patients')/patients/patient" value="./id" detail-select="patient_short" detail-confirm="patient_long"/>
     </session>

--- a/app/unit-tests/src/org/commcare/android/tests/activities/QueryRequestActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/QueryRequestActivityTest.java
@@ -1,6 +1,7 @@
 package org.commcare.android.tests.activities;
 
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
@@ -268,7 +269,7 @@ public class QueryRequestActivityTest {
                 CommCareApplication.instance().getCurrentSessionWrapper();
         CommCareSession session = sessionWrapper.getSession();
         session.setCommand(command);
-        if(session.getNeededDatum() instanceof ComputedDatum) {
+        if (session.getNeededDatum() instanceof ComputedDatum) {
             session.setComputedDatum(sessionWrapper.getEvaluationContext());
         }
     }
@@ -281,6 +282,8 @@ public class QueryRequestActivityTest {
 
         // set views
         LinearLayout promptsLayout = queryRequestActivity.findViewById(R.id.query_prompts);
+
+        assertEquals(promptsLayout.getChildCount(), 4);
 
         EditText patientName = promptsLayout.getChildAt(0).findViewById(R.id.prompt_et);
         patientName.setText("francisco");


### PR DESCRIPTION
@sravfeyn highlighted that as Web Apps is implementing more case search widgets, it would be a good idea for mobile to skip displaying any widgets it doesn't implement so as not to break searches in case of incompatible input types. 