### PR TITLE
remove leak canary due to strict mode violations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,9 +32,6 @@ configurations {
 }
 
 dependencies {
-    // debugImplementation because LeakCanary should only run in debug builds.
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
-
     testImplementation 'junit:junit:4.12'
     testImplementation('org.robolectric:robolectric:4.5.1') {
         exclude(group: 'org.bouncycastle', module: 'bcprov-jdk15on')


### PR DESCRIPTION
## Summary

Leak canary is causing the app to crash several times in debug mode due to strict mode violations. I tried updating the dependency to fix these crashes, though it didn't help. I think it's best to remove it for now and add it locally if we are doing any memory leak investigations. 


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly


### Safety story

Only affects debug build. 
