### PR TITLE
Map fix

### DIFF
--- a/app/src/org/commcare/gis/MapboxLocationPickerActivity.kt
+++ b/app/src/org/commcare/gis/MapboxLocationPickerActivity.kt
@@ -6,6 +6,7 @@ import android.content.IntentSender.SendIntentException
 import android.location.Location
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.gms.common.api.ResolvableApiException
@@ -32,6 +33,7 @@ import org.commcare.location.CommCareLocationListener
 import org.commcare.utils.GeoUtils
 import org.commcare.utils.Permissions
 import org.commcare.views.widgets.GeoPointWidget
+import org.javarosa.core.services.locale.Localization
 
 class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListener {
 
@@ -59,6 +61,10 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
             // Add marker.
             updateMarker(point)
             viewModel.reverseGeocode(point)
+        } else {
+            Toast.makeText(this,
+                    Localization.get("permission.location.denial.message"),
+                    Toast.LENGTH_LONG).show()
         }
         true
     }

--- a/app/src/org/commcare/gis/MapboxLocationPickerActivity.kt
+++ b/app/src/org/commcare/gis/MapboxLocationPickerActivity.kt
@@ -82,6 +82,7 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
                     .zoom(10.0)
                     .tilt(20.0)
                     .build()
+            isManualSelectedLocation = true
         }
         mapView.showCurrentLocationBtn(false)
     }

--- a/app/src/org/commcare/gis/MapboxLocationPickerActivity.kt
+++ b/app/src/org/commcare/gis/MapboxLocationPickerActivity.kt
@@ -6,7 +6,6 @@ import android.content.IntentSender.SendIntentException
 import android.location.Location
 import android.os.Bundle
 import android.view.View
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.gms.common.api.ResolvableApiException
@@ -38,10 +37,8 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
 
     companion object {
         const val MARKER_ICON_IMAGE_ID = "marker_icon_image"
-        const val LOCATION_PERMISSION_REQ = 100
         const val LOCATION_SETTING_REQ = 101
-        private val LOCATION_PERMISSIONS = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.ACCESS_COARSE_LOCATION)
+        private val LOCATION_PERMISSIONS = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
     }
 
     private lateinit var viewModel: MapboxLocationPickerViewModel
@@ -57,10 +54,12 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
     private var symbolManager: SymbolManager? = null
     private var symbol: Symbol? = null
     private val mapClickListener = MapboxMap.OnMapClickListener { point ->
-        isManualSelectedLocation = true
-        // Add marker.
-        updateMarker(point)
-        viewModel.reverseGeocode(point)
+        if (!Permissions.missingAppPermission(this, LOCATION_PERMISSIONS)) {
+            isManualSelectedLocation = true
+            // Add marker.
+            updateMarker(point)
+            viewModel.reverseGeocode(point)
+        }
         true
     }
 
@@ -249,7 +248,8 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
     }
 
     override fun missingPermissions() {
-        ActivityCompat.requestPermissions(this, LOCATION_PERMISSIONS, LOCATION_PERMISSION_REQ)
+        // Do nothing. Kujaku handles requesting permissions internally.
+        // https://github.com/onaio/kujaku/blob/4d737b89b23fb9eafe0850e83671034121c10e1d/library/src/main/java/io/ona/kujaku/helpers/PermissionsHelper.java#L17-L24
     }
 
     override fun onLocationRequestFailure(failure: CommCareLocationListener.Failure) {
@@ -268,10 +268,7 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
     }
 
     private fun requestLocation() {
-        // Check permissions
-        if (Permissions.missingAppPermission(this, LOCATION_PERMISSIONS)) {
-            missingPermissions()
-        } else {
+        if (!Permissions.missingAppPermission(this, LOCATION_PERMISSIONS)) {
             locationController.start()
         }
     }

--- a/app/src/org/commcare/gis/MapboxLocationPickerActivity.kt
+++ b/app/src/org/commcare/gis/MapboxLocationPickerActivity.kt
@@ -117,6 +117,9 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
         }
         current_location.setOnClickListener {
             isManualSelectedLocation = false
+            currentLocation?.let {
+                onLocationResult(it)
+            }
         }
     }
 
@@ -236,7 +239,7 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
         if (isManualSelectedLocation || inViewMode()) {
             return
         }
-        if (currentLocation == null || currentLocation!!.accuracy == 0f || result.accuracy < currentLocation!!.accuracy) {
+        if (currentLocation == null || currentLocation!!.accuracy == 0f || result.accuracy <= currentLocation!!.accuracy) {
             currentLocation = result
             val point = LatLng(result.latitude, result.longitude, result.altitude)
             viewModel.reverseGeocode(point)


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Fix for https://dimagi-dev.atlassian.net/browse/QA-3258

Basically, 3 issues: 
- currentLocation button click wasn't working properly, because we were relying on the underlying `onLocationChange` event which could take time to trigger. 
- improvements to permissions. We don't need to ask for permissions here since Kujaku handles it internally. Kujaku requests for `ACCESS_FINE_LOCATION` https://github.com/onaio/kujaku/blob/master/library/src/main/java/io/ona/kujaku/helpers/PermissionsHelper.java#L22
- While replacing location, mapview was automatically moving to current location because of `onLocationChange` event. We set `isManualSelection` to `true` to avoid this when we are replacing an already selected location. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage -NA

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
Will be QAed
