### PR TITLE
[SAAS-12119] Fix failures in fixture upload API

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/androidTests/LookupTableTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/LookupTableTest.kt
@@ -28,7 +28,7 @@ class LookupTableTest: BaseTest() {
     @Test
     fun testLookUpTable_UpdatesOnSync() {
         // Upload lookup table
-        HQApi.uploadFixture("initial_cities_table.xlsx")
+        HQApi.uploadFixture("initial_cities_table.xlsx", 0)
         installApp("Integration Tests", "integration_test_app.ccz")
         InstrumentationUtility.login("test", "123")
         syncAndGoToLookupTableForm()
@@ -36,7 +36,7 @@ class LookupTableTest: BaseTest() {
         InstrumentationUtility.matchChildCount(SelectOneWidget::class.java, RadioButton::class.java, 1)
 
         // Upload another lookup table
-        HQApi.uploadFixture("extended_cities_table.xlsx")
+        HQApi.uploadFixture("extended_cities_table.xlsx", 0)
         pressBack()
         onView(withText(R.string.do_not_save))
                 .perform(click())

--- a/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
+++ b/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
@@ -169,7 +169,7 @@ public class HQApi {
             } else {
                 Log.d(TAG, "Uploading Fixture " + retryCount + " time, failed :: " +
                         (response.body() != null ? response.body().string() : response.errorBody().string()));
-                if (retryCount < 10) { // In case of failure, retry 10 times.
+                if (retryCount < 5) { // In case of failure, retry 5 times.
                     uploadFixture(fixtureName, retryCount + 1);
                 }
             }

--- a/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
+++ b/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
@@ -153,7 +153,7 @@ public class HQApi {
         }
     }
 
-    public static void uploadFixture(String fixtureName) {
+    public static void uploadFixture(String fixtureName, int retryCount) {
         ClassLoader classLoader = InstrumentationRegistry.getInstrumentation().getTargetContext().getClassLoader();
         RequestBody requestFile = new InputStreamRequestBody(MediaType.parse("text/xlsx"), classLoader, fixtureName);
         List<MultipartBody.Part> parts = new ArrayList<>();
@@ -167,8 +167,11 @@ public class HQApi {
             if (response.isSuccessful()) {
                 Log.d(TAG, "Uploading Fixture succeeded :: " + response.body().string());
             } else {
-                Log.d(TAG, "Uploading Fixture failed :: " +
+                Log.d(TAG, "Uploading Fixture " + retryCount + " time, failed :: " +
                         (response.body() != null ? response.body().string() : response.errorBody().string()));
+                if (retryCount < 10) { // In case of failure, retry 10 times.
+                    uploadFixture(fixtureName, retryCount + 1);
+                }
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/instrumentation-tests/src/org/commcare/utils/InputStreamRequestBody.kt
+++ b/app/instrumentation-tests/src/org/commcare/utils/InputStreamRequestBody.kt
@@ -19,6 +19,11 @@ class InputStreamRequestBody(private val contentType: MediaType,
         return contentType
     }
 
+    override fun contentLength(): Long {
+        val stream = classLoader.getResourceAsStream(fileName)
+        return stream.available().toLong()
+    }
+
     override fun writeTo(sink: BufferedSink) {
         okio.Okio.source(classLoader.getResourceAsStream(fileName)).use {
             sink.writeAll(it)


### PR DESCRIPTION
As noted by Amit, the fixture upload api call is failing intermittently with this error on nginx: 
```
 [error] 9910#9910: *326082837 client sent invalid chunked body, client: 65.74.184.76, server: www.commcarehq.org, request: ""POST /a/commcare-tests/fixtures/fixapi/ HTTP/1.1"", host: ""www.commcarehq.org""
```
We also noticed that if we retry the upload, it succeeds. 

I'm not really sure about this issue, but it seems like retrofit doesn't know the content-length when the upload starts(although, the network logs suggests that the request has correct `bodySize`, so I might be wrong).

This PR will use the `inputstream#available` method to determine the content length. But since the method doesn't always gives an accurate result, we'll retry the upload call 5 times, before it fails the test.