### PR TITLE
Add tests to show document media provider crashes

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/androidTests/UriToFilePathTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/UriToFilePathTest.kt
@@ -1,0 +1,24 @@
+package org.commcare.androidTests
+
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.commcare.annotations.BrowserstackTests
+import org.commcare.utils.UriToFilePath
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.NullPointerException
+
+/**
+ * @author $|-|!˅@M
+ */
+@BrowserstackTests
+@RunWith(AndroidJUnit4::class)
+class UriToFilePathTest {
+
+    @Test(expected = NullPointerException::class)
+    fun testDocumentMediaProviderUriCrashes() {
+        val uri = Uri.parse("content://com.android.providers.media.documents/document/document:59845")
+        UriToFilePath.getPathFromUri(InstrumentationRegistry.getInstrumentation().context, uri)
+    }
+}


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

Adds a test to confirm this crash: 
```
Caused by java.lang.NullPointerException: uri
       at java.util.Objects.requireNonNull(Objects.java:245)
       at android.content.ContentResolver.query(ContentResolver.java:1171)
       at android.content.ContentResolver.query(ContentResolver.java:1128)
       at android.content.ContentResolver.query(ContentResolver.java:1084)
       at org.commcare.utils.UriToFilePath.getDataColumn(UriToFilePath.java:120)
       at org.commcare.utils.UriToFilePath.getPathFromUri(UriToFilePath.java:83)
       at org.commcare.utils.FileUtil.getFileLocationFromIntent(FileUtil.java:775)
       at org.commcare.utils.FileUtil.updateFileLocationFromIntent(FileUtil.java:754)
       at org.commcare.activities.InstallArchiveActivity.onActivityResult(InstallArchiveActivity.java:105)
       at android.app.Activity.dispatchActivityResult(Activity.java:8460)
       at android.app.ActivityThread.deliverResults(ActivityThread.java:5091)
       at android.app.ActivityThread.handleSendResult(ActivityThread.java:5139)
       at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:51)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2104)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:236)
       at android.app.ActivityThread.main(ActivityThread.java:7861)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:600)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:967)
```

I initially wanted to add it as a unit test, but I couldn't get it work with the content resolver queries. 

Details about the crash: 
`ACTION_GET_CONTENT` has an option for documents provider just like it has options for image, audio or video providers. When you select a pdf document from a document provider, it gives a uri like this: 
`content://com.android.providers.media.documents/document/document:59845`. 
https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/utils/UriToFilePath.java#L64-L83 Our code here correctly identifies it as a media provider uri, and then it checks the type. In our case the type is `document`, but the checks only exists for image, audio and video types. 
So the call to `getDataColumn` happens with a null `contentUri` and it fails. 

The only thing that I'm concerned here is that https://android.googlesource.com/platform/packages/providers/MediaProvider/+/5d36def/src/com/android/providers/media/MediaDocumentsProvider.java#123 the official `MediaDocumentProvider` class also only checks the types to be one of image, audio or video. So I'm not sure if this should be handled here or not. 

Addtionally, the crash happens when users are installing the offline `ccz` but rather than providing a path to valid ccz file, they're selecting any random path. 
So perhaps we should first check the file extension before doing any processing maybe? 
But also, we should be able to support getting paths for document file types using `UriToFilePath`. 

This is just a test PR. Will create a follow up PR for the fix. 


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [ ] If the PR is high risk, "High Risk" label is set
- [ ] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
