### PR TITLE
Make endpoint args error more user friendly

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -437,8 +437,7 @@
     <string name="root_detected_title" cc:translatable="true">Rooted Device Detected</string>
     <string name="root_detected_message" cc:translatable="true">You are not allowed to run CommCare on a rooted device. Please use a non rooted device</string>
     <string name="session_endpoint_unavailable" cc:translatable="true">No endpoint exist with id %1$s. Valid endpoints are %2$s</string>
-    <string name="session_endpoint_invalid_arguments" cc:translatable="true">Incorrect number of arguments supplied for endpoint %1$s. Supplied arguments: %2$s. Expected arguments: %3$s.</string>
-    <string name="session_endpoint_no_argument_with_name" cc:translatable="true">%1$s argument needs to be provided for endpoint %2$s</string>
+    <string name="session_endpoint_invalid_arguments" cc:translatable="true">Incorrect arguments supplied for endpoint %1$s. Supplied arguments: %2$s. Expected arguments: %3$s.</string>
     <string name="selected_location" cc:translatable="true">Selected Location</string>
     <string name="confirm_location" cc:translatable="true">Confirm location</string>
 </resources>

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -231,12 +231,6 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                     }
                     return true;
                 } catch (Endpoint.InvalidEndpointArgumentsException e) {
-                    String noArgumentWithNameError = org.commcare.utils.StringUtils.getStringRobust(
-                            this,
-                            R.string.session_endpoint_no_argument_with_name,
-                            new String[]{e.getArgumentName(), endpoint.getId()});
-                    UserfacingErrorHandling.createErrorDialog(this, noArgumentWithNameError, true);
-                } catch (Endpoint.InvalidNumberOfEndpointArgumentsException e) {
                     String invalidEndpointArgsError = org.commcare.utils.StringUtils.getStringRobust(
                             this,
                             R.string.session_endpoint_invalid_arguments,


### PR DESCRIPTION
## Summary
[QA-3382](https://dimagi-dev.atlassian.net/browse/QA-3382)

Update exception handling to support https://github.com/dimagi/commcare-core/pull/1026

Also depends on https://github.com/dimagi/commcare-core/pull/1027

## Feature Flag
Session endpoints

## Product Description
Changes error message for invalid session endpoint links so that it always explains which arguments are missing and which are invalid.


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

None.

### Safety story
This change has a pretty limited footprint and is in a flagged area of the code.