### PR TITLE
fixes mime type for encrypted files

### DIFF
--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -343,7 +343,7 @@ public class FormUploadUtil {
                     numAttachmentsSuccessfullyAdded += addPartToEntity(parts, f, contentType, key);
                 } else if (isSupportedMultimediaFile(fileName)) {
                     numAttachmentsInInstanceFolder++;
-                    String mimeType = FileUtil.getMimeType(f.getPath());
+                    String mimeType = FileUtil.getMimeType(fileName);
                     if (StringUtils.isEmpty(mimeType)) {
                         mimeType = "application/octet-stream";
                     }


### PR DESCRIPTION
## Summary

Media Encryption PR broke the mime type handling when uplading the file to server. This PR fixes it by using the non `.aes` filename to deduce the mime type. 


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

