### PR TITLE
No op refactor to modularize mediaWidget

### DIFF
--- a/app/src/org/commcare/views/widgets/MediaWidget.java
+++ b/app/src/org/commcare/views/widgets/MediaWidget.java
@@ -56,7 +56,6 @@ public abstract class MediaWidget extends QuestionWidget {
 
     private int oversizedMediaSize;
 
-    protected String recordedFileName;
     protected String customFileTag;
     private String destMediaPath;
 
@@ -143,7 +142,7 @@ public abstract class MediaWidget extends QuestionWidget {
      * @return whether the media file has a valid extension
      */
     private boolean ifMediaExtensionChecks(String binaryPath) {
-        String extension = FileUtil.getExtension(recordedFileName);
+        String extension = FileUtil.getExtension(binaryPath);
         if (!FormUploadUtil.isSupportedMultimediaFile(binaryPath)) {
             Toast.makeText(getContext(),
                     Localization.get("form.attachment.invalid"),
@@ -231,11 +230,8 @@ public abstract class MediaWidget extends QuestionWidget {
             return;
         }
 
-        File newMedia;
-        recordedFileName = FileUtil.getFileName(binaryPath);
         copyRecordedFileToDestination(binaryPath);
-
-        newMedia = new File(destMediaPath);
+        File newMedia = new File(destMediaPath);
         if (newMedia.exists()) {
             showToast("form.attachment.success");
         }
@@ -244,7 +240,7 @@ public abstract class MediaWidget extends QuestionWidget {
     }
 
     private void copyRecordedFileToDestination(String binaryPath) {
-        String extension = FileUtil.getExtension(recordedFileName);
+        String extension = FileUtil.getExtension(binaryPath);
         destMediaPath = mInstanceFolder + System.currentTimeMillis() + customFileTag + "." + extension;
 
         // Copy to destMediaPath


### PR DESCRIPTION
## Summary

Refactors Media widget to modularize the media checks in their own functions. 

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

