### PR TITLE
Adds XPathJsonPropertyFunc to fix test

### DIFF
--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -340,6 +340,7 @@ public class FormStorageTest {
 
             // Added in 2.53
             , "org.javarosa.xpath.expr.XPathDecryptStringFunc"
+            , "org.javarosa.xpath.expr.XPathJsonPropertyFunc"
     );
 
 


### PR DESCRIPTION
Adds `XPathJsonPropertyFunc` from https://github.com/dimagi/commcare-core/pull/1128 to the list of Externalizable classes. 