### PR TITLE
Fix for crashes when grid images are wider than the screen

### DIFF
--- a/app/src/org/commcare/views/widgets/GridWidget.java
+++ b/app/src/org/commcare/views/widgets/GridWidget.java
@@ -134,7 +134,7 @@ public class GridWidget extends QuestionWidget {
         int screenWidth = display.getWidth();
 
         // Use the user's choice for num columns, otherwise decide based upon what will fit.
-        int maxColumnsThatWillFit = screenWidth / maxImageWidth;
+        int maxColumnsThatWillFit = Math.max(screenWidth / maxImageWidth, 1);
         if (numColumns > 0) {
             gridview.setNumColumns(numColumns);
         } else {


### PR DESCRIPTION
## Summary
Basic fix for [this issue](https://dimagi-dev.atlassian.net/browse/SUPPORT-16630). Essentially, forms will crash if the image for a grid select view is wider in pixels than the native display. 

Release Note:
* Fix for a crash which could occur with compact image selection widgets on small screens with large images

## Feature Flag
It is specific to an uncommon pattern involving the use of the `compact` attribute on `<select>` and `<select1>` questions with images on the select items, which displays a grid of images to choose from. 

## Product Description
N/A

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly


### Automated test coverage

I think we should consider seeing if we could usefully automate some tests around the image grid selection if we don't have them currently, as the project reporting this issue is quite high-value and high-impact, and they use the 'grid' pattern images in multiple places. Testing image widths and how the screen changes would be a valuable component of those tests. 

### Safety story

This fix has been tested locally after replicating the original issue. There's very small risk of introducing a regression due to the limited scope of the change. 