### PR TITLE
Bug fix: default values are not visibile for free text case prompts

### DIFF
--- a/app/src/org/commcare/activities/QueryRequestActivity.java
+++ b/app/src/org/commcare/activities/QueryRequestActivity.java
@@ -58,6 +58,7 @@ import java.util.Vector;
 import androidx.annotation.NonNull;
 
 import static org.commcare.activities.EntitySelectActivity.BARCODE_FETCH;
+import static org.commcare.session.RemoteQuerySessionManager.isPromptSupported;
 import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_SELECT1;
 
 /**
@@ -154,10 +155,6 @@ public class QueryRequestActivity
             promptsLayout.addView(promptView);
             promptsBoxes.put(promptId, inputView);
         }
-    }
-
-    private boolean isPromptSupported(QueryPrompt queryPrompt) {
-        return queryPrompt.getInput() == null || queryPrompt.getInput().contentEquals(INPUT_TYPE_SELECT1);
     }
 
     private void setUpBarCodeScanButton(View promptView, String promptId, QueryPrompt queryPrompt) {

--- a/app/src/org/commcare/activities/QueryRequestActivity.java
+++ b/app/src/org/commcare/activities/QueryRequestActivity.java
@@ -257,6 +257,9 @@ public class QueryRequestActivity
             promptEditText.setImeOptions(EditorInfo.IME_ACTION_NEXT);
         }
 
+        Hashtable<String, String> userAnswers = remoteQuerySessionManager.getUserAnswers();
+        promptEditText.setText(userAnswers.get(queryPrompt.getKey()));
+
         promptEditText.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {

--- a/app/src/org/commcare/activities/QueryRequestActivity.java
+++ b/app/src/org/commcare/activities/QueryRequestActivity.java
@@ -49,6 +49,7 @@ import org.javarosa.xpath.XPathException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -58,7 +59,6 @@ import java.util.Vector;
 import androidx.annotation.NonNull;
 
 import static org.commcare.activities.EntitySelectActivity.BARCODE_FETCH;
-import static org.commcare.session.RemoteQuerySessionManager.isPromptSupported;
 import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_SELECT1;
 
 /**
@@ -100,7 +100,7 @@ public class QueryRequestActivity
         try {
             remoteQuerySessionManager =
                     RemoteQuerySessionManager.buildQuerySessionManager(sessionWrapper.getSession(),
-                            sessionWrapper.getEvaluationContext());
+                            sessionWrapper.getEvaluationContext(), getSupportedPrompts());
         } catch (XPathException xpe) {
             UserfacingErrorHandling.createErrorDialog(this, xpe.getMessage(), true);
             return;
@@ -113,6 +113,12 @@ public class QueryRequestActivity
         } else {
             setupUI();
         }
+    }
+
+    private ArrayList<String> getSupportedPrompts() {
+        ArrayList<String> supportedPrompts = new ArrayList<>();
+        supportedPrompts.add(INPUT_TYPE_SELECT1);
+        return supportedPrompts;
     }
 
     private void setupUI() {
@@ -143,7 +149,7 @@ public class QueryRequestActivity
         View promptView = LayoutInflater.from(this).inflate(R.layout.query_prompt_layout, promptsLayout, false);
         setLabelText(promptView, queryPrompt.getDisplay());
         View inputView;
-        if (isPromptSupported(queryPrompt)) {
+        if (remoteQuerySessionManager.isPromptSupported(queryPrompt)) {
             String input = queryPrompt.getInput();
             if (input != null && input.contentEquals(INPUT_TYPE_SELECT1)) {
                 inputView = buildSpinnerView(promptView, queryPrompt);

--- a/app/unit-tests/src/org/commcare/android/tests/activities/PostRequestActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/PostRequestActivityTest.java
@@ -22,6 +22,7 @@ import org.commcare.network.CommcareRequestEndpointsMock;
 import org.commcare.network.LocalReferencePullResponseFactory;
 import org.commcare.session.CommCareSession;
 import org.commcare.session.RemoteQuerySessionManager;
+import org.commcare.suite.model.QueryPrompt;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.xml.util.InvalidStructureException;
@@ -38,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -201,9 +203,11 @@ public class PostRequestActivityTest {
         InputStream is =
                 PostRequestActivity.class.getClassLoader().getResourceAsStream("commcare-apps/case_search_and_claim/good-query-result.xml");
 
+        ArrayList<String> supportedPrompts = new ArrayList<>();
+        supportedPrompts.add(QueryPrompt.INPUT_TYPE_SELECT1);
         RemoteQuerySessionManager remoteQuerySessionManager =
                 RemoteQuerySessionManager.buildQuerySessionManager(sessionWrapper.getSession(),
-                        sessionWrapper.getEvaluationContext());
+                        sessionWrapper.getEvaluationContext(),supportedPrompts);
         Pair<ExternalDataInstance, String> instanceOrError =
                 remoteQuerySessionManager.buildExternalDataInstance(is);
         session.setQueryDatum(instanceOrError.first);


### PR DESCRIPTION
1. Before this default values were not getting shown for text intput case prompts on mobile. 
2. Default values for the unsupported prompts were getting passed to search query which was breaking the search. 

cross-request: https://github.com/dimagi/commcare-core/pull/982