### PR TITLE
Fix mutability flag

### DIFF
--- a/app/src/org/commcare/CommCareNoficationManager.java
+++ b/app/src/org/commcare/CommCareNoficationManager.java
@@ -64,21 +64,19 @@ public class CommCareNoficationManager {
             // The PendingIntent to launch our activity if the user selects this notification
             Intent i = new Intent(context, MessageActivity.class);
 
-            PendingIntent contentIntent;
+            int intentFlags = 0;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-                contentIntent = PendingIntent.getActivity(context, 0, i, PendingIntent.FLAG_IMMUTABLE);
-            else
-                contentIntent = PendingIntent.getActivity(context, 0, i,0);
+                intentFlags = PendingIntent.FLAG_IMMUTABLE;
+            PendingIntent contentIntent = PendingIntent.getActivity(context, 0, i, intentFlags);
 
             String additional = pendingMessages.size() > 1 ? Localization.get("notifications.prompt.more", new String[]{String.valueOf(pendingMessages.size() - 1)}) : "";
-
             Notification messageNotification = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ERRORS_ID)
                     .setContentTitle(title)
                     .setContentText(Localization.get("notifications.prompt.details", new String[]{additional}))
                     .setSmallIcon(R.drawable.notification)
                     .setNumber(pendingMessages.size())
                     .setContentIntent(contentIntent)
-                    .setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationClearReceiver.class), 0))
+                    .setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationClearReceiver.class), intentFlags))
                     .setOngoing(true)
                     .setWhen(System.currentTimeMillis())
                     .build();

--- a/app/src/org/commcare/views/dialogs/PinnedNotificationWithProgress.java
+++ b/app/src/org/commcare/views/dialogs/PinnedNotificationWithProgress.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.os.Build;
+
 import androidx.core.app.NotificationCompat;
 
 import org.commcare.CommCareNoficationManager;
@@ -60,9 +62,13 @@ public class PinnedNotificationWithProgress
     }
 
     private PendingIntent buildPendingIntent(Context ctx) {
+        int intentFlags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            intentFlags = intentFlags | PendingIntent.FLAG_IMMUTABLE;
+
         Intent i = new Intent(ctx, UpdateActivity.class);
         i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        return PendingIntent.getActivity(ctx, 0, i, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getActivity(ctx, 0, i, intentFlags);
     }
 
     @Override


### PR DESCRIPTION
## Summary
This PR sets the mutability flag to Pending Intents as [required by applications targeting Android 12](https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability).
