### PR TITLE
Enable Dependabot Version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+  - package-ecosystem: gradle
+    directory: "/app"
+    schedule:
+      interval: daily
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary
This PR enables Dependabot version updates. 

## Safety Assurance
- [x ] I have confidence that this PR will not introduce a regression for the reasons below
