### PR TITLE
Store attachment name rather than path in formdef

### DIFF
--- a/app/src/org/commcare/android/javarosa/IntentCallout.java
+++ b/app/src/org/commcare/android/javarosa/IntentCallout.java
@@ -319,7 +319,7 @@ public class IntentCallout implements Externalizable {
 
             //That code throws no errors, so we have to manually check whether the copy worked.
             if (newFile.exists() && newFile.length() == src.length()) {
-                formDef.setValue(new StringData(newFile.toString()), ref);
+                formDef.setValue(new StringData(newFile.getName()), ref);
             } else {
                 Log.e(TAG, "CommCare failed to property write a file to " + newFile.toString());
                 formDef.setValue(null, ref);


### PR DESCRIPTION
Jira https://dimagi-dev.atlassian.net/browse/SAAS-11917

There's an issue with CommCare where we're saving the absolute path to the attachment in the form when the attachment was captured using an external app. 
This PR makes changes this behaviour and sets attachment name in the form def instead of path.  