### PR TITLE
Replace asynctask with coroutines

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,11 +53,13 @@ dependencies {
     testImplementation project(path: ':commcare-core', configuration: 'testsAsJar')
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'io.mockk:mockk-android:1.10.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.2.0'
+    androidTestImplementation 'androidx.test.espresso.idling:idling-concurrent:3.4.0'
 
     // need uiautomator to rotate the device.
     // this only works with API >=18

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     testImplementation project(path: ':commcare-core', configuration: 'testsAsJar')
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'io.mockk:mockk-android:1.10.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.2.0'

--- a/app/instrumentation-tests/src/org/commcare/CommCareInstrumentationTestApplication.java
+++ b/app/instrumentation-tests/src/org/commcare/CommCareInstrumentationTestApplication.java
@@ -9,7 +9,14 @@ import org.commcare.tasks.DataPullTask;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+import androidx.test.espresso.idling.concurrent.IdlingThreadPoolExecutor;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import kotlinx.coroutines.CoroutineDispatcher;
+import kotlinx.coroutines.ExecutorsKt;
 
 public class CommCareInstrumentationTestApplication extends CommCareApplication implements Application.ActivityLifecycleCallbacks {
 
@@ -17,6 +24,14 @@ public class CommCareInstrumentationTestApplication extends CommCareApplication 
      * We only wanna store the activity that's currently on top of the screen.
      */
     private Activity currentActivity;
+    public IdlingThreadPoolExecutor idlingThreadPoolExecutor = new IdlingThreadPoolExecutor("testDispatcher",
+            Runtime.getRuntime().availableProcessors(),
+            Runtime.getRuntime().availableProcessors(),
+            0L,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue(),
+            Executors.defaultThreadFactory());
+    private CoroutineDispatcher asyncDispatcher = ExecutorsKt.from(idlingThreadPoolExecutor);
 
     @Override
     public void onCreate() {
@@ -66,5 +81,15 @@ public class CommCareInstrumentationTestApplication extends CommCareApplication 
 
     public Activity getCurrentActivity() {
         return currentActivity;
+    }
+
+    @Override
+    public CoroutineDispatcher serialDispatcher() {
+        return asyncDispatcher;
+    }
+
+    @Override
+    public CoroutineDispatcher parallelDispatcher() {
+        return asyncDispatcher;
     }
 }

--- a/app/instrumentation-tests/src/org/commcare/CommCareJUnitRunner.java
+++ b/app/instrumentation-tests/src/org/commcare/CommCareJUnitRunner.java
@@ -2,17 +2,9 @@ package org.commcare;
 
 import android.app.Application;
 import android.content.Context;
-import android.os.Bundle;
 import androidx.test.runner.AndroidJUnitRunner;
 
 public class CommCareJUnitRunner extends AndroidJUnitRunner {
-
-    @Override
-    public void onCreate(Bundle arguments) {
-        // A fix for java.lang.NoClassDefFoundError: Failed resolution of: Lkotlin/reflect/jvm/internal/KPropertyImpl;
-        arguments.putString("package", "org.commcare.androidTests");
-        super.onCreate(arguments);
-    }
 
     @Override
     public Application newApplication(ClassLoader cl, String className, Context context) throws ClassNotFoundException, IllegalAccessException, InstantiationException {

--- a/app/instrumentation-tests/src/org/commcare/CommCareJUnitRunner.java
+++ b/app/instrumentation-tests/src/org/commcare/CommCareJUnitRunner.java
@@ -2,10 +2,18 @@ package org.commcare;
 
 import android.app.Application;
 import android.content.Context;
-
+import android.os.Bundle;
 import androidx.test.runner.AndroidJUnitRunner;
 
 public class CommCareJUnitRunner extends AndroidJUnitRunner {
+
+    @Override
+    public void onCreate(Bundle arguments) {
+        // A fix for java.lang.NoClassDefFoundError: Failed resolution of: Lkotlin/reflect/jvm/internal/KPropertyImpl;
+        arguments.putString("package", "org.commcare.androidTests");
+        super.onCreate(arguments);
+    }
+
     @Override
     public Application newApplication(ClassLoader cl, String className, Context context) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
         return super.newApplication(cl, CommCareInstrumentationTestApplication.class.getName(), context);

--- a/app/instrumentation-tests/src/org/commcare/androidTests/BaseTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/BaseTest.kt
@@ -3,23 +3,17 @@ package org.commcare.androidTests
 import android.Manifest
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.IdlingRegistry
-import androidx.test.espresso.idling.concurrent.IdlingThreadPoolExecutor
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
-import io.mockk.every
-import io.mockk.mockkObject
-import kotlinx.coroutines.asCoroutineDispatcher
 import org.commcare.CommCareApplication
+import org.commcare.CommCareInstrumentationTestApplication
 import org.commcare.activities.DispatchActivity
-import org.commcare.tasks.templates.CoroutinesAsyncTask
 import org.commcare.utils.InstrumentationUtility
 import org.junit.Rule
 import org.junit.runner.RunWith
-import java.util.concurrent.Executors
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
@@ -43,21 +37,9 @@ abstract class BaseTest {
     )
 
     protected open fun installApp(appName: String, ccz: String, force: Boolean = false) {
-        val executor = IdlingThreadPoolExecutor("testDispatcher",
-                Runtime.getRuntime().availableProcessors(),
-                Runtime.getRuntime().availableProcessors(),
-                0L,
-                TimeUnit.MILLISECONDS,
-                LinkedBlockingQueue(),
-                Executors.defaultThreadFactory())
-        val dispatcher = executor.asCoroutineDispatcher()
-
-        mockkObject(CoroutinesAsyncTask)
-        every { CoroutinesAsyncTask.parallelDispatcher() } returns dispatcher
-        every { CoroutinesAsyncTask.serialDispatcher() } returns dispatcher
-
-        IdlingRegistry.getInstance().register(executor)
-        IdlingRegistry.getInstance().register(executor)
+        val application = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+                as CommCareInstrumentationTestApplication
+        IdlingRegistry.getInstance().register(application.idlingThreadPoolExecutor)
 
         if (CommCareApplication.instance().currentApp == null) {
             InstrumentationUtility.installApp(ccz)

--- a/app/instrumentation-tests/src/org/commcare/androidTests/BaseTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/BaseTest.kt
@@ -2,15 +2,24 @@ package org.commcare.androidTests
 
 import android.Manifest
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.idling.concurrent.IdlingThreadPoolExecutor
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.rule.GrantPermissionRule
+import io.mockk.every
+import io.mockk.mockkObject
+import kotlinx.coroutines.asCoroutineDispatcher
 import org.commcare.CommCareApplication
 import org.commcare.activities.DispatchActivity
+import org.commcare.tasks.templates.CoroutinesAsyncTask
 import org.commcare.utils.InstrumentationUtility
 import org.junit.Rule
 import org.junit.runner.RunWith
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
@@ -34,6 +43,22 @@ abstract class BaseTest {
     )
 
     protected open fun installApp(appName: String, ccz: String, force: Boolean = false) {
+        val executor = IdlingThreadPoolExecutor("testDispatcher",
+                Runtime.getRuntime().availableProcessors(),
+                Runtime.getRuntime().availableProcessors(),
+                0L,
+                TimeUnit.MILLISECONDS,
+                LinkedBlockingQueue(),
+                Executors.defaultThreadFactory())
+        val dispatcher = executor.asCoroutineDispatcher()
+
+        mockkObject(CoroutinesAsyncTask)
+        every { CoroutinesAsyncTask.parallelDispatcher() } returns dispatcher
+        every { CoroutinesAsyncTask.serialDispatcher() } returns dispatcher
+
+        IdlingRegistry.getInstance().register(executor)
+        IdlingRegistry.getInstance().register(executor)
+
         if (CommCareApplication.instance().currentApp == null) {
             InstrumentationUtility.installApp(ccz)
         } else if (appName != CommCareApplication.instance().currentApp.appRecord.displayName || force) {

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -81,6 +81,7 @@ import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.DeleteLogs;
 import org.commcare.tasks.LogSubmissionTask;
 import org.commcare.tasks.PurgeStaleArchivedFormsTask;
+import org.commcare.tasks.templates.CoroutineAsyncTaskHelper;
 import org.commcare.tasks.templates.ManagedAsyncTask;
 import org.commcare.update.UpdateHelper;
 import org.commcare.update.UpdateWorker;
@@ -117,6 +118,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -137,6 +140,8 @@ import androidx.work.WorkManager;
 import io.noties.markwon.Markwon;
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin;
 import io.noties.markwon.ext.tables.TablePlugin;
+import kotlinx.coroutines.CoroutineDispatcher;
+import kotlinx.coroutines.ExecutorsKt;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 
@@ -1178,5 +1183,13 @@ public class CommCareApplication extends MultiDexApplication {
 
     public AsyncRestoreHelper getAsyncRestoreHelper(DataPullTask task) {
         return new AsyncRestoreHelper(task);
+    }
+
+    public CoroutineDispatcher serialDispatcher() {
+        return CoroutineAsyncTaskHelper.INSTANCE.serialDispatcher();
+    }
+
+    public CoroutineDispatcher parallelDispatcher() {
+        return CoroutineAsyncTaskHelper.INSTANCE.parallelDispatcher();
     }
 }

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -10,7 +10,6 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.graphics.Rect;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.speech.tts.TextToSpeech;
@@ -59,6 +58,7 @@ import org.commcare.models.FormRecordProcessor;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.tasks.FormLoaderTask;
 import org.commcare.tasks.SaveToDiskTask;
+import org.commcare.tasks.templates.CoroutinesAsyncTask;
 import org.commcare.tts.TextToSpeechCallback;
 import org.commcare.tts.TextToSpeechConverter;
 import org.commcare.util.LogTypes;
@@ -684,11 +684,11 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     @Override
     public Object onRetainCustomNonConfigurationInstance() {
         // if a form is loading, pass the loader task
-        if (mFormLoaderTask != null && mFormLoaderTask.getStatus() != AsyncTask.Status.FINISHED)
+        if (mFormLoaderTask != null && mFormLoaderTask.getStatus() != CoroutinesAsyncTask.Status.FINISHED)
             return mFormLoaderTask;
 
         // if a form is writing to disk, pass the save to disk task
-        if (mSaveToDiskTask != null && mSaveToDiskTask.getStatus() != AsyncTask.Status.FINISHED)
+        if (mSaveToDiskTask != null && mSaveToDiskTask.getStatus() != CoroutinesAsyncTask.Status.FINISHED)
             return mSaveToDiskTask;
 
         // mFormEntryController is static so we don't need to pass it.
@@ -798,7 +798,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
         // If a save task is already running, just let it do its thing
         if ((mSaveToDiskTask != null) &&
-                (mSaveToDiskTask.getStatus() != AsyncTask.Status.FINISHED)) {
+                (mSaveToDiskTask.getStatus() != CoroutinesAsyncTask.Status.FINISHED)) {
             return;
         }
 
@@ -1129,7 +1129,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             // We have to call cancel to terminate the thread, otherwise it
             // lives on and retains the FEC in memory.
             // but only if it's done, otherwise the thread never returns
-            if (mFormLoaderTask.getStatus() == AsyncTask.Status.FINISHED) {
+            if (mFormLoaderTask.getStatus() == CoroutinesAsyncTask.Status.FINISHED) {
                 mFormLoaderTask.cancel(true);
                 mFormLoaderTask.destroy();
             }
@@ -1137,7 +1137,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         if (mSaveToDiskTask != null) {
             // We have to call cancel to terminate the thread, otherwise it
             // lives on and retains the FEC in memory.
-            if (mSaveToDiskTask.getStatus() == AsyncTask.Status.FINISHED) {
+            if (mSaveToDiskTask.getStatus() == CoroutinesAsyncTask.Status.FINISHED) {
                 mSaveToDiskTask.cancel(false);
             }
         }

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -2,7 +2,6 @@ package org.commcare.activities;
 
 import androidx.appcompat.app.AppCompatActivity;
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -31,6 +30,7 @@ import org.commcare.tasks.InstallStagedUpdateTask;
 import org.commcare.tasks.ResultAndError;
 import org.commcare.tasks.TaskListener;
 import org.commcare.tasks.TaskListenerRegistrationException;
+import org.commcare.tasks.templates.CoroutinesAsyncTask;
 import org.commcare.update.UpdateTask;
 import org.commcare.update.UpdateWorker;
 import org.commcare.update.UpdateHelper;
@@ -242,7 +242,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
         uiController.refreshView();
     }
 
-    private void setUiStateFromTaskStatus(AsyncTask.Status taskStatus) {
+    private void setUiStateFromTaskStatus(CoroutinesAsyncTask.Status taskStatus) {
         switch (taskStatus) {
             case RUNNING:
                 uiController.downloadingUiState();

--- a/app/src/org/commcare/adapters/IncompleteFormListAdapter.java
+++ b/app/src/org/commcare/adapters/IncompleteFormListAdapter.java
@@ -3,7 +3,6 @@ package org.commcare.adapters;
 
 import android.content.Context;
 import android.database.DataSetObserver;
-import android.os.AsyncTask.Status;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
@@ -18,6 +17,7 @@ import org.commcare.suite.model.Suite;
 import org.commcare.suite.model.Text;
 import org.commcare.tasks.FormRecordLoadListener;
 import org.commcare.tasks.FormRecordLoaderTask;
+import org.commcare.tasks.templates.CoroutinesAsyncTask;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.StorageUtils;
 import org.commcare.views.IncompleteFormRecordView;
@@ -144,10 +144,10 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
      */
     public void resetRecords() {
         // reload the form records, even if they are currently being loaded
-        if (loader.getStatus() == Status.RUNNING) {
+        if (loader.getStatus() == CoroutinesAsyncTask.Status.RUNNING) {
             loader.cancel(false);
             loader = loader.spawn();
-        } else if (loader.getStatus() == Status.FINISHED) {
+        } else if (loader.getStatus() == CoroutinesAsyncTask.Status.FINISHED) {
             loader = loader.spawn();
         }
 
@@ -376,7 +376,7 @@ public class IncompleteFormListAdapter extends BaseAdapter implements FormRecord
     }
 
     public void release() {
-        if (loader.getStatus() == Status.RUNNING) {
+        if (loader.getStatus() == CoroutinesAsyncTask.Status.RUNNING) {
             loader.cancel(false);
         }
     }

--- a/app/src/org/commcare/fragments/FileServerFragment.java
+++ b/app/src/org/commcare/fragments/FileServerFragment.java
@@ -2,8 +2,6 @@ package org.commcare.fragments;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import android.util.Log;
@@ -14,6 +12,7 @@ import android.widget.TextView;
 
 import org.commcare.activities.CommCareWiFiDirectActivity;
 import org.commcare.dalvik.R;
+import org.commcare.tasks.templates.CoroutinesAsyncTask;
 import org.javarosa.core.services.Logger;
 
 import java.io.File;
@@ -82,18 +81,14 @@ public class FileServerFragment extends Fragment {
 
         //Execute on a true multithreaded chain. We should probably replace all of our calls with this
         //but this is the big one for now.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            mFileServer.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-        } else {
-            mFileServer.execute();
-        }
+        mFileServer.executeOnExecutor();
     }
 
     /**
      * A simple server socket that accepts connection and writes some data on
      * the stream.
      */
-    static class FileServerAsyncTask extends AsyncTask<Void, String, String> {
+    static class FileServerAsyncTask extends CoroutinesAsyncTask<Void, String, String> {
 
         private final FileServerFragment mListener;
         private boolean socketOccupied;

--- a/app/src/org/commcare/fragments/TaskConnectorFragment.java
+++ b/app/src/org/commcare/fragments/TaskConnectorFragment.java
@@ -1,7 +1,6 @@
 package org.commcare.fragments;
 
 import android.content.Context;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
@@ -10,6 +9,7 @@ import android.util.Log;
 
 import org.commcare.activities.CommCareActivity;
 import org.commcare.tasks.templates.CommCareTask;
+import org.commcare.tasks.templates.CoroutinesAsyncTask;
 
 /**
  * Hold a reference to current task to report its progress and results The
@@ -47,7 +47,7 @@ public class TaskConnectorFragment<R> extends Fragment {
 
     public boolean isCurrentTaskRunning() {
         return this.currentTask != null &&
-                this.currentTask.getStatus() == AsyncTask.Status.RUNNING;
+                this.currentTask.getStatus() == CoroutinesAsyncTask.Status.RUNNING;
     }
 
     @Override

--- a/app/src/org/commcare/print/TemplatePrinterTask.java
+++ b/app/src/org/commcare/print/TemplatePrinterTask.java
@@ -1,10 +1,10 @@
 package org.commcare.print;
 
-import android.os.AsyncTask;
 import android.os.Bundle;
 
 import org.commcare.google.services.analytics.AnalyticsParamValue;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
+import org.commcare.tasks.templates.CoroutinesAsyncTask;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.PrintValidationException;
 import org.commcare.utils.TemplatePrinterUtils;
@@ -21,7 +21,7 @@ import java.io.Serializable;
  * @author Richard Lu
  * @author amstone
  */
-public class TemplatePrinterTask extends AsyncTask<Void, Void, TemplatePrinterTask.PrintTaskResult> {
+public class TemplatePrinterTask extends CoroutinesAsyncTask<Void, Void, TemplatePrinterTask.PrintTaskResult> {
 
     public enum PrintTaskResult {
         SUCCESS, IO_ERROR, VALIDATION_ERROR_MUSTACHE, VALIDATION_ERROR_CHEVRON

--- a/app/src/org/commcare/sync/ProcessAndSendTask.java
+++ b/app/src/org/commcare/sync/ProcessAndSendTask.java
@@ -1,55 +1,24 @@
 package org.commcare.sync;
 
 import android.content.Context;
-import android.os.AsyncTask;
-
-import net.sqlcipher.database.SQLiteDatabase;
-
-import org.apache.commons.lang3.StringUtils;
 import org.commcare.CommCareApplication;
 import org.commcare.activities.SyncCapableCommCareActivity;
-import org.commcare.android.database.user.models.FormRecord;
-import org.commcare.models.FormRecordProcessor;
-import org.commcare.suite.model.Profile;
 import org.commcare.tasks.DataSubmissionListener;
-import org.commcare.tasks.FormRecordCleanupTask;
 import org.commcare.tasks.FormSubmissionProgressBarListener;
 import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.tasks.templates.CommCareTaskConnector;
-import org.commcare.util.LogTypes;
 import org.commcare.utils.FormUploadResult;
-import org.commcare.utils.FormUploadUtil;
-import org.commcare.utils.QuarantineUtil;
 import org.commcare.utils.SessionUnavailableException;
-import org.commcare.views.notifications.NotificationMessage;
 import org.commcare.views.notifications.NotificationMessageFactory;
 import org.commcare.views.notifications.ProcessIssues;
-import org.javarosa.core.model.User;
-import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
-import org.javarosa.xml.util.InvalidStructureException;
-import org.javarosa.xml.util.UnfullfilledRequirementsException;
-import org.xmlpull.v1.XmlPullParserException;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Queue;
-
-import javax.crypto.spec.SecretKeySpec;
 
 import static org.commcare.sync.FormSubmissionHelper.PROGRESS_ALL_PROCESSED;
-import static org.commcare.sync.FormSubmissionHelper.SUBMISSION_BEGIN;
 import static org.commcare.sync.FormSubmissionHelper.SUBMISSION_DONE;
 import static org.commcare.sync.FormSubmissionHelper.SUBMISSION_FAIL;
-import static org.commcare.sync.FormSubmissionHelper.SUBMISSION_NOTIFY;
-import static org.commcare.sync.FormSubmissionHelper.SUBMISSION_START;
-import static org.commcare.sync.FormSubmissionHelper.SUBMISSION_SUCCESS;
 
 /**
  * @author ctsims

--- a/app/src/org/commcare/tasks/LogSubmissionTask.java
+++ b/app/src/org/commcare/tasks/LogSubmissionTask.java
@@ -1,7 +1,6 @@
 package org.commcare.tasks;
 
 import android.content.SharedPreferences;
-import android.os.AsyncTask;
 
 import org.commcare.CommCareApplication;
 import org.commcare.android.javarosa.AndroidLogEntry;
@@ -17,6 +16,7 @@ import org.commcare.network.CommcareRequestGenerator;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.preferences.ServerUrls;
 import org.commcare.tasks.LogSubmissionTask.LogSubmitOutcomes;
+import org.commcare.tasks.templates.CoroutinesAsyncTask;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.FormUploadUtil;
 import org.commcare.utils.SessionUnavailableException;
@@ -44,7 +44,7 @@ import retrofit2.Response;
 /**
  * @author ctsims
  */
-public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> implements DataSubmissionListener {
+public class LogSubmissionTask extends CoroutinesAsyncTask<Void, Long, LogSubmitOutcomes> implements DataSubmissionListener {
 
     //Stole from the process and send task. See if we can unify a lot of this behavior
     private static final long SUBMISSION_BEGIN = 16;

--- a/app/src/org/commcare/tasks/SingletonTask.java
+++ b/app/src/org/commcare/tasks/SingletonTask.java
@@ -39,13 +39,8 @@ public abstract class SingletonTask<Params, Progress, Result>
     }
 
     @Override
-    protected void onCancelled(Result result) {
-        if (android.os.Build.VERSION.SDK_INT >= 11) {
-            super.onCancelled(result);
-        } else {
-            super.onCancelled();
-        }
-
+    protected void onCancelled() {
+        super.onCancelled();
         if (taskListener != null) {
             taskListener.handleTaskCancellation();
         }

--- a/app/src/org/commcare/tasks/templates/CommCareTask.java
+++ b/app/src/org/commcare/tasks/templates/CommCareTask.java
@@ -1,6 +1,5 @@
 package org.commcare.tasks.templates;
 
-import android.os.AsyncTask;
 import android.util.Log;
 
 import org.commcare.logging.UserCausedRuntimeException;
@@ -168,7 +167,7 @@ public abstract class CommCareTask<Params, Progress, Result, Receiver>
                 return connector;
             }
 
-            if (this.getStatus() == AsyncTask.Status.RUNNING && taskId != -1) {
+            if (this.getStatus() == CoroutinesAsyncTask.Status.RUNNING && taskId != -1) {
                 // If the connector is null and the task is associated with a
                 // dialog/activity (i.e. task id != -1) then cancel because the
                 // task isn't expected to live past the associated

--- a/app/src/org/commcare/tasks/templates/CoroutineAsyncTask.kt
+++ b/app/src/org/commcare/tasks/templates/CoroutineAsyncTask.kt
@@ -4,36 +4,13 @@ import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
-import java.util.concurrent.*
+import org.commcare.CommCareApplication
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * @author $|-|!˅@M
  */
 abstract class CoroutinesAsyncTask<Params, Progress, Result> {
-
-    companion object {
-        private val threadFactory = object : ThreadFactory {
-            private val mCount = AtomicInteger(1)
-            override fun newThread(r: Runnable): Thread {
-                return Thread(r, "CoroutinesAsyncTask #${mCount.getAndIncrement()}")
-            }
-        }
-        private val threadPoolExecutor = ThreadPoolExecutor(
-            1, // core pool size
-            20, // maximum pool size
-            3, // keep alive seconds
-            TimeUnit.SECONDS,
-            SynchronousQueue<Runnable>(),
-            threadFactory
-        )
-        private val serialExecutor = Executors.newSingleThreadExecutor()
-
-        fun serialDispatcher(): CoroutineDispatcher = serialExecutor.asCoroutineDispatcher()
-
-        fun parallelDispatcher(): CoroutineDispatcher = threadPoolExecutor.asCoroutineDispatcher()
-    }
 
     enum class Status {
         PENDING,
@@ -95,7 +72,7 @@ abstract class CoroutinesAsyncTask<Params, Progress, Result> {
      */
     @MainThread
     fun execute(vararg params: Params?) {
-        execute(serialDispatcher(), *params)
+        execute(CommCareApplication.instance().serialDispatcher(), *params)
     }
 
     /**
@@ -103,7 +80,7 @@ abstract class CoroutinesAsyncTask<Params, Progress, Result> {
      */
     @MainThread
     fun executeOnExecutor(vararg params: Params?) {
-        execute(parallelDispatcher(), *params)
+        execute(CommCareApplication.instance().parallelDispatcher(), *params)
     }
 
     @MainThread

--- a/app/src/org/commcare/tasks/templates/CoroutineAsyncTask.kt
+++ b/app/src/org/commcare/tasks/templates/CoroutineAsyncTask.kt
@@ -8,6 +8,7 @@ import org.commcare.CommCareApplication
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
+ * Inspired by https://github.com/ladrahul25/CoroutineAsyncTask/blob/master/app/src/main/java/com/example/background/CoroutinesAsyncTask.kt
  * @author $|-|!˅@M
  */
 abstract class CoroutinesAsyncTask<Params, Progress, Result> {

--- a/app/src/org/commcare/tasks/templates/CoroutineAsyncTask.kt
+++ b/app/src/org/commcare/tasks/templates/CoroutineAsyncTask.kt
@@ -27,10 +27,12 @@ abstract class CoroutinesAsyncTask<Params, Progress, Result> {
             TimeUnit.SECONDS,
             SynchronousQueue<Runnable>(),
             threadFactory
-        ).let {
-            it.asCoroutineDispatcher()
-        }
-        private val serialExecutor = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        )
+        private val serialExecutor = Executors.newSingleThreadExecutor()
+
+        fun serialDispatcher(): CoroutineDispatcher = serialExecutor.asCoroutineDispatcher()
+
+        fun parallelDispatcher(): CoroutineDispatcher = threadPoolExecutor.asCoroutineDispatcher()
     }
 
     enum class Status {
@@ -93,7 +95,7 @@ abstract class CoroutinesAsyncTask<Params, Progress, Result> {
      */
     @MainThread
     fun execute(vararg params: Params?) {
-        execute(serialExecutor, *params)
+        execute(serialDispatcher(), *params)
     }
 
     /**
@@ -101,7 +103,7 @@ abstract class CoroutinesAsyncTask<Params, Progress, Result> {
      */
     @MainThread
     fun executeOnExecutor(vararg params: Params?) {
-        execute(threadPoolExecutor, *params)
+        execute(parallelDispatcher(), *params)
     }
 
     @MainThread

--- a/app/src/org/commcare/tasks/templates/CoroutineAsyncTask.kt
+++ b/app/src/org/commcare/tasks/templates/CoroutineAsyncTask.kt
@@ -1,0 +1,150 @@
+package org.commcare.tasks.templates
+
+import androidx.annotation.MainThread
+import androidx.annotation.WorkerThread
+import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * @author $|-|!˅@M
+ */
+abstract class CoroutinesAsyncTask<Params, Progress, Result> {
+
+    companion object {
+        private val threadFactory = object : ThreadFactory {
+            private val mCount = AtomicInteger(1)
+            override fun newThread(r: Runnable): Thread {
+                return Thread(r, "CoroutinesAsyncTask #${mCount.getAndIncrement()}")
+            }
+        }
+        private val threadPoolExecutor = ThreadPoolExecutor(
+            1, // core pool size
+            20, // maximum pool size
+            3, // keep alive seconds
+            TimeUnit.SECONDS,
+            SynchronousQueue<Runnable>(),
+            threadFactory
+        ).let {
+            it.asCoroutineDispatcher()
+        }
+        private val serialExecutor = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+    }
+
+    enum class Status {
+        PENDING,
+        RUNNING,
+        FINISHED
+    }
+
+    private var status: Status = Status.PENDING
+    private var coroutineJob: Job? = null
+    private val _isCancelled = AtomicBoolean(false)
+    val isCancelled get() = _isCancelled.get()
+    private var executionResult: Result? = null
+
+    @WorkerThread
+    protected abstract fun doInBackground(vararg params: Params?): Result
+
+    @MainThread
+    protected open fun onProgressUpdate(vararg values: Progress?) {}
+
+    @MainThread
+    protected open fun onPostExecute(result: Result?) {}
+
+    @MainThread
+    protected open fun onPreExecute() {}
+
+    @MainThread
+    protected open fun onCancelled() {}
+
+    fun getStatus() = status
+
+    fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+        _isCancelled.set(true)
+        coroutineJob?.let { job ->
+            return if (job.isCompleted || job.isCancelled) {
+                false
+            } else {
+                if (mayInterruptIfRunning) {
+                    job.cancel()
+                }
+                true
+            }
+        } ?: kotlin.run {
+            return true
+        }
+    }
+
+    @WorkerThread
+    fun publishProgress(vararg progress: Progress) {
+        //this is called from background thread to update main thread.
+        GlobalScope.launch(Dispatchers.Main) {
+            if (!isCancelled) {
+                onProgressUpdate(*progress)
+            }
+        }
+    }
+
+    /**
+     * Executes asynctasks serially
+     */
+    @MainThread
+    fun execute(vararg params: Params?) {
+        execute(serialExecutor, *params)
+    }
+
+    /**
+     * Executes asynctasks parallelly
+     */
+    @MainThread
+    fun executeOnExecutor(vararg params: Params?) {
+        execute(threadPoolExecutor, *params)
+    }
+
+    @MainThread
+    private fun execute(dispatcher: CoroutineDispatcher, vararg params: Params?) {
+        if (status != Status.PENDING) {
+            when (status) {
+                Status.RUNNING -> throw IllegalStateException("Cannot execute task: the task is already running.")
+                Status.FINISHED -> throw IllegalStateException("Cannot execute task:"
+                        + " the task has already been executed "
+                        + "(a task can be executed only once)")
+            }
+        }
+
+        status = Status.RUNNING
+
+        onPreExecute()
+        GlobalScope.launch(dispatcher) {
+            try {
+                if (!isCancelled) {
+                    runInterruptible {
+                        executionResult = doInBackground(*params)
+                    }
+                }
+                if (isCancelled) {
+                    throw CancellationException()
+                }
+            } catch (t: Throwable) {
+                _isCancelled.set(true)
+            } finally {
+                finish()
+                status = Status.FINISHED
+            }
+        }
+    }
+
+    private fun finish() {
+        GlobalScope.launch(Dispatchers.Main) {
+            if (isCancelled) {
+                onCancelled()
+            } else {
+                onPostExecute(executionResult)
+            }
+        }
+    }
+
+}

--- a/app/src/org/commcare/tasks/templates/CoroutineAsyncTaskHelper.kt
+++ b/app/src/org/commcare/tasks/templates/CoroutineAsyncTaskHelper.kt
@@ -1,0 +1,31 @@
+package org.commcare.tasks.templates
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * @author $|-|!˅@M
+ */
+object CoroutineAsyncTaskHelper {
+    private val threadFactory = object : ThreadFactory {
+        private val mCount = AtomicInteger(1)
+        override fun newThread(r: Runnable): Thread {
+            return Thread(r, "CoroutinesAsyncTask #${mCount.getAndIncrement()}")
+        }
+    }
+    private val threadPoolExecutor = ThreadPoolExecutor(
+            1, // core pool size
+            20, // maximum pool size
+            3, // keep alive seconds
+            TimeUnit.SECONDS,
+            SynchronousQueue<Runnable>(),
+            threadFactory
+    )
+    private val serialExecutor = Executors.newSingleThreadExecutor()
+
+    fun serialDispatcher(): CoroutineDispatcher = serialExecutor.asCoroutineDispatcher()
+
+    fun parallelDispatcher(): CoroutineDispatcher = threadPoolExecutor.asCoroutineDispatcher()
+}

--- a/app/src/org/commcare/tasks/templates/ManagedAsyncTask.java
+++ b/app/src/org/commcare/tasks/templates/ManagedAsyncTask.java
@@ -1,8 +1,5 @@
 package org.commcare.tasks.templates;
 
-import android.os.AsyncTask;
-import android.os.Build;
-
 import java.util.ArrayList;
 
 /**
@@ -13,7 +10,7 @@ import java.util.ArrayList;
  * @author Phillip Mates (pmates@dimagi.com)
  */
 public abstract class ManagedAsyncTask<Params, Progress, Result>
-        extends AsyncTask<Params, Progress, Result> {
+        extends CoroutinesAsyncTask<Params, Progress, Result> {
 
     /**
      * List of running tasks. Tasks add/remove themselves automatically upon
@@ -27,7 +24,7 @@ public abstract class ManagedAsyncTask<Params, Progress, Result>
      */
     public static void cancelTasks() {
         synchronized (livingTasks) {
-            for (AsyncTask task : livingTasks) {
+            for (CoroutinesAsyncTask task : livingTasks) {
                 task.cancel(true);
             }
             livingTasks.clear();
@@ -75,10 +72,6 @@ public abstract class ManagedAsyncTask<Params, Progress, Result>
      * with data synchronization!
      */
     public void executeParallel(Params... params) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, params);
-        } else {
-            execute(params);
-        }
+        executeOnExecutor(params);
     }
 }

--- a/app/src/org/commcare/update/UpdateTask.java
+++ b/app/src/org/commcare/update/UpdateTask.java
@@ -82,8 +82,8 @@ public class UpdateTask extends SingletonTask<String, Integer, ResultAndError<Ap
     }
 
     @Override
-    protected void onCancelled(ResultAndError<AppInstallStatus> resultAndError) {
-        super.onCancelled(resultAndError);
+    protected void onCancelled() {
+        super.onCancelled();
         mUpdateHelper.OnUpdateCancelled();
         mUpdateHelper.clearInstance();
     }

--- a/app/src/org/commcare/utils/CachingAsyncImageLoader.java
+++ b/app/src/org/commcare/utils/CachingAsyncImageLoader.java
@@ -10,6 +10,8 @@ import android.os.AsyncTask;
 import android.util.LruCache;
 import android.widget.ImageView;
 
+import org.commcare.tasks.templates.CoroutinesAsyncTask;
+
 /**
  * Class used for managing the LoadImageTasks that load images into a list.
  * Ensures that proper caching occurs and attempts to limit overflows
@@ -40,7 +42,7 @@ public class CachingAsyncImageLoader implements ComponentCallbacks2 {
         if (image != null) {
             imageView.setImageBitmap(image);
         } else {
-            new SetImageTask(imageView, this.context, boundingWidth, boundingHeight).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, url);
+            new SetImageTask(imageView, this.context, boundingWidth, boundingHeight).executeOnExecutor(url);
         }
     }
 
@@ -49,7 +51,7 @@ public class CachingAsyncImageLoader implements ComponentCallbacks2 {
      *
      * @author wspride
      */
-    private class SetImageTask extends AsyncTask<String, Void, Bitmap> {
+    private class SetImageTask extends CoroutinesAsyncTask<String, Void, Bitmap> {
         private final ImageView mImageView;
         private final Context mContext;
         private final int mBoundingWidth;

--- a/app/src/org/commcare/utils/CommCareUtil.java
+++ b/app/src/org/commcare/utils/CommCareUtil.java
@@ -1,7 +1,6 @@
 package org.commcare.utils;
 
 import android.content.Context;
-import android.os.AsyncTask;
 import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
@@ -97,6 +96,6 @@ public class CommCareUtil {
                         url,
                         forceLogs);
         // Execute on a true multithreaded chain, since this is an asynchronous process
-        reportSubmitter.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        reportSubmitter.executeOnExecutor();
     }
 }

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -1,6 +1,5 @@
 package org.commcare.utils;
 
-import android.os.AsyncTask;
 import android.os.Environment;
 import android.util.Log;
 import android.webkit.MimeTypeMap;

--- a/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/CommCareSetupActivityTest.java
@@ -11,6 +11,8 @@ import org.commcare.CommCareTestApplication;
 import org.commcare.activities.CommCareSetupActivity;
 import org.commcare.activities.InstallArchiveActivity;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.commcare.utils.MockUtilsKt;
 import org.javarosa.core.services.locale.Localization;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,6 +46,7 @@ public class CommCareSetupActivityTest {
      */
     @Test
     public void invalidAppInstall() {
+        MockUtilsKt.mockAsyncTaskDispatchers();
         String invalidUpdateReference = "jr://resource/commcare-apps/update_tests/invalid_suite_update/profile.ccpr";
 
 

--- a/app/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
+++ b/app/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
@@ -11,6 +11,7 @@ import org.commcare.core.parse.ParseUtils;
 import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.models.database.user.DemoUserBuilder;
 import org.commcare.tasks.ResourceEngineTask;
+import org.commcare.utils.MockUtilsKt;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.util.PropertyUtils;
@@ -45,6 +46,7 @@ public class TestAppInstaller {
     public static void installAppAndLogin(String appPath,
                                           String username,
                                           String password) {
+        MockUtilsKt.mockAsyncTaskDispatchers();
         installAppAndUser(appPath, username, password);
         login(username, password);
     }

--- a/app/unit-tests/src/org/commcare/utils/MockUtils.kt
+++ b/app/unit-tests/src/org/commcare/utils/MockUtils.kt
@@ -3,13 +3,13 @@ package org.commcare.utils
 import io.mockk.every
 import io.mockk.mockkObject
 import kotlinx.coroutines.Dispatchers
-import org.commcare.tasks.templates.CoroutinesAsyncTask
+import org.commcare.tasks.templates.CoroutineAsyncTaskHelper
 
 /**
  * @author $|-|!˅@M
  */
 fun mockAsyncTaskDispatchers() {
-    mockkObject(CoroutinesAsyncTask)
-    every { CoroutinesAsyncTask.parallelDispatcher() } returns Dispatchers.Main
-    every { CoroutinesAsyncTask.serialDispatcher() } returns Dispatchers.Main
+    mockkObject(CoroutineAsyncTaskHelper)
+    every { CoroutineAsyncTaskHelper.parallelDispatcher() } returns Dispatchers.Main
+    every { CoroutineAsyncTaskHelper.serialDispatcher() } returns Dispatchers.Main
 }

--- a/app/unit-tests/src/org/commcare/utils/MockUtils.kt
+++ b/app/unit-tests/src/org/commcare/utils/MockUtils.kt
@@ -1,0 +1,15 @@
+package org.commcare.utils
+
+import io.mockk.every
+import io.mockk.mockkObject
+import kotlinx.coroutines.Dispatchers
+import org.commcare.tasks.templates.CoroutinesAsyncTask
+
+/**
+ * @author $|-|!˅@M
+ */
+fun mockAsyncTaskDispatchers() {
+    mockkObject(CoroutinesAsyncTask)
+    every { CoroutinesAsyncTask.parallelDispatcher() } returns Dispatchers.Main
+    every { CoroutinesAsyncTask.serialDispatcher() } returns Dispatchers.Main
+}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
This PR introduced a `CoroutinesAsyncTask` class which is a replacement for the asynctask. It uses the same `threadpoolexecutor` from asynctask as a coroutine dispatcher. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
