### PR TITLE
ensure singular value for last query string

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -122,3 +122,101 @@
 -keep class kotlin.collections.ArraysKt { *; }
 -keep class kotlin.collections.CollectionsKt { *; }
 -keep class kotlin.text.StringsKt { *; }
+
+# Guava Config Start
+-dontwarn javax.lang.model.element.Modifier
+
+# Note: We intentionally don't add the flags we'd need to make Enums work.
+# That's because the Proguard configuration required to make it work on
+# optimized code would preclude lots of optimization, like converting enums
+# into ints.
+
+# Throwables uses internal APIs for lazy stack trace resolution
+-dontnote sun.misc.SharedSecrets
+-keep class sun.misc.SharedSecrets {
+  *** getJavaLangAccess(...);
+}
+-dontnote sun.misc.JavaLangAccess
+-keep class sun.misc.JavaLangAccess {
+  *** getStackTraceElement(...);
+  *** getStackTraceDepth(...);
+}
+
+# FinalizableReferenceQueue calls this reflectively
+# Proguard is intelligent enough to spot the use of reflection onto this, so we
+# only need to keep the names, and allow it to be stripped out if
+# FinalizableReferenceQueue is unused.
+-keepnames class com.google.common.base.internal.Finalizer {
+  *** startFinalizer(...);
+}
+# However, it cannot "spot" that this method needs to be kept IF the class is.
+-keepclassmembers class com.google.common.base.internal.Finalizer {
+  *** startFinalizer(...);
+}
+-keepnames class com.google.common.base.FinalizableReference {
+  void finalizeReferent();
+}
+-keepclassmembers class com.google.common.base.FinalizableReference {
+  void finalizeReferent();
+}
+
+# Striped64, LittleEndianByteArray, UnsignedBytes, AbstractFuture
+-dontwarn sun.misc.Unsafe
+
+# Striped64 appears to make some assumptions about object layout that
+# really might not be safe. This should be investigated.
+-keepclassmembers class com.google.common.cache.Striped64 {
+  *** base;
+  *** busy;
+}
+-keepclassmembers class com.google.common.cache.Striped64$Cell {
+  <fields>;
+}
+
+-dontwarn java.lang.SafeVarargs
+
+-keep class java.lang.Throwable {
+  *** addSuppressed(...);
+}
+
+# Futures.getChecked, in both of its variants, is incompatible with proguard.
+
+# Used by AtomicReferenceFieldUpdater and sun.misc.Unsafe
+-keepclassmembers class com.google.common.util.concurrent.AbstractFuture** {
+  *** waiters;
+  *** value;
+  *** listeners;
+  *** thread;
+  *** next;
+}
+-keepclassmembers class com.google.common.util.concurrent.AtomicDouble {
+  *** value;
+}
+-keepclassmembers class com.google.common.util.concurrent.AggregateFutureState {
+  *** remaining;
+  *** seenExceptions;
+}
+
+# Since Unsafe is using the field offsets of these inner classes, we don't want
+# to have class merging or similar tricks applied to these classes and their
+# fields. It's safe to allow obfuscation, since the by-name references are
+# already preserved in the -keep statement above.
+-keep,allowshrinking,allowobfuscation class com.google.common.util.concurrent.AbstractFuture** {
+  <fields>;
+}
+
+# Futures.getChecked (which often won't work with Proguard anyway) uses this. It
+# has a fallback, but again, don't use Futures.getChecked on Android regardless.
+-dontwarn java.lang.ClassValue
+
+# MoreExecutors references AppEngine
+-dontnote com.google.appengine.api.ThreadManager
+-keep class com.google.appengine.api.ThreadManager {
+  static *** currentRequestThreadFactory(...);
+}
+-dontnote com.google.apphosting.api.ApiProxy
+-keep class com.google.apphosting.api.ApiProxy {
+  static *** getCurrentEnvironment (...);
+}
+
+# Guava Config End

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -219,4 +219,10 @@
   static *** getCurrentEnvironment (...);
 }
 
+# Multimaps come as null from bundle.getExtra without this
+-keep class com.google.common.collect.** { *; }
+
+# androidx.test.ext.truth.content.IntentSubject.hasAction fails in it-tests without this
+-keep class com.google.common.base.Preconditions { *; }
+
 # Guava Config End

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -29,6 +29,7 @@ import org.commcare.fragments.TaskConnectorFragment;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.logic.DetailCalloutListenerDefaultImpl;
 import org.commcare.preferences.LocalePreferences;
+import org.commcare.session.CommCareSession;
 import org.commcare.session.SessionFrame;
 import org.commcare.session.SessionInstanceBuilder;
 import org.commcare.suite.model.CalloutData;
@@ -446,7 +447,9 @@ public abstract class CommCareActivity<R> extends AppCompatActivity
     }
 
     protected void saveLastQueryString() {
-        CommCareApplication.instance().getCurrentSession().addExtraToCurrentFrameStep(SessionInstanceBuilder.KEY_LAST_QUERY_STRING, lastQueryString);
+        CommCareSession ccSession = CommCareApplication.instance().getCurrentSession();
+        ccSession.removeExtraFromCurrentFrameStep(SessionInstanceBuilder.KEY_LAST_QUERY_STRING);
+        ccSession.addExtraToCurrentFrameStep(SessionInstanceBuilder.KEY_LAST_QUERY_STRING, lastQueryString);
     }
 
     //Graphical stuff below, needs to get modularized


### PR DESCRIPTION
## Summary

1. Since we have changed StackFrameStep.getExtra to thrown [an error](https://github.com/dimagi/commcare-core/blob/formplayer/src/main/java/org/commcare/suite/model/StackFrameStep.java#L167) when multiple extras with same key are present, this ensures that we only save singular value for `LAST_QUERY_STRING` in the stack frame step extras
2.  Adds Proguard config for Guava from [here](https://github.com/google/guava/wiki/UsingProGuardWithGuava)


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

Changes are motivated from Instrumentation test failures. 

cross-request: https://github.com/dimagi/commcare-core/pull/1163
