### PR TITLE
Search view fix

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -54,7 +54,7 @@
         android:description="@string/permission_content_provider_description"
         android:label="@string/permission_content_provider_label"
         />
-    
+
     <permission
         android:description="@string/permission_content_provider_description"
         android:label="@string/permission_content_provider_label"
@@ -479,7 +479,7 @@
 
         <!-- Somehow this receiver is getting triggered in Android 8+ devices and causing
             IllegalStateException while trying to start map downloader service from background.
-            Below code removes this receiver's entry from Manifest. 
+            Below code removes this receiver's entry from Manifest.
          -->
         <receiver android:name="io.ona.kujaku.receivers.KujakuNetworkChangeReceiver"
             tools:node="remove"/>

--- a/app/src/org/commcare/activities/EntitySelectSearchUI.java
+++ b/app/src/org/commcare/activities/EntitySelectSearchUI.java
@@ -1,13 +1,11 @@
 package org.commcare.activities;
 
 import android.annotation.TargetApi;
-import android.content.Context;
 import android.os.Build;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.TextView;
@@ -15,7 +13,6 @@ import android.widget.TextView;
 import org.commcare.activities.components.EntitySelectCalloutSetup;
 import org.commcare.dalvik.R;
 import org.commcare.suite.model.Callout;
-import org.javarosa.core.services.locale.Localization;
 
 import androidx.appcompat.widget.SearchView;
 import androidx.core.view.MenuItemCompat;
@@ -29,7 +26,6 @@ class EntitySelectSearchUI implements TextWatcher {
     private SearchView searchView;
     private MenuItem searchMenuItem;
     private MenuItem barcodeMenuItem;
-    private EditText preHoneycombSearchBox;
     private TextView searchResultStatus;
     private ImageButton clearSearchButton;
     private View searchBanner;
@@ -108,9 +104,8 @@ class EntitySelectSearchUI implements TextWatcher {
     protected CharSequence getSearchText() {
         if (isUsingActionBar()) {
             return searchView.getQuery();
-        } else {
-            return preHoneycombSearchBox.getText();
         }
+        return "";
     }
 
     @SuppressWarnings("NewApi")
@@ -120,8 +115,6 @@ class EntitySelectSearchUI implements TextWatcher {
                 MenuItemCompat.expandActionView(searchMenuItem);
             }
             searchView.setQuery(text, false);
-        } else {
-            preHoneycombSearchBox.setText(text);
         }
     }
 

--- a/app/src/org/commcare/activities/EntitySelectSearchUI.java
+++ b/app/src/org/commcare/activities/EntitySelectSearchUI.java
@@ -32,7 +32,6 @@ class EntitySelectSearchUI implements TextWatcher {
     private final EntitySelectActivity activity;
 
     private String filterString = "";
-    private String searchText;
 
     EntitySelectSearchUI(EntitySelectActivity activity) {
         this.activity = activity;
@@ -74,12 +73,6 @@ class EntitySelectSearchUI implements TextWatcher {
                     return false;
                 }
             });
-
-            if (searchText != null) {
-                searchMenuItem.expandActionView();
-                searchView.setQuery(searchText, false);
-                searchText = null;
-            }
         };
     }
 
@@ -117,7 +110,7 @@ class EntitySelectSearchUI implements TextWatcher {
             searchMenuItem.expandActionView();
             searchView.setQuery(text, false);
         } else {
-            searchText = text.toString();
+            activity.setLastQueryString(text.toString());
         }
     }
 

--- a/app/src/org/commcare/activities/EntitySelectSearchUI.java
+++ b/app/src/org/commcare/activities/EntitySelectSearchUI.java
@@ -14,7 +14,6 @@ import org.commcare.dalvik.R;
 import org.commcare.suite.model.Callout;
 
 import androidx.appcompat.widget.SearchView;
-import androidx.core.view.MenuItemCompat;
 
 /**
  * Manages case list activity's search state and UI
@@ -96,7 +95,6 @@ class EntitySelectSearchUI implements TextWatcher {
         }
     }
 
-    @SuppressWarnings("NewApi")
     protected CharSequence getSearchText() {
         if (searchView != null) {
             return searchView.getQuery();
@@ -104,7 +102,6 @@ class EntitySelectSearchUI implements TextWatcher {
         return "";
     }
 
-    @SuppressWarnings("NewApi")
     protected void setSearchText(CharSequence text) {
         if (searchView != null) {
             searchMenuItem.expandActionView();


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SUPPORT-8015

This PR fixes a NPE while setting text in searchview after scanning barcode.  
```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void android.widget.EditText.setText(java.lang.CharSequence)' on a null object reference
       at org.commcare.activities.EntitySelectSearchUI.setSearchText(EntitySelectSearchUI.java:124)
       at org.commcare.activities.EntitySelectActivity.processBarcodeFetch(EntitySelectActivity.java:642)
       at org.commcare.activities.EntitySelectActivity.onActivityResultSessionSafe(EntitySelectActivity.java:574)
       at org.commcare.activities.SessionAwareHelper.onActivityResultHelper(SessionAwareHelper.java:49)
       at org.commcare.activities.SessionAwareCommCareActivity.onActivityResult(SessionAwareCommCareActivity.java:39)
       at android.app.Activity.dispatchActivityResult(Activity.java:8316)
       at android.app.ActivityThread.deliverResults(ActivityThread.java:5206)
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4618)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4663)
       at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:52)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2246)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:233)
       at android.app.ActivityThread.main(ActivityThread.java:8010)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:631)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:978)
```

The issue happens when the screen orientation changes while the user is scanning the barcode. 
So when the scan is completed, `onActivityResult` will be called. But because of orientation change, searchView becomes null and need to be set again from  `onOptionsMenuItem`. But the call to `onActivityResult` happens before `onOptionsMenuItem`
so it throws the NPE. 
