### PR TITLE
Improve app discoverability

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -86,6 +86,10 @@
             <action android:name="android.intent.action.SEND" />
             <data android:mimeType="*/*" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="*/*" android:scheme="*" />
+        </intent>
         <package android:name="com.google.android.apps.maps" />
         <package android:name="org.commcare.dalvik.reminders" />
         <package android:name="callout.commcare.org.sendussd" />

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -82,6 +82,10 @@
         <intent>
             <action android:name="android.intent.action.TTS_SERVICE" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="*/*" />
+        </intent>
         <package android:name="com.google.android.apps.maps" />
         <package android:name="org.commcare.dalvik.reminders" />
         <package android:name="callout.commcare.org.sendussd" />


### PR DESCRIPTION
## Summary
Considering the restrictions introduced in Android 11 to package visibility, apps have now to register other apps or components from other apps they rely to fulfil some of their requirements. This PR improves CommCare package visibility by adding intent filter signatures for actions SEND and VIEW, making apps with matching capabilities visible to CommCare. 
JIRA tickets: [QA-4487](https://dimagi-dev.atlassian.net/browse/QA-4487) and [QA-4492](https://dimagi-dev.atlassian.net/browse/QA-4492) 

## Safety Assurance

- [x] I have confidence that this PR will not introduce a regression for the reasons below

