### PR TITLE
Clean session before exiting from external launch

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -220,7 +220,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                     if (intentArgumentsAsBundle != null) {
                         CommCareApplication.instance().getCurrentSessionWrapper()
                                 .executeEndpointStack(endpoint, AndroidUtil.bundleAsMap(intentArgumentsAsBundle));
-                    } else {
+                    } else if (intentArgumentsAsList != null) {
                         CommCareApplication.instance().getCurrentSessionWrapper()
                                 .executeEndpointStack(endpoint, intentArgumentsAsList);
                     }
@@ -834,6 +834,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                 refreshUI();
 
                 if (wasExternal) {
+                    currentState.reset();
                     setResult(RESULT_CANCELED);
                     this.finish();
                     return false;


### PR DESCRIPTION
Repro:

1. Launch a form using External Launch 
2. Complete and Save the form
3. CommCare should finish itself
4. Open CommCare from the recent apps screen 

After step 4, User is presented with the start screen though the session still remains populated from the stack ops of external launch from step 1. This results in incorrect navigation when the user relaunched CC on step 4