### PR TITLE
Fixes interaction with gmaps on Android 11+ devices

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -82,6 +82,7 @@
         <intent>
             <action android:name="android.intent.action.TTS_SERVICE" />
         </intent>
+        <package android:name="com.google.android.apps.maps" />
     </queries>
 
     <application


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/SAAS-13334

Callouts to gmaps break on Android 11+ devices due to [package visibility restrictions](https://medium.com/androiddevelopers/package-visibility-in-android-11-cc857f221cd9) on Android 11

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly


