### PR TITLE
Fix Zip path traversal vulnerability

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -285,7 +285,7 @@ mult.install.bad=The selected ZIP file is not valid. Please choose a valid zip f
 mult.install.progress.baddest=Couldn't write multimedia to the local filesystem at: ${0}
 mult.install.progress.badentry=There was a bad entry in the zip file: ${0}
 mult.install.progress.errormoving=There was a problem copying the multimedia from the zip file, please try again.
-mult.install.progress.invalid.entry=The path of the entry ${0} doesn't match the parent folder, review the content of the ZIP file and try again!
+mult.install.progress.invalid.ccz=The selected CCZ file is invalid, please verify it and try again!
 
 mult.install.prompt=From here you can install your app multimedia from a ZIP file on the local filesystem
 mult.install.button=Install Multimedia

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -285,6 +285,7 @@ mult.install.bad=The selected ZIP file is not valid. Please choose a valid zip f
 mult.install.progress.baddest=Couldn't write multimedia to the local filesystem at: ${0}
 mult.install.progress.badentry=There was a bad entry in the zip file: ${0}
 mult.install.progress.errormoving=There was a problem copying the multimedia from the zip file, please try again.
+mult.install.progress.invalid.entry=The path of the entry ${0} doesn't match the parent folder, review the content of the ZIP file and try again!
 
 mult.install.prompt=From here you can install your app multimedia from a ZIP file on the local filesystem
 mult.install.button=Install Multimedia

--- a/app/src/org/commcare/tasks/UnzipTask.java
+++ b/app/src/org/commcare/tasks/UnzipTask.java
@@ -87,7 +87,7 @@ public class UnzipTask extends CommCareTask<String, String, Integer, UnZipTaskLi
                 String outputCanonicalPath = entryOutput.getCanonicalPath();
                 // Check if the entry path aligns with the destination folder
                 if (!outputCanonicalPath.startsWith(destCanonicalPath)) {
-                    throw new SecurityException(Localization.get("mult.install.progress.invalid.entry", new String[]{entry.getName()}));
+                    throw new SecurityException(Localization.get("mult.install.progress.invalid.ccz"));
                 }
 
                 if (entry.isDirectory()) {

--- a/app/src/org/commcare/tasks/UnzipTask.java
+++ b/app/src/org/commcare/tasks/UnzipTask.java
@@ -77,38 +77,51 @@ public class UnzipTask extends CommCareTask<String, String, Integer, UnZipTaskLi
         int count = 0;
         ZipEntry entry = null;
         try {
+            String destCanonicalPath = destination.getCanonicalPath();
             while ((entry = zis.getNextEntry()) != null) {
                 publishProgress(Localization.get("mult.install.progress", new String[]{String.valueOf(count)}));
                 count++;
-
                 Logger.log(TAG, "Unzipped entry " + entry.getName());
 
+                File entryOutput = new File(destination, entry.getName());
+                String outputCanonicalPath = entryOutput.getCanonicalPath();
+                // Check if the entry path aligns with the destination folder
+                if (!outputCanonicalPath.startsWith(destCanonicalPath)) {
+                    throw new SecurityException(Localization.get("mult.install.progress.invalid.entry", new String[]{entry.getName()}));
+                }
+
                 if (entry.isDirectory()) {
-                    FileUtil.createFolder(new File(destination, entry.getName()).toString());
+                    FileUtil.createFolder(entryOutput.toString());
                     //If it's a directory we can move on to the next one
                     continue;
                 }
 
-                File outputFile = new File(destination, entry.getName());
-                if (!outputFile.getParentFile().exists()) {
-                    FileUtil.createFolder(outputFile.getParentFile().toString());
+                if (!entryOutput.getParentFile().exists()) {
+                    FileUtil.createFolder(entryOutput.getParentFile().toString());
                 }
-                if (outputFile.exists()) {
+
+                if (entryOutput.exists()) {
                     //Try to overwrite if we can
-                    if (!outputFile.delete()) {
+                    if (!entryOutput.delete()) {
                         //If we couldn't, just skip for now
                         continue;
                     }
                 }
 
-                if (!copyZipEntryToOutputFile(outputFile, zis)) {
+                if (!copyZipEntryToOutputFile(entryOutput, zis)) {
                     return -1;
                 }
             }
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             publishProgress(Localization.get("mult.install.progress.badentry", new String[]{entry.getName()}));
             return -1;
-        } finally {
+        }
+        catch (SecurityException e) {
+            publishProgress(e.getMessage());
+            return -1;
+        }
+        finally {
             StreamsUtil.closeStream(zis);
         }
         Logger.log(TAG, "Successfully unzipped files");


### PR DESCRIPTION
## Summary
This PR is to fix a vulnerability that can be exploited to gain unauthorized access to system or even private folders by using ZIP entries with path traversal characters, more info can be found [here](https://support.google.com/faqs/answer/9294009). The fix is basically to check whether each Zip entry path matches the destination folder, if it doesn't, then the decompression process is interrupted. 

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below