### PR TITLE
Add button to SSL errors to take user to date settings

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -121,6 +121,7 @@ sync.fail.empty.url=Sync url is not set. Please contact CommCare Support.
 sync.fail.bad.data=Server provided improperly formatted data, please try again or contact your supervisor.
 sync.fail.bad.local=Your information was fetched, but a problem occurred with the log in. Please try again.
 sync.fail.bad.network=Couldn't contact server. Please make sure an internet connection is available or try again later.
+sync.fail.badcert=Couldn't securely connect to the server.
 sync.fail.server.error=The server encountered an error processing your data. Please try again later. If the problem persists, contact CommCare Support.
 sync.fail.rate.limited.server.error=Our servers are unavailable at this time. Please try again later.
 sync.fail.unknown=An unexpected issue occurred during sync. Please try to sync again.
@@ -538,6 +539,7 @@ notification.restore.nonetwork.badpass.detail=Try re-entering your password. If 
 notification.bad.certificate.title=Couldn't securely connect to the server. 
 notification.bad.certificate.detail=CommCare couldn't validate the security information provided by the remote server. 
 notification.bad.certificate.action=Check your device's time and date to make sure they are correct. If the problem persists, try to connect to a secure server with the phone's browser
+notification.bad.certificate.button=Go to settings
 
 notification.restore.storagefull.title=Couldn't save your application's resources
 notification.restore.storagefull.detail=CommCare was not able to save one or more of your application's resources on the device. This could be because the entire application was too large, or because an individual fixture exceeded 1MB.
@@ -589,9 +591,10 @@ notification.install.missing.withmessage.title=Part of your app is not valid
 notification.install.missing.withmessage.detail=One of your app's resources (${0}) is not valid and must be fixed before it can be installed.
 notification.install.missing.withmessage.action=Installation error: ${0}
 
-notification.install.badcert.title=Bad Certificate
-notification.install.badcert.detail=The certificate you received from the server was invalid. This can be casued by many things, but is often do to a mis-set clock on your phone.
-notification.install.badcert.action=This is often due to your phone's internal clock being incorrect.
+notification.install.badcert.title=Couldn't securely connect to the server.
+notification.install.badcert.detail=CommCare couldn't validate the security information provided by the remote server.
+notification.install.badcert.action=Check your device's time and date to make sure they are correct. If the problem persists, try to connect to a secure server with the phone's browser
+notification.install.badcert.button=Go to settings
 
 notification.install.cancel.title=Update Cancelled
 notification.install.cancel.detail=An app update event was cancelled before it completed.

--- a/app/instrumentation-tests/src/org/commcare/androidTests/LetsEncryptTest.java
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/LetsEncryptTest.java
@@ -11,8 +11,6 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.HashMap;
 
-import javax.net.ssl.SSLHandshakeException;
-
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import okhttp3.Protocol;
 import okhttp3.ResponseBody;

--- a/app/res/layout/layout_note_msg.xml
+++ b/app/res/layout/layout_note_msg.xml
@@ -40,4 +40,10 @@
         android:text="What to do about it"
         android:textAppearance="?android:attr/textAppearanceMedium"/>
 
+    <Button
+        android:id="@+id/layout_note_msg_action_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Button" />
+
 </LinearLayout>

--- a/app/res/layout/layout_note_msg.xml
+++ b/app/res/layout/layout_note_msg.xml
@@ -44,6 +44,7 @@
         android:id="@+id/layout_note_msg_action_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Button" />
+        android:text="Button"
+        android:visibility="gone" />
 
 </LinearLayout>

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -203,7 +203,7 @@ public class CommCareApplication extends MultiDexApplication {
     public void onCreate() {
         super.onCreate();
 
-        //turnOnStrictMode();
+        turnOnStrictMode();
 
         CommCareApplication.app = this;
         CrashUtil.init();

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -203,7 +203,7 @@ public class CommCareApplication extends MultiDexApplication {
     public void onCreate() {
         super.onCreate();
 
-        turnOnStrictMode();
+        //turnOnStrictMode();
 
         CommCareApplication.app = this;
         CrashUtil.init();

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -55,6 +55,7 @@ import org.commcare.utils.Permissions;
 import org.commcare.views.ManagedUi;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogCreationHelpers;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
 import org.commcare.views.notifications.NotificationMessage;
 import org.commcare.views.notifications.NotificationMessageFactory;
 import org.javarosa.core.reference.InvalidReferenceException;
@@ -529,8 +530,8 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             case NoConnection:
                 receiver.failWithNotification(AppInstallStatus.NoConnection);
                 break;
-            case BadCertificate:
-                receiver.failWithNotification(AppInstallStatus.BadCertificate);
+            case BadSSLCertificate:
+                receiver.failWithNotification(AppInstallStatus.BadSSLCertificate, NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS);
                 break;
             case DuplicateApp:
                 receiver.failWithNotification(AppInstallStatus.DuplicateApp);
@@ -815,7 +816,12 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
     @Override
     public void failWithNotification(AppInstallStatus statusFailState) {
-        fail(NotificationMessageFactory.message(statusFailState), true);
+        failWithNotification(statusFailState, NotificationActionButtonInfo.ButtonAction.NONE);
+    }
+
+    @Override
+    public void failWithNotification(AppInstallStatus statusFailState, NotificationActionButtonInfo.ButtonAction buttonAction) {
+        fail(NotificationMessageFactory.message(statusFailState, buttonAction), true);
     }
 
     @Override

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -530,8 +530,8 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             case NoConnection:
                 receiver.failWithNotification(AppInstallStatus.NoConnection);
                 break;
-            case BadSSLCertificate:
-                receiver.failWithNotification(AppInstallStatus.BadSSLCertificate, NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS);
+            case BadSslCertificate:
+                receiver.failWithNotification(AppInstallStatus.BadSslCertificate, NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS);
                 break;
             case DuplicateApp:
                 receiver.failWithNotification(AppInstallStatus.DuplicateApp);

--- a/app/src/org/commcare/activities/DataPullController.java
+++ b/app/src/org/commcare/activities/DataPullController.java
@@ -1,6 +1,7 @@
 package org.commcare.activities;
 
 import org.commcare.views.notifications.MessageTag;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
 import org.commcare.views.notifications.NotificationMessage;
 
 /**
@@ -23,6 +24,7 @@ public interface DataPullController {
     void dataPullCompleted();
 
     void raiseLoginMessage(MessageTag messageTag, boolean showTop);
+    void raiseLoginMessage(MessageTag messageTag, boolean showTop, NotificationActionButtonInfo.ButtonAction buttonAction);
 
     void raiseLoginMessageWithInfo(MessageTag messageTag, String additionalInfo, boolean showTop);
 

--- a/app/src/org/commcare/activities/DriftHelper.java
+++ b/app/src/org/commcare/activities/DriftHelper.java
@@ -48,7 +48,7 @@ public class DriftHelper {
                 context.getResources().getString(R.string.incorrect_time_dialog_message),
                 null);
         driftDialog.setPositiveButton(context.getResources().getString(R.string.incorrect_time_dialog_correct_time), (dialog, which) -> {
-            context.startActivity(new Intent(android.provider.Settings.ACTION_DATE_SETTINGS));
+            SettingsHelper.launchDateSettings(context);
             dialog.dismiss();
         });
         driftDialog.setNegativeButton(context.getResources().getString(R.string.incorrect_time_dialog_cancel), ((dialog, which) -> dialog.dismiss()));

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -79,45 +79,10 @@ public class FormAndDataSyncer {
                             ((WithUIController)receiver).getUIController().refreshView();
                         }
 
-                        switch (result) {
-                            case FULL_SUCCESS:
-                                receiver.handleFormSendResult(getLabelForFormsSent(), true);
+                        receiver.handleFormUploadResult(result, getLabelForFormsSent(), userTriggered);
 
-                                if (syncAfterwards) {
-                                    syncDataForLoggedInUser(receiver, true, userTriggered);
-                                }
-                                break;
-                            case AUTH_FAILURE:
-                                receiver.handleFormSendResult(Localization.get("sync.fail.auth.loggedin"), false);
-                                break;
-                            case TRANSPORT_FAILURE:
-                                receiver.handleFormSendResult(Localization.get("sync.fail.bad.network"), false);
-                                break;
-                            case BAD_CERTIFICATE:
-                                CommCareApplication.notificationManager().reportNotificationMessage(
-                                        NotificationMessageFactory.message(NotificationMessageFactory.StockMessages.BadSSLCertificate,
-                                                NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS));
-                                receiver.handleFormSendResult(Localization.get("sync.fail.badcert"), false);
-                                break;
-                            case PROCESSING_FAILURE:
-                                receiver.handleFormSendResult(Localization.get("sync.fail.server.error"), false);
-                                break;
-                            case RECORD_FAILURE:
-                                receiver.handleFormSendResult(Localization.get("sync.fail.individual"), false);
-                                break;
-                            case ACTIONABLE_FAILURE:
-                                receiver.handleFormSendResult(result.getErrorMessage(), false);
-                                break;
-                            case RATE_LIMITED:
-                                receiver.showRateLimitError(userTriggered);
-                                break;
-                            case INVALID_CASE_GRAPH:
-                                receiver.handleFormSendResult(Localization.get("sync.fail.invalid.case.graph"), false);
-                                break;
-                            case FAILURE:
-                            default:
-                                receiver.handleFormSendResult(Localization.get("sync.fail.unknown"), false);
-                                break;
+                        if(result == FormUploadResult.FULL_SUCCESS && syncAfterwards) {
+                            syncDataForLoggedInUser(receiver, true, userTriggered);
                         }
                     }
 
@@ -127,14 +92,13 @@ public class FormAndDataSyncer {
 
                     @Override
                     protected void deliverError(SyncCapableCommCareActivity receiver, Exception e) {
-                        receiver.handleFormSendResult(Localization.get("sync.fail.unsent"), false);
+                        receiver.handleFormUploadResult(FormUploadResult.UNSENT, getLabelForFormsSent(), userTriggered);
                     }
 
                     @Override
                     protected void handleCancellation(SyncCapableCommCareActivity receiver) {
                         super.handleCancellation(receiver);
-                        receiver.handleFormSendResult(Localization.get("activity.task.cancelled.message")
-                                + " " + getLabelForFormsSent(), false);
+                        receiver.handleFormUploadResult(FormUploadResult.CANCELLED, getLabelForFormsSent(), userTriggered);
                     }
                 };
 

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -23,6 +23,8 @@ import org.commcare.tasks.PullTaskResultReceiver;
 import org.commcare.tasks.ResultAndError;
 import org.commcare.utils.FormUploadResult;
 import org.commcare.utils.StorageUtils;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
+import org.commcare.views.notifications.NotificationMessageFactory;
 import org.javarosa.core.model.User;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
@@ -90,6 +92,12 @@ public class FormAndDataSyncer {
                                 break;
                             case TRANSPORT_FAILURE:
                                 receiver.handleFormSendResult(Localization.get("sync.fail.bad.network"), false);
+                                break;
+                            case BAD_CERTIFICATE:
+                                CommCareApplication.notificationManager().reportNotificationMessage(
+                                        NotificationMessageFactory.message(NotificationMessageFactory.StockMessages.BadSSLCertificate,
+                                                NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS));
+                                receiver.handleFormSendResult(Localization.get("sync.fail.badcert"), false);
                                 break;
                             case PROCESSING_FAILURE:
                                 receiver.handleFormSendResult(Localization.get("sync.fail.server.error"), false);

--- a/app/src/org/commcare/activities/HomeButtons.java
+++ b/app/src/org/commcare/activities/HomeButtons.java
@@ -63,6 +63,7 @@ public class HomeButtons {
                         R.drawable.home_incomplete,
                         R.color.solid_dark_orange,
                         getIncompleteButtonListener(activity),
+                        null,
                         getIncompleteButtonTextSetter(activity)),
                 HomeCardDisplayData.homeCardDataWithNotification(Localization.get(syncKey), R.color.white,
                         R.color.white,
@@ -70,6 +71,7 @@ public class HomeButtons {
                         R.color.cc_brand_color,
                         R.color.cc_brand_text,
                         getSyncButtonListener(activity),
+                        getSyncButtonSubTextListener(activity),
                         getSyncButtonTextSetter(activity)),
                 HomeCardDisplayData.homeCardDataWithStaticText(Localization.get("home.report"), R.color.white,
                         R.drawable.home_report, R.color.cc_attention_negative_color,
@@ -78,6 +80,7 @@ public class HomeButtons {
                         R.color.white,
                         R.drawable.home_logout, R.color.cc_neutral_color, R.color.cc_neutral_text,
                         getLogoutButtonListener(activity),
+                        null,
                         getLogoutButtonTextSetter(activity)),
         };
 
@@ -109,6 +112,13 @@ public class HomeButtons {
         return v -> {
             reportButtonClick(AnalyticsParamValue.SYNC_BUTTON);
             activity.syncButtonPressed();
+        };
+    }
+
+    private static View.OnClickListener getSyncButtonSubTextListener(final StandardHomeActivity activity) {
+        return v -> {
+            reportButtonClick(AnalyticsParamValue.SYNC_SUBTEXT);
+            activity.syncSubTextPressed();
         };
     }
 

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -49,6 +49,7 @@ import org.commcare.views.ViewUtil;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogCreationHelpers;
 import org.commcare.views.notifications.MessageTag;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
 import org.commcare.views.notifications.NotificationMessage;
 import org.commcare.views.notifications.NotificationMessageFactory;
 import org.commcare.views.notifications.NotificationMessageFactory.StockMessages;
@@ -466,10 +467,14 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         raiseMessage(message, showTop);
     }
 
-    @Override
     public void raiseLoginMessage(MessageTag messageTag, boolean showTop) {
+        raiseLoginMessage(messageTag, showTop, NotificationActionButtonInfo.ButtonAction.NONE);
+    }
+
+    @Override
+    public void raiseLoginMessage(MessageTag messageTag, boolean showTop, NotificationActionButtonInfo.ButtonAction buttonAction) {
         NotificationMessage message = NotificationMessageFactory.message(messageTag,
-                NOTIFICATION_MESSAGE_LOGIN);
+                NOTIFICATION_MESSAGE_LOGIN, buttonAction);
         raiseMessage(message, showTop);
     }
 

--- a/app/src/org/commcare/activities/MessageActivity.java
+++ b/app/src/org/commcare/activities/MessageActivity.java
@@ -73,15 +73,15 @@ public class MessageActivity extends CommcareListActivity {
                     action.setText(actionText);
                 }
 
-                if(msg.getButtonInfo() == null) {
-                    actionButton.setVisibility(View.GONE);
-                } else {
+                if(msg.getButtonInfo() != null) {
+                    actionButton.setVisibility(View.VISIBLE);
                     actionButton.setText(msg.getButtonInfo().getButtonText());
 
                     actionButton.setOnClickListener(v -> {
                         switch(msg.getButtonInfo().getButtonAction()) {
                             case LAUNCH_DATE_SETTINGS -> SettingsHelper.launchDateSettings(getContext());
                             //Future actions will be added here once implemented
+                            default -> throw new RuntimeException("Unhandled button action: " + msg.getButtonInfo().getButtonAction());
                         }
                     });
                 }

--- a/app/src/org/commcare/activities/MessageActivity.java
+++ b/app/src/org/commcare/activities/MessageActivity.java
@@ -7,10 +7,12 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.TextView;
 
 import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
 import org.commcare.views.notifications.NotificationMessage;
 
 import java.text.DateFormat;
@@ -58,6 +60,8 @@ public class MessageActivity extends CommcareListActivity {
                 TextView body = messageView.findViewById(R.id.layout_note_msg_body);
                 TextView date = messageView.findViewById(R.id.layout_note_msg_date);
                 TextView action = messageView.findViewById(R.id.layout_note_msg_action);
+                Button actionButton = messageView.findViewById(R.id.layout_note_msg_action_button);
+
                 title.setText(msg.getTitle());
                 body.setText(msg.getDetails());
                 date.setText(DateUtils.formatSameDayTime(msg.getDate().getTime(), System.currentTimeMillis(), DateFormat.DEFAULT, DateFormat.DEFAULT));
@@ -67,6 +71,19 @@ public class MessageActivity extends CommcareListActivity {
                     action.setVisibility(View.GONE);
                 } else {
                     action.setText(actionText);
+                }
+
+                if(msg.getButtonInfo() == null) {
+                    actionButton.setVisibility(View.GONE);
+                } else {
+                    actionButton.setText(msg.getButtonInfo().getButtonText());
+
+                    actionButton.setOnClickListener(v -> {
+                        switch(msg.getButtonInfo().getButtonAction()) {
+                            case LAUNCH_DATE_SETTINGS -> SettingsHelper.launchDateSettings(getContext());
+                            //Future actions will be added here once implemented
+                        }
+                    });
                 }
 
                 return messageView;

--- a/app/src/org/commcare/activities/SettingsHelper.java
+++ b/app/src/org/commcare/activities/SettingsHelper.java
@@ -1,0 +1,10 @@
+package org.commcare.activities;
+
+import android.content.Context;
+import android.content.Intent;
+
+public class SettingsHelper {
+    public static void launchDateSettings(Context context) {
+        context.startActivity(new Intent(android.provider.Settings.ACTION_DATE_SETTINGS));
+    }
+}

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -7,6 +7,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import org.commcare.CommCareApplication;
+import org.commcare.CommCareNoficationManager;
 import org.commcare.google.services.analytics.AnalyticsParamValue;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.interfaces.CommCareActivityUIController;
@@ -111,6 +112,12 @@ public class StandardHomeActivity
         }
         CommCareApplication.notificationManager().clearNotifications(AIRPLANE_MODE_CATEGORY);
         sendFormsOrSync(true);
+    }
+
+    void syncSubTextPressed() {
+        if(CommCareApplication.notificationManager().messagesForCommCareArePending()) {
+            CommCareNoficationManager.performIntentCalloutToNotificationsView(this);
+        }
     }
 
     @Override

--- a/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
+++ b/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
@@ -25,6 +25,8 @@ import org.commcare.tasks.ResultAndError;
 import org.commcare.utils.SyncDetailCalculations;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.StandardAlertDialog;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
+import org.commcare.views.notifications.NotificationMessageFactory;
 import org.javarosa.core.services.locale.Localization;
 
 import androidx.annotation.AnimRes;
@@ -109,6 +111,7 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
                 updateUiAfterDataPullOrSend(Localization.get("sync.fail.bad.data"), FAIL);
                 break;
             case DOWNLOAD_SUCCESS:
+                CommCareApplication.notificationManager().clearNotifications(NotificationMessageFactory.StockMessages.BadSSLCertificate.getCategory());
                 updateUiAfterDataPullOrSend(Localization.get("sync.success.synced"), SUCCESS);
                 break;
             case SERVER_ERROR:
@@ -146,6 +149,12 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
                 break;
             case CAPTIVE_PORTAL:
                 updateUiAfterDataPullOrSend(Localization.get("connection.captive_portal.action"), FAIL);
+                break;
+            case BAD_CERTIFICATE:
+                CommCareApplication.notificationManager().reportNotificationMessage(
+                        NotificationMessageFactory.message(NotificationMessageFactory.StockMessages.BadSSLCertificate,
+                                NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS));
+                updateUiAfterDataPullOrSend(Localization.get("sync.fail.badcert"), FAIL);
                 break;
         }
 

--- a/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
+++ b/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
@@ -22,6 +22,7 @@ import org.commcare.sync.ProcessAndSendTask;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.PullTaskResultReceiver;
 import org.commcare.tasks.ResultAndError;
+import org.commcare.utils.FormUploadResult;
 import org.commcare.utils.SyncDetailCalculations;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.StandardAlertDialog;
@@ -111,7 +112,7 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
                 updateUiAfterDataPullOrSend(Localization.get("sync.fail.bad.data"), FAIL);
                 break;
             case DOWNLOAD_SUCCESS:
-                CommCareApplication.notificationManager().clearNotifications(NotificationMessageFactory.StockMessages.BadSSLCertificate.getCategory());
+                CommCareApplication.notificationManager().clearNotifications(NotificationMessageFactory.StockMessages.BadSslCertificate.getCategory());
                 updateUiAfterDataPullOrSend(Localization.get("sync.success.synced"), SUCCESS);
                 break;
             case SERVER_ERROR:
@@ -152,7 +153,7 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
                 break;
             case BAD_CERTIFICATE:
                 CommCareApplication.notificationManager().reportNotificationMessage(
-                        NotificationMessageFactory.message(NotificationMessageFactory.StockMessages.BadSSLCertificate,
+                        NotificationMessageFactory.message(NotificationMessageFactory.StockMessages.BadSslCertificate,
                                 NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS));
                 updateUiAfterDataPullOrSend(Localization.get("sync.fail.badcert"), FAIL);
                 break;
@@ -228,6 +229,40 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
         displayToast(message);
     }
 
+    public void handleFormUploadResult(FormUploadResult result, String formLabel, boolean userTriggered) {
+        switch (result) {
+            case FULL_SUCCESS:
+                handleFormSendResult(formLabel, true);
+                break;
+            case BAD_CERTIFICATE:
+                CommCareApplication.notificationManager().reportNotificationMessage(
+                        NotificationMessageFactory.message(NotificationMessageFactory.StockMessages.BadSslCertificate,
+                                NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS));
+
+                handleFormSendResult(Localization.get(result.getLocaleKeyBase()), false);
+                break;
+            case ACTIONABLE_FAILURE:
+                handleFormSendResult(result.getErrorMessage(), false);
+                break;
+            case RATE_LIMITED:
+                showRateLimitError(userTriggered);
+                break;
+            case CANCELLED:
+                handleFormSendResult(Localization.get(result.getLocaleKeyBase())
+                        + " " + formLabel, false);
+                break;
+            case AUTH_FAILURE:
+            case TRANSPORT_FAILURE:
+            case PROCESSING_FAILURE:
+            case RECORD_FAILURE:
+            case INVALID_CASE_GRAPH:
+            case FAILURE:
+            default:
+                handleFormSendResult(Localization.get(result.getLocaleKeyBase()), false);
+                break;
+        }
+    }
+
     public void handleFormSendResult(String message, boolean success) {
         updateUiAfterDataPullOrSend(message, success);
         if (success) {
@@ -237,9 +272,8 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
     }
 
     public void showRateLimitError(boolean userTriggered) {
-
         if (HiddenPreferences.isRateLimitPopupDisabled() || !userTriggered) {
-            handleFormSendResult(Localization.get("form.send.rate.limit.error.toast"), false);
+            handleFormUploadResult(FormUploadResult.RATE_LIMITED, null, userTriggered);
             return;
         }
         String title = Localization.get("form.send.rate.limit.error.title");

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -355,9 +355,11 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
                 break;
         }
 
-        CommCareApplication.notificationManager()
-                .reportNotificationMessage(notificationMessage, true);
-        uiController.setNotificationsVisible();
+        if(notificationMessage != null) {
+            CommCareApplication.notificationManager()
+                    .reportNotificationMessage(notificationMessage, true);
+            uiController.setNotificationsVisible();
+        }
     }
 
     private void finishWithResult(String result) {

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -350,10 +350,6 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
                             NotificationMessageFactory.message(AppInstallStatus.UpdateFailedGeneral,
                                     new String[]{null, errorMessage, null},
                                     NotificationActionButtonInfo.ButtonAction.NONE);
-                } else {
-                    notificationMessage =
-                            NotificationMessageFactory.message(status,
-                                    NotificationActionButtonInfo.ButtonAction.NONE);
                 }
 
                 break;

--- a/app/src/org/commcare/adapters/HomeCardDisplayData.java
+++ b/app/src/org/commcare/adapters/HomeCardDisplayData.java
@@ -19,6 +19,7 @@ public class HomeCardDisplayData {
     public final int subTextColor;
     public final int subTextBgColor;
     public final View.OnClickListener listener;
+    public final View.OnClickListener subTextListener;
     public final HomeButtons.TextSetter textSetter;
 
     public static HomeCardDisplayData homeCardDataWithStaticText(String text,
@@ -28,7 +29,7 @@ public class HomeCardDisplayData {
                                                                  View.OnClickListener listener) {
         return new HomeCardDisplayData(text, textColor, R.color.white,
                 imageResource, bgColor, R.color.cc_brand_color,
-                listener, new DefaultTextSetter());
+                listener, null, new DefaultTextSetter());
     }
 
     /**
@@ -39,10 +40,11 @@ public class HomeCardDisplayData {
                                                                   int imageResource,
                                                                   int bgColor,
                                                                   View.OnClickListener listener,
+                                                                  View.OnClickListener subTextListener,
                                                                   HomeButtons.TextSetter textSetter) {
         return new HomeCardDisplayData(text, textColor, R.color.white,
                 imageResource, bgColor, R.color.cc_brand_color,
-                listener, textSetter);
+                listener, subTextListener, textSetter);
     }
 
     /**
@@ -55,15 +57,17 @@ public class HomeCardDisplayData {
                                                                    int bgColor,
                                                                    int subTextBgColor,
                                                                    View.OnClickListener listener,
+                                                                   View.OnClickListener subTextListener,
                                                                    HomeButtons.TextSetter textSetter) {
         return new HomeCardDisplayData(text, textColor, subTextColor,
-                imageResource, bgColor, subTextBgColor, listener, textSetter);
+                imageResource, bgColor, subTextBgColor, listener, subTextListener, textSetter);
     }
 
     private HomeCardDisplayData(String text, int textColor,
                                 int subTextColor, int imageResource,
                                 int bgColor, int subTextBgColor,
                                 View.OnClickListener listener,
+                                View.OnClickListener subTextListener,
                                 HomeButtons.TextSetter textSetter) {
         this.bgColor = bgColor;
         this.textColor = textColor;
@@ -72,6 +76,7 @@ public class HomeCardDisplayData {
         this.subTextColor = subTextColor;
         this.subTextBgColor = subTextBgColor;
         this.listener = listener;
+        this.subTextListener = subTextListener;
         this.textSetter = textSetter;
     }
 

--- a/app/src/org/commcare/adapters/SquareButtonAdapter.java
+++ b/app/src/org/commcare/adapters/SquareButtonAdapter.java
@@ -106,6 +106,10 @@ abstract class SquareButtonAdapter
         squareButtonViewHolder.imageView.setImageDrawable(buttonDrawable);
         squareButtonViewHolder.cardView.setOnClickListener(cardDisplayData.listener);
 
+        if(cardDisplayData.subTextListener != null) {
+            squareButtonViewHolder.subTextView.setOnClickListener(cardDisplayData.subTextListener);
+        }
+
         StateListDrawable bgDrawable = bgDrawStates(context, cardDisplayData.bgColor);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {

--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -45,8 +45,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Vector;
 
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLException;
 
 import androidx.core.util.Pair;
 
@@ -115,13 +114,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
             table.commit(r, status);
 
             return true;
-        } catch (SSLHandshakeException | SSLPeerUnverifiedException e) {
-            // SSLHandshakeException is thrown by the CommcareRequestGenerator on
-            // 4.3 devices when the peer certificate is bad.
-            //
-            // SSLPeerUnverifiedException is thrown by the CommcareRequestGenerator
-            // on 2.3 devices when the peer certificate is bad.
-            //
+        } catch (SSLException e) { //Wrap in UnresolvedResourceExcption
             // Deliver these errors upstream to the SetupActivity as an
             // UnresolvedResourceException
             e.printStackTrace();

--- a/app/src/org/commcare/engine/references/JavaHttpReference.java
+++ b/app/src/org/commcare/engine/references/JavaHttpReference.java
@@ -21,8 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLException;
 
 import okhttp3.Headers;
 import okhttp3.ResponseBody;
@@ -68,7 +67,7 @@ public class JavaHttpReference implements Reference, ReleasedOnTimeSupportedRefe
         Response<ResponseBody> response;
         try {
             response = generator.simpleGet(uri, ImmutableMultimap.of(), params);
-        } catch (SSLHandshakeException | SSLPeerUnverifiedException e) {
+        } catch (SSLException e) {
             if(NetworkStatus.isCaptivePortal()) {
                 throw new CaptivePortalRedirectException();
             }

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -40,7 +40,7 @@ public enum AppInstallStatus implements MessageTag {
     NoConnection("notification.install.no.connection"),
     NetworkFailure("notification.install.network.failure"),
     RateLimited("notification.install.rate.limited"),
-    BadSSLCertificate("notification.install.badcert"),
+    BadSslCertificate("notification.install.badcert"),
 
 
     /**
@@ -87,7 +87,7 @@ public enum AppInstallStatus implements MessageTag {
     // whether to include in the counter for update reset
     public boolean causeUpdateReset() {
         return !(this == Cancelled ||
-                this == BadSSLCertificate ||
+                this == BadSslCertificate ||
                 this == NoConnection ||
                 this == CaptivePortal ||
                 this == RateLimited ||
@@ -96,7 +96,7 @@ public enum AppInstallStatus implements MessageTag {
 
     public boolean isNonPersistentFailure() {
         return (this == Cancelled ||
-                this == BadSSLCertificate ||
+                this == BadSslCertificate ||
                 this == NoConnection ||
                 this == CaptivePortal ||
                 this == RateLimited ||

--- a/app/src/org/commcare/engine/resource/AppInstallStatus.java
+++ b/app/src/org/commcare/engine/resource/AppInstallStatus.java
@@ -40,7 +40,7 @@ public enum AppInstallStatus implements MessageTag {
     NoConnection("notification.install.no.connection"),
     NetworkFailure("notification.install.network.failure"),
     RateLimited("notification.install.rate.limited"),
-    BadCertificate("notification.install.badcert"),
+    BadSSLCertificate("notification.install.badcert"),
 
 
     /**
@@ -87,7 +87,7 @@ public enum AppInstallStatus implements MessageTag {
     // whether to include in the counter for update reset
     public boolean causeUpdateReset() {
         return !(this == Cancelled ||
-                this == BadCertificate ||
+                this == BadSSLCertificate ||
                 this == NoConnection ||
                 this == CaptivePortal ||
                 this == RateLimited ||
@@ -96,7 +96,7 @@ public enum AppInstallStatus implements MessageTag {
 
     public boolean isNonPersistentFailure() {
         return (this == Cancelled ||
-                this == BadCertificate ||
+                this == BadSSLCertificate ||
                 this == NoConnection ||
                 this == CaptivePortal ||
                 this == RateLimited ||

--- a/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
+++ b/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
@@ -27,7 +27,7 @@ import java.net.URL;
 import java.security.cert.CertificateException;
 import java.util.Date;
 
-import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLException;
 
 /**
  * Helpers to track app state and handle errors for installation and updates.
@@ -125,10 +125,6 @@ public class ResourceInstallUtils {
         // couldn't find a resource, which isn't good.
         exception.printStackTrace();
 
-        if (ResourceInstallUtils.isBadCertificateError(exception)) {
-            return AppInstallStatus.BadCertificate;
-        }
-
         if(exception instanceof UnreliableSourceException) {
             if (exception.getCause() instanceof CaptivePortalRedirectException) {
                 Logger.log(LogTypes.TYPE_WARNING_NETWORK,
@@ -142,26 +138,19 @@ public class ResourceInstallUtils {
             return AppInstallStatus.NetworkFailure;
         }
 
+        if(exception.getCause() instanceof SSLException){
+            return AppInstallStatus.BadSSLCertificate;
+        }
+
         if(exception.getCause() instanceof RateLimitedException){
             return AppInstallStatus.RateLimited;
         }
+
         if (exception.isMessageUseful()) {
             return AppInstallStatus.MissingResourcesWithMessage;
         } else {
             return AppInstallStatus.MissingResources;
         }
-    }
-
-    private static boolean isBadCertificateError(UnresolvedResourceException e) {
-        Throwable mExceptionCause = e.getCause();
-
-        if (mExceptionCause instanceof SSLHandshakeException) {
-            Throwable mSecondExceptionCause = mExceptionCause.getCause();
-            if (mSecondExceptionCause instanceof CertificateException) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
+++ b/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
@@ -139,7 +139,7 @@ public class ResourceInstallUtils {
         }
 
         if(exception.getCause() instanceof SSLException){
-            return AppInstallStatus.BadSSLCertificate;
+            return AppInstallStatus.BadSslCertificate;
         }
 
         if(exception.getCause() instanceof RateLimitedException){

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -57,6 +57,7 @@ public class AnalyticsParamValue {
     public static final String SYNC_FAIL_ACTIONABLE = "actionable_failure";
     public static final String SYNC_FAIL_AUTH_OVER_HTTP = "auth_over_http";
     public static final String SYNC_FAIL_CAPTIVE_PORTAL = "captive_portal";
+    public static final String SYNC_FAIL_BAD_CERTIFICATE = "bad_certificate";
     public static final String SYNC_SUCCESS = "success";
 
     // Param values for feature usage
@@ -85,6 +86,7 @@ public class AnalyticsParamValue {
     public static final String SAVED_FORMS_BUTTON = "saved_forms";
     public static final String INCOMPLETE_FORMS_BUTTON = "incomplete_forms";
     public static final String SYNC_BUTTON = "sync";
+    public static final String SYNC_SUBTEXT = "sync_subtext";
     public static final String REPORT_BUTTON = "report_an_issue";
 
     // Param values for form types

--- a/app/src/org/commcare/network/HttpCalloutTask.java
+++ b/app/src/org/commcare/network/HttpCalloutTask.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.UnknownHostException;
 
-import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLException;
 
 import okhttp3.ResponseBody;
 import retrofit2.Response;
@@ -38,7 +38,7 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, Ht
         BadResponse,
         AuthFailed,
         UnknownError,
-        BadCertificate,
+        BadSSLCertificate,
         Success,
         NetworkFailureBadPassword,
         IncorrectPin,
@@ -86,9 +86,9 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, Ht
                 }
             } catch (UnknownHostException e) {
                 outcome = HttpCalloutOutcomes.NetworkFailure;
-            } catch (SSLPeerUnverifiedException e) {
+            } catch (SSLException e) {
                 // Couldn't get a valid SSL certificate
-                outcome = HttpCalloutOutcomes.BadCertificate;
+                outcome = HttpCalloutOutcomes.BadSSLCertificate;
             } catch (AuthenticationInterceptor.PlainTextPasswordException e) {
                 e.printStackTrace();
                 outcome = HttpCalloutOutcomes.AuthOverHttp;

--- a/app/src/org/commcare/network/HttpCalloutTask.java
+++ b/app/src/org/commcare/network/HttpCalloutTask.java
@@ -38,7 +38,7 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, Ht
         BadResponse,
         AuthFailed,
         UnknownError,
-        BadSSLCertificate,
+        BadSslCertificate,
         Success,
         NetworkFailureBadPassword,
         IncorrectPin,
@@ -88,7 +88,7 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, Ht
                 outcome = HttpCalloutOutcomes.NetworkFailure;
             } catch (SSLException e) {
                 // Couldn't get a valid SSL certificate
-                outcome = HttpCalloutOutcomes.BadSSLCertificate;
+                outcome = HttpCalloutOutcomes.BadSslCertificate;
             } catch (AuthenticationInterceptor.PlainTextPasswordException e) {
                 e.printStackTrace();
                 outcome = HttpCalloutOutcomes.AuthOverHttp;

--- a/app/src/org/commcare/recovery/measures/ExecuteRecoveryMeasuresActivity.java
+++ b/app/src/org/commcare/recovery/measures/ExecuteRecoveryMeasuresActivity.java
@@ -21,6 +21,7 @@ import org.commcare.tasks.UnZipTaskListener;
 import org.commcare.utils.StringUtils;
 import org.commcare.views.ManagedUi;
 import org.commcare.views.UiElement;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.services.locale.Localization;
 
@@ -184,6 +185,11 @@ public class ExecuteRecoveryMeasuresActivity extends CommCareActivity<ExecuteRec
 
     @Override
     public void failWithNotification(AppInstallStatus status) {
+        mPresenter.appInstallExecutionFailed(status, "notification");
+    }
+
+    @Override
+    public void failWithNotification(AppInstallStatus status, NotificationActionButtonInfo.ButtonAction buttonAction) {
         mPresenter.appInstallExecutionFailed(status, "notification");
     }
 

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -61,6 +61,7 @@ import java.util.Hashtable;
 import java.util.NoSuchElementException;
 
 import javax.crypto.SecretKey;
+import javax.net.ssl.SSLException;
 
 /**
  * @author ctsims
@@ -285,6 +286,10 @@ public abstract class DataPullTask<R>
             e.printStackTrace();
             Logger.log(LogTypes.TYPE_WARNING_NETWORK, "Couldn't sync due to presense of captive portal");
             responseError = PullTaskResult.CAPTIVE_PORTAL;
+        } catch(SSLException e) {
+            e.printStackTrace();
+            Logger.log(LogTypes.TYPE_WARNING_NETWORK, "Couldn't sync due to SSL error");
+            responseError = PullTaskResult.BAD_CERTIFICATE;
         } catch (IOException e) {
             e.printStackTrace();
             Logger.log(LogTypes.TYPE_WARNING_NETWORK, "Couldn't sync due to IO Error|" + e.getMessage());
@@ -684,7 +689,8 @@ public abstract class DataPullTask<R>
         RATE_LIMITED_SERVER_ERROR(AnalyticsParamValue.SYNC_FAIL_RATE_LIMITED_SERVER_ERROR),
         STORAGE_FULL(AnalyticsParamValue.SYNC_FAIL_STORAGE_FULL),
         CAPTIVE_PORTAL(AnalyticsParamValue.SYNC_FAIL_CAPTIVE_PORTAL),
-        AUTH_OVER_HTTP(AnalyticsParamValue.SYNC_FAIL_AUTH_OVER_HTTP);
+        AUTH_OVER_HTTP(AnalyticsParamValue.SYNC_FAIL_AUTH_OVER_HTTP),
+        BAD_CERTIFICATE(AnalyticsParamValue.SYNC_FAIL_BAD_CERTIFICATE);
 
         public final String analyticsFailureReasonParam;
 

--- a/app/src/org/commcare/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/tasks/ManageKeyRecordTask.java
@@ -187,9 +187,9 @@ public abstract class ManageKeyRecordTask<R extends DataPullController> extends 
                 Logger.log(LogTypes.TYPE_USER, "ManageKeyRecordTask error|bad network");
                 receiver.raiseLoginMessage(StockMessages.Remote_NoNetwork_BadPass, true);
                 break;
-            case BadSSLCertificate:
+            case BadSslCertificate:
                 Logger.log(LogTypes.TYPE_USER, "ManageKeyRecordTask error|bad certificate");
-                receiver.raiseLoginMessage(StockMessages.BadSSLCertificate, true, NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS);
+                receiver.raiseLoginMessage(StockMessages.BadSslCertificate, true, NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS);
                 break;
             case UnknownError:
                 Logger.log(LogTypes.TYPE_USER, "ManageKeyRecordTask error|unknown error");

--- a/app/src/org/commcare/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/tasks/ManageKeyRecordTask.java
@@ -18,6 +18,7 @@ import org.commcare.network.HttpCalloutTask;
 import org.commcare.preferences.ServerUrls;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.SessionUnavailableException;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
 import org.commcare.views.notifications.NotificationMessageFactory;
 import org.commcare.views.notifications.NotificationMessageFactory.StockMessages;
 import org.commcare.xml.KeyRecordParser;
@@ -186,9 +187,9 @@ public abstract class ManageKeyRecordTask<R extends DataPullController> extends 
                 Logger.log(LogTypes.TYPE_USER, "ManageKeyRecordTask error|bad network");
                 receiver.raiseLoginMessage(StockMessages.Remote_NoNetwork_BadPass, true);
                 break;
-            case BadCertificate:
+            case BadSSLCertificate:
                 Logger.log(LogTypes.TYPE_USER, "ManageKeyRecordTask error|bad certificate");
-                receiver.raiseLoginMessage(StockMessages.BadSSLCertificate, false);
+                receiver.raiseLoginMessage(StockMessages.BadSSLCertificate, true, NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS);
                 break;
             case UnknownError:
                 Logger.log(LogTypes.TYPE_USER, "ManageKeyRecordTask error|unknown error");

--- a/app/src/org/commcare/tasks/ResourceEngineListener.java
+++ b/app/src/org/commcare/tasks/ResourceEngineListener.java
@@ -3,6 +3,7 @@ package org.commcare.tasks;
 import org.commcare.engine.resource.AppInstallStatus;
 import org.commcare.resources.model.InvalidResourceException;
 import org.commcare.resources.model.UnresolvedResourceException;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
 import org.javarosa.core.reference.InvalidReferenceException;
 
 public interface ResourceEngineListener {
@@ -21,6 +22,7 @@ public interface ResourceEngineListener {
     void updateResourceProgress(int done, int pending, int phase);
 
     void failWithNotification(AppInstallStatus statusfailstate);
+    void failWithNotification(AppInstallStatus statusfailstate, NotificationActionButtonInfo.ButtonAction buttonAction);
 
     void failTargetMismatch();
 }

--- a/app/src/org/commcare/tasks/ResourceEngineTask.java
+++ b/app/src/org/commcare/tasks/ResourceEngineTask.java
@@ -132,7 +132,7 @@ public abstract class ResourceEngineTask<R>
             } catch (UnresolvedResourceException e) {
                 AppInstallStatus outcome =
                         ResourceInstallUtils.processUnresolvedResource(e);
-                if (outcome != AppInstallStatus.BadCertificate) {
+                if (outcome != AppInstallStatus.BadSSLCertificate) {
                     missingResourceException = e;
                 }
                 return outcome;

--- a/app/src/org/commcare/tasks/ResourceEngineTask.java
+++ b/app/src/org/commcare/tasks/ResourceEngineTask.java
@@ -132,7 +132,7 @@ public abstract class ResourceEngineTask<R>
             } catch (UnresolvedResourceException e) {
                 AppInstallStatus outcome =
                         ResourceInstallUtils.processUnresolvedResource(e);
-                if (outcome != AppInstallStatus.BadSSLCertificate) {
+                if (outcome != AppInstallStatus.BadSslCertificate) {
                     missingResourceException = e;
                 }
                 return outcome;

--- a/app/src/org/commcare/update/UpdateHelper.java
+++ b/app/src/org/commcare/update/UpdateHelper.java
@@ -90,7 +90,7 @@ public class UpdateHelper implements TableStateListener {
             return new ResultAndError<>(stageUpdate(profileRef, resourceInstallContext));
         } catch (InvalidResourceException e) {
             ResourceInstallUtils.logInstallError(e,
-                    "Structure error ocurred during install|");
+                    "Structure error occurred during install|");
             return new ResultAndError<>(AppInstallStatus.InvalidResource, buildCombinedErrorMessage(e.resourceName, e.getMessage()));
         } catch (LocalStorageUnavailableException e) {
             ResourceInstallUtils.logInstallError(e,

--- a/app/src/org/commcare/utils/FormUploadResult.java
+++ b/app/src/org/commcare/utils/FormUploadResult.java
@@ -1,88 +1,109 @@
 package org.commcare.utils;
 
+import org.commcare.views.notifications.MessageTag;
+
 /**
  * @author Phillip Mates (pmates@dimagi.com)
  */
-public enum FormUploadResult {
+public enum FormUploadResult implements MessageTag {
     /**
      * Everything worked great!
      */
-    FULL_SUCCESS(0),
+    FULL_SUCCESS(0, ""),
 
     /**
      * Non-specific error used as default assumption before attempting submission, and when
      * certain exceptions are encountered (IOException or TaskCancelledException)
      */
-    FAILURE(1),
+    FAILURE(1, "sync.fail.unknown"),
 
     /**
      * There is a problem with this record that prevented submission success for this record
      * specifically, but others will be allowed to continue trying
      */
-    RECORD_FAILURE(2),
+    RECORD_FAILURE(2, "sync.fail.individual"),
 
     /**
      * Form processing resulted in introducing an invalid case relationship most probably resulting in cycles into case graph
      */
-    INVALID_CASE_GRAPH(3),
+    INVALID_CASE_GRAPH(3, "sync.fail.invalid.case.graph"),
 
     /**
      * HQ received the form submission but encountered an error while processing it, so the
      * form has not resulted in any changes to the HQ database
      */
-    PROCESSING_FAILURE(4),
+    PROCESSING_FAILURE(4, "sync.fail.server.error"),
 
 
     /**
      * We attempted an authenticated request over http
      */
-    AUTH_OVER_HTTP(5),
+    AUTH_OVER_HTTP(5, "sync.fail.unknown"),
 
     /**
      * The server returned an authentication error
      */
-    AUTH_FAILURE(6),
+    AUTH_FAILURE(6, "sync.fail.auth.loggedin"),
 
     /**
      * There was a problem with the transport layer during transit
      */
-    TRANSPORT_FAILURE(7),
+    TRANSPORT_FAILURE(7, "sync.fail.bad.network"),
 
     /**
      * Server has some action directives for user to resolve this error
      */
-    ACTIONABLE_FAILURE(8),
+    ACTIONABLE_FAILURE(8, ""),
 
     /**
      * The user session ended while trying to upload a form
      */
-    PROGRESS_LOGGED_OUT(9),
+    PROGRESS_LOGGED_OUT(9, "sync.fail.unknown"),
 
-    PROGRESS_SDCARD_REMOVED(10),
+    PROGRESS_SDCARD_REMOVED(10, "sync.fail.unknown"),
 
     /**
      * The server can't couldn't handle the submission due to load, we
      * shouldn't keep retrying it
      */
-    RATE_LIMITED(11),
+    RATE_LIMITED(11, "form.send.rate.limit.error.toast"),
 
     /**
      * User is behind a captive portal, no need to try re-submissions
      */
-    CAPTIVE_PORTAL(12),
+    CAPTIVE_PORTAL(12, "sync.fail.unknown"),
 
     /**
      * Error involving SSL certificate, no need to try re-submission
      * This is often related to local clock settings
      */
-    BAD_CERTIFICATE(13)
+    BAD_CERTIFICATE(13, "sync.fail.badcert"),
+    /**
+     * Delivery error
+     */
+    UNSENT(14, "sync.fail.unsent"),
+    /**
+     * Upload cancelled
+     */
+    CANCELLED(15, "activity.task.cancelled.message"),
     ;
 
     private final int orderVal;
     private String errorMessage;
+    private final String root;
 
-    FormUploadResult(int orderVal) {
+    FormUploadResult(int orderVal, String root) {
         this.orderVal = orderVal;
+        this.root = root;
+    }
+
+    @Override
+    public String getLocaleKeyBase() {
+        return root;
+    }
+
+    public String getCategory() {
+        return "form_upload";
     }
 
     public String getErrorMessage() {

--- a/app/src/org/commcare/utils/FormUploadResult.java
+++ b/app/src/org/commcare/utils/FormUploadResult.java
@@ -69,7 +69,13 @@ public enum FormUploadResult {
     /**
      * User is behind a captive portal, no need to try re-submissions
      */
-    CAPTIVE_PORTAL(12)
+    CAPTIVE_PORTAL(12),
+
+    /**
+     * Error involving SSL certificate, no need to try re-submission
+     * This is often related to local clock settings
+     */
+    BAD_CERTIFICATE(13)
     ;
 
     private final int orderVal;

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
+import javax.net.ssl.SSLException;
 
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
@@ -186,6 +187,10 @@ public class FormUploadUtil {
             e.printStackTrace();
             Logger.log(LogTypes.TYPE_WARNING_NETWORK, "Captive portal detected while form submission");
             return FormUploadResult.CAPTIVE_PORTAL;
+        } catch (SSLException e) {
+            e.printStackTrace();
+            Logger.log(LogTypes.TYPE_WARNING_NETWORK, "SSL error during form submission");
+            return FormUploadResult.BAD_CERTIFICATE;
         } catch (IOException | IllegalStateException e) {
             Logger.exception("Error reading form during submission: " + e.getMessage(), e);
             return FormUploadResult.TRANSPORT_FAILURE;

--- a/app/src/org/commcare/views/notifications/NotificationActionButtonInfo.java
+++ b/app/src/org/commcare/views/notifications/NotificationActionButtonInfo.java
@@ -1,17 +1,53 @@
 package org.commcare.views.notifications;
 
-public class NotificationActionButtonInfo {
-    private String text;
-    private ButtonAction action;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import java.util.Date;
+
+public class NotificationActionButtonInfo implements Parcelable {
+    private final String text;
+    private final ButtonAction action;
 
     public enum ButtonAction {
         NONE,
         LAUNCH_DATE_SETTINGS
     }
 
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        String buttonText = getButtonText();
+        String buttonAction = getButtonAction().name();
+        dest.writeStringArray(new String[]{buttonText, buttonAction});
+    }
+
+    public static final Creator<NotificationActionButtonInfo> CREATOR = new Creator<>() {
+        @Override
+        public NotificationActionButtonInfo createFromParcel(Parcel source) {
+            String[] array = new String[2];
+            source.readStringArray(array);
+
+            return new NotificationActionButtonInfo(array[0], ButtonAction.valueOf(array[1]));
+        }
+
+        @Override
+        public NotificationActionButtonInfo[] newArray(int size) {
+            return new NotificationActionButtonInfo[size];
+        }
+    };
+
     public NotificationActionButtonInfo(String buttonText, ButtonAction buttonAction) {
         text = buttonText;
         action = buttonAction;
+
+        if (buttonText == null) {
+            throw new NullPointerException("NotificationActionButtonInfo can not have null button text");
+        }
     }
 
     public String getButtonText() {
@@ -20,5 +56,18 @@ public class NotificationActionButtonInfo {
 
     public ButtonAction getButtonAction() {
         return action;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof NotificationActionButtonInfo bi)) {
+            return false;
+        }
+
+        if(!bi.getButtonText().equals(this.getButtonText())) {
+            return false;
+        }
+
+        return bi.getButtonAction().equals(this.getButtonAction());
     }
 }

--- a/app/src/org/commcare/views/notifications/NotificationActionButtonInfo.java
+++ b/app/src/org/commcare/views/notifications/NotificationActionButtonInfo.java
@@ -1,0 +1,24 @@
+package org.commcare.views.notifications;
+
+public class NotificationActionButtonInfo {
+    private String text;
+    private ButtonAction action;
+
+    public enum ButtonAction {
+        NONE,
+        LAUNCH_DATE_SETTINGS
+    }
+
+    public NotificationActionButtonInfo(String buttonText, ButtonAction buttonAction) {
+        text = buttonText;
+        action = buttonAction;
+    }
+
+    public String getButtonText() {
+        return text;
+    }
+
+    public ButtonAction getButtonAction() {
+        return action;
+    }
+}

--- a/app/src/org/commcare/views/notifications/NotificationActionButtonInfo.java
+++ b/app/src/org/commcare/views/notifications/NotificationActionButtonInfo.java
@@ -3,8 +3,6 @@ package org.commcare.views.notifications;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import java.util.Date;
-
 public class NotificationActionButtonInfo implements Parcelable {
     private final String text;
     private final ButtonAction action;
@@ -21,18 +19,14 @@ public class NotificationActionButtonInfo implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        String buttonText = getButtonText();
-        String buttonAction = getButtonAction().name();
-        dest.writeStringArray(new String[]{buttonText, buttonAction});
+        dest.writeString(text);
+        dest.writeString(action.name());
     }
 
     public static final Creator<NotificationActionButtonInfo> CREATOR = new Creator<>() {
         @Override
         public NotificationActionButtonInfo createFromParcel(Parcel source) {
-            String[] array = new String[2];
-            source.readStringArray(array);
-
-            return new NotificationActionButtonInfo(array[0], ButtonAction.valueOf(array[1]));
+            return new NotificationActionButtonInfo(source.readString(), ButtonAction.valueOf(source.readString()));
         }
 
         @Override

--- a/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
+++ b/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
@@ -162,7 +162,7 @@ public class NotificationMessageFactory {
         /**
          * Bad SSL Certificate *
          */
-        BadSSLCertificate("notification.bad.certificate");
+        BadSslCertificate("notification.bad.certificate");
 
         StockMessages(String root) {
             this.root = root;
@@ -183,19 +183,19 @@ public class NotificationMessageFactory {
     }
 
     public static NotificationMessage message(MessageTag message) {
-        return message(message, new String[4]);
+        return message(message, new String[3]);
     }
 
     public static NotificationMessage message(MessageTag message, String customCategory) {
-        return message(message, new String[4], customCategory);
+        return message(message, new String[3], customCategory);
     }
 
     public static NotificationMessage message(MessageTag message, NotificationActionButtonInfo.ButtonAction buttonAction) {
-        return message(message, new String[4], message.getCategory(), buttonAction);
+        return message(message, new String[3], message.getCategory(), buttonAction);
     }
 
     public static NotificationMessage message(MessageTag message, String customCategory, NotificationActionButtonInfo.ButtonAction buttonAction) {
-        return message(message, new String[4], customCategory, buttonAction);
+        return message(message, new String[3], customCategory, buttonAction);
     }
 
     public static NotificationMessage message(MessageTag message, String[] parameters) {
@@ -228,14 +228,8 @@ public class NotificationMessageFactory {
             }
 
             NotificationActionButtonInfo buttonInfo = null;
-            try {
-                String button = parameters[3] == null ? Localization.get(base + ".button") : Localization.get(base + ".button", new String[]{parameters[3]});
-                buttonInfo = new NotificationActionButtonInfo(button, buttonAction);
-            } catch (Exception e) {
-                if(buttonAction != NotificationActionButtonInfo.ButtonAction.NONE) {
-                    //Need text to be defined for the button since an action is defined
-                    throw e;
-                }
+            if(buttonAction != NotificationActionButtonInfo.ButtonAction.NONE) {
+                buttonInfo = new NotificationActionButtonInfo(Localization.get(base + ".button"), buttonAction);
             }
 
             return new NotificationMessage(customCategory, title, detail, action, new Date(), buttonInfo);

--- a/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
+++ b/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
@@ -183,18 +183,34 @@ public class NotificationMessageFactory {
     }
 
     public static NotificationMessage message(MessageTag message) {
-        return message(message, new String[3]);
+        return message(message, new String[4]);
     }
 
     public static NotificationMessage message(MessageTag message, String customCategory) {
-        return message(message, new String[3], customCategory);
+        return message(message, new String[4], customCategory);
+    }
+
+    public static NotificationMessage message(MessageTag message, NotificationActionButtonInfo.ButtonAction buttonAction) {
+        return message(message, new String[4], message.getCategory(), buttonAction);
+    }
+
+    public static NotificationMessage message(MessageTag message, String customCategory, NotificationActionButtonInfo.ButtonAction buttonAction) {
+        return message(message, new String[4], customCategory, buttonAction);
     }
 
     public static NotificationMessage message(MessageTag message, String[] parameters) {
         return message(message, parameters, message.getCategory());
     }
 
+    public static NotificationMessage message(MessageTag message, String[] parameters, NotificationActionButtonInfo.ButtonAction buttonAction) {
+        return message(message, parameters, message.getCategory(), buttonAction);
+    }
+
     public static NotificationMessage message(MessageTag message, String[] parameters, String customCategory) {
+        return message(message, parameters, customCategory, NotificationActionButtonInfo.ButtonAction.NONE);
+    }
+
+    public static NotificationMessage message(MessageTag message, String[] parameters, String customCategory, NotificationActionButtonInfo.ButtonAction buttonAction) {
         String base = message.getLocaleKeyBase();
         if (base == null) {
             throw new NullPointerException("No Locale Key base for message tag!");
@@ -211,7 +227,18 @@ public class NotificationMessageFactory {
                 //No big deal, key doesn't need to exist
             }
 
-            return new NotificationMessage(customCategory, title, detail, action, new Date());
+            NotificationActionButtonInfo buttonInfo = null;
+            try {
+                String button = parameters[3] == null ? Localization.get(base + ".button") : Localization.get(base + ".button", new String[]{parameters[3]});
+                buttonInfo = new NotificationActionButtonInfo(button, buttonAction);
+            } catch (Exception e) {
+                if(buttonAction != NotificationActionButtonInfo.ButtonAction.NONE) {
+                    //Need text to be defined for the button since an action is defined
+                    throw e;
+                }
+            }
+
+            return new NotificationMessage(customCategory, title, detail, action, new Date(), buttonInfo);
         }
         //TODO: Release v. debug mode for these?
         catch (NoLocalizedTextException e) {

--- a/app/unit-tests/src/org/commcare/activities/DataPullControllerMock.java
+++ b/app/unit-tests/src/org/commcare/activities/DataPullControllerMock.java
@@ -3,6 +3,7 @@ package org.commcare.activities;
 import org.commcare.tasks.templates.CommCareTask;
 import org.commcare.tasks.templates.CommCareTaskConnector;
 import org.commcare.views.notifications.MessageTag;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
 import org.commcare.views.notifications.NotificationMessage;
 
 import static org.junit.Assert.assertEquals;
@@ -69,6 +70,11 @@ public class DataPullControllerMock implements DataPullController, CommCareTaskC
 
     @Override
     public void raiseLoginMessage(MessageTag messageTag, boolean showTop) {
+        assertEquals(expectedMessage, messageTag);
+    }
+
+    @Override
+    public void raiseLoginMessage(MessageTag messageTag, boolean showTop, NotificationActionButtonInfo.ButtonAction buttonAction) {
         assertEquals(expectedMessage, messageTag);
     }
 


### PR DESCRIPTION
## Summary
https://dimagi-dev.atlassian.net/browse/SAAS-10301

## Feature Flag
None

## Product Description
When encountering an SSL error in the app, the detailed error message which indicates that an incorrect date/time may be responsible for the issue now includes a button the user can press to take them directly to the date/time settings.

## Safety Assurance

- [ ] If the PR is high risk, "High Risk" label is set
- [ ] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage
None

### Safety story
The change involves providing more consistent messaging for SSL errors and the ability to launch a settings page. This functionality is only shown in the rare event of an SSL error, and otherwise has no effect on app functionality.

cross-request: https://github.com/dimagi/commcare-core/pull/1220