### PR TITLE
[SAAS-12009] Add Danger

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,27 @@
+# Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+if github.pr_title.include? "[WIP]"
+    warn "PR is classed as Work in Progress"
+end
+
+# Warning to encourage a PR description
+if github.pr_body.length == 0
+    warn "Please provide a summary in the PR description to make it easier to review"
+end
+
+# Ensure that labels have been used on the PR
+if github.pr_labels.empty?
+    failure "Please add labels to this PR"
+end
+
+# Make danger out jira ticket link
+jira.check(
+    key: ["SAAS"],
+    url: "https://dimagi-dev.atlassian.net/browse",
+    fail_on_warning: false
+)
+
+# Output lint issues on PR using 'danger-android_lint'  https://github.com/loadsmart/danger-android_lint
+android_lint.report_file = "app/build/reports/lint-results-commcareRelease.xml"
+android_lint.filtering = true
+android_lint.skip_gradle_task = true
+android_lint.lint(inline_mode: true)

--- a/scripts/run_danger.sh
+++ b/scripts/run_danger.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# To run on jenkins, use `bash scripts/run_danger.sh` in shell.
+
+# Assumes that we're in commcare-android directory.
+
+# Unfortunately jenkins errors out `source: not found` so we can't really save these in .bashrc
+export PATH="$HOME/.rbenv/bin:$PATH"
+export PATH="$HOME/.rbenv/shims:$PATH"
+export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"
+
+# We need ruby v3.0.0 to be able to use gems.
+rbenv global 3.0.0
+
+gem install danger
+gem install danger-jira
+gem install danger-android_lint
+
+danger --fail-on-errors=true


### PR DESCRIPTION
Added support for Danger https://danger.systems/ruby/

Makes use of `android_lint` plugin to output any lint issues on the PR. 