### PR TITLE
Remove kotlin android extension

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,6 @@ import com.android.builder.core.DefaultManifestParser
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions' // TODO this is deprecated
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
 apply from: 'jacoco.gradle'
@@ -505,6 +504,9 @@ android {
     testBuildType project.ext.TEST_BUILD_TYPE
     androidResources {
         ignoreAssetsPattern '!*.max.js:!*.max.css'
+    }
+    buildFeatures {
+        viewBinding true
     }
 }
 

--- a/app/src/org/commcare/gis/BaseMapboxActivity.kt
+++ b/app/src/org/commcare/gis/BaseMapboxActivity.kt
@@ -4,12 +4,14 @@ import android.os.Bundle
 import com.mapbox.mapboxsdk.Mapbox
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import io.ona.kujaku.KujakuLibrary
-import kotlinx.android.synthetic.main.activity_entity_mapbox.*
+import io.ona.kujaku.views.KujakuMapView
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import org.commcare.activities.CommCareActivity
 import org.commcare.dalvik.BuildConfig
+import org.commcare.dalvik.R
 import org.commcare.interfaces.CommCareActivityUIController
+import org.commcare.views.UiElement
 
 /**
  * Base class for Mapbox based map activites
@@ -18,6 +20,9 @@ abstract class BaseMapboxActivity : CommCareActivity<BaseMapboxActivity>() {
 
     val jobs = ArrayList<Job>()
     lateinit var map: MapboxMap
+
+    @UiElement(value = R.id.mapView)
+    lateinit var mapView: KujakuMapView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         KujakuLibrary.init(this)
@@ -29,7 +34,6 @@ abstract class BaseMapboxActivity : CommCareActivity<BaseMapboxActivity>() {
         } else {
             (uiManager as CommCareActivityUIController).setupUI()
         }
-
         mapView.onCreate(savedInstanceState)
         initMap()
     }

--- a/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
+++ b/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
@@ -14,7 +14,6 @@ import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
 import io.ona.kujaku.manager.DrawingManager
-import kotlinx.android.synthetic.main.activity_entity_mapbox.*
 import org.commcare.activities.components.FormEntryInstanceState
 import org.commcare.android.javarosa.IntentCallout
 import org.commcare.dalvik.R

--- a/app/src/org/commcare/gis/EntityMapboxActivity.kt
+++ b/app/src/org/commcare/gis/EntityMapboxActivity.kt
@@ -27,7 +27,6 @@ import com.mapbox.mapboxsdk.style.layers.PropertyFactory
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
 import io.ona.kujaku.manager.AnnotationRepositoryManager
-import kotlinx.android.synthetic.main.activity_entity_mapbox.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch

--- a/app/src/org/commcare/gis/MapboxLocationPickerActivity.kt
+++ b/app/src/org/commcare/gis/MapboxLocationPickerActivity.kt
@@ -23,10 +23,10 @@ import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.plugins.annotation.Symbol
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions
-import kotlinx.android.synthetic.main.activity_mapbox_location_picker.*
 import org.commcare.activities.components.FormEntryConstants
 import org.commcare.activities.components.FormEntryDialogs
 import org.commcare.dalvik.R
+import org.commcare.dalvik.databinding.ActivityMapboxLocationPickerBinding
 import org.commcare.location.CommCareLocationController
 import org.commcare.location.CommCareLocationControllerFactory
 import org.commcare.location.CommCareLocationListener
@@ -43,6 +43,7 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
         private val LOCATION_PERMISSIONS = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
     }
 
+    private lateinit var binding: ActivityMapboxLocationPickerBinding
     private lateinit var viewModel: MapboxLocationPickerViewModel
     private lateinit var locationController: CommCareLocationController
     private val mapStyles = arrayOf(
@@ -75,6 +76,7 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        binding = ActivityMapboxLocationPickerBinding.inflate(layoutInflater)
         viewModel = ViewModelProvider(this, ViewModelProvider.AndroidViewModelFactory.getInstance(application))
                 .get(MapboxLocationPickerViewModel::class.java)
         attachListener()
@@ -94,12 +96,12 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
     }
 
     private fun attachListener() {
-        confirm_location_button.visibility = if (inViewMode()) {
+        binding.confirmLocationButton.visibility = if (inViewMode()) {
             View.GONE
         } else {
             View.VISIBLE
         }
-        confirm_location_button.setOnClickListener {
+        binding.confirmLocationButton.setOnClickListener {
             // Use the map target's coordinates to make a reverse geocoding search
             Intent().apply {
                 putExtra(FormEntryConstants.LOCATION_RESULT, GeoUtils.locationToString(viewModel.getLocation()))
@@ -108,10 +110,10 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
                 finish()
             }
         }
-        cancel_button.setOnClickListener {
+        binding.cancelButton.setOnClickListener {
             finish()
         }
-        switch_map.setOnClickListener {
+        binding.switchMap.setOnClickListener {
             currentMapStyleIndex = (currentMapStyleIndex + 1) % mapStyles.size
             val style = Style.Builder()
                     .fromUri(mapStyles[currentMapStyleIndex])
@@ -121,7 +123,7 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
                 updateMarker(LatLng(loc.latitude, loc.longitude, loc.altitude))
             }
         }
-        current_location.setOnClickListener {
+        binding.currentLocation.setOnClickListener {
             isManualSelectedLocation = false
             currentLocation?.let {
                 onLocationResult(it)
@@ -144,8 +146,8 @@ class MapboxLocationPickerActivity : BaseMapboxActivity(), CommCareLocationListe
 
     private fun observeViewModel() {
         viewModel.placeName.observe(this, androidx.lifecycle.Observer {
-            confirm_location_button.isEnabled = true
-            location.text = it
+            binding.confirmLocationButton.isEnabled = true
+            binding.location.text = it
         })
     }
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
On top of https://github.com/dimagi/commcare-android/pull/2526
This PR removes the deprecated `kotlin-android-extension` plugin and uses `viewBinding`. 
cross-request: dimagi/commcare-core#1034
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
