### PR TITLE
Revert zxing library update

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -48,7 +48,7 @@
 
     <uses-sdk tools:overrideLibrary="com.dimagi.android.zebraprinttool, com.simprints.libsimprints,
     ru.noties.markwon.il, ru.noties.markwon.view, ru.noties.markwon.renderer,
-    com.google.firebase.crashlytics, com.google.firebase.iid, com.google.zxing.client.android"/>
+    com.google.firebase.crashlytics, com.google.firebase.iid"/>
 
     <permission-group
         android:name="commcare.permission-group.DATABASE"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,8 +98,7 @@ dependencies {
     implementation 'com.carrotsearch:hppc:0.7.2'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
-    implementation ('com.journeyapps:zxing-android-embedded:4.2.0') { transitive = false }
-    implementation 'com.google.zxing:core:3.3.0'
+    implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
     implementation 'com.google.firebase:firebase-analytics:17.5.0'
     implementation 'com.google.firebase:firebase-crashlytics:17.2.1'
     implementation 'androidx.legacy:legacy-support-core-ui:1.0.0'


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Reverts https://github.com/dimagi/commcare-android/pull/2456

Reason: 
CommCare is crashing on pre-lollipop devices when user tries to capture a barcode. 
```
Fatal Exception: java.lang.NoClassDefFoundError: android.media.AudioAttributes$Builder
       at com.google.zxing.client.android.BeepManager.playBeepSound(BeepManager.java:97)
       at com.google.zxing.client.android.BeepManager.playBeepSoundAndVibrate(BeepManager.java:84)
       at com.journeyapps.barcodescanner.CaptureManager$1.barcodeResult(CaptureManager.java:80)
       at com.journeyapps.barcodescanner.DecoratedBarcodeView$WrappedCallback.barcodeResult(DecoratedBarcodeView.java:50)
       at com.journeyapps.barcodescanner.BarcodeView$1.handleMessage(BarcodeView.java:52)
       at android.os.Handler.dispatchMessage(Handler.java:98)
       at android.os.Looper.loop(Looper.java:136)
       at android.app.ActivityThread.main(ActivityThread.java:5584)
       at java.lang.reflect.Method.invokeNative(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:515)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1268)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1084)
       at dalvik.system.NativeStart.main(NativeStart.java)
```

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
