### PR TITLE
Handle receiver register/unregister calls in onResume and onPause only

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -36,7 +36,6 @@ import org.commcare.core.network.HTTPMethod;
 import org.commcare.core.network.ModernHttpRequester;
 import org.commcare.core.services.CommCarePreferenceManagerFactory;
 import org.commcare.dalvik.BuildConfig;
-import org.commcare.dalvik.R;
 import org.commcare.engine.references.ArchiveFileRoot;
 import org.commcare.engine.references.AssetFileRoot;
 import org.commcare.engine.references.JavaHttpRoot;
@@ -95,7 +94,7 @@ import org.commcare.utils.GlobalConstants;
 import org.commcare.utils.MarkupUtil;
 import org.commcare.utils.MultipleAppsUtil;
 import org.commcare.utils.PendingCalcs;
-import org.commcare.utils.SessionActivityRegistration;
+import org.commcare.utils.SessionRegistrationHelper;
 import org.commcare.utils.SessionStateUninitException;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.views.widgets.CleanRawMedia;
@@ -347,7 +346,7 @@ public class CommCareApplication extends MultiDexApplication {
         synchronized (serviceLock) {
             // if we already have a connection established to
             // CommCareSessionService, close it and open a new one
-            SessionActivityRegistration.unregisterSessionExpiration();
+            SessionRegistrationHelper.unregisterSessionExpiration();
             if (this.sessionServiceIsBound) {
                 releaseUserResourcesAndServices();
             }
@@ -389,8 +388,8 @@ public class CommCareApplication extends MultiDexApplication {
     public void expireUserSession() {
         synchronized (serviceLock) {
             closeUserSession();
-            SessionActivityRegistration.registerSessionExpiration();
-            sendBroadcast(new Intent(SessionActivityRegistration.USER_SESSION_EXPIRED));
+            SessionRegistrationHelper.registerSessionExpiration();
+            sendBroadcast(new Intent(SessionRegistrationHelper.USER_SESSION_EXPIRED));
         }
     }
 

--- a/app/src/org/commcare/activities/SessionAwareCommCareActivity.java
+++ b/app/src/org/commcare/activities/SessionAwareCommCareActivity.java
@@ -27,6 +27,7 @@ public abstract class SessionAwareCommCareActivity<R> extends CommCareActivity<R
     @Override
     protected void onResume() {
         super.onResume();
+        SessionActivityRegistration.registerSessionExpirationReceiver(this);
         SessionAwareHelper.onResumeHelper(this, this, redirectedInOnCreate);
     }
 

--- a/app/src/org/commcare/activities/SessionAwareCommCareActivity.java
+++ b/app/src/org/commcare/activities/SessionAwareCommCareActivity.java
@@ -3,7 +3,7 @@ package org.commcare.activities;
 import android.content.Intent;
 import android.os.Bundle;
 
-import org.commcare.utils.SessionActivityRegistration;
+import org.commcare.utils.SessionRegistrationHelper;
 
 /**
  * Manage redirection to login screen when session expiration occurs.
@@ -27,7 +27,7 @@ public abstract class SessionAwareCommCareActivity<R> extends CommCareActivity<R
     @Override
     protected void onResume() {
         super.onResume();
-        SessionActivityRegistration.registerSessionExpirationReceiver(this);
+        SessionRegistrationHelper.registerSessionExpirationReceiver(this);
         SessionAwareHelper.onResumeHelper(this, this, redirectedInOnCreate);
     }
 
@@ -47,6 +47,6 @@ public abstract class SessionAwareCommCareActivity<R> extends CommCareActivity<R
     @Override
     protected void onPause() {
         super.onPause();
-        SessionActivityRegistration.unregisterSessionExpirationReceiver(this);
+        SessionRegistrationHelper.unregisterSessionExpirationReceiver(this);
     }
 }

--- a/app/src/org/commcare/activities/SessionAwareHelper.java
+++ b/app/src/org/commcare/activities/SessionAwareHelper.java
@@ -30,7 +30,7 @@ public class SessionAwareHelper {
     protected static void onResumeHelper(AppCompatActivity a, SessionAwareInterface sessionAware,
                                          boolean redirectedInOnCreate) {
         boolean redirectedToLogin =
-                SessionActivityRegistration.handleOrListenForSessionExpiration(a) ||
+                SessionActivityRegistration.handleSessionExpiration(a) ||
                         redirectedInOnCreate;
         if (!redirectedToLogin) {
             try {
@@ -44,7 +44,7 @@ public class SessionAwareHelper {
     protected static void onActivityResultHelper(AppCompatActivity a, SessionAwareInterface sessionAware,
                                                  int requestCode, int resultCode, Intent intent) {
         boolean redirectedToLogin =
-                SessionActivityRegistration.handleOrListenForSessionExpiration(a);
+                SessionActivityRegistration.handleSessionExpiration(a);
         if (!redirectedToLogin) {
             sessionAware.onActivityResultSessionSafe(requestCode, resultCode, intent);
         }

--- a/app/src/org/commcare/activities/SessionAwareHelper.java
+++ b/app/src/org/commcare/activities/SessionAwareHelper.java
@@ -5,7 +5,7 @@ import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 
 import org.commcare.CommCareApplication;
-import org.commcare.utils.SessionActivityRegistration;
+import org.commcare.utils.SessionRegistrationHelper;
 import org.commcare.utils.SessionUnavailableException;
 
 /**
@@ -21,7 +21,7 @@ public class SessionAwareHelper {
             sessionAware.onCreateSessionSafe(savedInstanceState);
             return false;
         } catch (SessionUnavailableException e) {
-            SessionActivityRegistration.redirectToLogin(a);
+            SessionRegistrationHelper.redirectToLogin(a);
             a.finish();
             return true;
         }
@@ -30,13 +30,13 @@ public class SessionAwareHelper {
     protected static void onResumeHelper(AppCompatActivity a, SessionAwareInterface sessionAware,
                                          boolean redirectedInOnCreate) {
         boolean redirectedToLogin =
-                SessionActivityRegistration.handleSessionExpiration(a) ||
+                SessionRegistrationHelper.handleSessionExpiration(a) ||
                         redirectedInOnCreate;
         if (!redirectedToLogin) {
             try {
                 sessionAware.onResumeSessionSafe();
             } catch (SessionUnavailableException e) {
-                SessionActivityRegistration.redirectToLogin(a);
+                SessionRegistrationHelper.redirectToLogin(a);
             }
         }
     }
@@ -44,7 +44,7 @@ public class SessionAwareHelper {
     protected static void onActivityResultHelper(AppCompatActivity a, SessionAwareInterface sessionAware,
                                                  int requestCode, int resultCode, Intent intent) {
         boolean redirectedToLogin =
-                SessionActivityRegistration.handleSessionExpiration(a);
+                SessionRegistrationHelper.handleSessionExpiration(a);
         if (!redirectedToLogin) {
             sessionAware.onActivityResultSessionSafe(requestCode, resultCode, intent);
         }

--- a/app/src/org/commcare/activities/SessionAwareListActivity.java
+++ b/app/src/org/commcare/activities/SessionAwareListActivity.java
@@ -28,6 +28,7 @@ public abstract class SessionAwareListActivity extends CommcareListActivity impl
     @Override
     protected void onResume() {
         super.onResume();
+        SessionActivityRegistration.registerSessionExpirationReceiver(this);
         SessionAwareHelper.onResumeHelper(this, this, redirectedInOnCreate);
     }
 

--- a/app/src/org/commcare/activities/SessionAwareListActivity.java
+++ b/app/src/org/commcare/activities/SessionAwareListActivity.java
@@ -1,10 +1,9 @@
 package org.commcare.activities;
 
-import android.app.ListActivity;
 import android.content.Intent;
 import android.os.Bundle;
 
-import org.commcare.utils.SessionActivityRegistration;
+import org.commcare.utils.SessionRegistrationHelper;
 
 /**
  * Reproduction of SessionAwareCommCareActivity, but for an activity that must extend ListActivity
@@ -28,7 +27,7 @@ public abstract class SessionAwareListActivity extends CommcareListActivity impl
     @Override
     protected void onResume() {
         super.onResume();
-        SessionActivityRegistration.registerSessionExpirationReceiver(this);
+        SessionRegistrationHelper.registerSessionExpirationReceiver(this);
         SessionAwareHelper.onResumeHelper(this, this, redirectedInOnCreate);
     }
 
@@ -39,7 +38,7 @@ public abstract class SessionAwareListActivity extends CommcareListActivity impl
     @Override
     protected void onPause() {
         super.onPause();
-        SessionActivityRegistration.unregisterSessionExpirationReceiver(this);
+        SessionRegistrationHelper.unregisterSessionExpirationReceiver(this);
     }
 
     @Override

--- a/app/src/org/commcare/activities/SessionAwarePreferenceActivity.java
+++ b/app/src/org/commcare/activities/SessionAwarePreferenceActivity.java
@@ -14,7 +14,7 @@ public class SessionAwarePreferenceActivity extends CommCarePreferenceActivity {
     @Override
     protected void onResume() {
         super.onResume();
-
+        SessionActivityRegistration.registerSessionExpirationReceiver(this);
         SessionActivityRegistration.handleOrListenForSessionExpiration(this);
     }
 

--- a/app/src/org/commcare/activities/SessionAwarePreferenceActivity.java
+++ b/app/src/org/commcare/activities/SessionAwarePreferenceActivity.java
@@ -1,7 +1,5 @@
 package org.commcare.activities;
 
-import android.preference.PreferenceActivity;
-
 import org.commcare.utils.SessionActivityRegistration;
 
 /**
@@ -15,7 +13,7 @@ public class SessionAwarePreferenceActivity extends CommCarePreferenceActivity {
     protected void onResume() {
         super.onResume();
         SessionActivityRegistration.registerSessionExpirationReceiver(this);
-        SessionActivityRegistration.handleOrListenForSessionExpiration(this);
+        SessionActivityRegistration.handleSessionExpiration(this);
     }
 
     @Override

--- a/app/src/org/commcare/activities/SessionAwarePreferenceActivity.java
+++ b/app/src/org/commcare/activities/SessionAwarePreferenceActivity.java
@@ -1,6 +1,6 @@
 package org.commcare.activities;
 
-import org.commcare.utils.SessionActivityRegistration;
+import org.commcare.utils.SessionRegistrationHelper;
 
 /**
  * Manage redirection to login screen when session expiration occurs.
@@ -12,14 +12,14 @@ public class SessionAwarePreferenceActivity extends CommCarePreferenceActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        SessionActivityRegistration.registerSessionExpirationReceiver(this);
-        SessionActivityRegistration.handleSessionExpiration(this);
+        SessionRegistrationHelper.registerSessionExpirationReceiver(this);
+        SessionRegistrationHelper.handleSessionExpiration(this);
     }
 
     @Override
     protected void onPause() {
         super.onPause();
 
-        SessionActivityRegistration.unregisterSessionExpirationReceiver(this);
+        SessionRegistrationHelper.unregisterSessionExpirationReceiver(this);
     }
 }

--- a/app/src/org/commcare/utils/CommCareExceptionHandler.java
+++ b/app/src/org/commcare/utils/CommCareExceptionHandler.java
@@ -83,7 +83,7 @@ public class CommCareExceptionHandler implements UncaughtExceptionHandler {
 
         Throwable sessionUnavailableException = getSessionUnavailableException(causes);
         if (sessionUnavailableException != null) {
-            SessionActivityRegistration.redirectToLogin(ctx);
+            SessionRegistrationHelper.redirectToLogin(ctx);
             return true;
         }
         return false;

--- a/app/src/org/commcare/utils/SessionActivityRegistration.java
+++ b/app/src/org/commcare/utils/SessionActivityRegistration.java
@@ -41,8 +41,6 @@ public class SessionActivityRegistration {
      * methods of activities that are session sensitive.
      */
     public static boolean handleOrListenForSessionExpiration(AppCompatActivity activity) {
-        activity.registerReceiver(userSessionExpiredReceiver, expirationFilter);
-
         synchronized (registrationLock) {
             if (unredirectedSessionExpiration) {
                 unredirectedSessionExpiration = false;
@@ -51,6 +49,10 @@ public class SessionActivityRegistration {
             }
             return false;
         }
+    }
+
+    public static void registerSessionExpirationReceiver(AppCompatActivity activity) {
+        activity.registerReceiver(userSessionExpiredReceiver, expirationFilter);
     }
 
     /**

--- a/app/src/org/commcare/utils/SessionActivityRegistration.java
+++ b/app/src/org/commcare/utils/SessionActivityRegistration.java
@@ -40,7 +40,7 @@ public class SessionActivityRegistration {
      * listen for session expiration broadcasts. Call this method in onResume
      * methods of activities that are session sensitive.
      */
-    public static boolean handleOrListenForSessionExpiration(AppCompatActivity activity) {
+    public static boolean handleSessionExpiration(AppCompatActivity activity) {
         synchronized (registrationLock) {
             if (unredirectedSessionExpiration) {
                 unredirectedSessionExpiration = false;

--- a/app/src/org/commcare/utils/SessionRegistrationHelper.java
+++ b/app/src/org/commcare/utils/SessionRegistrationHelper.java
@@ -14,14 +14,14 @@ import org.commcare.activities.DispatchActivity;
  *
  * @author Phillip Mates (pmates@dimagi.com)
  */
-public class SessionActivityRegistration {
-    private static final String TAG = SessionActivityRegistration.class.getSimpleName();
+public class SessionRegistrationHelper {
+    private static final String TAG = SessionRegistrationHelper.class.getSimpleName();
 
     public static final String USER_SESSION_EXPIRED =
             "org.commcare.dalvik.application.user_session_expired";
 
     private static final IntentFilter expirationFilter =
-            new IntentFilter(SessionActivityRegistration.USER_SESSION_EXPIRED);
+            new IntentFilter(SessionRegistrationHelper.USER_SESSION_EXPIRED);
 
     private static boolean unredirectedSessionExpiration;
     private static final Object registrationLock = new Object();


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SAAS-11948

`onActivityResultHelper` was calling `SessionActivityRegistration.handleOrListenForSessionExpiration` which was also registering the broadcast receiver, thereby making the activity to register  twice for the same receiver and causing a memory leak.

This PR will seperate the code to register and unregister the broadcast receiver in different methods so that they can be used only in `onResume` and `onPause` of the activity. 

