### PR TITLE
Add support of heic images

### DIFF
--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -56,7 +56,7 @@ public class FormUploadUtil {
 
     // This list is also maintained server side and any changes to this should be replicated on server as well
     private static final String[] SUPPORTED_FILE_EXTS =
-            {".xml", ".jpg", "jpeg", ".3gpp", ".3gp", ".3ga", ".3g2", ".mp3",
+            {".xml", ".jpg", "jpeg", ".heic", ".3gpp", ".3gp", ".3ga", ".3g2", ".mp3",
                     ".wav", ".amr", ".mp4", ".3gp2", ".mpg4", ".mpeg4",
                     ".m4v", ".mpg", ".mpeg", ".qcp", ".ogg"};
 


### PR DESCRIPTION
Product Note: CommCare will allow `heic` images in the Image Upload questions. 