### PR TITLE
Improve error handling for restore parse errors

### DIFF
--- a/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
+++ b/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
@@ -225,6 +225,8 @@ public class NotificationMessageFactory {
                 action = parameters[2] == null ? Localization.get(base + ".action") : Localization.get(base + ".action", new String[]{parameters[2]});
             } catch (Exception e) {
                 //No big deal, key doesn't need to exist
+                // pass in parameter value as it is
+                action = parameters[2];
             }
 
             NotificationActionButtonInfo buttonInfo = null;


### PR DESCRIPTION
## Summary
[Jira](https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/issue/SUPPORT-17011)

In case of bad restore data, we were not showing the actual exception as there is no locale key present corresponding to the particular error's action. 

I think it makes sense to pass the action as it is for some errors like this when there is no locale key present. 

Improved error response - 

![Screenshot_1687971421](https://github.com/dimagi/commcare-android/assets/4679137/a5ef6dc3-e17d-4aef-8fa4-bb5385aa6abb)


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
