### PR TITLE
Target android 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ git clone https://github.com/dimagi/commcare-core.git
 
 - Open Android Studio
 - If this is your first time using Android Studio, click "Config" and setup the Android SDK.
-- Download the Android 7 (API 24) SDK Platform and the Google APIs for 24.
+- Download the Android 12 (API 31) SDK Platform and the Google APIs for 31.
 - Now go back to the Android Studio Welcome dashboard and click "Import project (Eclipse ADT, Gradle, etc.)"
 - Select AndroidStudioProjects > CommCare > commcare-android and hit OK
 - Click "OK" to use the Gradle wrapper

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -382,14 +382,18 @@
             </intent-filter>
         </activity>
 
-        <receiver android:name="org.commcare.provider.ExternalApiReceiver">
+        <receiver
+            android:name="org.commcare.provider.ExternalApiReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.api.action.ExternalAction"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </receiver>
 
-        <receiver android:name="org.commcare.provider.CommCareLogoutReceiver"
+        <receiver
+            android:exported="false"
+            android:name="org.commcare.provider.CommCareLogoutReceiver"
             android:permission="org.commcare.dalvik.permission.COMMCARE_LOGOUT">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.api.action.CommCareLogoutAction"/>
@@ -397,14 +401,18 @@
             </intent-filter>
         </receiver>
 
-        <receiver android:name="org.commcare.provider.RefreshToLatestBuildReceiver">
+        <receiver
+            android:name="org.commcare.provider.RefreshToLatestBuildReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.api.action.RefreshToLatestBuildAction"/>
 
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </receiver>
-        <receiver android:name="org.commcare.provider.DebugControlsReceiver">
+        <receiver
+            android:name="org.commcare.provider.DebugControlsReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.api.action.SessionCaptureAction"/>
 

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -98,6 +98,7 @@
 
         <activity
             android:label="@string/application_name"
+            android:exported="true"
             android:name="org.commcare.activities.DispatchActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
@@ -112,6 +113,7 @@
         </activity>
         <activity
             android:label="@string/manager_activity_name"
+            android:exported="true"
             android:name="org.commcare.activities.AppManagerActivity"
             android:taskAffinity="org.commcare.Manage">
             <intent-filter>
@@ -169,7 +171,9 @@
             android:name="org.commcare.activities.SessionAwarePreferenceActivity"
             android:theme="@style/PreferenceTheme">
         </activity>
-        <activity android:name="org.commcare.activities.DotsEntryActivity">
+        <activity
+            android:exported="false"
+            android:name="org.commcare.activities.DotsEntryActivity">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.action.DotsEntry"/>
 
@@ -180,6 +184,7 @@
         </activity>
         <activity
             android:name="org.commcare.activities.CommCareSetupActivity"
+            android:exported="true"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
@@ -304,7 +309,9 @@
             android:theme="@style/Theme.AppCompat.Light.NoActionBar">
         </activity>
 
-        <activity android:name="org.commcare.gis.DrawingBoundaryActivity"
+        <activity
+            android:name="org.commcare.gis.DrawingBoundaryActivity"
+            android:exported="false"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.action.DrawBoundary"/>
@@ -356,14 +363,18 @@
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </activity>
-        <activity android:name="org.commcare.android.nfc.NfcWriteActivity">
+        <activity
+            android:exported="false"
+            android:name="org.commcare.android.nfc.NfcWriteActivity">
             <intent-filter>
                 <action android:name="org.commcare.nfc.WRITE"/>
 
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </activity>
-        <activity android:name="org.commcare.android.nfc.NfcReadActivity">
+        <activity
+            android:exported="false"
+            android:name="org.commcare.android.nfc.NfcReadActivity">
             <intent-filter>
                 <action android:name="org.commcare.nfc.READ"/>
 
@@ -449,6 +460,7 @@
         </activity>
         <activity
             android:name="org.commcare.print.TemplatePrinterActivity"
+            android:exported="false"
             android:theme="@style/Theme.Dialog.NoTitle">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.action.PRINT"/>
@@ -472,6 +484,7 @@
         <activity android:name="org.commcare.activities.PromptCczUpdateActivity"/>
         <activity
             android:label="@string/title_data_change_logs_activity"
+            android:exported="true"
             android:name="org.commcare.activities.DataChangeLogsActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -520,6 +520,15 @@
         <receiver android:name="io.ona.kujaku.receivers.KujakuNetworkChangeReceiver"
             tools:node="remove"/>
 
+        <!-- The zebra-print-android library is not yet targeting Android 12 and at least one
+            Activity doesn't have the required attribute exported. The entry below adds the
+            attribute to the final Manifest.
+        -->
+        <activity
+            android:exported="true"
+            android:name="com.dimagi.android.zebraprinttool.PrintReceiverActivity"
+            tools:node="merge"/>
+
     </application>
 
 </manifest>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -392,7 +392,7 @@
         </receiver>
 
         <receiver
-            android:exported="false"
+            android:exported="true"
             android:name="org.commcare.provider.CommCareLogoutReceiver"
             android:permission="org.commcare.dalvik.permission.COMMCARE_LOGOUT">
             <intent-filter>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -492,7 +492,7 @@
         <activity android:name="org.commcare.activities.PromptCczUpdateActivity"/>
         <activity
             android:label="@string/title_data_change_logs_activity"
-            android:exported="true"
+            android:exported="false"
             android:name="org.commcare.activities.DataChangeLogsActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>

--- a/app/CommcareAndroidManifest.xml
+++ b/app/CommcareAndroidManifest.xml
@@ -5,6 +5,7 @@
         <!-- Enable Shortcuts for Command Actions -->
         <activity
             android:name="org.commcare.utils.AndroidShortcuts"
+            android:exported="true"
             android:theme="@android:style/Theme.Translucent.NoTitleBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
@@ -13,7 +14,8 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="org.commcare.utils.ManagerShortcut">
+            android:name="org.commcare.utils.ManagerShortcut"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.DEFAULT"/>
@@ -22,6 +24,7 @@
 
         <activity-alias
             android:name=".application.ShortcutGenerator"
+            android:exported="true"
             android:label="CommCare Action"
             android:targetActivity="org.commcare.utils.AndroidShortcuts">
 
@@ -35,6 +38,7 @@
 
         <activity-alias
             android:name=".application.ManagerGenerator"
+            android:exported="true"
             android:label="App Manager"
             android:targetActivity="org.commcare.utils.ManagerShortcut">
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'androidx.test:runner:1.4.0'
     testImplementation 'androidx.test.ext:junit:1.1.3'
-    testImplementation 'androidx.work:work-testing:2.4.0'
+    testImplementation 'androidx.work:work-testing:2.7.0'
     testImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     testImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2"
@@ -121,8 +121,8 @@ dependencies {
     implementation ('io.ona.kujaku:library:0.9.0'){
         exclude module: 'xpp3'
     }
-    implementation "androidx.work:work-runtime:2.4.0"
-    implementation "androidx.work:work-runtime-ktx:2.4.0"
+    implementation "androidx.work:work-runtime:2.7.0"
+    implementation "androidx.work:work-runtime-ktx:2.7.0"
 
     implementation 'com.google.android.play:core:1.7.3'
     implementation 'android.arch.lifecycle:common-java8:1.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -226,7 +226,7 @@ static def getDate() {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     lintOptions {
         abortOnError false
@@ -249,7 +249,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         multiDexEnabled true
         applicationId "org.commcare.dalvik"
         project.ext.COMMCARE_APP_ID = applicationId

--- a/app/src/org/commcare/CommCareNoficationManager.java
+++ b/app/src/org/commcare/CommCareNoficationManager.java
@@ -1,5 +1,6 @@
 package org.commcare;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.NotificationChannel;
@@ -49,7 +50,7 @@ public class CommCareNoficationManager {
         toaster = new PopupHandler(context);
     }
 
-
+    @SuppressLint("UnspecifiedImmutableFlag")
     private void updateMessageNotification() {
         NotificationManager mNM = (NotificationManager)context.getSystemService(NOTIFICATION_SERVICE);
         synchronized (pendingMessages) {
@@ -63,7 +64,12 @@ public class CommCareNoficationManager {
             // The PendingIntent to launch our activity if the user selects this notification
             Intent i = new Intent(context, MessageActivity.class);
 
-            PendingIntent contentIntent = PendingIntent.getActivity(context, 0, i, PendingIntent.FLAG_IMMUTABLE);
+            // The FLAG_IMMUTABLE flag was added in API level 23
+            PendingIntent contentIntent;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                contentIntent = PendingIntent.getActivity(context, 0, i, PendingIntent.FLAG_IMMUTABLE);
+            else
+                contentIntent = PendingIntent.getActivity(context, 0, i,0);
 
             String additional = pendingMessages.size() > 1 ? Localization.get("notifications.prompt.more", new String[]{String.valueOf(pendingMessages.size() - 1)}) : "";
 

--- a/app/src/org/commcare/CommCareNoficationManager.java
+++ b/app/src/org/commcare/CommCareNoficationManager.java
@@ -64,7 +64,6 @@ public class CommCareNoficationManager {
             // The PendingIntent to launch our activity if the user selects this notification
             Intent i = new Intent(context, MessageActivity.class);
 
-            // The FLAG_IMMUTABLE flag was added in API level 23
             PendingIntent contentIntent;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
                 contentIntent = PendingIntent.getActivity(context, 0, i, PendingIntent.FLAG_IMMUTABLE);

--- a/app/src/org/commcare/CommCareNoficationManager.java
+++ b/app/src/org/commcare/CommCareNoficationManager.java
@@ -63,7 +63,7 @@ public class CommCareNoficationManager {
             // The PendingIntent to launch our activity if the user selects this notification
             Intent i = new Intent(context, MessageActivity.class);
 
-            PendingIntent contentIntent = PendingIntent.getActivity(context, 0, i, 0);
+            PendingIntent contentIntent = PendingIntent.getActivity(context, 0, i, PendingIntent.FLAG_IMMUTABLE);
 
             String additional = pendingMessages.size() > 1 ? Localization.get("notifications.prompt.more", new String[]{String.valueOf(pendingMessages.size() - 1)}) : "";
 

--- a/app/src/org/commcare/android/nfc/NfcActivity.java
+++ b/app/src/org/commcare/android/nfc/NfcActivity.java
@@ -75,10 +75,16 @@ public abstract class NfcActivity extends AppCompatActivity {
      * FLAG_ACTIVITY_SINGLE_TOP makes it so that onNewIntent() can be called in this activity when
      * the intent is started.
      **/
+    @SuppressLint("UnspecifiedImmutableFlag")
     protected void createPendingRestartIntent() {
         Intent i = new Intent(this, getClass());
         i.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        this.pendingNfcIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_IMMUTABLE);
+
+        // The FLAG_IMMUTABLE flag was added in API level 23
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            this.pendingNfcIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_IMMUTABLE);
+        else
+            this.pendingNfcIntent = PendingIntent.getActivity(this, 0, i,0);
     }
 
     @Override

--- a/app/src/org/commcare/android/nfc/NfcActivity.java
+++ b/app/src/org/commcare/android/nfc/NfcActivity.java
@@ -78,7 +78,7 @@ public abstract class NfcActivity extends AppCompatActivity {
     protected void createPendingRestartIntent() {
         Intent i = new Intent(this, getClass());
         i.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        this.pendingNfcIntent = PendingIntent.getActivity(this, 0, i, 0);
+        this.pendingNfcIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_IMMUTABLE);
     }
 
     @Override

--- a/app/src/org/commcare/android/nfc/NfcActivity.java
+++ b/app/src/org/commcare/android/nfc/NfcActivity.java
@@ -80,7 +80,6 @@ public abstract class NfcActivity extends AppCompatActivity {
         Intent i = new Intent(this, getClass());
         i.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
-        // The FLAG_IMMUTABLE flag was added in API level 23
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
             this.pendingNfcIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_IMMUTABLE);
         else

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -242,7 +242,9 @@ public class CommCareSessionService extends Service {
 
         Intent i = new Intent(this, DispatchActivity.class);
         i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
         PendingIntent contentIntent = null;
+        // The FLAG_IMMUTABLE flag was added in API level 23
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
             contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         else

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -7,6 +7,7 @@ import android.app.Service;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 import android.text.format.DateFormat;
 import android.util.Log;
@@ -241,7 +242,11 @@ public class CommCareSessionService extends Service {
 
         Intent i = new Intent(this, DispatchActivity.class);
         i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent contentIntent = null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        else
+            contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT);
 
         Notification notification = new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_USER_SESSION_ID)
                 .setContentTitle(this.getString(R.string.expirenotification))

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -207,7 +207,6 @@ public class CommCareSessionService extends Service {
         callable.addCategory("android.intent.category.LAUNCHER");
 
         // The PendingIntent to launch our activity if the user selects this notification
-        // The FLAG_IMMUTABLE flag was added in API level 23
         PendingIntent contentIntent;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
             contentIntent = PendingIntent.getActivity(this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
@@ -252,7 +251,6 @@ public class CommCareSessionService extends Service {
         i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
         PendingIntent contentIntent = null;
-        // The FLAG_IMMUTABLE flag was added in API level 23
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
             contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         else
@@ -550,7 +548,6 @@ public class CommCareSessionService extends Service {
                 callable.addCategory("android.intent.category.LAUNCHER");
 
                // The PendingIntent to launch our activity if the user selects this notification
-               // The FLAG_IMMUTABLE flag was added in API level 23
                //TODO: Put something here that will, I dunno, cancel submission or something? Maybe show it live?
                PendingIntent contentIntent;
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -1,5 +1,6 @@
 package org.commcare.services;
 
+import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -198,6 +199,7 @@ public class CommCareSessionService extends Service {
     /**
      * Show a notification while this service is running.
      */
+    @SuppressLint("UnspecifiedImmutableFlag")
     public void showLoggedInNotification(@Nullable User user) {
         //We always want this click to simply bring the live stack back to the top
         Intent callable = new Intent(this, DispatchActivity.class);
@@ -205,7 +207,12 @@ public class CommCareSessionService extends Service {
         callable.addCategory("android.intent.category.LAUNCHER");
 
         // The PendingIntent to launch our activity if the user selects this notification
-        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
+        // The FLAG_IMMUTABLE flag was added in API level 23
+        PendingIntent contentIntent;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            contentIntent = PendingIntent.getActivity(this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
+        else
+            contentIntent = PendingIntent.getActivity(this, 0, callable,0);
 
         String notificationText;
         if (AppUtils.getInstalledAppRecords().size() > 1) {
@@ -237,6 +244,7 @@ public class CommCareSessionService extends Service {
     /**
      * Notify the user that they've been timed out and need to relog in
      */
+    @SuppressLint("UnspecifiedImmutableFlag")
     private void showLoggedOutNotification() {
         this.stopForeground(true);
 
@@ -531,6 +539,7 @@ public class CommCareSessionService extends Service {
             int lastUpdate = 0;
 
             @Override
+            @SuppressLint("UnspecifiedImmutableFlag")
             public void beginSubmissionProcess(int totalItems) {
                 this.totalItems = totalItems;
 
@@ -540,9 +549,14 @@ public class CommCareSessionService extends Service {
                 callable.setAction("android.intent.action.MAIN");
                 callable.addCategory("android.intent.category.LAUNCHER");
 
-                // The PendingIntent to launch our activity if the user selects this notification
-                //TODO: Put something here that will, I dunno, cancel submission or something? Maybe show it live?
-                PendingIntent contentIntent = PendingIntent.getActivity(CommCareSessionService.this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
+               // The PendingIntent to launch our activity if the user selects this notification
+               // The FLAG_IMMUTABLE flag was added in API level 23
+               //TODO: Put something here that will, I dunno, cancel submission or something? Maybe show it live?
+               PendingIntent contentIntent;
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                    contentIntent = PendingIntent.getActivity(CommCareSessionService.this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
+                else
+                    contentIntent = PendingIntent.getActivity(CommCareSessionService.this, 0, callable,0);
 
                 submissionNotification = new NotificationCompat.Builder(CommCareSessionService.this,
                         CommCareNoficationManager.NOTIFICATION_CHANNEL_SERVER_COMMUNICATIONS_ID)

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -204,7 +204,7 @@ public class CommCareSessionService extends Service {
         callable.addCategory("android.intent.category.LAUNCHER");
 
         // The PendingIntent to launch our activity if the user selects this notification
-        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, callable, 0);
+        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
 
         String notificationText;
         if (AppUtils.getInstalledAppRecords().size() > 1) {
@@ -535,7 +535,7 @@ public class CommCareSessionService extends Service {
 
                 // The PendingIntent to launch our activity if the user selects this notification
                 //TODO: Put something here that will, I dunno, cancel submission or something? Maybe show it live?
-                PendingIntent contentIntent = PendingIntent.getActivity(CommCareSessionService.this, 0, callable, 0);
+                PendingIntent contentIntent = PendingIntent.getActivity(CommCareSessionService.this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
 
                 submissionNotification = new NotificationCompat.Builder(CommCareSessionService.this,
                         CommCareNoficationManager.NOTIFICATION_CHANNEL_SERVER_COMMUNICATIONS_ID)


### PR DESCRIPTION
## Summary
This PR adds support to Android 12 (Android SDK 31). Most of the changes are related to adding the 'exported' attribute to Activities and Receivers and setting the mutability flag of Pending Intents.  
- JIRA ticket: https://dimagi-dev.atlassian.net/browse/SAAS-13635

## Safety Assurance

- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Test coverage
It passed all 413 Unit Tests and the results of the Instrumentation Tests were satisfactory, the results can be found [here](https://docs.google.com/document/d/14-uYpTs6K0LnLjIPiFVBFwreRwpaNDXw-Mrbs7bYkzw).

