### PR TITLE
Prevent npe for motionEvent in onFling

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -734,7 +734,6 @@ public abstract class CommCareActivity<R> extends AppCompatActivity
     @Override
     public boolean dispatchTouchEvent(MotionEvent mv) {
         return !(mGestureDetector == null || !mGestureDetector.onTouchEvent(mv)) || super.dispatchTouchEvent(mv);
-
     }
 
     @Override
@@ -744,6 +743,9 @@ public abstract class CommCareActivity<R> extends AppCompatActivity
 
     @Override
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+        if (e1 == null || e2 == null) {
+            return false;
+        }
         if (isHorizontalSwipe(this, e1, e2) && !isMainScreenBlocked) {
             if (LocalePreferences.isLocaleRTL()) {
                 if (velocityX <= 0) {


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Fix for NPE crash https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/0eab22845e5c04753d944c94540423b2?time=last-thirty-days&versions=2.52.1%20(464182)&sessionEventKey=6138CA48031E00010D6A09C02D28AADF_1584024537772241884
StackTrace:: 
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'float android.view.MotionEvent.getX()' on a null object reference
       at org.commcare.activities.CommCareActivity.isHorizontalSwipe(CommCareActivity.java:825)
       at org.commcare.activities.CommCareActivity.onFling(CommCareActivity.java:747)
       at android.view.GestureDetector.onTouchEvent(GestureDetector.java:745)
       at org.commcare.activities.CommCareActivity.dispatchTouchEvent(CommCareActivity.java:736)
       at androidx.appcompat.view.WindowCallbackWrapper.dispatchTouchEvent(WindowCallbackWrapper.java:69)
       at com.android.internal.policy.DecorView.dispatchTouchEvent(DecorView.java:423)
       at android.view.View.dispatchPointerEvent(View.java:13731)
       at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent(ViewRootImpl.java:5684)
       at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:5471)
       at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4961)
       at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5014)
       at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4980)
       at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:5120)
       at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:4988)
       at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:5177)
       at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4961)
       at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:5014)
       at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4980)
       at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:4988)
       at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4961)
       at android.view.ViewRootImpl.deliverInputEvent(ViewRootImpl.java:7784)
       at android.view.ViewRootImpl.doProcessInputEvents(ViewRootImpl.java:7753)
       at android.view.ViewRootImpl.enqueueInputEvent(ViewRootImpl.java:7704)
       at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent(ViewRootImpl.java:7923)
       at android.view.InputEventReceiver.dispatchInputEvent(InputEventReceiver.java:188)
       at android.os.MessageQueue.nativePollOnce(MessageQueue.java)
       at android.os.MessageQueue.next(MessageQueue.java:336)
       at android.os.Looper.loop(Looper.java:174)
       at android.app.ActivityThread.main(ActivityThread.java:7554)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:980)
```
The `MotionEvent` param in the overridden `onFling` method are sometimes null and calling `e1 or e2.getX()` throws the NPE.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
