### PR TITLE
[2.51.3 hotfix] Fixes navigation drawer view 

### DIFF
--- a/app/src/org/commcare/activities/HomeNavDrawerController.java
+++ b/app/src/org/commcare/activities/HomeNavDrawerController.java
@@ -64,10 +64,11 @@ public class HomeNavDrawerController {
         refreshItems();
 
         ActionBar actionBar = activity.getSupportActionBar();
+        actionBar.setHomeAsUpIndicator(R.drawable.ic_menu_bar);
         actionBar.setHomeButtonEnabled(true);
-        actionBar.setDisplayHomeAsUpEnabled(false);
+        actionBar.setDisplayHomeAsUpEnabled(true);
         actionBar.setDisplayUseLogoEnabled(false);
-        actionBar.setIcon(R.drawable.ic_menu_bar);
+
 
         if (savedInstanceState != null &&
                 savedInstanceState.getBoolean(KEY_DRAWER_WAS_OPEN)) {


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SC-1494

Somehow the `actionBar.setIcon()` doesn't seem to have an effect with support action bar. So setting the icon by using the `actionBar.setHomeAsUpIndicator` 