### PR TITLE
Fixes NPE in LocationController

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1143,7 +1143,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
 
         TextToSpeechConverter.INSTANCE.shutDown();
-        PollSensorController.INSTANCE.destroy();
         super.onDestroy();
     }
 

--- a/app/src/org/commcare/android/javarosa/PollSensorController.java
+++ b/app/src/org/commcare/android/javarosa/PollSensorController.java
@@ -144,11 +144,4 @@ public enum PollSensorController implements CommCareLocationListener {
             mLocationController.stop();
         }
     }
-
-    public void destroy() {
-        if (mLocationController != null) {
-            mLocationController.destroy();
-        }
-    }
-
 }

--- a/app/src/org/commcare/location/CommCareFusedLocationController.kt
+++ b/app/src/org/commcare/location/CommCareFusedLocationController.kt
@@ -11,6 +11,7 @@ class CommCareFusedLocationController(private var mContext: Context?,
                                       private var mListener: CommCareLocationListener?): CommCareLocationController {
 
     private val mFusedLocationClient = LocationServices.getFusedLocationProviderClient(mContext!!)
+    private val settingsClient = LocationServices.getSettingsClient(mContext!!)
     private val mLocationRequest = LocationRequest.create().apply {
         priority = LocationRequest.PRIORITY_HIGH_ACCURACY
         interval = LOCATION_UPDATE_INTERVAL
@@ -29,7 +30,7 @@ class CommCareFusedLocationController(private var mContext: Context?,
     }
 
     private fun requestUpdates() {
-        if (isLocationPermissionGranted(mContext!!)) {
+        if (isLocationPermissionGranted(mContext)) {
             mFusedLocationClient.requestLocationUpdates(mLocationRequest, mLocationCallback, null)
         } else {
             mListener?.missingPermissions()
@@ -41,7 +42,6 @@ class CommCareFusedLocationController(private var mContext: Context?,
                 .addLocationRequest(mLocationRequest)
                 .setAlwaysShow(true)
                 .build()
-        val settingsClient = LocationServices.getSettingsClient(mContext!!)
         settingsClient.checkLocationSettings(locationSettingsRequest)
                 .addOnSuccessListener {
                     mListener?.onLocationRequestStart()

--- a/app/src/org/commcare/location/CommCareLocationController.kt
+++ b/app/src/org/commcare/location/CommCareLocationController.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.location.Location
 import androidx.core.content.ContextCompat
-import org.commcare.CommCareApplicationg
+import org.commcare.CommCareApplication
 
 /**
  * @author $|-|!˅@M

--- a/app/src/org/commcare/location/CommCareLocationController.kt
+++ b/app/src/org/commcare/location/CommCareLocationController.kt
@@ -4,10 +4,8 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.location.Location
-import androidx.core.app.ActivityCompat
-import com.google.android.gms.common.ConnectionResult
-import com.google.android.gms.common.GoogleApiAvailability
-import javax.annotation.Nullable
+import androidx.core.content.ContextCompat
+import org.commcare.CommCareApplicationg
 
 /**
  * @author $|-|!˅@M
@@ -19,7 +17,8 @@ interface CommCareLocationController {
     fun destroy()
 }
 
-fun CommCareLocationController.isLocationPermissionGranted(mContext: Context): Boolean {
-    return ActivityCompat.checkSelfPermission(mContext, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED &&
-            ActivityCompat.checkSelfPermission(mContext, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+fun CommCareLocationController.isLocationPermissionGranted(mContext: Context?): Boolean {
+    val context = mContext ?: CommCareApplication.instance()
+    return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
 }

--- a/app/src/org/commcare/location/CommCareProviderLocationController.kt
+++ b/app/src/org/commcare/location/CommCareProviderLocationController.kt
@@ -43,7 +43,7 @@ class CommCareProviderLocationController(private var mContext: Context?,
     }
 
     override fun start() {
-        if (!isLocationPermissionGranted(mContext!!)) {
+        if (!isLocationPermissionGranted(mContext)) {
             mListener?.missingPermissions()
             return
         }


### PR DESCRIPTION
Fixes an NPE 
```
Fatal Exception: kotlin.KotlinNullPointerException
       at org.commcare.location.CommCareFusedLocationController.requestUpdates(CommCareFusedLocationController.java:32)
       at org.commcare.location.CommCareFusedLocationController.access$setMCurrentLocation$p(CommCareFusedLocationController.java:10)
       at org.commcare.location.CommCareFusedLocationController$start$1.onSuccess(CommCareFusedLocationController.java:48)
       at org.commcare.location.CommCareFusedLocationController$start$1.onSuccess(CommCareFusedLocationController.java:10)
       at com.google.android.gms.tasks.zzn.run(zzn.java:4)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:216)
       at android.app.ActivityThread.main(ActivityThread.java:7266)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:494)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:975)
```

This was introduced in https://github.com/dimagi/commcare-android/pull/2443. We made context nullable but were force unwrapping `!!` causing crashes if it was accessed after the call to `destroy()`. 


Crashlytics: [issue1](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/b0b5f1f87f508e84d88be4f157fb4745?time=last-seven-days&versions=2.51.2%20(463994);2.51.2%20(463987);2.51.2%20(463988);2.51.2%20(463983)) and [issue2](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/01827d9b2a5c803d8365ff53e1ed9749?time=last-seven-days&versions=2.51.2%20(463994);2.51.2%20(463987);2.51.2%20(463988);2.51.2%20(463983)&sessionEventKey=60582BE501EF000119E42531A08C21E8_1521083592693210800)