### PR TITLE
External callout bug fixes

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -16,6 +16,18 @@ import android.os.StrictMode;
 import android.text.format.DateUtils;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.multidex.MultiDexApplication;
+import androidx.preference.PreferenceManager;
+import androidx.work.BackoffPolicy;
+import androidx.work.Constraints;
+import androidx.work.ExistingPeriodicWorkPolicy;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.NetworkType;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
+
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import net.sqlcipher.database.SQLiteDatabase;
@@ -121,18 +133,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 import javax.crypto.SecretKey;
-
-import androidx.annotation.NonNull;
-import androidx.multidex.MultiDexApplication;
-import androidx.preference.PreferenceManager;
-import androidx.work.BackoffPolicy;
-import androidx.work.Constraints;
-import androidx.work.ExistingPeriodicWorkPolicy;
-import androidx.work.ExistingWorkPolicy;
-import androidx.work.NetworkType;
-import androidx.work.OneTimeWorkRequest;
-import androidx.work.PeriodicWorkRequest;
-import androidx.work.WorkManager;
 
 import io.noties.markwon.Markwon;
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin;
@@ -805,7 +805,12 @@ public class CommCareApplication extends MultiDexApplication {
         // class name because we want a specific service implementation that
         // we know will be running in our own process (and thus won't be
         // supporting component replacement by other applications).
-        startService(new Intent(this, CommCareSessionService.class));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(new Intent(this, CommCareSessionService.class));
+        } else {
+            startService(new Intent(this, CommCareSessionService.class));
+        }
+
         bindService(new Intent(this, CommCareSessionService.class), mConnection, Context.BIND_AUTO_CREATE);
         sessionServiceIsBinding = true;
     }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -726,6 +726,7 @@ public class CommCareApplication extends MultiDexApplication {
                     mCurrentServiceBindTimeout = MAX_BIND_TIMEOUT;
 
                     mBoundService = ((CommCareSessionService.LocalBinder)service).getService();
+                    mBoundService.showLoggedInNotification(null);
 
                     // Don't let anyone touch this until it's logged in
                     // Open user database

--- a/app/src/org/commcare/android/database/global/models/AndroidSharedKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/AndroidSharedKeyRecord.java
@@ -54,7 +54,7 @@ public class AndroidSharedKeyRecord extends Persisted {
     public static AndroidSharedKeyRecord generateNewSharingKey() {
         try {
             KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-            generator.initialize(256, new SecureRandom());
+            generator.initialize(512, new SecureRandom());
             KeyPair pair = generator.genKeyPair();
             byte[] encodedPrivate = pair.getPrivate().getEncoded();
             String privateEncoding = pair.getPrivate().getFormat();

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -44,6 +44,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.locks.ReentrantLock;
 
+import javax.annotation.Nullable;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
@@ -122,6 +123,7 @@ public class CommCareSessionService extends Service {
     // done at least once during this session?
     private boolean appHealthChecksCompleted;
     public static final String LOG_SUBMISSION_RESULT_PREF = "log_submission_result";
+
     /**
      * Class for clients to access.  Because we know this service always
      * runs in the same process as its clients, we don't need to deal with
@@ -195,7 +197,7 @@ public class CommCareSessionService extends Service {
     /**
      * Show a notification while this service is running.
      */
-    private void showLoggedInNotification(User user) {
+    public void showLoggedInNotification(@Nullable User user) {
         //We always want this click to simply bring the live stack back to the top
         Intent callable = new Intent(this, DispatchActivity.class);
         callable.setAction("android.intent.action.MAIN");
@@ -217,17 +219,18 @@ public class CommCareSessionService extends Service {
         }
 
         // Set the icon, scrolling text and timestamp
-        Notification notification = new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_ERRORS_ID)
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_ERRORS_ID)
                 .setContentTitle(notificationText)
-                .setContentText("Session Expires: " + DateFormat.format("MMM dd h:mmaa", sessionExpireDate))
-                .setSmallIcon(org.commcare.dalvik.R.drawable.notification)
-                .setContentIntent(contentIntent)
-                .build();
+                .setSmallIcon(R.drawable.notification)
+                .setContentIntent(contentIntent);
 
         if (user != null) {
-            //Send the notification.
-            this.startForeground(NOTIFICATION, notification);
+            String contentText = "Session Expires: " + DateFormat.format("MMM dd h:mmaa", sessionExpireDate);
+            notificationBuilder.setContentText(contentText);
         }
+
+        //Send the notification.
+        this.startForeground(NOTIFICATION, notificationBuilder.build());
     }
 
     /**
@@ -531,7 +534,7 @@ public class CommCareSessionService extends Service {
                 callable.addCategory("android.intent.category.LAUNCHER");
 
                 // The PendingIntent to launch our activity if the user selects this notification
-                //TODO: Put something here that will, I dunno, cancel submission or something? Maybe show it live? 
+                //TODO: Put something here that will, I dunno, cancel submission or something? Maybe show it live?
                 PendingIntent contentIntent = PendingIntent.getActivity(CommCareSessionService.this, 0, callable, 0);
 
                 submissionNotification = new NotificationCompat.Builder(CommCareSessionService.this,


### PR DESCRIPTION
## Summary

Couple fixes. 

1. https://github.com/dimagi/commcare-android/commit/3b57a482c81c34c54b6f8068e7d4a9a2dc5bc0a4 to fix

```
E/MethodChannel#io.c4us.sms_forwarder/receiveintent(26449): Failed to handle method call
E/MethodChannel#io.c4us.sms_forwarder/receiveintent(26449): com.android.org.bouncycastle.crypto.DataLengthException: input too large for RSA cipher.
E/MethodChannel#io.c4us.sms_forwarder/receiveintent(26449): 	at com.android.org.bouncycastle.crypto.engines.RSACoreEngine.convertInput(RSACoreEngine.java:117)
E/MethodChannel#io.c4us.sms_forwarder/receiveintent(26449): 	at com.android.org.bouncycastle.crypto.engines.RSABlindedEngine.processBlock(RSABlindedEngine.java:98)
E/MethodChannel#io.c4us.sms_forwarder/receiveintent(26449): 	at com.android.org.bouncycastle.jcajce.provider.asymmetric.rsa.CipherSpi.getOutput(CipherSpi.java:549)
E/MethodChannel#io.c4us.sms_forwarder/receiveintent(26449): 	at com.android.org.bouncycastle.jcajce.provider.asymmetric.rsa.CipherSpi.engineDoFinal(CipherSpi.java:498)
E/MethodChannel#io.c4us.sms_forwarder/receiveintent(26449): 	at javax.crypto.Cipher.doFinal(Cipher.java:2055)
```

This happens when we try to encrypt the aes key using the RSA key for example [here](https://github.com/dimagi/commcare-tester-app/blob/2891bc139d1f443309919d6a2402eca4bd79e033/src/com/dimagi/test/external/ExternalAppActivity.java#L164). Though it's more sporadic in nature and doesn't always happen. 

I didn't give much thought to RSA key length here and there might be more optimal key length than 512 bits. I tried using just slightly higher than 256 i.e. 264 but was still getting the issue. 


2. https://github.com/dimagi/commcare-android/commit/691186a34c8578f40b326c61a80b7067b96405fe to fix 

```
022-03-05 16:19:50.258 25069-25069/org.commcare.dalvik.debug W/System.err: java.lang.IllegalStateException: Not allowed to start service Intent { cmp=org.commcare.dalvik.debug/org.commcare.services.CommCareSessionService }: app is in background uid UidR2ecord{6c006fe u0a489 RCVR idle change:uncached procs:1 seq(0,0,0)}
2022-03-05 16:19:50.258 25069-25069/org.commcare.dalvik.debug W/System.err:     at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1795)
2022-03-05 16:19:50.258 25069-25069/org.commcare.dalvik.debug W/System.err:     at android.app.ContextImpl.startService(ContextImpl.java:1740)
2022-03-05 16:19:50.258 25069-25069/org.commcare.dalvik.debug W/System.err:     at android.content.ContextWrapper.startService(ContextWrapper.java:738)
2022-03-05 16:19:50.259 25069-25069/org.commcare.dalvik.debug W/System.err:     at org.commcare.CommCareApplication.bindUserSessionService(CommCareApplication.java:808)
2022-03-05 16:19:50.259 25069-25069/org.commcare.dalvik.debug W/System.err:     at org.commcare.CommCareApplication.startUserSession(CommCareApplication.java:356)
2022-03-05 16:19:50.259 25069-25069/org.commcare.dalvik.debug W/System.err:     at org.commcare.provider.ExternalApiReceiver.tryLocalLogin(ExternalApiReceiver.java:205)
2022-03-05 16:19:50.259 25069-25069/org.commcare.dalvik.debug W/System.err:     at org.commcare.provider.ExternalApiReceiver.performAction(ExternalApiReceiver.java:104)
2022-03-05 16:19:50.259 25069-25069/org.commcare.dalvik.debug W/System.err:     at org.commcare.provider.ExternalApiReceiver.onReceive(ExternalApiReceiver.java:96)
```

This happens because of the [Android 8 background execution limits](https://developer.android.com/about/versions/oreo/android-8.0-changes#back-all)

And is supported by https://github.com/dimagi/commcare-android/pull/2550/commits/9d4d1c0a7975ab8d2eea4a7c1ba3c03bd4d5a87a as we always need to show foreground notification for a service started by `startForegroundService`

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
