### PR TITLE
Fix starting Foreground services from the background

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -349,8 +349,9 @@
         <activity android:name="org.commcare.activities.MessageActivity">
         </activity>
 
-        <receiver android:name="org.commcare.views.notifications.NotificationClearReceiver">
-        </receiver>
+        <receiver android:name="org.commcare.views.notifications.NotificationClearReceiver"/>
+
+        <receiver android:name="org.commcare.services.CommCareSessionInitiatorReceiver"/>
 
         <activity
             android:label="@string/title_activity_report_problem"

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -28,7 +28,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <uses-feature
         android:name="android.hardware.telephony"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,7 +125,8 @@ dependencies {
     implementation "androidx.work:work-runtime-ktx:2.7.0"
 
     implementation 'com.google.android.play:core:1.7.3'
-    implementation 'android.arch.lifecycle:common-java8:1.1.1'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:$lifecycle_version'
+    implementation 'androidx.lifecycle:lifecycle-process:$lifecycle_version'
 
     //Robust TLS 1.2 ciphers on Android 9-19
     implementation "org.conscrypt:conscrypt-android:2.4.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,8 +125,8 @@ dependencies {
     implementation "androidx.work:work-runtime-ktx:2.7.0"
 
     implementation 'com.google.android.play:core:1.7.3'
-    implementation 'androidx.lifecycle:lifecycle-common-java8:$lifecycle_version'
-    implementation 'androidx.lifecycle:lifecycle-process:$lifecycle_version'
+    implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-process:$lifecycle_version"
 
     //Robust TLS 1.2 ciphers on Android 9-19
     implementation "org.conscrypt:conscrypt-android:2.4.0"

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -808,13 +808,28 @@ public class CommCareApplication extends MultiDexApplication {
         // we know will be running in our own process (and thus won't be
         // supporting component replacement by other applications).
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            startForegroundService(new Intent(this, CommCareSessionService.class));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && isAppInTheBackground())
+                startForegroundServiceWithAlarmManager();
+            else
+                startForegroundService(new Intent(this, CommCareSessionService.class));
         } else {
             startService(new Intent(this, CommCareSessionService.class));
         }
 
         bindService(new Intent(this, CommCareSessionService.class), mConnection, Context.BIND_AUTO_CREATE);
         sessionServiceIsBinding = true;
+    }
+
+    /**
+     * From Android 12, it's not allowed for an app to start a Foreground Service while
+     * running in the background. This method leverages AlarmManager to initiate the Service
+     */
+    private void startForegroundServiceWithAlarmManager() {
+
+    }
+
+    private boolean isAppInTheBackground() {
+        return false;
     }
 
     private void cleanRawMedia() {

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -94,6 +94,7 @@ import org.commcare.preferences.HiddenPreferences;
 import org.commcare.preferences.LocalePreferences;
 import org.commcare.services.CommCareSessionInitiatorReceiver;
 import org.commcare.services.CommCareSessionService;
+import org.commcare.services.ForegroundComponentType;
 import org.commcare.session.CommCareSession;
 import org.commcare.sync.FormSubmissionHelper;
 import org.commcare.sync.FormSubmissionWorker;
@@ -842,8 +843,14 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
     @RequiresApi(api = Build.VERSION_CODES.O)
     private void startForegroundServiceWithAlarmManager() {
         Intent receiverIntent = new Intent(this, CommCareSessionInitiatorReceiver.class);
+        ForegroundComponentType foregroundComponentType = ForegroundComponentType.SERVICE;
+        receiverIntent.putExtra(CommCareSessionService.EXTRA_COMPONENT_TYPE, foregroundComponentType);
 
-        PendingIntent pendingIntent = new PendingIntent.getBroadcast(this, 0, receiverIntent, PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(
+                this,
+                foregroundComponentType.ordinal(),
+                receiverIntent,
+                PendingIntent.FLAG_IMMUTABLE);
 
         AlarmManager alarmmanager = (AlarmManager) getSystemService(ALARM_SERVICE);
         alarmmanager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, Calendar.getInstance().getTimeInMillis(), pendingIntent);

--- a/app/src/org/commcare/services/CommCareSessionInitiatorReceiver.java
+++ b/app/src/org/commcare/services/CommCareSessionInitiatorReceiver.java
@@ -1,0 +1,36 @@
+package org.commcare.services;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Broadcast receiver to start foreground services and notifications
+ *
+ */
+public class CommCareSessionInitiatorReceiver extends BroadcastReceiver {
+
+    public enum ForegroundComponent {
+        SERVICE,
+        NOTIFICATION
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        ForegroundComponent component = checkForegroundComponent(intent);
+
+        cancelAlarm(intent);
+
+        switch (component){
+            case SERVICE: break;
+            case NOTIFICATION: break;
+        }
+    }
+
+    private void cancelAlarm(Intent intent) {
+    }
+
+    private ForegroundComponent checkForegroundComponent(Intent intent) {
+        return ForegroundComponent.SERVICE;
+    }
+}

--- a/app/src/org/commcare/services/CommCareSessionInitiatorReceiver.java
+++ b/app/src/org/commcare/services/CommCareSessionInitiatorReceiver.java
@@ -1,13 +1,24 @@
 package org.commcare.services;
 
+import androidx.annotation.RequiresApi;
+
+import android.app.AlarmManager;
+import android.app.Notification;
+import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+import org.commcare.CommCareApp;
+import org.commcare.CommCareApplication;
 
 /**
  * Broadcast receiver to start foreground services and notifications
  *
  */
+@RequiresApi(api = Build.VERSION_CODES.O)
 public class CommCareSessionInitiatorReceiver extends BroadcastReceiver {
 
     public enum ForegroundComponent {
@@ -19,18 +30,35 @@ public class CommCareSessionInitiatorReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         ForegroundComponent component = checkForegroundComponent(intent);
 
-        cancelAlarm(intent);
+        cancelAlarm(intent, component);
 
         switch (component){
-            case SERVICE: break;
-            case NOTIFICATION: break;
+            case SERVICE:
+                context.startForegroundService(new Intent(context, CommCareSessionService.class));
+                break;
+            case NOTIFICATION:
+                if (intent.hasExtra(CommCareSessionService.EXTRA_NOTIFICATION_ID)) {
+                    Bundle intentData = intent.getExtras();
+                    int notificationId =intentData.getInt(CommCareSessionService.EXTRA_NOTIFICATION_ID);
+                    Notification notification = intentData.getParcelable(CommCareSessionService.EXTRA_NOTIFICATION_OBJ);
+
+                    CommCareApplication.instance().getSession().startForeground(notificationId, notification);
+                }
         }
     }
 
-    private void cancelAlarm(Intent intent) {
+    private void cancelAlarm(Intent intent, ForegroundComponent component) {
+        int requestCode = component == ForegroundComponent.SERVICE? 0: 1;
+        PendingIntent pendingIntent = new PendingIntent.getBroadcast(this, requestCode, intent, PendingIntent.FLAG_IMMUTABLE);
+
+        AlarmManager alarmmanager = (AlarmManager) getSystemService(ALARM_SERVICE);
+        if (pendingIntent != null)
+            alarmmanager.cancel(pendingIntent);
     }
 
     private ForegroundComponent checkForegroundComponent(Intent intent) {
+        if (intent.hasExtra(CommCareSessionService.EXTRA_NOTIFICATION_ID))
+            return ForegroundComponent.NOTIFICATION;
         return ForegroundComponent.SERVICE;
     }
 }

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -69,8 +69,8 @@ public class CommCareSessionService extends Service {
     /**
      * Names of the extra data for the CommCareServiceInitiatorReceiver intent
      */
-    private static final String EXTRA_NOTIFICATION_ID = "commcare.intent.extra.notification-id";
-    private static final String EXTRA_NOTIFICATION_OBJ = "commcare.intent.extra.notification";
+    public static final String EXTRA_NOTIFICATION_ID = "commcare.intent.extra.notification-id";
+    public static final String EXTRA_NOTIFICATION_OBJ = "commcare.intent.extra.notification";
 
     private NotificationManager mNM;
 

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -71,6 +71,7 @@ public class CommCareSessionService extends Service {
      */
     public static final String EXTRA_NOTIFICATION_ID = "commcare.intent.extra.notification-id";
     public static final String EXTRA_NOTIFICATION_OBJ = "commcare.intent.extra.notification";
+    public static final String EXTRA_COMPONENT_TYPE = "commcare.intent.extra.component-type";
 
     private NotificationManager mNM;
 
@@ -262,11 +263,18 @@ public class CommCareSessionService extends Service {
      */
     @RequiresApi(api = Build.VERSION_CODES.O)
     private void startForegroundNotificationWithAlarmManager(int notificationId, Notification notification) {
+        ForegroundComponentType foregroundComponentType = ForegroundComponentType.NOTIFICATION;
+
         Intent receiverIntent = new Intent(this, CommCareSessionInitiatorReceiver.class);
+        receiverIntent.putExtra(EXTRA_COMPONENT_TYPE, foregroundComponentType);
         receiverIntent.putExtra(EXTRA_NOTIFICATION_ID, notificationId);
         receiverIntent.putExtra(EXTRA_NOTIFICATION_OBJ, notification);
 
-        PendingIntent pendingIntent = new PendingIntent.getBroadcast(this, 1, receiverIntent, PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(
+                this,
+                foregroundComponentType.ordinal(),
+                receiverIntent,
+                PendingIntent.FLAG_IMMUTABLE);
 
         AlarmManager alarmmanager = (AlarmManager) getSystemService(ALARM_SERVICE);
         alarmmanager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, Calendar.getInstance().getTimeInMillis(), pendingIntent);

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -246,7 +246,7 @@ public class CommCareSessionService extends Service {
         }
 
         //Send the notification
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && isAppInTheBackground())
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && CommCareApplication.isAppInBackground())
             startForegroundNotificationWithAlarmManager(NOTIFICATION, notificationBuilder.build());
         else
             this.startForeground(NOTIFICATION, notificationBuilder.build());
@@ -260,10 +260,10 @@ public class CommCareSessionService extends Service {
      * From Android 12, it's not allowed for an app to start a Foreground notification while
      * running in the background. This method leverages AlarmManager to trigger the notification
      */
-    @RequiresApi(api = Build.VERSION_CODES.M)
+    @RequiresApi(api = Build.VERSION_CODES.O)
     private void startForegroundNotificationWithAlarmManager(int notificationId, Notification notification) {
         Intent receiverIntent = new Intent(this, CommCareSessionInitiatorReceiver.class);
-        receiverIntent.putExtra(EXTRA_NOTIFICATION_ID, NOTIFICATION);
+        receiverIntent.putExtra(EXTRA_NOTIFICATION_ID, notificationId);
         receiverIntent.putExtra(EXTRA_NOTIFICATION_OBJ, notification);
 
         PendingIntent pendingIntent = new PendingIntent.getBroadcast(this, 1, receiverIntent, PendingIntent.FLAG_IMMUTABLE);

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -236,8 +236,22 @@ public class CommCareSessionService extends Service {
             notificationBuilder.setContentText(contentText);
         }
 
-        //Send the notification.
-        this.startForeground(NOTIFICATION, notificationBuilder.build());
+        //Send the notification
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && isAppInTheBackground())
+            startForegroundNotificationWithAlarmManager();
+        else
+            this.startForeground(NOTIFICATION, notificationBuilder.build());
+    }
+
+    private boolean isAppInTheBackground() {
+        return false;
+    }
+
+    /**
+     * From Android 12, it's not allowed for an app to start a Foreground notification while
+     * running in the background. This method leverages AlarmManager to trigger the notification
+     */
+    private void startForegroundNotificationWithAlarmManager() {
     }
 
     /**

--- a/app/src/org/commcare/services/ForegroundComponentType.java
+++ b/app/src/org/commcare/services/ForegroundComponentType.java
@@ -1,0 +1,12 @@
+package org.commcare.services;
+
+/**
+ * Enum used to represent the different types of foreground elements that need to be initiated
+ * when the app is in the background.
+ *
+ */
+public enum ForegroundComponentType {
+    SERVICE,
+    NOTIFICATION
+}
+


### PR DESCRIPTION
## Summary
This PR resolves a restriction on Android 12+ with [starting foreground services while the application is in the background](https://developer.android.com/guide/components/foreground-services#background-start-restrictions), which is causing 
[ForegroundServiceStartNotAllowedException](https://developer.android.com/reference/android/app/ForegroundServiceStartNotAllowedException) errors.

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance
- [ X ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
<!-- Identify the related test coverage and the tests it would catch -->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
