### PR TITLE
Fixes Nfc tag always null 

### DIFF
--- a/app/src/org/commcare/android/nfc/NfcActivity.java
+++ b/app/src/org/commcare/android/nfc/NfcActivity.java
@@ -80,8 +80,8 @@ public abstract class NfcActivity extends AppCompatActivity {
         Intent i = new Intent(this, getClass());
         i.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            this.pendingNfcIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_IMMUTABLE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+            this.pendingNfcIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_MUTABLE);
         else
             this.pendingNfcIntent = PendingIntent.getActivity(this, 0, i,0);
     }


### PR DESCRIPTION
## Summary

With Android 12 updates, we marked all Peding Intents immutable, though the nfc pending intent needs to be mutable for Android OS to load tag information in the intent. ([info](https://developer.android.com/guide/topics/connectivity/nfc/advanced-nfc#foreground-dispatch))

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

Not feasible as it needs additional hardware

### Safety story

Performed all NFC related test cases from [here](https://docs.google.com/spreadsheets/d/1GdbgDbTJbfKQXvBoMzAeyTqygxc9xQkWPC74dNnXPBs/edit#gid=2107518479)  to make sure everything works. 
