### PR TITLE
Use file backed storage for reading fixture while purging case

### DIFF
--- a/app/src/org/commcare/utils/CommCareUtil.java
+++ b/app/src/org/commcare/utils/CommCareUtil.java
@@ -22,8 +22,8 @@ import java.util.Vector;
  */
 public class CommCareUtil {
     public static FormInstance loadFixture(String refId, String userId) {
-        IStorageUtilityIndexed<FormInstance> userFixtureStorage = CommCareApplication.instance().getUserStorage("fixture", FormInstance.class);
-        IStorageUtilityIndexed<FormInstance> appFixtureStorage = CommCareApplication.instance().getAppStorage("fixture", FormInstance.class);
+        IStorageUtilityIndexed<FormInstance> userFixtureStorage = CommCareApplication.instance().getFileBackedUserStorage("fixture", FormInstance.class);
+        IStorageUtilityIndexed<FormInstance> appFixtureStorage = CommCareApplication.instance().getFileBackedAppStorage("fixture", FormInstance.class);
 
         Vector<Integer> userFixtures = userFixtureStorage.getIDsForValue(FormInstance.META_ID, refId);
         ///... Nooooot so clean.


### PR DESCRIPTION
**Jira**: https://dimagi-dev.atlassian.net/browse/SAAS-12191

**StackTrace**: 
```
Non-fatal Exception: java.lang.NullPointerException: Attempt to get length of null array
       at java.io.ByteArrayInputStream.<init>(ByteArrayInputStream.java:106)
       at org.commcare.models.database.SqlStorage.newObject(SqlStorage.java:249)
       at org.commcare.models.database.SqlStorage.read(SqlStorage.java:450)
       at org.commcare.models.database.SqlStorage.read(SqlStorage.java:43)
       at org.commcare.utils.CommCareUtil.loadFixture(CommCareUtil.java:32)
       at org.commcare.engine.cases.CaseUtils.purgeCases(CaseUtils.java:93)
       at org.commcare.tasks.DataPullTask.doTaskBackgroundHelper(DataPullTask.java:166)
       at org.commcare.tasks.DataPullTask.doTaskBackground(DataPullTask.java:139)
       at org.commcare.tasks.DataPullTask.doTaskBackground(DataPullTask.java:64)
       at org.commcare.tasks.templates.CommCareTask.doInBackground(CommCareTask.java:40)
       at android.os.AsyncTask$3.call(AsyncTask.java:378)
       at java.util.concurrent.FutureTask.run(FutureTask.java:266)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run(Thread.java:919)
```

**Summary**: 
The issue was happening in the sync process. While doing a case purge, we try to read the `user-groups` fixture in `CommCareUtil` class which used `SqlStorage` instead of `HybridFileBackedSqlStorage`. 

At the time of writing this `user-groups` fixture to the memory, the object size was more than 1 MB, so rather than storing the object to `DATA_COL` we instead stored it in a file and saved the file location to `FILE_COL`.

But, at the time of reading the fixture from db, we used `SqlStorage` which only checks the value in `DATA_COL` which was null and caused the NPE. 
