### PR TITLE
NPE fix in error handling for Session Endpoint

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -263,7 +263,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                     this,
                     R.string.session_endpoint_unavailable,
                     new String[]{
-                            endpoint.getId(),
+                            sessionEndpointId,
                             StringUtils.join(allEndpoints.keySet(), ",")});
             UserfacingErrorHandling.createErrorDialog(this, invalidEndpointError, true);
             return null;


### PR DESCRIPTION
## Summary

Fixes a npe with session endpoint error handling

https://dimagi-dev.atlassian.net/browse/QA-3059?focusedCommentId=148906

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

no coverage


### Safety story
- very minor change in error handling in a specific part of code 
- Tested manually
