### PR TITLE
Add checkbox support in Case Search

### DIFF
--- a/app/res/layout/query_prompt_layout.xml
+++ b/app/res/layout/query_prompt_layout.xml
@@ -15,7 +15,7 @@
         android:layout_marginBottom="@dimen/activity_vertical_margin"
         android:layout_gravity="left"
         android:gravity="center|left"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content" />
 
 
     <Spinner
@@ -32,6 +32,13 @@
         android:layout_width="0dp"
         android:layout_weight="1"
         android:singleLine="true" />
+
+    <LinearLayout
+        android:id="@+id/prompt_checkbox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_weight="1" />
 
     <ImageView
         android:id="@+id/assist_view"

--- a/app/res/layout/query_prompt_layout.xml
+++ b/app/res/layout/query_prompt_layout.xml
@@ -39,6 +39,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:visibility="gone"
         android:layout_weight="1" />
 
     <ImageView

--- a/app/res/layout/query_prompt_layout.xml
+++ b/app/res/layout/query_prompt_layout.xml
@@ -31,6 +31,7 @@
         android:layout_height="wrap_content"
         android:layout_width="0dp"
         android:layout_weight="1"
+        android:visibility="gone"
         android:singleLine="true" />
 
     <LinearLayout

--- a/app/src/org/commcare/activities/QueryRequestActivity.java
+++ b/app/src/org/commcare/activities/QueryRequestActivity.java
@@ -1,6 +1,7 @@
 package org.commcare.activities;
 
 import static org.commcare.activities.EntitySelectActivity.BARCODE_FETCH;
+import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_CHECKBOX;
 import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_DATERANGE;
 import static org.commcare.suite.model.QueryPrompt.INPUT_TYPE_SELECT1;
 
@@ -71,6 +72,7 @@ public class QueryRequestActivity
         ArrayList<String> supportedPrompts = new ArrayList<>();
         supportedPrompts.add(INPUT_TYPE_SELECT1);
         supportedPrompts.add(INPUT_TYPE_DATERANGE);
+        supportedPrompts.add(INPUT_TYPE_CHECKBOX);
         return supportedPrompts;
     }
 

--- a/app/src/org/commcare/activities/QueryRequestUiController.kt
+++ b/app/src/org/commcare/activities/QueryRequestUiController.kt
@@ -249,7 +249,6 @@ class QueryRequestUiController(
     private fun buildSpinnerView(promptView: View, queryPrompt: QueryPrompt): Spinner? {
         val promptSpinner = promptView.findViewById<Spinner>(R.id.prompt_spinner)
         promptSpinner.visibility = View.VISIBLE
-        promptView.findViewById<View>(R.id.prompt_et).visibility = View.GONE
         promptSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
                 var value = ""
@@ -307,7 +306,6 @@ class QueryRequestUiController(
         val promptEditText = promptView.findViewById<EditText>(R.id.prompt_et)
         promptEditText.visibility = View.VISIBLE
         promptEditText.isFocusable = false
-        promptView.findViewById<View>(R.id.prompt_spinner).visibility = View.GONE
         val userAnswers = remoteQuerySessionManager.userAnswers
         val humanReadableDateRange = DateRangeUtils.getHumanReadableDateRange(userAnswers[queryPrompt.key])
         promptEditText.setText(humanReadableDateRange)

--- a/app/src/org/commcare/activities/QueryRequestUiController.kt
+++ b/app/src/org/commcare/activities/QueryRequestUiController.kt
@@ -215,7 +215,8 @@ class QueryRequestUiController(
             throw InvalidPromptValueException("Can't set multiple values to Spinner")
         }
         for (selectedPosition in selectedPositions) {
-            promptSpinner.setSelection(selectedPosition)
+            // first choice is blank in adapter
+            promptSpinner.setSelection(selectedPosition + 1)
         }
     }
 
@@ -229,7 +230,7 @@ class QueryRequestUiController(
             val item = items[i]
             choices[i] = item.labelInnerText
             if (item.value in promptAnswers) {
-                selectedPositions.add(i + 1) // first choice is blank in adapter
+                selectedPositions.add(i)
             }
         }
         return Pair(selectedPositions, choices)

--- a/app/src/org/commcare/activities/QueryRequestUiController.kt
+++ b/app/src/org/commcare/activities/QueryRequestUiController.kt
@@ -195,6 +195,7 @@ class QueryRequestUiController(
 
     private fun buildCheckboxView(promptView: View, queryPrompt: QueryPrompt): View {
         val checboxView = promptView.findViewById<LinearLayout>(R.id.prompt_checkbox)
+        checboxView.visibility = View.VISIBLE
         checboxView.tag = QueryPrompt.INPUT_TYPE_CHECKBOX
         remoteQuerySessionManager.populateItemSetChoices(queryPrompt)
         var selectedPosAndChoices = calculateItemChoices(queryPrompt)

--- a/app/src/org/commcare/activities/QueryRequestUiController.kt
+++ b/app/src/org/commcare/activities/QueryRequestUiController.kt
@@ -201,6 +201,21 @@ class QueryRequestUiController(
     }
 
     private fun setSpinnerData(queryPrompt: QueryPrompt, promptSpinner: Spinner) {
+        var selectedPosAndChoices = calculateItemChoices(queryPrompt);
+        val  selectedPosition = selectedPosAndChoices.first
+        val choices = selectedPosAndChoices.second
+        val adapter: ArrayAdapter<String> = ArrayAdapter<String>(
+            queryRequestActivity,
+            android.R.layout.simple_spinner_item,
+            SpinnerWidget.getChoicesWithEmptyFirstSlot(choices)
+        )
+        promptSpinner.adapter = adapter
+        if (selectedPosition != -1) {
+            promptSpinner.setSelection(selectedPosition)
+        }
+    }
+
+    private fun calculateItemChoices(queryPrompt: QueryPrompt): Pair<Int, Array<String?>> {
         val items = queryPrompt.itemsetBinding!!.choices
         val choices = arrayOfNulls<String>(items.size)
         var selectedPosition = -1
@@ -213,15 +228,7 @@ class QueryRequestUiController(
                 selectedPosition = i + 1 // first choice is blank in adapter
             }
         }
-        val adapter: ArrayAdapter<String> = ArrayAdapter<String>(
-            queryRequestActivity,
-            android.R.layout.simple_spinner_item,
-            SpinnerWidget.getChoicesWithEmptyFirstSlot(choices)
-        )
-        promptSpinner.adapter = adapter
-        if (selectedPosition != -1) {
-            promptSpinner.setSelection(selectedPosition)
-        }
+        return Pair(selectedPosition, choices)
     }
 
     private fun buildDateRangeView(promptView: View, queryPrompt: QueryPrompt): View? {

--- a/app/src/org/commcare/activities/QueryRequestUiController.kt
+++ b/app/src/org/commcare/activities/QueryRequestUiController.kt
@@ -196,7 +196,6 @@ class QueryRequestUiController(
     private fun buildCheckboxView(promptView: View, queryPrompt: QueryPrompt): View {
         val checboxView = promptView.findViewById<LinearLayout>(R.id.prompt_checkbox)
         checboxView.tag = QueryPrompt.INPUT_TYPE_CHECKBOX
-        checboxView.removeAllViews()
         remoteQuerySessionManager.populateItemSetChoices(queryPrompt)
         var selectedPosAndChoices = calculateItemChoices(queryPrompt)
         val selectedPositions = selectedPosAndChoices.first

--- a/app/src/org/commcare/activities/QueryRequestUiController.kt
+++ b/app/src/org/commcare/activities/QueryRequestUiController.kt
@@ -194,18 +194,18 @@ class QueryRequestUiController(
     }
 
     private fun buildCheckboxView(promptView: View, queryPrompt: QueryPrompt): View {
-        val checboxView = promptView.findViewById<LinearLayout>(R.id.prompt_checkbox)
-        checboxView.visibility = View.VISIBLE
-        checboxView.tag = QueryPrompt.INPUT_TYPE_CHECKBOX
+        val checkboxView = promptView.findViewById<LinearLayout>(R.id.prompt_checkbox)
+        checkboxView.visibility = View.VISIBLE
+        checkboxView.tag = QueryPrompt.INPUT_TYPE_CHECKBOX
         remoteQuerySessionManager.populateItemSetChoices(queryPrompt)
         var selectedPosAndChoices = calculateItemChoices(queryPrompt)
         val selectedPositions = selectedPosAndChoices.first
         val choices = selectedPosAndChoices.second
         val items = queryPrompt.itemsetBinding!!.choices
         items.forEachIndexed { index, item ->
-            addCheckboxView(checboxView, item, choices[index]!!, index in selectedPositions, items, queryPrompt)
+            addCheckboxView(checkboxView, item, choices[index]!!, index in selectedPositions, items, queryPrompt)
         }
-        return checboxView
+        return checkboxView
     }
 
     private fun addCheckboxView(
@@ -268,7 +268,7 @@ class QueryRequestUiController(
     }
 
     private fun setSpinnerData(queryPrompt: QueryPrompt, promptSpinner: Spinner) {
-        var selectedPosAndChoices = calculateItemChoices(queryPrompt);
+        var selectedPosAndChoices = calculateItemChoices(queryPrompt)
         val selectedPositions = selectedPosAndChoices.first
         val choices = selectedPosAndChoices.second
         val adapter: ArrayAdapter<String> = ArrayAdapter<String>(

--- a/app/unit-tests/resources/commcare-apps/case_search_and_claim/suite.xml
+++ b/app/unit-tests/resources/commcare-apps/case_search_and_claim/suite.xml
@@ -398,6 +398,18 @@
             </text>
           </display>
         </prompt>
+        <prompt key="multi_state" input="checkbox">
+          <display>
+            <text>
+              <locale id="query.state"/>
+            </text>
+          </display>
+          <itemset nodeset="instance('state')/state_list/state">
+            <label ref="name"/>
+            <value ref="id"/>
+            <sort ref="id"/>
+          </itemset>
+        </prompt>
       </query>
       <datum id="case_id" nodeset="instance('patients')/patients/patient" value="./id" detail-select="patient_short" detail-confirm="patient_long"/>
     </session>

--- a/app/unit-tests/resources/commcare-apps/case_search_and_claim/user_restore.xml
+++ b/app/unit-tests/resources/commcare-apps/case_search_and_claim/user_restore.xml
@@ -57,6 +57,10 @@
                 <id>rj</id>
                 <name>Raj as than</name>
             </state>
+            <state>
+                <id>up</id>
+                <name>Uttar Pradesh</name>
+            </state>
         </state_list>
     </fixture>
 

--- a/app/unit-tests/src/org/commcare/android/mocks/ModernHttpRequesterMock.java
+++ b/app/unit-tests/src/org/commcare/android/mocks/ModernHttpRequesterMock.java
@@ -86,7 +86,7 @@ public class ModernHttpRequesterMock extends ModernHttpRequester {
         }
 
         if (!expectedUrlStack.isEmpty()) {
-            assertUrlsEqual(expectedUrlStack.remove(0), buildUrlWithParams());
+            assertUrlsEqual(expectedUrlStack.remove(0), Uri.decode(buildUrlWithParams()));
         }
 
         if (requestPayloadStack.isEmpty()) {

--- a/app/unit-tests/src/org/commcare/android/tests/activities/QueryRequestActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/QueryRequestActivityTest.java
@@ -56,8 +56,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(AndroidJUnit4.class)
 public class QueryRequestActivityTest {
     private static final String EXPECTED_CASE_SEARCH_URL =
-            "https://www.fake.com/patient_search/?device_id=000000000000000&multi_state=ka#,"
-                    + "#up&patient_id=123&district=baran&name=francisco&state=rj";
+            "https://www.fake.com/patient_search/?device_id=000000000000000&multi_state=ka&"
+                    + "multi_state=up&patient_id=123&district=baran&name=francisco&state=rj";
 
     @Before
     public void setup() {

--- a/app/unit-tests/src/org/commcare/android/tests/activities/QueryRequestActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/QueryRequestActivityTest.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
@@ -45,6 +46,7 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -53,6 +55,10 @@ import static org.junit.Assert.assertTrue;
 @Config(application = CommCareTestApplication.class)
 @RunWith(AndroidJUnit4.class)
 public class QueryRequestActivityTest {
+    private static final String EXPECTED_CASE_SEARCH_URL =
+            "https://www.fake.com/patient_search/?device_id=000000000000000&multi_state=ka#,"
+                    + "#up&patient_id=123&district=baran&name=francisco&state=rj";
+
     @Before
     public void setup() {
         TestAppInstaller.installAppAndLogin(
@@ -95,7 +101,7 @@ public class QueryRequestActivityTest {
     public void makeSuccessfulQueryRequestTest() {
         ModernHttpRequesterMock.setResponseCodes(new Integer[]{200});
         ModernHttpRequesterMock.setExpectedUrls(
-                new String[]{"https://www.fake.com/patient_search/?name=francisco&state=rj&device_id=000000000000000&patient_id=123&district=baran"});
+                new String[]{EXPECTED_CASE_SEARCH_URL});
         ModernHttpRequesterMock.setRequestPayloads(
                 new String[]{"jr://resource/commcare-apps/case_search_and_claim/good-query-result.xml"});
 
@@ -115,7 +121,7 @@ public class QueryRequestActivityTest {
     public void makeQueryWithBadServerPayloadTest() {
         ModernHttpRequesterMock.setResponseCodes(new Integer[]{200});
         ModernHttpRequesterMock.setExpectedUrls(
-                new String[]{"https://www.fake.com/patient_search/?name=francisco&state=rj&device_id=000000000000000&patient_id=123&district=baran"});
+                new String[]{EXPECTED_CASE_SEARCH_URL});
         ModernHttpRequesterMock.setRequestPayloads(
                 new String[]{"jr://resource/commcare-apps/case_search_and_claim/bad-query-result.xml"});
 
@@ -152,10 +158,11 @@ public class QueryRequestActivityTest {
         Spinner districtSpinner = promptsLayout.getChildAt(3).findViewById(R.id.prompt_spinner);
 
         // Confirm Start State
-        assertEquals(3, stateSpinner.getAdapter().getCount());
+        assertEquals(4, stateSpinner.getAdapter().getCount());
         assertEquals("", stateSpinner.getAdapter().getItem(0));
         assertEquals("karnataka", stateSpinner.getAdapter().getItem(1));
         assertEquals("Raj as than", stateSpinner.getAdapter().getItem(2));
+        assertEquals("Uttar Pradesh", stateSpinner.getAdapter().getItem(3));
         assertEquals(1, districtSpinner.getAdapter().getCount());
         assertEquals("", districtSpinner.getAdapter().getItem(0));
 
@@ -174,10 +181,11 @@ public class QueryRequestActivityTest {
 
         // changes to district doesn't affect state
         districtSpinner.setSelection(2);
-        assertEquals(3, stateSpinner.getAdapter().getCount());
+        assertEquals(4, stateSpinner.getAdapter().getCount());
         assertEquals("", stateSpinner.getAdapter().getItem(0));
         assertEquals("karnataka", stateSpinner.getAdapter().getItem(1));
         assertEquals("Raj as than", stateSpinner.getAdapter().getItem(2));
+        assertEquals("Uttar Pradesh", stateSpinner.getAdapter().getItem(3));
         assertEquals(2, stateSpinner.getSelectedItemPosition());
 
     }
@@ -214,6 +222,11 @@ public class QueryRequestActivityTest {
 
         Spinner districtSpinner = promptsLayout.getChildAt(3).findViewById(R.id.prompt_spinner);
         assertEquals(1, districtSpinner.getSelectedItemPosition());
+
+        LinearLayout checkboxView = promptsLayout.getChildAt(5).findViewById(R.id.prompt_checkbox);
+        assertTrue(((CheckBox)checkboxView.getChildAt(0)).isChecked());
+        assertFalse(((CheckBox)checkboxView.getChildAt(1)).isChecked());
+        assertTrue(((CheckBox)checkboxView.getChildAt(2)).isChecked());
     }
 
     /**
@@ -274,7 +287,7 @@ public class QueryRequestActivityTest {
         // set views
         LinearLayout promptsLayout = queryRequestActivity.findViewById(R.id.query_prompts);
 
-        assertEquals(5, promptsLayout.getChildCount());
+        assertEquals(6, promptsLayout.getChildCount());
 
         EditText patientName = promptsLayout.getChildAt(0).findViewById(R.id.prompt_et);
         patientName.setText("francisco");
@@ -286,6 +299,11 @@ public class QueryRequestActivityTest {
 
         Spinner districtSpinner = promptsLayout.getChildAt(3).findViewById(R.id.prompt_spinner);
         districtSpinner.setSelection(1);
+
+        LinearLayout checkboxView = promptsLayout.getChildAt(5).findViewById(R.id.prompt_checkbox);
+        ((CheckBox)checkboxView.getChildAt(0)).setChecked(true);
+        ((CheckBox)checkboxView.getChildAt(2)).setChecked(true);
+
         return controller;
     }
 


### PR DESCRIPTION
## Summary

Implements `checkbox` input type for `query` prompts 

## Feature Flag

HQ UI for this is currently feature flagged by `USH_CASE_CLAIM_UPDATES` [See](https://github.com/dimagi/commcare-hq/pull/32290)

## Product Description

<img src="https://user-images.githubusercontent.com/4679137/218124347-6070ef8e-275f-42fe-b9a6-a4b5fea621df.png" width="400" height="600">

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

PR adds robolectric tests to check for right state of checkbox views. We have [Instrumentation tests](https://github.com/dimagi/commcare-android/blob/master/app/instrumentation-tests/src/org/commcare/androidTests/CaseClaimTest.java) for checking basic navigation on this screen as well. 

### Safety story

Relying on tests and manual testing plus labeled as `QA Note` for QA to do a pass as part of 2.54 release testing

#### Reviewer Notes:

You can use [this app](https://staging.commcarehq.org/a/shubhamgoyaltest/apps/view/200afa70734685b604075e8b721068fa/module/b2e7db65daff4fcaa47cd427b72176c6/#case-detail-screen-config-tab) to see how it's configured on HQ and also install this app with this branch to see this code working. Here are the steps to do so - 
1. Install [CommCare app](https://staging.commcarehq.org/a/shubhamgoyaltest/apps/view/200afa70734685b604075e8b721068fa/releases/) 
2. Login or `enter practice mode`
2. Navigate as Case List -> Add Child to see the checkbox UI

cross-request: https://github.com/dimagi/commcare-core/pull/1219
