### PR TITLE
Ensure button styles doesn't break with custom colors

### DIFF
--- a/app/res/layout/list_gregorian_widget.xml
+++ b/app/res/layout/list_gregorian_widget.xml
@@ -49,6 +49,7 @@
                 android:text="+"
                 android:textSize="@dimen/text_largest"
                 android:textColor="@color/white"
+                style="@style/CommCare.Button.Default"
                 android:background="@color/bright_blue_grad_start"
                 android:elevation="@dimen/button_elevation"/>
 
@@ -70,6 +71,7 @@
                 android:layout_height="wrap_content"
                 android:text="-"
                 android:textSize="@dimen/text_largest"
+                style="@style/CommCare.Button.Default"
                 android:textColor="@color/white"
                 android:background="@color/dark_blue"
                 android:elevation="@dimen/button_elevation" />
@@ -92,6 +94,7 @@
                 android:layout_marginLeft="5dp"
                 android:text="+"
                 android:textSize="@dimen/text_largest"
+                style="@style/CommCare.Button.Default"
                 android:textColor="@color/white"
                 android:background="@color/bright_blue_grad_start"
                 android:elevation="@dimen/button_elevation"
@@ -110,6 +113,7 @@
                 android:layout_marginLeft="5dp"
                 android:text="-"
                 android:textSize="@dimen/text_largest"
+                style="@style/CommCare.Button.Default"
                 android:textColor="@color/white"
                 android:background="@color/dark_blue"
                 android:elevation="@dimen/button_elevation"
@@ -132,6 +136,7 @@
                 android:layout_marginLeft="5dp"
                 android:text="+"
                 android:textSize="@dimen/text_largest"
+                style="@style/CommCare.Button.Default"
                 android:textColor="@color/white"
                 android:background="@color/bright_blue_grad_start"
                 android:elevation="@dimen/button_elevation"
@@ -159,6 +164,7 @@
                 android:layout_marginLeft="5dp"
                 android:text="-"
                 android:textSize="@dimen/text_largest"
+                style="@style/CommCare.Button.Default"
                 android:textColor="@color/white"
                 android:background="@color/dark_blue"
                 android:elevation="@dimen/button_elevation"

--- a/app/res/layout/recording_fragment.xml
+++ b/app/res/layout/recording_fragment.xml
@@ -102,6 +102,8 @@
             android:layout_gravity="end"
             android:layout_marginBottom="10dp"
             android:enabled="false"
+            style="@style/CommCare.Button.Default"
+            android:minHeight="@dimen/dp60"
             android:background="@color/cc_attention_positive_color"
             android:textColor="@color/white"
             android:visibility="invisible"

--- a/app/res/layout/universal_date_widget.xml
+++ b/app/res/layout/universal_date_widget.xml
@@ -17,8 +17,7 @@
             android:layout_height="wrap_content"
             android:background="@drawable/date_button_top"
             android:text="+"
-            android:textSize="@dimen/text_largest"
-            android:textColor="@color/darkest_grey"/>
+            android:textSize="@dimen/text_largest"/>
 
         <TextView
             android:id="@+id/daytxt"
@@ -37,8 +36,7 @@
             android:layout_below="@id/daytxt"
             android:background="@drawable/date_button_bottom"
             android:text="-"
-            android:textSize="@dimen/text_largest"
-            android:textColor="#666"/>
+            android:textSize="@dimen/text_largest"/>
 
         <Button
             android:id="@+id/monthupbtn"
@@ -49,7 +47,6 @@
             android:background="@drawable/date_button_top"
             android:text="+"
             android:textSize="@dimen/text_largest"
-            android:textColor="#666"
             android:layout_toEndOf="@id/dayupbtn"
             android:layout_marginStart="5dp" />
 
@@ -77,7 +74,6 @@
             android:background="@drawable/date_button_bottom"
             android:text="-"
             android:textSize="@dimen/text_largest"
-            android:textColor="#666"
             android:layout_toEndOf="@id/daydownbtn"
             android:layout_marginStart="5dp" />
 
@@ -90,7 +86,6 @@
             android:background="@drawable/date_button_top"
             android:text="+"
             android:textSize="@dimen/text_largest"
-            android:textColor="#666"
             android:layout_toEndOf="@id/monthupbtn"
             android:layout_marginStart="5dp" />
 
@@ -118,7 +113,6 @@
             android:background="@drawable/date_button_bottom"
             android:text="-"
             android:textSize="@dimen/text_largest"
-            android:textColor="#666"
             android:layout_toEndOf="@id/monthdownbtn"
             android:layout_marginStart="5dp" />
     </RelativeLayout>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Follow up on https://github.com/dimagi/commcare-android/pull/2461#issuecomment-870506640. 

## Feature Flag - NA
<!-- If this is specific to a feature flag, which one? -->

## Product Description -NA
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage - NA

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
Went over the codebase to look for all the button styles that are defining custom colors and made sure that they work well with the updated colored styles of buttons. 