### PR TITLE
Fix npe in FormRecordListActivity onDestroy

### DIFF
--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -625,7 +625,9 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        adapter.release();
+        if (adapter != null) {
+            adapter.release();
+        }
     }
 
     @Override


### PR DESCRIPTION
Stack trace 
```
2021-03-22 20:05:04.460 31436-31436/org.commcare.dalvik.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.commcare.dalvik.debug, PID: 31436
    java.lang.RuntimeException: Unable to destroy activity {org.commcare.dalvik.debug/org.commcare.activities.FormRecordListActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.commcare.adapters.IncompleteFormListAdapter.release()' on a null object reference
        at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5034)
        at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5063)
        at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:44)
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2044)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:224)
        at android.app.ActivityThread.main(ActivityThread.java:7562)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.commcare.adapters.IncompleteFormListAdapter.release()' on a null object reference
        at org.commcare.activities.FormRecordListActivity.onDestroy(FormRecordListActivity.java:628)
        at android.app.Activity.performDestroy(Activity.java:8180)
        at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1342)
        at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5019)
        at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5063) 
        at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:44) 
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2044) 
        at android.os.Handler.dispatchMessage(Handler.java:107) 
        at android.os.Looper.loop(Looper.java:224) 
        at android.app.ActivityThread.main(ActivityThread.java:7562) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950) 
2021-03-22 20:05:04.478 31436-31474/org.commcare.dalvik.debug E/FirebaseCrashlytics: Tried to write a fatal exception while no session was open.
```

Crashlytics link [here](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/0b879055cc217b980ebffbbc94455a1e?time=last-seven-days&versions=2.51.2%20(463994);2.51.2%20(463987);2.51.2%20(463988);2.51.2%20(463983)&sessionEventKey=605891FE003A00013F74AC02FD5B51AA_1520904975733987199). 

I was able to reproduce the issue by using `Terminate Application` button of logcat. So basically, when commcare is in background and android system destroys the `FormRecordListActivity` then it crashes. 