### PR TITLE
Fix External test app

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -395,7 +395,7 @@
 
         <receiver
             android:name="org.commcare.provider.ExternalApiReceiver"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.api.action.ExternalAction"/>
                 <category android:name="android.intent.category.DEFAULT"/>


### PR DESCRIPTION
## Summary
This PR is to make the ExternalApiReceiver able to get messages from other apps, one of them being the CommCare Tester App.
JIRA ticket: [QA-4482](https://dimagi-dev.atlassian.net/browse/QA-4482)

## Safety Assurance

- [x] I have confidence that this PR will not introduce a regression for the reasons below
