### PR TITLE
Use applicationId variable for logout permission

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -71,7 +71,7 @@
     </permission>
 
     <permission
-        android:name="org.commcare.dalvik.permission.COMMCARE_LOGOUT"
+        android:name="${applicationId}.permission.COMMCARE_LOGOUT"
         android:description="@string/permission_commcare_logout_description"
         android:label="@string/permission_commcare_logout_label"
         android:permissionGroup="commcare.permission-group.EXTERNAL_ACTION"


### PR DESCRIPTION
**Reason for the change:** 
I was trying to install the release apk, while the debug apk was already installed in the device. And I got this error:
```
➜  adb install release.apk
Performing Streamed Install
adb: failed to install release.apk: Failure [INSTALL_FAILED_DUPLICATE_PERMISSION: Package org.commcare.dalvik attempting to redeclare permission org.commcare.dalvik.permission.COMMCARE_LOGOUT already owned by org.commcare.dalvik.debug]
```

This PR should fix above error. 