### PR TITLE
Bump work-runtime and work-runtime-ktx from 2.7.0 to 2.7.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,8 +118,8 @@ dependencies {
     implementation ('io.ona.kujaku:library:0.9.0'){
         exclude module: 'xpp3'
     }
-    implementation "androidx.work:work-runtime:2.7.0"
-    implementation "androidx.work:work-runtime-ktx:2.7.0"
+    implementation "androidx.work:work-runtime:2.7.1"
+    implementation "androidx.work:work-runtime-ktx:2.7.1"
 
     implementation 'com.google.android.play:core:1.7.3'
     implementation 'android.arch.lifecycle:common-java8:1.1.1'


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
