### PR TITLE
Robolectric 4.8.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,10 +33,10 @@ configurations {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testImplementation('org.robolectric:robolectric:4.5.1') {
+    testImplementation('org.robolectric:robolectric:4.8.2') {
         exclude(group: 'org.bouncycastle', module: 'bcprov-jdk15on')
     }
-    testImplementation 'org.robolectric:shadows-multidex:4.3.1'
+    testImplementation 'org.robolectric:shadows-multidex:4.8.2'
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'androidx.test:runner:1.4.0'
     testImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -17,6 +17,7 @@ import org.commcare.core.network.ModernHttpRequester;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.heartbeat.HeartbeatRequester;
 import org.commcare.heartbeat.TestHeartbeatRequester;
+import org.commcare.logging.DataChangeLogger;
 import org.commcare.models.AndroidPrototypeFactory;
 import org.commcare.models.database.AndroidPrototypeFactorySetup;
 import org.commcare.models.database.HybridFileBackedSqlStorage;
@@ -66,6 +67,9 @@ public class CommCareTestApplication extends CommCareApplication implements Test
 
     @Override
     public void onCreate() {
+        // set if before calling super to initialte the dataChangeLogger correctly
+        setExternalStorageState(Environment.MEDIA_MOUNTED);
+
         super.onCreate();
 
         // allow "jr://resource" references
@@ -75,7 +79,6 @@ public class CommCareTestApplication extends CommCareApplication implements Test
             asyncExceptions.add(ex);
             Assert.fail(ex.getMessage());
         });
-        setExternalStorageState(Environment.MEDIA_MOUNTED);
     }
 
     protected void attachISRGCert() {

--- a/app/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
@@ -83,7 +83,7 @@ public class EndOfFormTest {
         finishButton.performClick();
         RobolectricUtil.flushBackgroundThread(formEntryActivity);
         ShadowActivity shadowFormEntryActivity = Shadows.shadowOf(formEntryActivity);
-        while (!shadowFormEntryActivity.isFinishing()) {
+        while (!formEntryActivity.isFinishing()) {
             Log.d(TAG, "Waiting for the form to save and the form entry activity to finish");
         }
 

--- a/app/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formsave/FormRecordProcessingTest.java
@@ -130,7 +130,7 @@ public class FormRecordProcessingTest {
         ShadowActivity shadowFormEntryActivity = Shadows.shadowOf(formEntryActivity);
 
         long waitStartTime = new Date().getTime();
-        while (!shadowFormEntryActivity.isFinishing()) {
+        while (!formEntryActivity.isFinishing()) {
             Log.d(TAG, "Waiting for the form to save and the form entry activity to finish");
             if ((new Date().getTime()) - waitStartTime > 5000) {
                 Assert.fail("form entry activity took too long to finish");

--- a/app/unit-tests/src/org/commcare/android/tests/processing/XFormUpdateInfoTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/XFormUpdateInfoTest.java
@@ -90,7 +90,7 @@ public class XFormUpdateInfoTest {
         RobolectricUtil.flushBackgroundThread(formEntryActivity);
 
         ShadowActivity shadowFormEntryActivity = Shadows.shadowOf(formEntryActivity);
-        while (!shadowFormEntryActivity.isFinishing()) {
+        while (!formEntryActivity.isFinishing()) {
             Log.d(TAG, "Waiting for the form to save and the form entry activity to finish");
         }
 

--- a/app/unit-tests/src/org/commcare/logging/DataChangeLoggerTest.java
+++ b/app/unit-tests/src/org/commcare/logging/DataChangeLoggerTest.java
@@ -18,11 +18,6 @@ import static junit.framework.Assert.assertTrue;
 @RunWith(AndroidJUnit4.class)
 public class DataChangeLoggerTest {
 
-    @Before
-    public void setupTests() {
-        DataChangeLogger.init(CommCareTestApplication.instance());
-    }
-
     @Test
     public void getLogs_shouldContainLoggedMessages() {
         assertTrue(DataChangeLogger.getLogs().contains(new DataChangeLog.CommCareInstall().getMessage()));

--- a/app/unit-tests/src/org/commcare/recovery/measures/RecoveryMeasuresTest.java
+++ b/app/unit-tests/src/org/commcare/recovery/measures/RecoveryMeasuresTest.java
@@ -124,8 +124,7 @@ public class RecoveryMeasuresTest {
         requestRecoveryMeasures(REINSTALL_AND_UPDATE_VALID_FOR_CURRENT_APP_VERSION);
         LoginActivity loginActivity =
                 Robolectric.buildActivity(LoginActivity.class, null).create().resume().get();
-        ShadowActivity shadowActivity = Shadows.shadowOf(loginActivity);
-        assertTrue(shadowActivity.isFinishing());
+        assertTrue(loginActivity.isFinishing());
     }
 
     @Test
@@ -152,7 +151,7 @@ public class RecoveryMeasuresTest {
         ShadowActivity shadowHomeActivity = Shadows.shadowOf(homeActivity);
 
         // Verify HomeActivity finishes since recovery measures are pending
-        assertTrue(shadowHomeActivity.isFinishing());
+        assertTrue(homeActivity.isFinishing());
 
         shadowDispatchActivity.receiveResult(homeActivityIntent,
                 shadowHomeActivity.getResultCode(),


### PR DESCRIPTION
## Summary

Updates robolectric to 4.8.2 (this also resolves some issues for M1 users in running tests)


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

commit by commit
