### PR TITLE
Disable lint warning for usage of Timber log #trivial

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,3 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
+    <!-- Disable the "Using Log instead of Timber" lint warnings -->
+    <issue id="LogNotTimber" severity="ignore" />
 </lint>


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
Configure the lint.xml file to disable "Using Log instead of Timber" lint warnings. https://developer.android.com/studio/write/lint#pref

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [ ] If the PR is high risk, "High Risk" label is set
- [ ] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
