### PR TITLE
Drop Github action for cURL

### DIFF
--- a/.github/workflows/commcare-android-pr-workflow.yml
+++ b/.github/workflows/commcare-android-pr-workflow.yml
@@ -18,9 +18,8 @@ jobs:
         with:
           python-version: '3.x'
       - name: Download cross request script
-        uses: wei/curl@v1
-        with:
-          args: https://raw.githubusercontent.com/dimagi/mobile-deploy/master/checkout_cross_request_repo.py -o checkout_cross_request_repo.py
+        run: |
+          curl https://raw.githubusercontent.com/dimagi/mobile-deploy/master/checkout_cross_request_repo.py -o checkout_cross_request_repo.py
       - name: Run cross request script
         run: |
           python3 checkout_cross_request_repo commcare-android ${{ github.event.pull_request.number }} commcare-core


### PR DESCRIPTION
## Summary
The [Github action for cURL](https://github.com/marketplace/actions/github-action-for-curl) doesn't support MacOS, this PR drops the action and replaces it with a command call.