### PR TITLE
Support Lib Maven Central Changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.jacoco:org.jacoco.core:0.8.5'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
     }
 }
 

--- a/commcare-support-library/README.md
+++ b/commcare-support-library/README.md
@@ -1,0 +1,57 @@
+# CommCare Support Library
+
+[CommCare](https://github.com/dimagi/commcare-android/) is an extensible form management application with a number of hooks
+to enable integration with other Android applications that want to use CommCare as a form entry engine
+or as a data backend.
+The CommCare support library provides a set of utility functions for using these APIs [mobile APIs](https://github.com/dimagi/commcare-android/wiki)
+without having to understand and implement the underlying Android Cursors and Intents.
+
+### Installation
+
+The support library is hosted on [JCenter](https://bintray.com/wsp260/commcare-support-library/commcare-support-library).
+You can include this in Gradle in your `build.gradle`:
+
+```
+repositories {
+    ...
+    jcenter()
+}
+```
+
+and:
+```
+dependencies {
+    ...
+    compile 'org.commcare:support-library:12.3'
+}
+```
+
+### Examples
+
+#### Cases
+
+Get the name of a case by its `case_id`:
+
+`CaseUtils.getCaseName(Context context, String caseId)`
+
+Get the value of a specified property of a case by its `case_id`:
+
+`CaseUtils.getCaseProperty(Context context, String caseId, String caseProperty)`
+
+Or get an entire list of case properties:
+
+`CaseUtils.getCaseProperties(Context context, String caseId, ArrayList<String> caseProperties)`
+
+Get a list of all the caseIds in the current user database:
+
+`CaseUtils.getCaseIds(Context context)`
+
+#### Fixtures
+
+Get a list of IDs of all the fixtures in the current database:
+
+`FixtureUtils.getFixtureIdList(Context context)`
+
+Then retrieve the XML for a specific fixture from this list:
+
+`FixtureUtils.getFixtureXml(Context context, String fixtureId`

--- a/commcare-support-library/README.md
+++ b/commcare-support-library/README.md
@@ -6,15 +6,17 @@ or as a data backend.
 The CommCare support library provides a set of utility functions for using these APIs [mobile APIs](https://github.com/dimagi/commcare-android/wiki)
 without having to understand and implement the underlying Android Cursors and Intents.
 
+CommCare Support library also provides APIs for a biometric provider to integrate with CommCare. Read more [here](https://github.com/dimagi/commcare-android/blob/master/commcare-support-library/src/main/java/org/commcare/commcaresupportlibrary/identity/identity_integration.md)
+
 ### Installation
 
-The support library is hosted on [JCenter](https://bintray.com/wsp260/commcare-support-library/commcare-support-library).
+The support library is hosted on Maven Central.
 You can include this in Gradle in your `build.gradle`:
 
 ```
 repositories {
     ...
-    jcenter()
+    mavenCentral()
 }
 ```
 
@@ -22,7 +24,7 @@ and:
 ```
 dependencies {
     ...
-    compile 'org.commcare:support-library:12.3'
+    implementation 'org.commcare:support-library:12.4'
 }
 ```
 
@@ -55,3 +57,4 @@ Get a list of IDs of all the fixtures in the current database:
 Then retrieve the XML for a specific fixture from this list:
 
 `FixtureUtils.getFixtureXml(Context context, String fixtureId`
+

--- a/commcare-support-library/build.gradle
+++ b/commcare-support-library/build.gradle
@@ -1,19 +1,14 @@
 apply plugin: 'com.android.library'
-apply plugin: 'maven-publish'
+apply plugin: 'com.vanniktech.maven.publish'
 
 version '12.4'
-
-ext {
-    BINTRAY_USERNAME = project.properties['BINTRAY_USERNAME'] ?: ""
-    BINTRAY_PASSWORD = project.properties['BINTRAY_PASSWORD'] ?: ""
-}
 
 afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
                 from components.release
-                groupId 'org.commcare'
+                groupId 'org.commcarehq.commcare'
                 artifactId 'support-library'
                 version this.version
 
@@ -38,16 +33,6 @@ afterEvaluate {
                         url = 'https://github.com/dimagi/commcare-support-library.git'
                     }
                 }
-            }
-        }
-        repositories {
-            maven {
-                credentials {
-                    username project.ext.BINTRAY_USERNAME
-                    password project.ext.BINTRAY_PASSWORD
-                }
-                name = 'dimagi-commcare-support-library'
-                url = 'https://api.bintray.com/maven/dimagi/commcare-support-library/commcare-support-library/;publish=1'
             }
         }
     }

--- a/commcare-support-library/build.gradle
+++ b/commcare-support-library/build.gradle
@@ -15,7 +15,7 @@ afterEvaluate {
                 pom {
                     name = 'CommCare Support Library'
                     description = 'Provides a set of utility functions for using CommCare Android mobile APIs'
-                    url = 'https://github.com/dimagi/commcare-support-library'
+                    url = 'https://github.com/dimagi/commcare-android/tree/master/commcare-support-library'
                     licenses {
                         license {
                             name = 'The Apache Software License, Version 2.0'
@@ -30,7 +30,7 @@ afterEvaluate {
                         }
                     }
                     scm {
-                        url = 'https://github.com/dimagi/commcare-support-library.git'
+                        url = 'https://github.com/dimagi/commcare-android.git'
                     }
                 }
             }

--- a/commcare-support-library/build.gradle
+++ b/commcare-support-library/build.gradle
@@ -39,10 +39,10 @@ afterEvaluate {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip


### PR DESCRIPTION
Adds [this plugin](https://github.com/vanniktech/gradle-maven-publish-plugin) to manage upload to Maven Central. 

Followed the usage instructions from [here](https://proandroiddev.com/publishing-your-first-android-library-to-mavencentral-be2c51330b88). This is only locally setup from my computer right now, and next steps would be to set this up on Jenkins. 

There are login credentials for https://oss.sonatype.org/ in the `dimagi_shared` keepass with title `sonatype jira`  