### PR TITLE
bugfix: Latest CC version getting set incorrectly

### DIFF
--- a/app/src/org/commcare/heartbeat/HeartbeatRequester.java
+++ b/app/src/org/commcare/heartbeat/HeartbeatRequester.java
@@ -156,7 +156,9 @@ public class HeartbeatRequester extends GetAndParseActor {
                     if (latestVersionInfo.has("force")) {
                         forceString = latestVersionInfo.getString("force");
                     }
-                    HiddenPreferences.setLatestCommcareVersion(versionValue);
+                    if (updateType == UpdateToPrompt.Type.APK_UPDATE) {
+                        HiddenPreferences.setLatestCommcareVersion(versionValue);
+                    }
                     UpdateToPrompt updateToPrompt = new UpdateToPrompt(versionValue, forceString, updateType);
                     updateToPrompt.registerWithSystem();
                 }

--- a/app/unit-tests/src/org/commcare/android/tests/HeartbeatAndPromptedUpdateTests.java
+++ b/app/unit-tests/src/org/commcare/android/tests/HeartbeatAndPromptedUpdateTests.java
@@ -16,6 +16,7 @@ import org.commcare.heartbeat.HeartbeatWorker;
 import org.commcare.heartbeat.TestHeartbeatRequester;
 import org.commcare.heartbeat.UpdatePromptHelper;
 import org.commcare.heartbeat.UpdateToPrompt;
+import org.commcare.preferences.HiddenPreferences;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +25,7 @@ import org.robolectric.annotation.Config;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
 /**
@@ -86,6 +88,8 @@ public class HeartbeatAndPromptedUpdateTests {
 
         UpdateToPrompt apkUpdate = UpdatePromptHelper.getCurrentUpdateToPrompt(UpdateToPrompt.Type.APK_UPDATE);
         Assert.assertNull(apkUpdate);
+
+        assertEquals("2.25.0", HiddenPreferences.getLatestCommcareVersion());
     }
 
     @Test


### PR DESCRIPTION

## Summary

Fix for [crash](https://console.firebase.google.com/u/1/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/83958493f023c2da3597b9bb4062c106?time=last-ninety-days&sessionEventKey=60DED19002750001754F3E03A954DA53_1558698498712440908)

Issue would have impacted projects with CC update prompts on in app settings. Crash would have happened after the apk update is finished which is probably the reason we see a limited number of these crashes as one user would have seen this crash at most once for a CC release.


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

Added a check for the right CC version after parsing the heartbeat response


