### PR TITLE
Adds daterange picker for case search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,6 +130,8 @@ dependencies {
     implementation('com.squareup.okhttp3:okhttp-tls:3.12.12') {
         exclude(group: 'org.bouncycastle', module: 'bcprov-jdk15on')
     }
+
+    implementation 'com.google.android.material:material:1.3.0'
 }
 
 ext {

--- a/app/res/drawable-anydpi/ic_create.xml
+++ b/app/res/drawable-anydpi/ic_create.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/app/res/layout/query_prompt_layout.xml
+++ b/app/res/layout/query_prompt_layout.xml
@@ -34,12 +34,10 @@
         android:singleLine="true" />
 
     <ImageView
-        android:id="@+id/barcode_scanner"
+        android:id="@+id/assist_view"
         android:layout_height="match_parent"
         android:layout_marginLeft="4dp"
         android:layout_marginStart="4dp"
-        android:layout_width="32dp"
-        android:background="@color/blue"
-        app:srcCompat="@drawable/startup_barcode" />
+        android:layout_width="32dp" />
 
 </LinearLayout>

--- a/app/res/values/themes.xml
+++ b/app/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <style name="CommonTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="CommonTheme" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge">
         <item name="colorPrimary">@color/cc_brand_color</item>
         <item name="colorPrimaryDark">@color/cc_brand_text</item>
         <item name="colorAccent">@color/cc_dark_cool_accent_color</item>
@@ -31,6 +31,11 @@
         <item name="android:scrollViewStyle">@style/fading_edge</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:dropDownListViewStyle">@style/dropDownListView</item>
+
+        <!--  Material Components styling that can be removed when we migrate to a material component theme from the bridge theme-->
+        <item name="materialCalendarStyle">@style/Widget.MaterialComponents.MaterialCalendar</item>
+        <item name="materialCalendarFullscreenTheme">@style/ThemeOverlay.MaterialComponents.MaterialCalendar.Fullscreen</item>
+        <item name="materialCalendarTheme">@style/ThemeOverlay.MaterialComponents.MaterialCalendar</item>
     </style>
 
     <style name="AppBaseTheme" parent="CommonTheme" />

--- a/app/src/org/commcare/utils/DateRangeUtils.java
+++ b/app/src/org/commcare/utils/DateRangeUtils.java
@@ -7,6 +7,8 @@ import java.util.Locale;
 
 import javax.annotation.Nullable;
 
+import androidx.core.util.Pair;
+
 /**
  * Utility functions for DateRangePicker widget
  */
@@ -24,14 +26,14 @@ public class DateRangeUtils {
      * @throws ParseException if the given humanReadableDateRange is not in 'yyyy-mm-dd to yyyy-mm-dd' format
      */
     @Nullable
-    public static androidx.core.util.Pair<Long, Long> parseHumanReadableDate(String humanReadableDateRange) throws ParseException {
+    public static Pair<Long, Long> parseHumanReadableDate(String humanReadableDateRange) throws ParseException {
         if (humanReadableDateRange.contains(DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER)) {
             String[] humanReadableDateRangeSplit = humanReadableDateRange.split(DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER);
             if (humanReadableDateRangeSplit.length == 2) {
                 SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT, Locale.US);
                 Date startDate = sdf.parse(humanReadableDateRangeSplit[0]);
                 Date endDate = sdf.parse(humanReadableDateRangeSplit[1]);
-                return new androidx.core.util.Pair<>(getTimeFromDateOffsettingTz(startDate), getTimeFromDateOffsettingTz(endDate));
+                return new Pair<>(getTimeFromDateOffsettingTz(startDate), getTimeFromDateOffsettingTz(endDate));
             }
         }
         throw new ParseException("Argument " + humanReadableDateRange + " should be formatted as 'yyyy-mm-dd to yyyy-mm-dd'", 0);

--- a/app/src/org/commcare/utils/DateRangeUtils.java
+++ b/app/src/org/commcare/utils/DateRangeUtils.java
@@ -1,0 +1,75 @@
+package org.commcare.utils;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import javax.annotation.Nullable;
+
+/**
+ * Utility functions for DateRangePicker widget
+ */
+public class DateRangeUtils {
+
+    // Changing this will require changing this format on ES end as well
+    public static final String DATE_RANGE_ANSWER_PREFIX = "__range__";
+    public static final String DATE_RANGE_ANSWER_DELIMITER = "__";
+    public static final String DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER = " to ";
+    private static final String DATE_FORMAT = "yyyy-MM-dd";
+
+    /**
+     * @param humanReadableDateRange human readable fomat for date range as 'startDate to endDate'
+     * @return a Pair of start time and end time that can be supplied to MaterialDatePicker to set a date range,
+     * @throws ParseException if the given humanReadableDateRange is not in 'yyyy-mm-dd to yyyy-mm-dd' format
+     */
+    @Nullable
+    public static androidx.core.util.Pair<Long, Long> parseHumanReadableDate(String humanReadableDateRange) throws ParseException {
+        if (humanReadableDateRange.contains(DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER)) {
+            String[] humanReadableDateRangeSplit = humanReadableDateRange.split(DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER);
+            if (humanReadableDateRangeSplit.length == 2) {
+                SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT, Locale.US);
+                Date startDate = sdf.parse(humanReadableDateRangeSplit[0]);
+                Date endDate = sdf.parse(humanReadableDateRangeSplit[1]);
+                return new androidx.core.util.Pair<>(getTimeFromDateOffsettingTz(startDate), getTimeFromDateOffsettingTz(endDate));
+            }
+        }
+        throw new ParseException("Argument " + humanReadableDateRange + " should be formatted as 'yyyy-mm-dd to yyyy-mm-dd'", 0);
+    }
+
+    private static Long getTimeFromDateOffsettingTz(Date date) {
+        return date.getTime() - date.getTimezoneOffset() * 60 * 1000;
+    }
+
+    /**
+     * Formats __range__startDate__endDate as 'startDate to EndDate'
+     *
+     * @param dateRangeAnswer A date range value in form of '__range__startDate__endDate'
+     * @return human readable format 'startDate to EndDate' for given dateRangeAnswer
+     */
+    public static String getHumanReadableDateRange(String dateRangeAnswer) {
+        if (dateRangeAnswer != null && dateRangeAnswer.startsWith(DATE_RANGE_ANSWER_PREFIX)) {
+            String[] dateRangeSplit = dateRangeAnswer.split(DATE_RANGE_ANSWER_DELIMITER);
+            if (dateRangeSplit.length == 3) {
+                return getHumanReadableDateRange(dateRangeSplit[2], dateRangeSplit[3]);
+            }
+        }
+        return dateRangeAnswer;
+    }
+
+
+    // Formats as 'startDate to endDate'
+    public static String getHumanReadableDateRange(String startDate, String endDate) {
+        return startDate + DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER + endDate;
+    }
+
+    // Formats as '__range__startDate__endDate'
+    public static String formatDateRangeAnswer(String startDate, String endDate) {
+        return DATE_RANGE_ANSWER_PREFIX + startDate + DATE_RANGE_ANSWER_DELIMITER + endDate;
+    }
+
+    // Convers given time as yyyy-mm-dd
+    public static String getDateFromTime(Long time) {
+        return new SimpleDateFormat(DATE_FORMAT, Locale.US).format(new Date(time));
+    }
+}

--- a/app/unit-tests/resources/commcare-apps/case_search_and_claim/default/app_strings.txt
+++ b/app/unit-tests/resources/commcare-apps/case_search_and_claim/default/app_strings.txt
@@ -22,6 +22,7 @@ query.name=Patient Name
 query.id=Patient ID
 query.state=State
 query.district=District
+query.date=Date
 case_sharing.exactly_one_group=The case sharing settings for your user are incorrect. This user must be in exactly one case sharing group. Please contact your supervisor.
 cchq.case=Case
 cchq.referral=Referral

--- a/app/unit-tests/resources/commcare-apps/case_search_and_claim/suite.xml
+++ b/app/unit-tests/resources/commcare-apps/case_search_and_claim/suite.xml
@@ -255,79 +255,6 @@
 
   <remote-request>
     <post url="https://www.fake.com/claim_patient/"
-          relevant="count(instance('casedb')/casedb/case[@case_id=instance('session')/session/data/case_id]) = 0">
-      <data key="selected_case_id" ref="instance('session')/session/data/case_id"/>
-    </post>
-    <command id="patient-search">
-      <display>
-        <text>Global search for person</text>
-      </display>
-    </command>
-    <instance id="session" src="jr://instance/session"/>
-    <instance id="casedb" src="jr://instance/casedb"/>
-    <instance id="district" src="jr://fixture/item-list:district"/>
-    <instance id="state" src="jr://fixture/item-list:state"/>
-    <session>
-      <query url="https://www.fake.com/patient_search/" storage-instance="patients">
-        <data key="device_id" ref="instance('session')/session/context/deviceid"/>
-        <prompt key="name">
-          <display>
-            <text>
-              <locale id="query.name"/>
-            </text>
-          </display>
-        </prompt>
-        <prompt key="patient_id">
-          <display>
-            <text>
-              <locale id="query.id"/>
-            </text>
-          </display>
-        </prompt>
-        <prompt key="state" input="select1">
-          <display>
-            <text>
-              <locale id="query.state"/>
-            </text>
-          </display>
-          <itemset nodeset="instance('state')/state_list/state">
-            <label ref="name"/>
-            <value ref="id"/>
-            <sort ref="id"/>
-          </itemset>
-        </prompt>
-        <prompt key="district" input="select1">
-          <display>
-            <text>
-              <locale id="query.district"/>
-            </text>
-          </display>
-          <itemset nodeset="instance('district')/district_list/district[state_id = $state]">
-            <label ref="name"/>
-            <value ref="id"/>
-            <sort ref="id"/>
-          </itemset>
-        </prompt>
-        <prompt key="invalid" input="foobar">
-          <display>
-            <text>
-              <locale id="query.district"/>
-            </text>
-          </display>
-        </prompt>
-      </query>
-      <datum id="case_id" nodeset="instance('patients')/patients/patient" value="./id" detail-select="patient_short" detail-confirm="patient_long"/>
-    </session>
-    <stack>
-      <push>
-        <command value="'m1-f0'"/>
-        <datum id="calculated_data" value="'claimed'"/>
-      </push>
-    </stack>
-  </remote-request>
-
-  <remote-request>
-    <post url="https://www.fake.com/claim_patient/"
         relevant="count(instance('casedb')/casedb/case[@case_id=instance('session')/session/data/case_id]) = 0">
       <data key="selected_case_id" ref="instance('session')/session/data/case_id"/>
     </post>
@@ -381,6 +308,20 @@
             <value ref="id"/>
             <sort ref="id"/>
           </itemset>
+        </prompt>
+        <prompt key="date" input="daterange">
+          <display>
+            <text>
+              <locale id="query.date"/>
+            </text>
+          </display>
+        </prompt>
+        <prompt key="invalid" input="foobar">
+          <display>
+            <text>
+              <locale id="query.district"/>
+            </text>
+          </display>
         </prompt>
       </query>
       <datum id="case_id" nodeset="instance('patients')/patients/patient" value="./id" detail-select="patient_short" detail-confirm="patient_long"/>

--- a/app/unit-tests/resources/commcare-apps/case_search_and_claim/suite.xml
+++ b/app/unit-tests/resources/commcare-apps/case_search_and_claim/suite.xml
@@ -258,6 +258,79 @@
         relevant="count(instance('casedb')/casedb/case[@case_id=instance('session')/session/data/case_id]) = 0">
       <data key="selected_case_id" ref="instance('session')/session/data/case_id"/>
     </post>
+    <command id="patient-search">
+      <display>
+        <text>Global search for person</text>
+      </display>
+    </command>
+    <instance id="session" src="jr://instance/session"/>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="district" src="jr://fixture/item-list:district"/>
+    <instance id="state" src="jr://fixture/item-list:state"/>
+    <session>
+      <query url="https://www.fake.com/patient_search/" storage-instance="patients">
+        <data key="device_id" ref="instance('session')/session/context/deviceid"/>
+        <prompt key="name">
+          <display>
+            <text>
+              <locale id="query.name"/>
+            </text>
+          </display>
+        </prompt>
+        <prompt key="patient_id">
+          <display>
+            <text>
+              <locale id="query.id"/>
+            </text>
+          </display>
+        </prompt>
+        <prompt key="state" input="select1">
+          <display>
+            <text>
+              <locale id="query.state"/>
+            </text>
+          </display>
+          <itemset nodeset="instance('state')/state_list/state">
+            <label ref="name"/>
+            <value ref="id"/>
+            <sort ref="id"/>
+          </itemset>
+        </prompt>
+        <prompt key="district" input="select1">
+          <display>
+            <text>
+              <locale id="query.district"/>
+            </text>
+          </display>
+          <itemset nodeset="instance('district')/district_list/district[state_id = $state]">
+            <label ref="name"/>
+            <value ref="id"/>
+            <sort ref="id"/>
+          </itemset>
+        </prompt>
+        <prompt key="invalid" input="foobar">
+          <display>
+            <text>
+              <locale id="query.district"/>
+            </text>
+          </display>
+        </prompt>
+      </query>
+      <datum id="case_id" nodeset="instance('patients')/patients/patient" value="./id" detail-select="patient_short" detail-confirm="patient_long"/>
+    </session>
+    <stack>
+      <push>
+        <command value="'m1-f0'"/>
+        <datum id="calculated_data" value="'claimed'"/>
+      </push>
+    </stack>
+  </remote-request>
+
+  <remote-request>
+    <post url="https://www.fake.com/claim_patient/"
+        relevant="count(instance('casedb')/casedb/case[@case_id=instance('session')/session/data/case_id]) = 0">
+      <data key="selected_case_id" ref="instance('session')/session/data/case_id"/>
+    </post>
     <command id="patient-search-complex">
       <display>
         <text>Global search for person</text>

--- a/app/unit-tests/src/org/commcare/android/tests/activities/QueryRequestActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/QueryRequestActivityTest.java
@@ -283,7 +283,7 @@ public class QueryRequestActivityTest {
         // set views
         LinearLayout promptsLayout = queryRequestActivity.findViewById(R.id.query_prompts);
 
-        assertEquals(promptsLayout.getChildCount(), 4);
+        assertEquals(5, promptsLayout.getChildCount());
 
         EditText patientName = promptsLayout.getChildAt(0).findViewById(R.id.prompt_et);
         patientName.setText("francisco");

--- a/app/unit-tests/src/org/commcare/utils/DateRangeUtilsTest.java
+++ b/app/unit-tests/src/org/commcare/utils/DateRangeUtilsTest.java
@@ -1,0 +1,22 @@
+package org.commcare.utils;
+
+import org.junit.Test;
+
+import java.text.ParseException;
+
+import androidx.core.util.Pair;
+
+public class DateRangeUtilsTest {
+
+    @Test
+    public void testDateConversion() throws ParseException {
+        String dateRange = "2020-02-15 to 2021-03-18";
+        Pair<Long, Long> selection = DateRangeUtils.parseHumanReadableDate(dateRange);
+        String startDate = DateRangeUtils.getDateFromTime(selection.first);
+        String endDate = DateRangeUtils.getDateFromTime(selection.second);
+        String humanReadableDateRange = DateRangeUtils.getHumanReadableDateRange(startDate, endDate);
+        assert dateRange.contentEquals(humanReadableDateRange);
+        assert DateRangeUtils.formatDateRangeAnswer(startDate, endDate).contentEquals("__range__2020-02-15__2021-03-18");
+    }
+
+}


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SC-1465

Adds a widget to select a date range in case search

## Feature Flag

https://www.commcarehq.org/hq/flags/edit/search_claim/

## Product Description

Allows user to search a case property in a date range. 

<img src="https://user-images.githubusercontent.com/4679137/124115661-b4967280-da8b-11eb-9f72-c7bc7cbfaf75.jpg" width="400" height="600">

Clicking edit in the query screen opens up the date picker as shown below - 

<img src="https://user-images.githubusercontent.com/4679137/124115667-b6f8cc80-da8b-11eb-8f93-2ff82de547e6.jpg" width="400" height="600">

HQ changes were merged earlier in https://github.com/dimagi/commcare-hq/pull/29035 

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

Added test around date conversion utility used for the widget which handles major functionality around the datepicker. Would rely on Manual QA for end to end testing on this as datepicker range is proving to be difficult to test with robolectric. 

### Safety story

Tested locally, would go through manual QA as well,
Impact if any would largely be limited to the apps using the case claim with the daterange widget. To use the datepicker widget I had to change the app theme to a [Material Component Bridge theme](https://github.com/material-components/material-components-android/blob/master/docs/getting-started.md#bridge-themes). Though this should not cause any UI changes, there can be minor UI sideeffects elsewhere in app. 