### PR TITLE
Shift audio rec codec to he-aac

### DIFF
--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -5,6 +5,7 @@ import android.os.Environment;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
 
+import org.apache.commons.lang3.StringUtils;
 import org.commcare.core.network.AuthenticationInterceptor;
 import org.commcare.core.network.CaptivePortalRedirectException;
 import org.commcare.network.CommcareRequestGenerator;
@@ -110,7 +111,7 @@ public class FormUploadUtil {
      *                               file-system
      */
     public static FormUploadResult sendInstance(int submissionNumber, File folder,
-                                                @Nullable  SecretKeySpec key, String url,
+                                                @Nullable SecretKeySpec key, String url,
                                                 @Nullable DataSubmissionListener listener, User user)
             throws FileNotFoundException {
 
@@ -341,7 +342,11 @@ public class FormUploadUtil {
                     numAttachmentsSuccessfullyAdded += addPartToEntity(parts, f, contentType);
                 } else if (isSupportedMultimediaFile(f.getName())) {
                     numAttachmentsInInstanceFolder++;
-                    numAttachmentsSuccessfullyAdded += addPartToEntity(parts, f, "application/octet-stream");
+                    String mimeType = FileUtil.getMimeType(f.getPath());
+                    if (StringUtils.isEmpty(mimeType)) {
+                        mimeType = "application/octet-stream";
+                    }
+                    numAttachmentsSuccessfullyAdded += addPartToEntity(parts, f, mimeType);
                 } else {
                     Logger.log(LogTypes.TYPE_FORM_SUBMISSION,
                             "Could not add unsupported file type to submission entity: " + f.getName());

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -33,8 +33,6 @@ import java.util.Date;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.DialogFragment;
 
-import static android.media.MediaFormat.MIMETYPE_AUDIO_AAC;
-
 /**
  * A popup dialog fragment that handles recording_fragment and saving of audio
  * files without external callout.
@@ -44,6 +42,8 @@ import static android.media.MediaFormat.MIMETYPE_AUDIO_AAC;
 public class RecordingFragment extends DialogFragment {
 
     public static final String AUDIO_FILE_PATH_ARG_KEY = "audio_file_path";
+
+    private static final String MIMETYPE_AUDIO_AAC = "audio/mp4a-latm";
 
     private String fileName;
     private static final String FILE_EXT = ".mp3";

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -4,11 +4,12 @@ import android.content.DialogInterface;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.graphics.Rect;
+import android.media.MediaCodecInfo;
+import android.media.MediaCodecList;
 import android.media.MediaPlayer;
 import android.media.MediaRecorder;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Environment;
 import android.os.SystemClock;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -31,6 +32,8 @@ import java.util.Date;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.DialogFragment;
+
+import static android.media.MediaFormat.MIMETYPE_AUDIO_AAC;
 
 /**
  * A popup dialog fragment that handles recording_fragment and saving of audio
@@ -177,12 +180,44 @@ public class RecordingFragment extends DialogFragment {
         recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
         recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
         recorder.setOutputFile(fileName);
-        recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
+        if (isHeAacEncoderSupported()) {
+            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.HE_AAC);
+        } else {
+            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
+        }
         try {
             recorder.prepare();
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    // Checks whether the device supports High Efficiency AAC (HE-AAC) audio codec
+    private boolean isHeAacEncoderSupported() {
+        int numCodecs = MediaCodecList.getCodecCount();
+
+        for (int i = 0; i < numCodecs; i++) {
+            MediaCodecInfo codecInfo = MediaCodecList.getCodecInfoAt(i);
+
+            if (!codecInfo.isEncoder()) {
+                continue;
+            }
+
+            for (String supportedType : codecInfo.getSupportedTypes()) {
+                if (supportedType.equalsIgnoreCase(MIMETYPE_AUDIO_AAC)) {
+                    MediaCodecInfo.CodecCapabilities cap = codecInfo.getCapabilitiesForType(MIMETYPE_AUDIO_AAC);
+                    MediaCodecInfo.CodecProfileLevel[] profileLevels = cap.profileLevels;
+                    for (MediaCodecInfo.CodecProfileLevel profileLevel : profileLevels) {
+                        int profile = profileLevel.profile;
+                        if (profile == MediaCodecInfo.CodecProfileLevel.AACObjectHE || profile == MediaCodecInfo.CodecProfileLevel.AACObjectHE_PS) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     private void stopRecording() {


### PR DESCRIPTION
## Summary

In order to support browser playbacks on HQ, we need to shit the audio encoding to AAC. This PR checks if the `he_aac` is available on the device and uses that when so. If not, it falls back to the earlier codec `AMR_NB`. 

This PR also attempts to set the right content types on the files when uploading to HQ. 

Part of this scope of work: https://docs.google.com/document/d/11S0O_PGa90an-7s3fH953eM-OBp1XwvkxuyEpZ6n0AA/edit

## Product Description

Changes the default audio recording codec to `HE_AAC` instead of `AMR_NB`

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly


