### PR TITLE
Improve attachment oversize warning message

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -169,7 +169,7 @@
     <string name="activity_not_found" cc:translatable="true">No activity found to handle: %s</string>
     <string name="advance" cc:translatable="true">forward to\nnext\nprompt</string>
     <string name="altitude" cc:translatable="true">Altitude</string>
-    <string name="attachment_oversized" cc:translatable="true">Warning: attached large file of size %s kb. This could cause problems with submitting to the server depending on your network conditions.</string>
+    <string name="attachment_oversized" cc:translatable="true">Warning: attached large file of size %s mb. This could cause problems with submitting to the server depending on your network conditions.</string>
     <string name="attachment_above_size_limit" formatted="false" cc:translatable="true">Media attachment too large (%1$s mb). Max allowed size is %2$s mb.</string>
     <string name="audio_file_error" cc:translatable="true">No audio file was specified.</string>
     <string name="audio_file_invalid" cc:translatable="true">File: %s is not a valid audio file.</string>

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -746,7 +746,7 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
             return true;
         } else if (FileUtil.isFileOversized(file) && !HiddenPreferences.isFileOversizeWarningDisabled()) {
             notifyWarning(StringUtils.getStringRobust(getContext(), R.string.attachment_oversized,
-                    FileUtil.getFileSize(file) + ""));
+                    FileUtil.getFileSizeInMegs(file) + ""));
         }
         return false;
     }


### PR DESCRIPTION
Product Note: Attachment oversize warning message will show file size in MBs instead of KBs. 