### PR TITLE
NPE fix for motion events

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -820,6 +820,10 @@ public abstract class CommCareActivity<R> extends AppCompatActivity
      * @return True iff the movement is a definitive horizontal swipe.
      */
     private static boolean isHorizontalSwipe(AppCompatActivity activity, MotionEvent e1, MotionEvent e2) {
+        if (e1 == null || e2 == null) {
+            return false;
+        }
+
         DisplayMetrics dm = new DisplayMetrics();
         activity.getWindowManager().getDefaultDisplay().getMetrics(dm);
 


### PR DESCRIPTION
## Summary

[Crash](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/0eab22845e5c04753d944c94540423b2?time=last-ninety-days&sessionEventKey=61DE5C73013800010848A074C6C82659_1630657244017356678)

````
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'float android.view.MotionEvent.getX()' on a null object reference
       at org.commcare.activities.CommCareActivity.isHorizontalSwipe(CommCareActivity.java:825)
       at org.commcare.activities.CommCareActivity.onFling(CommCareActivity.java:747)
       at android.view.GestureDetector.onTouchEvent(GestureDetector.java:812)
````


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

