### PR TITLE
Call installApp from parent class instead of InstrumentationUtility

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/androidTests/ApkDependenciesTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/ApkDependenciesTest.kt
@@ -34,7 +34,7 @@ class ApkDependenciesTest : BaseTest() {
 
     @Test
     fun testAppDependenciesCheck() {
-        InstrumentationUtility.installApp(CCZ_NAME)
+        installApp(APP_NAME, CCZ_NAME)
         val unstatisfiedDependencies = ImmutableList.of("Reminders", "Test")
         verifyDependencyDialog(unstatisfiedDependencies)
         InstrumentationUtility.login("test", "123");


### PR DESCRIPTION
## Summary
This PR is just to change the method used to install the app for the instrumentation test, instead calling from InstrumentationUtility it's now calling from the parent class which also calls the former but it has additional checks.

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below

