### PR TITLE
Enable secure flag

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -1,5 +1,7 @@
 package org.commcare.activities;
 
+import static org.commcare.preferences.HiddenPreferences.isFlagSecureEnabled;
+
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -18,6 +20,7 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -126,6 +129,10 @@ public abstract class CommCareActivity<R> extends AppCompatActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (isFlagSecureEnabled()) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        }
 
         FragmentManager fm = this.getSupportFragmentManager();
 

--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -554,7 +554,6 @@ public class HiddenPreferences {
     }
 
     public static boolean isFlagSecureEnabled() {
-        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        return PrefValues.YES.equals(properties.getString(ENABLE_SECURE_FLAG, PrefValues.NO));
+        return DeveloperPreferences.doesPropertyMatch(ENABLE_SECURE_FLAG, PrefValues.NO, PrefValues.YES);
     }
 }

--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -96,6 +96,7 @@ public class HiddenPreferences {
 
 
     private static final long NO_OF_HOURS_TO_WAIT_TO_RESUME_BACKGROUND_WORK = 36;
+    private static final String ENABLE_SECURE_FLAG = "cc-enable-secure-flag";
 
 
     /**
@@ -550,5 +551,10 @@ public class HiddenPreferences {
     public static void markRawMediaCleanUpComplete() {
         CommCareApplication.instance().getCurrentApp().getAppPreferences()
                 .edit().putBoolean(RAW_MEDIA_CLEANUP_COMPLETE, true).apply();
+    }
+
+    public static boolean isFlagSecureEnabled() {
+        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        return PrefValues.YES.equals(properties.getString(ENABLE_SECURE_FLAG, PrefValues.NO));
     }
 }

--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -2,7 +2,6 @@ package org.commcare.preferences;
 
 import android.content.SharedPreferences;
 
-import org.commcare.AppUtils;
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.activities.GeoPointActivity;
@@ -96,7 +95,7 @@ public class HiddenPreferences {
 
 
     private static final long NO_OF_HOURS_TO_WAIT_TO_RESUME_BACKGROUND_WORK = 36;
-    private static final String ENABLE_SECURE_FLAG = "cc-enable-secure-flag";
+    private static final String ENABLE_ANDROID_WINDOW_SECURE_FLAG = "cc-enable-android-window-secure-flag";
 
 
     /**
@@ -554,6 +553,6 @@ public class HiddenPreferences {
     }
 
     public static boolean isFlagSecureEnabled() {
-        return DeveloperPreferences.doesPropertyMatch(ENABLE_SECURE_FLAG, PrefValues.NO, PrefValues.YES);
+        return DeveloperPreferences.doesPropertyMatch(ENABLE_ANDROID_WINDOW_SECURE_FLAG, PrefValues.NO, PrefValues.YES);
     }
 }


### PR DESCRIPTION
## Summary
This PR addresses an issue raised by the ABDM auditors in which sensitive data could be accessible to attackers in certain parts of the Android OS, such as in the Recent Apps. This PR enables the FLAG_SECURE flag, which enforces security features of the window, this includes blanking the window when the application goes to the background and preventing screenshots.

## Feature Flag
This feature is behind a CommCare custom property called `cc-enable-secure-flag`

## Product Description
When this flag is enabled, here's what the user sees when they see the app in the Recent apps. 
<img src="https://github.com/dimagi/commcare-android/assets/19228119/26cc162a-881c-43e5-9a7b-6d27b50625e1" width="200px" alt="Sync attempt during Form Entry" />

## Safety Assurance
- [X] I have confidence that this PR will not introduce a regression for the reasons below
