### PR TITLE
Nfc delimiter Fix

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -901,6 +901,7 @@ nfc.not.supported=This Android device does not have NFC capabilities
 nfc.not.enabled=NFC capabilities are not currently enabled on this device. You can enable them in Settings and then try again.
 nfc.write.no.payload=NFC write action requires specifying a payload
 nfc.write.encryption.error=An error occurred while attempting to encrypt the NFC message
+nfc.write.payload.error=The message you are trying to write is invalid. Make sure it doesn't contain ^⸘^
 nfc.write.no.type=NFC write action requires specifying a type for the payload
 nfc.read.no.type=NFC read action requires specifying at least 1 acceptable type
 nfc.write.type.not.supported=The well-known type you tried to write is not supported by CommCare. The only well-known type that CommCare supports is 'text'

--- a/app/src/org/commcare/android/nfc/NfcManager.java
+++ b/app/src/org/commcare/android/nfc/NfcManager.java
@@ -18,7 +18,7 @@ import androidx.appcompat.app.AppCompatActivity;
 public class NfcManager {
 
     public static final String NFC_ENCRYPTION_SCHEME = "encryption_aes_v1";
-    public static final String PAYLOAD_DELIMITER = "\0";
+    public static final String PAYLOAD_DELIMITER = "^⸘^";
     private final boolean allowUntaggedRead;
 
     private Context context;
@@ -100,6 +100,9 @@ public class NfcManager {
         if (!StringUtils.isEmpty(encryptionKey)) {
             payload = EncryptionUtils.encrypt(payload, encryptionKey);
         }
+        if (payload.contains(PAYLOAD_DELIMITER)) {
+            throw new InvalidPayloadException();
+        }
         return getPayloadTag() + payload;
     }
 
@@ -109,6 +112,9 @@ public class NfcManager {
 
     public class NfcNotEnabledException extends Exception {
 
+    }
+
+    public class InvalidPayloadException extends RuntimeException {
     }
 
     public class InvalidPayloadTagException extends RuntimeException {

--- a/app/src/org/commcare/android/nfc/NfcWriteActivity.java
+++ b/app/src/org/commcare/android/nfc/NfcWriteActivity.java
@@ -44,6 +44,8 @@ public class NfcWriteActivity extends NfcActivity {
             payloadToWrite = nfcManager.tagAndEncryptPayload(getIntent().getStringExtra(NFC_PAYLOAD_TO_WRITE));
         } catch (EncryptionUtils.EncryptionException e) {
             finishWithErrorToast("nfc.write.encryption.error", e);
+        } catch (NfcManager.InvalidPayloadException e) {
+            finishWithErrorToast("nfc.write.payload.error", e);
         }
     }
 


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/QA-3294

Changes delimiter to avoid a form save error caused when reading an encrypted payload untagged. The issue happens because of including the null character '/0' in the form. 

Also throws an error when the delimiter is included in the payload itself. 


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly


