### PR TITLE
Updated README to specify Java 11 instead of Java 8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,18 +163,6 @@ cp .android_studio_settings/codestyles/CommCare\ Coding\ Style.xml ~/Library/Pre
 
 ### Common Errors
 
-#### If you experience the following exception when running the tests:
-```
-java.security.InvalidKeyException: Illegal key size or default parameters
-```
-you will need to upgrade the JCE policy files that are being used. Note that this is no longer necessary when using JDK 11, since the stronger cryptographic algorithms are included by default starting with JDK 9. To update JCE for JDK 8:
-
-1. Download the JCE Unlimited Strength policy files for Java 8 (Last we checked they could be found [here](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html), but this can change
-2. Find the java home directory on your machine. On mac you can do so by entering the following into the command line: `echo $(/usr/libexec/java_home)`
-3. From there, cd into `jre/lib/security`, and replace the local\_policy.jar and US\_export\_policy.jar files found there with the ones in the zip file you downloaded
-
-NOTE that if you are running the tests from Android Studio, it may be using a different version of Java than that in your java home directory. The first line of the test output will usually show the directory from which Android Studio is running Java (Usually `/Applications/Android Studio.app/Contents/jre/jdk/Contents/Home/jre/lib/security`). If it is indeed different, you should follow the steps above for that directory as well.
-
 #### If you experience the following exception when running individual tests from Android Studio Editor on Mac
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository represents the Android version of CommCare. It depends on the [C
 To set up an Android dev environmnet for commcare-android, do the following:
 
 - Install [Android Studio](https://developer.android.com/sdk/index.html).
-- Install Java 8 if you don't have it yet. For ease of test suite setup ([see below](#tests)) OpenJDK is preferred over Oracle's version of Java.
+- Install Java 11 if you don't have it yet. For ease of test suite setup ([see below](#tests)) OpenJDK is preferred over Oracle's version of Java.
 
 Go ahead and open Android Studio if this is your first time using it;
 it may take you through some sort of setup wizard, and it's nice to get that out of the way.
@@ -167,7 +167,7 @@ cp .android_studio_settings/codestyles/CommCare\ Coding\ Style.xml ~/Library/Pre
 ```
 java.security.InvalidKeyException: Illegal key size or default parameters
 ```
-you will need to upgrade the JCE policy files that are being used. To do so:
+you will need to upgrade the JCE policy files that are being used. Note that this is no longer necessary when using JDK 11, since the stronger cryptographic algorithms are included by default starting with JDK 9. To update JCE for JDK 8:
 
 1. Download the JCE Unlimited Strength policy files for Java 8 (Last we checked they could be found [here](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html), but this can change
 2. Find the java home directory on your machine. On mac you can do so by entering the following into the command line: `echo $(/usr/libexec/java_home)`


### PR DESCRIPTION
## Summary
Updated the README in two locations to indicate Java 11 instead of Java 8.

The first is in the Prerequisites section and it a straight-forward change.

The second is in the Common Errors section, but perhaps a larger change is necessary here. There are instructions for upgrading the JCE policy files for JDK 8, but starting with JDK 9 that is apparently no longer necessary. I added text specifying that this fix should no longer apply, but otherwise left the fix in. Would it be better for me to remove the text about the JCE fix entirely?

## Feature Flag
(none)

## Product Description
Directs user to install Java 11, as the Android build will no longer work with Java 8.

## Safety Assurance

- [ ] If the PR is high risk, "High Risk" label is set
- [x ] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage
No related tests.

### Safety story
Documentation only. No risk of breaking build.
