### PR TITLE
Fix hint text visibility

### DIFF
--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -129,7 +129,9 @@ public class QuestionsView extends ScrollView
             qw.setId(VIEW_ID + widgetIdCount++);
 
             //Suppress the hint text if we bubbled it
-            qw.hideHintText();
+            if (hintText != null) {
+                qw.hideHintText();
+            }
 
             widgets.add(qw);
             mView.addView(qw, mLayout);


### PR DESCRIPTION
Fixes an issue caused by https://github.com/dimagi/commcare-android/pull/2417/ where hint text gets hidden always. 