### PR TITLE
Adds support for adding multimap params to network requests

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/androidTests/LetsEncryptTest.java
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/LetsEncryptTest.java
@@ -53,7 +53,7 @@ public class LetsEncryptTest {
     }
 
     private void makeGetRequest(String url, int expectedCode) throws IOException {
-        Response<ResponseBody> response = commCareNetworkService.makeGetRequest(url, new HashMap<>(), new HashMap<>()).execute();
+        Response<ResponseBody> response = commCareNetworkService.makeGetRequest(url, new HashMap<>()).execute();
         assertTrue(response.code() == expectedCode);
         assertEquals(Protocol.HTTP_2, response.raw().protocol());
         if (response.body() != null) {

--- a/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
+++ b/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
@@ -166,7 +166,7 @@ public class HQApi {
         CommCareNetworkService networkService = createTestNetworkService();
         Response<ResponseBody> response;
         try {
-            response = networkService.makeMultipartPostRequest(FIXTURE_UPLOAD_URL, new HashMap<>(), new HashMap<>(), parts).execute();
+            response = networkService.makeMultipartPostRequest(FIXTURE_UPLOAD_URL, new HashMap<>(), parts).execute();
             if (response.isSuccessful()) {
                 Log.d(TAG, "Uploading Fixture succeeded :: " + response.body().string());
             } else {
@@ -207,7 +207,7 @@ public class HQApi {
         String url = String.format(USER_URL, userId);
         CommCareNetworkService networkService = createTestNetworkService();
         try {
-            Response<ResponseBody> response = networkService.makeDeleteRequest(url, new HashMap<>(), new HashMap<>()).execute();
+            Response<ResponseBody> response = networkService.makeDeleteRequest(url, new HashMap<>()).execute();
             return response.isSuccessful();
         } catch (IOException e) {
             e.printStackTrace();
@@ -265,7 +265,7 @@ public class HQApi {
         CommCareNetworkService networkService = createTestNetworkService();
         Response<ResponseBody> response = null;
         try {
-            response = networkService.makeMultipartPostRequest(FORM_UPLOAD_URL, new HashMap<>(), new HashMap<>(), parts).execute();
+            response = networkService.makeMultipartPostRequest(FORM_UPLOAD_URL, new HashMap<>(), parts).execute();
             return response.isSuccessful();
         } catch (IOException e) {
             e.printStackTrace();
@@ -306,7 +306,7 @@ public class HQApi {
             url += query;
         }
         CommCareNetworkService networkService = createTestNetworkService();
-        return networkService.makeGetRequest(url, new HashMap<>(), new HashMap<>()).execute();
+        return networkService.makeGetRequest(url, new HashMap<>()).execute();
     }
 
     private static Response<ResponseBody> postRequest(String url, String query, RequestBody body) throws IOException {
@@ -314,7 +314,7 @@ public class HQApi {
             url += query;
         }
         CommCareNetworkService networkService = createTestNetworkService();
-        return networkService.makePostRequest(url, new HashMap<>(), new HashMap<>(), body).execute();
+        return networkService.makePostRequest(url, new HashMap<>(), body).execute();
     }
 
     private static CommCareNetworkService createTestNetworkService() {

--- a/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
+++ b/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
@@ -2,6 +2,9 @@ package org.commcare.utils;
 
 import android.util.Log;
 import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.google.common.collect.ArrayListMultimap;
+
 import org.commcare.core.network.AuthInfo;
 import org.commcare.core.network.CommCareNetworkService;
 import org.commcare.core.network.CommCareNetworkServiceGenerator;
@@ -320,7 +323,8 @@ public class HQApi {
                 CommCareNetworkServiceGenerator.createCommCareNetworkService(
                         HttpUtils.getCredential(authInfo),
                         true,
-                        true);
+                        true,
+                        ArrayListMultimap.create());
         return networkService;
     }
 }

--- a/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
+++ b/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
@@ -4,6 +4,7 @@ import android.util.Log;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMultimap;
 
 import org.commcare.core.network.AuthInfo;
 import org.commcare.core.network.CommCareNetworkService;
@@ -324,7 +325,7 @@ public class HQApi {
                         HttpUtils.getCredential(authInfo),
                         true,
                         true,
-                        ArrayListMultimap.create());
+                        ImmutableMultimap.of());
         return networkService;
     }
 }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -28,6 +28,8 @@ import androidx.work.OneTimeWorkRequest;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import net.sqlcipher.database.SQLiteDatabase;
@@ -1150,12 +1152,13 @@ public class CommCareApplication extends MultiDexApplication {
     public ModernHttpRequester createGetRequester(Context context, String url, Map<String, String> params,
                                                   HashMap headers, AuthInfo authInfo,
                                                   @Nullable HttpResponseProcessor responseProcessor) {
-        return buildHttpRequester(context, url, params, headers, null, null,
+        return buildHttpRequester(context, url, params, ArrayListMultimap.create(), headers, null, null,
                 HTTPMethod.GET, authInfo, responseProcessor, true);
     }
 
     public ModernHttpRequester buildHttpRequester(Context context, String url,
                                                   Map<String, String> params,
+                                                  Multimap<String, String> multiParams,
                                                   HashMap headers, RequestBody requestBody,
                                                   List<MultipartBody.Part> parts,
                                                   HTTPMethod method,
@@ -1168,7 +1171,7 @@ public class CommCareApplication extends MultiDexApplication {
         } else {
             networkService = CommCareNetworkServiceGenerator.createCommCareNetworkService(
                     HttpUtils.getCredential(authInfo),
-                    DeveloperPreferences.isEnforceSecureEndpointEnabled(), retry);
+                    DeveloperPreferences.isEnforceSecureEndpointEnabled(), retry, multiParams);
         }
 
         return new ModernHttpRequester(new AndroidCacheDirSetup(context),

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -1149,16 +1149,15 @@ public class CommCareApplication extends MultiDexApplication {
     }
 
 
-    public ModernHttpRequester createGetRequester(Context context, String url, Map<String, String> params,
+    public ModernHttpRequester createGetRequester(Context context, String url, Multimap<String, String> params,
                                                   HashMap headers, AuthInfo authInfo,
                                                   @Nullable HttpResponseProcessor responseProcessor) {
-        return buildHttpRequester(context, url, params, ArrayListMultimap.create(), headers, null, null,
+        return buildHttpRequester(context, url, params, headers, null, null,
                 HTTPMethod.GET, authInfo, responseProcessor, true);
     }
 
     public ModernHttpRequester buildHttpRequester(Context context, String url,
-                                                  Map<String, String> params,
-                                                  Multimap<String, String> multiParams,
+                                                  Multimap<String, String> params,
                                                   HashMap headers, RequestBody requestBody,
                                                   List<MultipartBody.Part> parts,
                                                   HTTPMethod method,
@@ -1171,12 +1170,11 @@ public class CommCareApplication extends MultiDexApplication {
         } else {
             networkService = CommCareNetworkServiceGenerator.createCommCareNetworkService(
                     HttpUtils.getCredential(authInfo),
-                    DeveloperPreferences.isEnforceSecureEndpointEnabled(), retry, multiParams);
+                    DeveloperPreferences.isEnforceSecureEndpointEnabled(), retry, params);
         }
 
         return new ModernHttpRequester(new AndroidCacheDirSetup(context),
                 url,
-                params,
                 headers,
                 requestBody,
                 parts,

--- a/app/src/org/commcare/activities/InstallFromListActivity.java
+++ b/app/src/org/commcare/activities/InstallFromListActivity.java
@@ -53,6 +53,8 @@ import java.util.List;
 
 import androidx.appcompat.widget.SwitchCompat;
 
+import com.google.common.collect.ImmutableMultimap;
+
 /**
  * Created by amstone326 on 2/3/17.
  */
@@ -234,7 +236,7 @@ public class InstallFromListActivity<T> extends CommCareActivity<T> implements H
             this.lastUsernameUsed = username;
             this.lastPasswordUsed = password;
             final View processingRequestView = findViewById(R.id.processing_request_view);
-            ModernHttpTask task = new ModernHttpTask(this, urlToTry, new HashMap(),
+            ModernHttpTask task = new ModernHttpTask(this, urlToTry, ImmutableMultimap.of(),
                     CommcareRequestGenerator.getHeaders(""),
                     new AuthInfo.ProvidedAuth(username, password)) {
 

--- a/app/src/org/commcare/activities/PostRequestActivity.java
+++ b/app/src/org/commcare/activities/PostRequestActivity.java
@@ -7,6 +7,8 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
+import com.google.common.collect.ImmutableMultimap;
+
 import org.commcare.core.network.AuthInfo;
 import org.commcare.core.network.AuthenticationInterceptor;
 import org.commcare.core.network.HTTPMethod;
@@ -111,7 +113,7 @@ public class PostRequestActivity
             if (!hasTaskLaunched && !inErrorState) {
                 RequestBody requestBody = ModernHttpRequester.getPostBody(params);
                 ModernHttpTask postTask =
-                        new ModernHttpTask(this, url.toString(), new HashMap(),
+                        new ModernHttpTask(this, url.toString(), ImmutableMultimap.of(),
                                 getContentHeadersForXFormPost(requestBody), requestBody,
                                 HTTPMethod.POST, new AuthInfo.CurrentAuth());
                 postTask.connect((CommCareTaskConnector)this);

--- a/app/src/org/commcare/activities/QueryRequestActivity.java
+++ b/app/src/org/commcare/activities/QueryRequestActivity.java
@@ -32,6 +32,7 @@ import androidx.annotation.NonNull;
 import androidx.core.content.res.ResourcesCompat;
 
 import com.google.android.material.datepicker.MaterialDatePicker;
+import com.google.common.collect.ImmutableMultimap;
 
 import org.commcare.CommCareApplication;
 import org.commcare.core.interfaces.HttpResponseProcessor;
@@ -393,7 +394,6 @@ public class QueryRequestActivity
         clearErrorState();
         ModernHttpTask httpTask = new ModernHttpTask(this,
                 remoteQuerySessionManager.getBaseUrl().toString(),
-                new HashMap<>(),
                 remoteQuerySessionManager.getRawQueryParams(false),
                 new HashMap(),
                 new AuthInfo.CurrentAuth());

--- a/app/src/org/commcare/activities/QueryRequestActivity.java
+++ b/app/src/org/commcare/activities/QueryRequestActivity.java
@@ -393,7 +393,8 @@ public class QueryRequestActivity
         clearErrorState();
         ModernHttpTask httpTask = new ModernHttpTask(this,
                 remoteQuerySessionManager.getBaseUrl().toString(),
-                new HashMap(remoteQuerySessionManager.getRawQueryParams(false)),
+                new HashMap<>(),
+                remoteQuerySessionManager.getRawQueryParams(false),
                 new HashMap(),
                 new AuthInfo.CurrentAuth());
         httpTask.connect((CommCareTaskConnector)this);

--- a/app/src/org/commcare/android/javarosa/AndroidXFormHttpRequester.java
+++ b/app/src/org/commcare/android/javarosa/AndroidXFormHttpRequester.java
@@ -1,5 +1,8 @@
 package org.commcare.android.javarosa;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
 import org.commcare.CommCareApplication;
 import org.commcare.network.CommcareRequestGenerator;
 import org.commcare.services.CommCareSessionService;
@@ -27,7 +30,7 @@ import retrofit2.Response;
 public class AndroidXFormHttpRequester implements FormSendCalloutHandler {
 
     @Override
-    public String performHttpCalloutForResponse(String url, Map<String, String> paramMap) {
+    public String performHttpCalloutForResponse(String url, Multimap<String, String> paramMap) {
         CommcareRequestGenerator generator;
         try {
             CommCareSessionService session = CommCareApplication.instance().getSession();
@@ -39,7 +42,7 @@ public class AndroidXFormHttpRequester implements FormSendCalloutHandler {
         }
 
         if (paramMap == null) {
-            paramMap = new HashMap<>();
+            paramMap = ArrayListMultimap.create();
         }
 
         try {

--- a/app/src/org/commcare/android/logging/ForceCloseLogger.java
+++ b/app/src/org/commcare/android/logging/ForceCloseLogger.java
@@ -2,6 +2,8 @@ package org.commcare.android.logging;
 
 import android.util.Log;
 
+import com.google.common.collect.ImmutableMultimap;
+
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
@@ -110,7 +112,7 @@ public class ForceCloseLogger {
         }
 
         try {
-            Response<ResponseBody> response = generator.postMultipart(submissionUri, parts, new HashMap<>());
+            Response<ResponseBody> response = generator.postMultipart(submissionUri, parts, ImmutableMultimap.of());
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             if (response.body() != null) {
                 StreamsUtil.writeFromInputToOutput(response.body().byteStream(), bos);

--- a/app/src/org/commcare/engine/references/JavaHttpReference.java
+++ b/app/src/org/commcare/engine/references/JavaHttpReference.java
@@ -1,5 +1,7 @@
 package org.commcare.engine.references;
 
+import com.google.common.collect.ImmutableMultimap;
+
 import org.commcare.core.network.CaptivePortalRedirectException;
 import org.commcare.interfaces.CommcareRequestEndpoints;
 import org.commcare.network.CommcareRequestGenerator;
@@ -65,7 +67,7 @@ public class JavaHttpReference implements Reference, ReleasedOnTimeSupportedRefe
     public InputStream getStream(Map<String, String> params) throws IOException {
         Response<ResponseBody> response;
         try {
-            response = generator.simpleGet(uri, new HashMap<>(), params);
+            response = generator.simpleGet(uri, ImmutableMultimap.of(), params);
         } catch (SSLHandshakeException | SSLPeerUnverifiedException e) {
             if(NetworkStatus.isCaptivePortal()) {
                 throw new CaptivePortalRedirectException();

--- a/app/src/org/commcare/heartbeat/HeartbeatRequester.java
+++ b/app/src/org/commcare/heartbeat/HeartbeatRequester.java
@@ -25,6 +25,9 @@ import java.util.TimeZone;
 
 import androidx.work.WorkManager;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
 /**
  * Responsible for making a heartbeat request to the server when signaled to do so by the current
  * session's HeartbeatLifecycleManager, and then parsing and handling the response. Currently,
@@ -53,8 +56,8 @@ public class HeartbeatRequester extends GetAndParseActor {
     }
 
     @Override
-    public HashMap<String, String> getRequestParams() {
-        HashMap<String, String> params = new HashMap<>();
+    public Multimap<String, String> getRequestParams() {
+        Multimap<String, String> params = ArrayListMultimap.create();
         params.put(APP_ID, CommCareApplication.instance().getCurrentApp().getUniqueId());
         params.put(DEVICE_ID, CommCareApplication.instance().getPhoneId());
         params.put(APP_VERSION, String.valueOf(ReportingUtils.getAppBuildNumber()));

--- a/app/src/org/commcare/interfaces/CommcareRequestEndpoints.java
+++ b/app/src/org/commcare/interfaces/CommcareRequestEndpoints.java
@@ -1,5 +1,7 @@
 package org.commcare.interfaces;
 
+import com.google.common.collect.Multimap;
+
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
@@ -22,7 +24,7 @@ public interface CommcareRequestEndpoints {
 
     Response<ResponseBody> makeKeyFetchRequest(String baseUri, @Nullable Date lastRequest) throws IOException;
 
-    Response<ResponseBody> postMultipart(String url, List<MultipartBody.Part> parts, HashMap<String, String> queryParams) throws IOException;
+    Response<ResponseBody> postMultipart(String url, List<MultipartBody.Part> parts, Multimap<String, String> queryParams) throws IOException;
 
     Response<ResponseBody> simpleGet(String uri) throws IOException;
 
@@ -32,7 +34,7 @@ public interface CommcareRequestEndpoints {
      * @param httpParams non URL-Encoded parameters to include in the HTTP request with the URL
      * @param httpHeaders http headers to use in the HTTP request
      */
-    Response<ResponseBody> simpleGet(String uri, Map<String, String> httpParams, Map<String, String> httpHeaders) throws IOException;
+    Response<ResponseBody> simpleGet(String uri, Multimap<String, String> httpParams, Map<String, String> httpHeaders) throws IOException;
 
     void abortCurrentRequest();
 

--- a/app/src/org/commcare/network/CommcareRequestEndpointsMock.java
+++ b/app/src/org/commcare/network/CommcareRequestEndpointsMock.java
@@ -1,5 +1,7 @@
 package org.commcare.network;
 
+import com.google.common.collect.Multimap;
+
 import org.commcare.core.network.OkHTTPResponseMockFactory;
 import org.commcare.interfaces.CommcareRequestEndpoints;
 
@@ -71,7 +73,7 @@ public class CommcareRequestEndpointsMock implements CommcareRequestEndpoints {
     }
 
     @Override
-    public Response<ResponseBody> postMultipart(String url, List<MultipartBody.Part> parts, HashMap<String, String> queryParams) throws IOException {
+    public Response<ResponseBody> postMultipart(String url, List<MultipartBody.Part> parts, Multimap<String, String> queryParams) throws IOException {
         throw new RuntimeException("Not yet mocked");
     }
 
@@ -80,7 +82,7 @@ public class CommcareRequestEndpointsMock implements CommcareRequestEndpoints {
         throw new RuntimeException("Not yet mocked");
     }
     @Override
-    public Response<ResponseBody> simpleGet(String uri, Map<String, String> params, Map<String, String> httpHeaders) throws IOException {
+    public Response<ResponseBody> simpleGet(String uri, Multimap<String, String> params, Map<String, String> httpHeaders) throws IOException {
         throw new RuntimeException("Not yet mocked");
     }
 

--- a/app/src/org/commcare/network/CommcareRequestGenerator.java
+++ b/app/src/org/commcare/network/CommcareRequestGenerator.java
@@ -1,9 +1,9 @@
 package org.commcare.network;
 
-import android.content.pm.PackageManager;
 import android.net.Uri;
 
-import org.commcare.AppUtils;
+import com.google.common.collect.ArrayListMultimap;
+
 import org.commcare.CommCareApplication;
 import org.commcare.android.database.user.models.ACase;
 import org.commcare.core.network.AuthInfo;
@@ -225,6 +225,7 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
                 CommCareApplication.instance(),
                 url,
                 queryParams,
+                ArrayListMultimap.create(),
                 getHeaders(getSyncToken(username)),
                 null,
                 parts,

--- a/app/src/org/commcare/network/CommcareRequestGenerator.java
+++ b/app/src/org/commcare/network/CommcareRequestGenerator.java
@@ -3,6 +3,8 @@ package org.commcare.network;
 import android.net.Uri;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 
 import org.commcare.CommCareApplication;
 import org.commcare.android.database.user.models.ACase;
@@ -93,7 +95,7 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
 
     @Override
     public Response<ResponseBody> makeCaseFetchRequest(String baseUri, boolean includeStateFlags) throws IOException {
-        HashMap<String, String> params = new HashMap<>();
+        Multimap<String, String> params = ArrayListMultimap.create();
 
         Uri serverUri = Uri.parse(baseUri);
         String vparam = serverUri.getQueryParameter("version");
@@ -161,7 +163,7 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
 
     @Override
     public Response<ResponseBody> makeKeyFetchRequest(String baseUri, @Nullable Date lastRequest) throws IOException {
-        HashMap params = new HashMap<>();
+        Multimap params = ArrayListMultimap.create();
 
         if (lastRequest != null) {
             params.put("last_issued", DateUtils.formatTime(lastRequest, DateUtils.FORMAT_ISO8601));
@@ -207,9 +209,9 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
     }
 
     @Override
-    public Response<ResponseBody> postMultipart(String url, List<MultipartBody.Part> parts, HashMap<String, String> params) throws IOException {
+    public Response<ResponseBody> postMultipart(String url, List<MultipartBody.Part> parts, Multimap<String, String> params) throws IOException {
 
-        HashMap<String, String> queryParams = new HashMap<>(params);
+        Multimap<String, String> queryParams = ArrayListMultimap.create(params);
 
         //If we're going to try to post with no credentials, we need to be explicit about the fact that we're not ready
         if (username == null || password == null) {
@@ -225,7 +227,6 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
                 CommCareApplication.instance(),
                 url,
                 queryParams,
-                ArrayListMultimap.create(),
                 getHeaders(getSyncToken(username)),
                 null,
                 parts,
@@ -239,11 +240,11 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
 
     @Override
     public Response<ResponseBody> simpleGet(String uri) throws IOException {
-        return simpleGet(uri, new HashMap<>(), new HashMap<>());
+        return simpleGet(uri, ImmutableMultimap.of(), new HashMap<>());
     }
 
     @Override
-    public Response<ResponseBody> simpleGet(String uri, Map<String, String> httpParams, Map<String, String> httpHeaders) throws IOException {
+    public Response<ResponseBody> simpleGet(String uri, Multimap<String, String> httpParams, Map<String, String> httpHeaders) throws IOException {
         HashMap<String, String> headers = new HashMap<>(getHeaders(null));
         headers.putAll(httpHeaders);
 
@@ -271,7 +272,7 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
 
     @Override
     public Response<ResponseBody> postLogs(String submissionUrl, List<MultipartBody.Part> parts, boolean forceLogs) throws IOException {
-        HashMap<String, String> queryParams = new HashMap<>();
+        Multimap<String, String> queryParams = ArrayListMultimap.create();
         queryParams.put(QUERY_PARAM_FORCE_LOGS, String.valueOf(forceLogs));
         return postMultipart(submissionUrl, parts, queryParams);
     }

--- a/app/src/org/commcare/network/GetAndParseActor.java
+++ b/app/src/org/commcare/network/GetAndParseActor.java
@@ -4,6 +4,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
+import com.google.common.collect.Multimap;
+
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.core.interfaces.HttpResponseProcessor;
@@ -53,7 +55,7 @@ public abstract class GetAndParseActor {
         requester.makeRequestAndProcess();
     }
 
-    public abstract HashMap<String, String> getRequestParams();
+    public abstract Multimap<String, String> getRequestParams();
 
     public abstract AuthInfo getAuth();
 

--- a/app/src/org/commcare/recovery/measures/RecoveryMeasuresRequester.java
+++ b/app/src/org/commcare/recovery/measures/RecoveryMeasuresRequester.java
@@ -1,5 +1,8 @@
 package org.commcare.recovery.measures;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
 import org.commcare.CommCareApplication;
 import org.commcare.core.network.AuthInfo;
 import org.commcare.network.GetAndParseActor;
@@ -27,8 +30,8 @@ public class RecoveryMeasuresRequester extends GetAndParseActor {
     }
 
     @Override
-    public HashMap<String, String> getRequestParams() {
-        HashMap<String, String> params = new HashMap<>();
+    public Multimap<String, String> getRequestParams() {
+        Multimap<String, String> params = ArrayListMultimap.create();
         params.put(APP_ID, CommCareApplication.instance().getCurrentApp().getUniqueId());
         return params;
     }

--- a/app/src/org/commcare/tasks/ConnectionDiagnosticTask.java
+++ b/app/src/org/commcare/tasks/ConnectionDiagnosticTask.java
@@ -127,7 +127,7 @@ public abstract class ConnectionDiagnosticTask<R> extends CommCareTask<Void, Str
         CommCareNetworkService commCareNetworkService = CommCareNetworkServiceGenerator.createNoAuthCommCareNetworkService();
         String htmlLine = "";
         try {
-            Response<ResponseBody> response = commCareNetworkService.makeGetRequest(url, new HashMap<>(), new HashMap<>()).execute();
+            Response<ResponseBody> response = commCareNetworkService.makeGetRequest(url, new HashMap<>()).execute();
             if (response.isSuccessful()) {
                 htmlLine = response.body().string();
             } else {

--- a/app/src/org/commcare/tasks/ModernHttpTask.java
+++ b/app/src/org/commcare/tasks/ModernHttpTask.java
@@ -40,30 +40,13 @@ public class ModernHttpTask
     private Response<ResponseBody> mResponse;
 
     // Use for GET request
-    public ModernHttpTask(Context context, String url, HashMap<String, String> params,
-                          Multimap<String, String> multiParams,
+    public ModernHttpTask(Context context, String url, Multimap<String, String> params,
                           HashMap<String, String> headers,
                           AuthInfo authInfo) {
-        this(context, url, params, multiParams, headers, null, HTTPMethod.GET, authInfo);
+        this(context, url, params, headers, null, HTTPMethod.GET, authInfo);
     }
 
-    // Use for GET request without multi-valued params
-    public ModernHttpTask(Context context, String url, HashMap<String, String> params,
-            HashMap<String, String> headers,
-            AuthInfo authInfo) {
-        this(context, url, params, ArrayListMultimap.create(), headers, null, HTTPMethod.GET, authInfo);
-    }
-
-    public ModernHttpTask(Context context, String url, HashMap<String, String> params,
-            HashMap<String, String> headers,
-            @Nullable RequestBody requestBody,
-            HTTPMethod method,
-            AuthInfo authInfo) {
-        this(context, url, params, ArrayListMultimap.create(), headers, requestBody, method, authInfo);
-    }
-
-    public ModernHttpTask(Context context, String url, HashMap<String, String> params,
-            Multimap<String, String> multiParams,
+    public ModernHttpTask(Context context, String url, Multimap<String, String> params,
             HashMap<String, String> headers,
             @Nullable RequestBody requestBody,
             HTTPMethod method,
@@ -73,7 +56,6 @@ public class ModernHttpTask
                 context,
                 url,
                 params,
-                multiParams,
                 headers,
                 requestBody,
                 null,

--- a/app/src/org/commcare/tasks/ModernHttpTask.java
+++ b/app/src/org/commcare/tasks/ModernHttpTask.java
@@ -2,6 +2,9 @@ package org.commcare.tasks;
 
 import android.content.Context;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
 import org.commcare.CommCareApplication;
 import org.commcare.core.interfaces.HttpResponseProcessor;
 import org.commcare.core.interfaces.ResponseStreamAccessor;
@@ -38,21 +41,39 @@ public class ModernHttpTask
 
     // Use for GET request
     public ModernHttpTask(Context context, String url, HashMap<String, String> params,
+                          Multimap<String, String> multiParams,
                           HashMap<String, String> headers,
                           AuthInfo authInfo) {
-        this(context, url, params, headers, null, HTTPMethod.GET, authInfo);
+        this(context, url, params, multiParams, headers, null, HTTPMethod.GET, authInfo);
+    }
+
+    // Use for GET request without multi-valued params
+    public ModernHttpTask(Context context, String url, HashMap<String, String> params,
+            HashMap<String, String> headers,
+            AuthInfo authInfo) {
+        this(context, url, params, ArrayListMultimap.create(), headers, null, HTTPMethod.GET, authInfo);
     }
 
     public ModernHttpTask(Context context, String url, HashMap<String, String> params,
-                          HashMap<String, String> headers,
-                          @Nullable RequestBody requestBody,
-                          HTTPMethod method,
-                          AuthInfo authInfo) {
+            HashMap<String, String> headers,
+            @Nullable RequestBody requestBody,
+            HTTPMethod method,
+            AuthInfo authInfo) {
+        this(context, url, params, ArrayListMultimap.create(), headers, requestBody, method, authInfo);
+    }
+
+    public ModernHttpTask(Context context, String url, HashMap<String, String> params,
+            Multimap<String, String> multiParams,
+            HashMap<String, String> headers,
+            @Nullable RequestBody requestBody,
+            HTTPMethod method,
+            AuthInfo authInfo) {
         taskId = SIMPLE_HTTP_TASK_ID;
         requester = CommCareApplication.instance().buildHttpRequester(
                 context,
                 url,
                 params,
+                multiParams,
                 headers,
                 requestBody,
                 null,

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -48,6 +48,8 @@ import retrofit2.Response;
 
 import static org.commcare.network.HttpUtils.parseUserVisibleError;
 
+import com.google.common.collect.ImmutableMultimap;
+
 public class FormUploadUtil {
     private static final String TAG = FormUploadUtil.class.getSimpleName();
 
@@ -162,7 +164,7 @@ public class FormUploadUtil {
         Response<ResponseBody> response;
 
         try {
-            response = generator.postMultipart(url, parts, new HashMap<>());
+            response = generator.postMultipart(url, parts, ImmutableMultimap.of());
         } catch (InputIOException ioe) {
             // This implies that there was a problem with the _source_ of the
             // transmission, not the processing or receiving end.

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -283,8 +283,7 @@ public class CommCareTestApplication extends CommCareApplication implements Test
     }
 
     @Override
-    public ModernHttpRequester buildHttpRequester(Context context, String url, Map<String, String> params,
-                                                  Multimap<String, String> multiParams,
+    public ModernHttpRequester buildHttpRequester(Context context, String url, Multimap<String, String> params,
                                                   HashMap headers, RequestBody requestBody, List<MultipartBody.Part> parts,
                                                   HTTPMethod method, AuthInfo authInfo, HttpResponseProcessor responseProcessor, boolean b) {
         return new ModernHttpRequesterMock(new AndroidCacheDirSetup(context),

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -52,6 +52,8 @@ import okhttp3.RequestBody;
 import static junit.framework.Assert.fail;
 import static org.robolectric.shadows.ShadowEnvironment.setExternalStorageState;
 
+import com.google.common.collect.Multimap;
+
 /**
  * @author Phillip Mates (pmates@dimagi.com).
  */
@@ -282,6 +284,7 @@ public class CommCareTestApplication extends CommCareApplication implements Test
 
     @Override
     public ModernHttpRequester buildHttpRequester(Context context, String url, Map<String, String> params,
+                                                  Multimap<String, String> multiParams,
                                                   HashMap headers, RequestBody requestBody, List<MultipartBody.Part> parts,
                                                   HTTPMethod method, AuthInfo authInfo, HttpResponseProcessor responseProcessor, boolean b) {
         return new ModernHttpRequesterMock(new AndroidCacheDirSetup(context),

--- a/app/unit-tests/src/org/commcare/android/mocks/ModernHttpRequesterMock.java
+++ b/app/unit-tests/src/org/commcare/android/mocks/ModernHttpRequesterMock.java
@@ -34,6 +34,8 @@ import retrofit2.Response;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.Multimap;
+
 /**
  * @author Phillip Mates (pmates@dimagi.com)
  */
@@ -47,11 +49,13 @@ public class ModernHttpRequesterMock extends ModernHttpRequester {
 
     private static boolean isAuthenticated = true;
     private static boolean enforceSecureEndpointValidation;
+    private final Multimap<String, String> params;
 
-    public ModernHttpRequesterMock(BitCacheFactory.CacheDirSetup cacheDirSetup, String url, Map<String, String> params,
+    public ModernHttpRequesterMock(BitCacheFactory.CacheDirSetup cacheDirSetup, String url, Multimap<String, String> params,
                                    HashMap<String, String> headers, @Nullable RequestBody requestBody, @Nullable List<MultipartBody.Part> parts,
                                    CommCareNetworkService commCareNetworkService, HTTPMethod method, HttpResponseProcessor responseProcessor) {
-        super(cacheDirSetup, url, params, headers, requestBody, parts, commCareNetworkService, method, responseProcessor);
+        super(cacheDirSetup, url, headers, requestBody, parts, commCareNetworkService, method, responseProcessor);
+        this.params = params;
     }
 
     /**
@@ -106,7 +110,7 @@ public class ModernHttpRequesterMock extends ModernHttpRequester {
 
     private String buildUrlWithParams() throws MalformedURLException {
         Uri.Builder b = Uri.parse(url).buildUpon();
-        for (Map.Entry<String, String> param : params.entrySet()) {
+        for (Map.Entry<String, String> param : params.entries()) {
             b.appendQueryParameter(param.getKey(), param.getValue());
         }
         return b.build().toString();


### PR DESCRIPTION
## Summary

https://dimagi-dev.atlassian.net/browse/USH-2141

Changes relating to adding query params from a MultiMap to the network requests. 

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

We have good integration test coverage on all network requests which I am relying to catch any failures on. 

cross-request: https://github.com/dimagi/commcare-core/pull/1151
