### PR TITLE
Resolve Intent redirection vulnerability

### DIFF
--- a/app/assets/locales/android_startup_strings.txt
+++ b/app/assets/locales/android_startup_strings.txt
@@ -17,6 +17,7 @@ install.perms.rationale.message=CommCare requires at least external storage read
 install.perms.denied.message=Crucial permissions denied ${0} times.\n\n If requesting permissions here fails, please enable permissions under Android's settings.
 install.choose.local.app=Available Apps
 install.wrong.code=The app code you have entered is incorrect. Please try scanning barcode or entering correct code.
+install.invalid.launch=Invalid CommCare launch, External applications should use a VIEW action to launch CommCare.
 
 menu.archive=Offline Install
 menu.sms=SMS Install

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -163,9 +163,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         fromManager = getIntent().getBooleanExtra(AppManagerActivity.KEY_LAUNCH_FROM_MANAGER, false);
-
         if (checkForMultipleAppsViolation()) {
             return;
         }
@@ -760,6 +758,9 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             Intent i = new Intent(getIntent());
             setResult(RESULT_OK, i);
         }
+        else
+            fail(Localization.get("install.invalid.launch"));
+
         finish();
     }
 

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -756,7 +756,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 Intent i = new Intent(getApplicationContext(), DispatchActivity.class);
                 startActivity(i);
             }
-        } else {
+        } else if (getCallingActivity().getPackageName().startsWith(BuildConfig.APPLICATION_ID)){
             Intent i = new Intent(getIntent());
             setResult(RESULT_OK, i);
         }

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -754,7 +754,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 Intent i = new Intent(getApplicationContext(), DispatchActivity.class);
                 startActivity(i);
             }
-        } else if (getCallingActivity().getPackageName().startsWith(BuildConfig.APPLICATION_ID)){
+        } else if (getCallingActivity()!= null && getCallingActivity().getPackageName().equals(BuildConfig.APPLICATION_ID)){
             Intent i = new Intent(getIntent());
             setResult(RESULT_OK, i);
         }


### PR DESCRIPTION
## Summary
This PR is to resolve a vulnerability that could be exploited to access protected CommCare components. The solution is to check if the source of the intent is CommCare before sharing any data. Note, it doesn't seem necessary to notify the user about when the check fails.

JIRA ticket: [SAAS-13974](https://dimagi-dev.atlassian.net/browse/SAAS-13974)

## Safety Assurance
- [x] If the PR is high risk, "High Risk" label is set
