### PR TITLE
[SAAS-12035] Fix calendarview UI cut off

### DIFF
--- a/app/src/org/commcare/views/widgets/DateTimeWidget.java
+++ b/app/src/org/commcare/views/widgets/DateTimeWidget.java
@@ -5,6 +5,7 @@ import android.os.Build;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.CalendarView;
 import android.widget.DatePicker;
 import android.widget.TimePicker;
 import android.widget.TimePicker.OnTimeChangedListener;
@@ -38,6 +39,7 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
         mDatePicker.setFocusable(!prompt.isReadOnly());
         mDatePicker.setEnabled(!prompt.isReadOnly());
         mDatePicker.setCalendarViewShown(true);
+        updateCalendarViewHeight();
 
         mTimePicker = (TimePicker)LayoutInflater.from(getContext()).inflate(R.layout.time_widget, this, false);
         mTimePicker.setFocusable(!prompt.isReadOnly());
@@ -86,6 +88,18 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
         addView(mDatePicker);
         addView(mTimePicker);
 
+    }
+
+    /**
+     * CalendarView bottom line gets cut off in appcompat theme because it's height is fixed here:
+     * https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/res/res/layout/date_picker_legacy.xml#L78
+     * This workaround updates the calendarview height to wrap content.
+     */
+    private void updateCalendarViewHeight() {
+        CalendarView calendarView = mDatePicker.getCalendarView();
+        LayoutParams params = (LayoutParams) calendarView.getLayoutParams();
+        params.height = LayoutParams.WRAP_CONTENT;
+        calendarView.setLayoutParams(params);
     }
 
     public void setAnswer() {


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Jira: https://dimagi-dev.atlassian.net/browse/SAAS-12035

This PR updates the calendarview height to `WRAP_CONTENT` in the date picker. 

Updated screenshot: 
![WhatsApp Image 2021-08-03 at 10 55 52 AM](https://user-images.githubusercontent.com/29516995/127962498-8ea7c732-083f-4b9d-b3d5-111a58ba8d7b.jpeg)


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->
Fixes an UI issue in date time widget where the last line of calendar wasn't visible fully. 

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
