### PR TITLE
Graph js fix

### DIFF
--- a/app/assets/graphing/graph.max.js
+++ b/app/assets/graphing/graph.max.js
@@ -76,6 +76,11 @@ var intervalID = setInterval(function() {
                 }
                 return 0;
             },
+            focus: {
+                expand: {
+                  enabled: false
+                }
+            },
         };
 
         // Add functions for custom tick label text (where foo-labels was an object).

--- a/app/assets/graphing/graph.max.js
+++ b/app/assets/graphing/graph.max.js
@@ -86,7 +86,7 @@ var intervalID = setInterval(function() {
         // Add functions for custom tick label text (where foo-labels was an object).
         // Don't do this if the tick format was already set by Java (which will
         // only happen for time-based graphs that are NOT using custom tick text).
-        if (config.axis.x.tick && !config.axis.x.tick.format) {
+        if (config.axis.x.tick && (config.axis.x.tick.values || config.axis.x.tick.count) && !config.axis.x.tick.format) {
             config.axis.x.tick.format = function(d) {
                 var key = String(d);
                 if (type === "time") {
@@ -108,7 +108,7 @@ var intervalID = setInterval(function() {
                 }
             };
         }
-        if (config.axis.y.tick) {
+        if (config.axis.y.tick && (config.axis.y.tick.values || config.axis.y.tick.count)) {
             config.axis.y.tick.format = function(d) {
                 return axis.yLabels[String(d)] || Math.round(d);
             };

--- a/app/assets/graphing/graph.min.js
+++ b/app/assets/graphing/graph.min.js
@@ -8,9 +8,9 @@ if(type==="bar"){html="<tr><td colspan='2'>"+data.barLabels[yData[0].x]+"</td></
 +formatXTooltip(yData[0].x)+"</td></tr>"
 +html;}
 html="<table>"+html+"</table>";html="<div id='tooltip'>"+html+"</div>";return html;},};config.point={r:function(d){if(data.radii[d.id]){return 30*data.radii[d.id][d.index]/ data.maxRadii[d.id];}
-return 0;},};if(config.axis.x.tick&&!config.axis.x.tick.format){config.axis.x.tick.format=function(d){var key=String(d);if(type==="time"){var time=key.match(/\d+:\d+:\d+/)[0];key=d.getFullYear()+"-"+(d.getMonth()+1)+"-"+d.getDate()+" "+time;}
+return 0;},focus:{expand:{enabled:false}},};if(config.axis.x.tick&&(config.axis.x.tick.values||config.axis.x.tick.count)&&!config.axis.x.tick.format){config.axis.x.tick.format=function(d){var key=String(d);if(type==="time"){var time=key.match(/\d+:\d+:\d+/)[0];key=d.getFullYear()+"-"+(d.getMonth()+1)+"-"+d.getDate()+" "+time;}
 var label=axis.xLabels[key]===undefined?d:axis.xLabels[key];var returnVal=String(Math.round(label)||label);if(characterLimit){var limit=parseInt(characterLimit);if(returnVal.length>limit){return String(returnVal).slice(0,limit-3)+"...";}else{return returnVal;}}else{return returnVal;}};}
-if(config.axis.y.tick){config.axis.y.tick.format=function(d){return axis.yLabels[String(d)]||Math.round(d);};}
+if(config.axis.y.tick&&(config.axis.y.tick.values||config.axis.y.tick.count)){config.axis.y.tick.format=function(d){return axis.yLabels[String(d)]||Math.round(d);};}
 if(config.axis.y2.tick){config.axis.y2.tick.format=function(d){return axis.y2Labels[String(d)]||Math.round(d);};}
 var hideSeries=[];for(var yID in config.data.xs){if(!data.isData[yID]){hideSeries.push(yID);}}
 config.legend.hide=hideSeries;var showDataLabels=!!config.data.labels;config.data.labels={format:function(value,id,index){if(showDataLabels&&data.isData[id]){return value||'';}else{return data.annotations[id]||'';}},};config.data.order=false;config.onrendered=function(){for(var yID in data.pointStyles){var symbol=data.pointStyles[yID];applyPointShape(yID,symbol);applyLegendShape(yID,symbol);}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
2 commits for 2 issues 

- https://dimagi-dev.atlassian.net/browse/QA-3283?focusedCommentId=156140 In a bubble graph, when we click on a bubble, it expands, and on second click, it collapses to normal state. There is an issue with the update where on clicking the second time, instead of collapsing, the bubble disappears completely. 
The error for the same is: 
```
Error: <circle> attribute r: Expected length, "NaN".
(anonymous) @ d3.js:1211
selection_each @ d3.js:1176
selection_attr @ d3.js:1233
ChartInternal.unexpandCircles @ c3.max.js:9759
mouseout @ c3.max.js:8004
(anonymous) @ c3.max.js:8098
(anonymous) @ d3.js:1526
```
It happens because the `d.index` we expect here https://github.com/dimagi/commcare-android/blob/master/app/assets/graphing/graph.max.js#L75 is undefined. 
When we expand the `d` variable looks like this : `{x: 99718, value: 25000, id: "y0", index: 3}` i.e it has an index and it works. 
But when we collapse, the `d` variable becomes: `{id: "y0", id_org: "y0", values: Array(6)}` no index. 

I couldn't find much documentation around what exactly is `d` supposed to be. So I used this c3 configuration https://c3js.org/reference.html#point-focus-expand-enabled to disable the expansion of the bubbles at all. 

- https://dimagi-dev.atlassian.net/browse/QA-3285, the axis tick values were getting incorrectly formatted. This happened because we introduced a change due to which `tick` variable is always defined and has atleast one value `rotate` https://github.com/dimagi/commcare-core/blob/commcare_2.52/src/main/java/org/commcare/core/graph/c3/AxisConfiguration.java#L158, which was not true earlier. Earlier, the tick could be undefined. 
So I modified the check on graph.js to make sure that when the tick variable is defined, then atleast one of `values` or `count` is defined and then only apply the formatting. 


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->
Removed support for expanding bubbles on click. 

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
