### PR TITLE
Increase Espresso Idling timeout

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/androidTests/AsyncRestoreTest.java
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/AsyncRestoreTest.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.test.espresso.IdlingPolicies;
 import androidx.test.espresso.IdlingRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
@@ -27,6 +28,8 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * @author $|-|!˅@M
  */
@@ -45,6 +48,10 @@ public class AsyncRestoreTest extends BaseTest {
     public void setup() {
         mContext = InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
         LocalBroadcastManager.getInstance(mContext).registerReceiver(mReceiver, new IntentFilter(CLEAR_CACHE_ACTION));
+
+        // The first sync takes a long time, make sure we don't time out
+        IdlingPolicies.setMasterPolicyTimeout(180, TimeUnit.SECONDS);
+        IdlingPolicies.setIdlingResourceTimeout(180, TimeUnit.SECONDS);
     }
 
     @After

--- a/app/instrumentation-tests/src/org/commcare/androidTests/CaseClaimTest.java
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/CaseClaimTest.java
@@ -51,7 +51,7 @@ public class CaseClaimTest extends BaseTest {
         HQApi.closeExistingCases(name, "human", "d58f7a55dbe2bf22d0b6838311ada205");
 
         // Waiting here cuz, HQ sometimes is out of sync and might give stale data.
-        InstrumentationUtility.sleep(15);
+        InstrumentationUtility.sleep(30);
 
         InstrumentationUtility.login("claim_test1", "123");
 


### PR DESCRIPTION
It seems like sync is taking more time than before on HQ lately causing 60 sec idle timeout to be breached with - `androidx.test.espresso.AppNotIdleException: Looped for 46006 iterations over 60 SECONDS`