### PR TITLE
Android 13 update

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -23,12 +23,17 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <!-- required to ensure app compatibility -->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-
 
     <uses-feature
         android:name="android.hardware.telephony"

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -113,7 +113,8 @@
         android:label="@string/application_name"
         android:hardwareAccelerated="true"
         android:usesCleartextTraffic="true"
-        android:theme="@style/AppBaseTheme">
+        android:theme="@style/AppBaseTheme"
+        android:enableOnBackInvokedCallback="false">
 
         <activity
             android:label="@string/application_name"

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -34,6 +34,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"/>
 
     <uses-feature
         android:name="android.hardware.telephony"

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:name="android.permission.INTERNET"/>
     <uses-permission
         xmlns:android="http://schemas.android.com/apk/res/android"
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32"/>
     <uses-permission android:name="android.permission.CALL_PHONE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
@@ -27,9 +28,9 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
         android:usesPermissionFlags="neverForLocation"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-feature
         android:name="android.hardware.telephony"

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -836,7 +836,7 @@ odk_perfect_match_color=\#87D13E
 odk_fuzzy_match_color=\#FFE88F
 
 permission.all.title=CommCare Permissions
-permission.all.message=CommCare needs permissions to read/write forms to memory, call/message from the case list, and provide location data during form entry.
+permission.all.message=CommCare needs permissions to read/write forms to memory, call/message from the case list, provide location data during form entry and notify the user about important events.
 permission.all.denial.message=CommCare doesn't have the necessary permissions. Please enable via Android's settings.
 permission.case.callout.title=Permissions for calling & messaging
 permission.case.callout.message=CommCare needs call & messaging permissions to enable communication with cases.

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -813,6 +813,9 @@ wifi.direct.status.receive.message=This will allow you to receive forms on this 
 wifi.direct.status.submit.header=You are in Submit Form Mode
 wifi.direct.status.submit.count=Device has ${0} unsubmitted forms.
 wifi.direct.status.submit.message=This mode will allow you to submit forms to the CommCare Server if you have an internet connection.
+wifi.direct.permission.nearby.wifi.title=Permission to access nearby Wi-Fi Devices
+wifi.direct.permission.nearby.wifi.message=In order to exchange data with nearby devices via Wi-Fi, CommCare needs access to Wi-Fi capabilities.
+wifi.direct.permission.nearby.wifi.denial=CommCare doesn't have permission to connect with nearby devices via Wi-Fi. Please enable via Android's settings.
 
 form.transfer.no.forms=No forms to send.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -225,7 +225,7 @@ static def getDate() {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     lintOptions {
         abortOnError false
@@ -248,7 +248,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         multiDexEnabled true
         applicationId "org.commcare.dalvik"
         testNamespace "org.commcare.dalvik.test"

--- a/app/src/org/commcare/CommCareNoficationManager.java
+++ b/app/src/org/commcare/CommCareNoficationManager.java
@@ -98,10 +98,13 @@ public class CommCareNoficationManager {
             for (NotificationMessage message : toRemove) {
                 pendingMessages.remove(message);
             }
-            if (pendingMessages.size() == 0) {
-                mNM.cancel(MESSAGE_NOTIFICATION);
-            } else {
-                updateMessageNotification();
+
+            if (areNotificationsEnabled()) {
+                if (pendingMessages.size() == 0) {
+                    mNM.cancel(MESSAGE_NOTIFICATION);
+                } else {
+                    updateMessageNotification();
+                }
             }
         }
     }
@@ -137,8 +140,20 @@ public class CommCareNoficationManager {
             }
 
             // Otherwise, add it to the queue, and update the notification
-            pendingMessages.add(message);
-            updateMessageNotification();
+            if (areNotificationsEnabled()) {
+                pendingMessages.add(message);
+                updateMessageNotification();
+            }
+        }
+    }
+
+    public boolean areNotificationsEnabled() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return ((NotificationManager)context.getSystemService(NOTIFICATION_SERVICE))
+                    .areNotificationsEnabled();
+        }
+        else {
+            return true;
         }
     }
 

--- a/app/src/org/commcare/CommCareNoficationManager.java
+++ b/app/src/org/commcare/CommCareNoficationManager.java
@@ -151,8 +151,7 @@ public class CommCareNoficationManager {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             return ((NotificationManager)context.getSystemService(NOTIFICATION_SERVICE))
                     .areNotificationsEnabled();
-        }
-        else {
+        } else {
             return true;
         }
     }

--- a/app/src/org/commcare/CommCareNoficationManager.java
+++ b/app/src/org/commcare/CommCareNoficationManager.java
@@ -59,29 +59,31 @@ public class CommCareNoficationManager {
                 return;
             }
 
-            String title = pendingMessages.get(0).getTitle();
+            if (areNotificationsEnabled()) {
+                String title = pendingMessages.get(0).getTitle();
 
-            // The PendingIntent to launch our activity if the user selects this notification
-            Intent i = new Intent(context, MessageActivity.class);
+                // The PendingIntent to launch our activity if the user selects this notification
+                Intent i = new Intent(context, MessageActivity.class);
 
-            int intentFlags = 0;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-                intentFlags = PendingIntent.FLAG_IMMUTABLE;
-            PendingIntent contentIntent = PendingIntent.getActivity(context, 0, i, intentFlags);
+                int intentFlags = 0;
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                    intentFlags = PendingIntent.FLAG_IMMUTABLE;
+                PendingIntent contentIntent = PendingIntent.getActivity(context, 0, i, intentFlags);
 
-            String additional = pendingMessages.size() > 1 ? Localization.get("notifications.prompt.more", new String[]{String.valueOf(pendingMessages.size() - 1)}) : "";
-            Notification messageNotification = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ERRORS_ID)
-                    .setContentTitle(title)
-                    .setContentText(Localization.get("notifications.prompt.details", new String[]{additional}))
-                    .setSmallIcon(R.drawable.notification)
-                    .setNumber(pendingMessages.size())
-                    .setContentIntent(contentIntent)
-                    .setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationClearReceiver.class), intentFlags))
-                    .setOngoing(true)
-                    .setWhen(System.currentTimeMillis())
-                    .build();
+                String additional = pendingMessages.size() > 1 ? Localization.get("notifications.prompt.more", new String[]{String.valueOf(pendingMessages.size() - 1)}) : "";
+                Notification messageNotification = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ERRORS_ID)
+                        .setContentTitle(title)
+                        .setContentText(Localization.get("notifications.prompt.details", new String[]{additional}))
+                        .setSmallIcon(R.drawable.notification)
+                        .setNumber(pendingMessages.size())
+                        .setContentIntent(contentIntent)
+                        .setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationClearReceiver.class), intentFlags))
+                        .setOngoing(true)
+                        .setWhen(System.currentTimeMillis())
+                        .build();
 
-            mNM.notify(MESSAGE_NOTIFICATION, messageNotification);
+                mNM.notify(MESSAGE_NOTIFICATION, messageNotification);
+            }
         }
     }
 
@@ -99,12 +101,10 @@ public class CommCareNoficationManager {
                 pendingMessages.remove(message);
             }
 
-            if (areNotificationsEnabled()) {
-                if (pendingMessages.size() == 0) {
-                    mNM.cancel(MESSAGE_NOTIFICATION);
-                } else {
-                    updateMessageNotification();
-                }
+            if (pendingMessages.size() == 0) {
+                mNM.cancel(MESSAGE_NOTIFICATION);
+            } else {
+                updateMessageNotification();
             }
         }
     }
@@ -140,10 +140,8 @@ public class CommCareNoficationManager {
             }
 
             // Otherwise, add it to the queue, and update the notification
-            if (areNotificationsEnabled()) {
-                pendingMessages.add(message);
-                updateMessageNotification();
-            }
+            pendingMessages.add(message);
+            updateMessageNotification();
         }
     }
 

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -49,8 +49,8 @@ public class FormAndDataSyncer {
 
     @SuppressLint("NewApi")
     protected void processAndSendForms(final SyncCapableCommCareActivity activity,
-                                     final boolean syncAfterwards,
-                                     final boolean userTriggered) {
+                                       final boolean syncAfterwards,
+                                       final boolean userTriggered) {
 
         ProcessAndSendTask<SyncCapableCommCareActivity> processAndSendTask =
                 new ProcessAndSendTask<SyncCapableCommCareActivity>(activity, syncAfterwards) {
@@ -74,7 +74,7 @@ public class FormAndDataSyncer {
 
                         receiver.handleFormUploadResult(result, getLabelForFormsSent(), userTriggered);
 
-                        if(result == FormUploadResult.FULL_SUCCESS && syncAfterwards) {
+                        if (result == FormUploadResult.FULL_SUCCESS && syncAfterwards) {
                             syncDataForLoggedInUser(receiver, true, userTriggered);
                         }
                     }

--- a/app/src/org/commcare/activities/FormAndDataSyncer.java
+++ b/app/src/org/commcare/activities/FormAndDataSyncer.java
@@ -1,15 +1,11 @@
 package org.commcare.activities;
 
 import android.annotation.SuppressLint;
-import android.content.Context;
 import android.content.SharedPreferences;
 
 import org.commcare.CommCareApplication;
-import org.commcare.android.database.user.models.FormRecord;
-import org.commcare.dalvik.R;
 import org.commcare.engine.resource.installers.SingleAppInstallation;
 import org.commcare.interfaces.WithUIController;
-import org.commcare.models.database.SqlStorage;
 import org.commcare.network.DataPullRequester;
 import org.commcare.network.LocalReferencePullResponseFactory;
 import org.commcare.network.mocks.LocalFilePullResponseFactory;
@@ -22,9 +18,6 @@ import org.commcare.sync.ProcessAndSendTask;
 import org.commcare.tasks.PullTaskResultReceiver;
 import org.commcare.tasks.ResultAndError;
 import org.commcare.utils.FormUploadResult;
-import org.commcare.utils.StorageUtils;
-import org.commcare.views.notifications.NotificationActionButtonInfo;
-import org.commcare.views.notifications.NotificationMessageFactory;
 import org.javarosa.core.model.User;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
@@ -102,8 +95,11 @@ public class FormAndDataSyncer {
                     }
                 };
 
-        processAndSendTask.addSubmissionListener(
-                CommCareApplication.instance().getSession().getListenerForSubmissionNotification());
+        if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
+            processAndSendTask.addSubmissionListener(
+                    CommCareApplication.instance().getSession().getListenerForSubmissionNotification());
+        }
+
         if (activity.usesSubmissionProgressBar()) {
             processAndSendTask.addProgressBarSubmissionListener(
                     new FormSubmissionProgressBarListener(activity));

--- a/app/src/org/commcare/activities/RecoveryActivity.java
+++ b/app/src/org/commcare/activities/RecoveryActivity.java
@@ -146,7 +146,10 @@ public class RecoveryActivity extends SessionAwareCommCareActivity<RecoveryActiv
 
                 };
 
-        mProcess.addSubmissionListener(CommCareApplication.instance().getSession().getListenerForSubmissionNotification());
+        if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
+            mProcess.addSubmissionListener(
+                    CommCareApplication.instance().getSession().getListenerForSubmissionNotification());
+        }
         mProcess.connect(this);
 
         //Execute on a true multithreaded chain. We should probably replace all of our calls with this

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -418,9 +418,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
         if (CommCareApplication.instance().isConsumerApp()) {
             showProgressDialog(DIALOG_CONSUMER_APP_UPGRADE);
         } else {
-            if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
-                updateTask.startPinnedNotification(this);
-            }
+            updateTask.startPinnedNotification(this);
         }
     }
 

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -417,7 +417,9 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
         if (CommCareApplication.instance().isConsumerApp()) {
             showProgressDialog(DIALOG_CONSUMER_APP_UPGRADE);
         } else {
-            updateTask.startPinnedNotification(this);
+            if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
+                updateTask.startPinnedNotification(this);
+            }
         }
     }
 

--- a/app/src/org/commcare/activities/UpdateActivity.java
+++ b/app/src/org/commcare/activities/UpdateActivity.java
@@ -1,6 +1,7 @@
 package org.commcare.activities;
 
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -355,7 +356,7 @@ public class UpdateActivity extends CommCareActivity<UpdateActivity>
                 break;
         }
 
-        if(notificationMessage != null) {
+        if (notificationMessage != null) {
             CommCareApplication.notificationManager()
                     .reportNotificationMessage(notificationMessage, true);
             uiController.setNotificationsVisible();

--- a/app/src/org/commcare/activities/components/EntitySelectCalloutSetup.java
+++ b/app/src/org/commcare/activities/components/EntitySelectCalloutSetup.java
@@ -53,13 +53,13 @@ public class EntitySelectCalloutSetup {
             if (b == null) {
                 // Input stream could not be used to derive bitmap, so
                 // showing error-indicating image
-                return context.getResources().getDrawable(R.drawable.ic_menu_archive);
+                return context.getDrawable(R.drawable.ic_menu_archive);
             } else {
                 return new BitmapDrawable(b);
             }
         } else {
             // no image passed in, draw a white background
-            return context.getResources().getDrawable(R.color.white);
+            return context.getDrawable(R.color.white);
         }
     }
 

--- a/app/src/org/commcare/activities/components/EntitySelectViewSetup.java
+++ b/app/src/org/commcare/activities/components/EntitySelectViewSetup.java
@@ -20,7 +20,7 @@ public class EntitySelectViewSetup {
             }
             dividerWidth += (int)context.getResources().getDimension(R.dimen.row_padding_horizontal);
 
-            LayerDrawable dividerDrawable = (LayerDrawable)context.getResources().getDrawable(R.drawable.divider_case_list_modern);
+            LayerDrawable dividerDrawable = (LayerDrawable)context.getDrawable(R.drawable.divider_case_list_modern);
             dividerDrawable.setLayerInset(0, dividerWidth, 0, 0, 0);
 
             view.setDivider(dividerDrawable);

--- a/app/src/org/commcare/activities/components/FormNavigationUI.java
+++ b/app/src/org/commcare/activities/components/FormNavigationUI.java
@@ -99,7 +99,7 @@ public class FormNavigationUI {
             expandAndShowFinishButton(context, finishButton);
         }
 
-        progressBar.setProgressDrawable(context.getResources().getDrawable(R.drawable.progressbar_full));
+        progressBar.setProgressDrawable(context.getDrawable(R.drawable.progressbar_full));
         progressBar.setProgress(details.totalQuestions);
 
         Log.i("Questions", "Form complete");
@@ -148,7 +148,7 @@ public class FormNavigationUI {
             finishButton.setVisibility(View.GONE);
         }
 
-        progressBar.setProgressDrawable(context.getResources().getDrawable(R.drawable.progressbar_modern));
+        progressBar.setProgressDrawable(context.getDrawable(R.drawable.progressbar_modern));
         progressBar.setProgress(details.completedQuestions);
     }
 

--- a/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
+++ b/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
@@ -198,9 +198,9 @@ class DrawingBoundaryActivity : BaseMapboxActivity(), LocationListener, MapboxMa
     override fun onLocationChanged(location: Location) {
         if (location != null && location.accuracy <= locationMinAccuracy) {
             val addLocation = previousLocation == null ||
-                    (location.distanceTo(previousLocation) >= location.accuracy + previousLocation!!.accuracy &&
+                    (location.distanceTo(previousLocation!!) >= location.accuracy + previousLocation!!.accuracy &&
                             location.time - previousLocation!!.time >= recordingIntervalMillis &&
-                            location.distanceTo(previousLocation) >= recordingIntervalMeters)
+                            location.distanceTo(previousLocation!!) >= recordingIntervalMeters)
             if (addLocation && isRecording) {
                 previousLocation = location
                 val latLng = LatLng(location.latitude, location.longitude)

--- a/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
+++ b/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
@@ -110,10 +110,10 @@ class DrawingBoundaryActivity : BaseMapboxActivity(), LocationListener, MapboxMa
     private fun freezeOrientation() {
         val orientation = resources.configuration.orientation
         requestedOrientation =
-            when (orientation) {
-                Configuration.ORIENTATION_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
-                else -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
-            }
+                when (orientation) {
+                    Configuration.ORIENTATION_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
+                    else -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
+                }
     }
 
     override fun onMapLoaded() {
@@ -261,21 +261,21 @@ class DrawingBoundaryActivity : BaseMapboxActivity(), LocationListener, MapboxMa
     }
 
     private fun initUI() {
-        viewBinding.startTrackingButton.text =  Localization.get("drawing.boundary.map.start.tracking")
+        viewBinding.startTrackingButton.text = Localization.get("drawing.boundary.map.start.tracking")
         viewBinding.startTrackingButton.setOnClickListener {
             startTracking()
         }
 
-        viewBinding.stopTrackingButton.text =  Localization.get("drawing.boundary.map.stop.tracking")
+        viewBinding.stopTrackingButton.text = Localization.get("drawing.boundary.map.stop.tracking")
         viewBinding.stopTrackingButton.setOnClickListener {
             stoppedUIState()
             stopTracking()
         }
-        viewBinding.okTrackingButton.text =  Localization.get("drawing.boundary.map.ok.tracking")
+        viewBinding.okTrackingButton.text = Localization.get("drawing.boundary.map.ok.tracking")
         viewBinding.okTrackingButton.setOnClickListener {
             finishTracking()
         }
-        viewBinding.redoTrackingButton.text =  Localization.get("drawing.boundary.map.redo.tracking")
+        viewBinding.redoTrackingButton.text = Localization.get("drawing.boundary.map.redo.tracking")
         viewBinding.redoTrackingButton.setOnClickListener {
             trackingUIState()
             redoTracking()

--- a/app/src/org/commcare/logic/FormHierarchyBuilder.java
+++ b/app/src/org/commcare/logic/FormHierarchyBuilder.java
@@ -138,7 +138,7 @@ public class FormHierarchyBuilder {
             isError = true;
         }
         formList.add(new HierarchyElement(context, questionText, fp.getAnswerText(),
-                fepIcon == -1 ? null : context.getResources().getDrawable(fepIcon),
+                fepIcon == -1 ? null : context.getDrawable(fepIcon),
                 isError, HierarchyEntryType.question, fp.getIndex()));
     }
 
@@ -157,7 +157,7 @@ public class FormHierarchyBuilder {
             // Only add the heading if it is the repeat group entry, not an element in the group.
             HierarchyElement group =
                     new HierarchyElement(context, fc.getLongText(), null,
-                            context.getResources().getDrawable(R.drawable.expander_ic_minimized),
+                            context.getDrawable(R.drawable.expander_ic_minimized),
                             false,
                             HierarchyEntryType.collapsed, fc.getIndex());
             formList.add(group);

--- a/app/src/org/commcare/logic/FormHierarchyBuilder.java
+++ b/app/src/org/commcare/logic/FormHierarchyBuilder.java
@@ -147,7 +147,7 @@ public class FormHierarchyBuilder {
 
         int fepIcon = R.drawable.avatar_vellum_repeat_group;
         formList.add(new HierarchyElement(context, fc.getLongText(), null,
-                context.getResources().getDrawable(fepIcon),
+                context.getDrawable(fepIcon),
                 false, HierarchyEntryType.question, fc.getIndex()));
     }
 

--- a/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
+++ b/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
@@ -83,9 +83,8 @@ object MissingMediaDownloadHelper : TableStateListener {
 
             RequestStats.register(InstallRequestSource.BACKGROUND_LAZY_RESOURCE)
             global.setInstallCancellationChecker(cancellationChecker)
-            if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
-                startPinnedNotification()
-            }
+
+            startPinnedNotification()
 
             val lazyResourceIds = global.lazyResourceIds
 
@@ -276,8 +275,10 @@ object MissingMediaDownloadHelper : TableStateListener {
     }
 
     private fun startPinnedNotification() {
-        mPinnedNotificationProgress = PinnedNotificationWithProgress(CommCareApplication.instance(), "media.pinned.download",
-                "media.pinned.progress", R.drawable.update_download_icon)
+        if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
+            mPinnedNotificationProgress = PinnedNotificationWithProgress(CommCareApplication.instance(), "media.pinned.download",
+                    "media.pinned.progress", R.drawable.update_download_icon)
+        }
     }
 
     private fun updateNotification(complete: Int, total: Int) {

--- a/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
+++ b/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
@@ -83,7 +83,7 @@ object MissingMediaDownloadHelper : TableStateListener {
 
             RequestStats.register(InstallRequestSource.BACKGROUND_LAZY_RESOURCE)
             global.setInstallCancellationChecker(cancellationChecker)
-            if (CommCareApplication.notificationManager().areNotificationsEnabled()){
+            if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
                 startPinnedNotification()
             }
 
@@ -125,18 +125,22 @@ object MissingMediaDownloadHelper : TableStateListener {
                 appInstallStatus = AppInstallStatus.InvalidResource
                 NotificationMessageFactory.message(appInstallStatus, arrayOf(null, it.resourceName, it.message))
             }
+
             is LocalStorageUnavailableException -> {
                 appInstallStatus = AppInstallStatus.NoLocalStorage
                 NotificationMessageFactory.message(appInstallStatus, arrayOf(null, null, it.message))
             }
+
             is UnresolvedResourceException -> {
                 appInstallStatus = ResourceInstallUtils.processUnresolvedResource(it)
                 NotificationMessageFactory.message(appInstallStatus, arrayOf(null, it.resource.descriptor, it.message))
             }
+
             is InstallCancelledException -> {
                 appInstallStatus = AppInstallStatus.Cancelled
                 NotificationMessageFactory.message(appInstallStatus, arrayOf(null, null, it.message))
             }
+
             else -> {
                 appInstallStatus = AppInstallStatus.UnknownFailure
                 NotificationMessageFactory.message(appInstallStatus, arrayOf(null, null, it.message))
@@ -191,7 +195,7 @@ object MissingMediaDownloadHelper : TableStateListener {
                 .filter { it != null }
                 .filter { AndroidResourceUtils.matchFileUriToResource(it, uri) }
                 .take(1)
-                .map { runBlocking { downloadResource(it) }}
+                .map { runBlocking { downloadResource(it) } }
                 .firstOrNull()
 
         if (result == null) {

--- a/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
+++ b/app/src/org/commcare/mediadownload/MissingMediaDownloadHelper.kt
@@ -83,7 +83,9 @@ object MissingMediaDownloadHelper : TableStateListener {
 
             RequestStats.register(InstallRequestSource.BACKGROUND_LAZY_RESOURCE)
             global.setInstallCancellationChecker(cancellationChecker)
-            startPinnedNotification()
+            if (CommCareApplication.notificationManager().areNotificationsEnabled()){
+                startPinnedNotification()
+            }
 
             val lazyResourceIds = global.lazyResourceIds
 
@@ -275,10 +277,14 @@ object MissingMediaDownloadHelper : TableStateListener {
     }
 
     private fun updateNotification(complete: Int, total: Int) {
-        mPinnedNotificationProgress.handleTaskUpdate(complete, total)
+        if (this::mPinnedNotificationProgress.isInitialized) {
+            mPinnedNotificationProgress.handleTaskUpdate(complete, total)
+        }
     }
 
     private fun cancelNotification() {
-        mPinnedNotificationProgress.handleTaskCancellation()
+        if (this::mPinnedNotificationProgress.isInitialized) {
+            mPinnedNotificationProgress.handleTaskCancellation()
+        }
     }
 }

--- a/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
+++ b/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
@@ -1,9 +1,15 @@
 package org.commcare.preferences;
 
+import static org.commcare.preferences.AdvancedActionsPreferences.PermissionAction.NO_ACTION;
+import static org.commcare.preferences.AdvancedActionsPreferences.PermissionAction.REJECT_FEATURE;
+import static org.commcare.preferences.AdvancedActionsPreferences.PermissionAction.REQUEST_PERMISSION;
+
+import android.Manifest;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.os.Bundle;
 import android.widget.Toast;
 
 import org.commcare.AppUtils;
@@ -35,6 +41,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.lifecycle.MutableLiveData;
 import androidx.preference.Preference;
 
 /**
@@ -70,6 +78,19 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
     public final static String KEY_NUMBER_DUMPED = "num_dumped";
 
     private final static Map<String, String> keyToTitleMap = new HashMap<>();
+    private final int NEARBY_WIFI_PERM_REQUEST = 2;
+    private final String SHOW_PERMISSION_DIALOG = "show-permission-dialog";
+
+    /**
+     * Responsible for showing a dialog to the user related with permissions acquisition and its
+     * restoration in case of configuration changes, it can take:
+     *  NO_ACTION - No action
+     *  REJECT_FEATURE - Inform the user about feature unavailability when the permission was not
+     *                   granted
+     *  REQUEST_PERMISSION - Show the reason for requiring the permission
+     *
+     */
+    private MutableLiveData<PermissionAction> showingPermissionDialog = new MutableLiveData<>();
 
     static {
         keyToTitleMap.put(REPORT_PROBLEM, "problem.report.menuitem");
@@ -84,6 +105,26 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
         keyToTitleMap.put(DISABLE_PRE_UPDATE_SYNC, "menu.disable.pre.update.sync");
         keyToTitleMap.put(ENABLE_RATE_LIMIT_POPUP, "menu.enable.rate.limit.popup");
         keyToTitleMap.put(ENABLE_MANUAL_FORM_QUARANTINE, "menu.enable.manual.form.quarantine");
+    }
+
+    public enum PermissionAction{
+        NO_ACTION,
+        REJECT_FEATURE,
+        REQUEST_PERMISSION;
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        super.onCreatePreferences(savedInstanceState, rootKey);
+
+        showingPermissionDialog.observe(this, value -> {
+            if (value == REJECT_FEATURE){
+                informUserAboutFeatureUnavailability();
+            }
+            else if (value == REQUEST_PERMISSION){
+                showNearbyWiFiPermissionRationale();
+            }
+        });
     }
 
     @NonNull
@@ -144,8 +185,18 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
         Preference wifiDirectButton = findPreference(WIFI_DIRECT);
         if (hasP2p()) {
             wifiDirectButton.setOnPreferenceClickListener(preference -> {
-                FirebaseAnalyticsUtil.reportAdvancedActionSelected(
-                        AnalyticsParamValue.WIFI_DIRECT);
+                if (Build.VERSION.SDK_INT >=Build.VERSION_CODES.TIRAMISU){
+                    if (isMissingNearbyWifiPermission()){
+                        if (this.shouldShowRequestPermissionRationale(
+                                Manifest.permission.NEARBY_WIFI_DEVICES)) {
+                            showingPermissionDialog.setValue(REQUEST_PERMISSION);
+                        } else {
+                           requestNearbyWifiPermission();
+                        }
+                        return false;
+                    }
+                }
+
                 startWifiDirect();
                 return true;
             });
@@ -246,6 +297,9 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
     }
 
     private void startWifiDirect() {
+        FirebaseAnalyticsUtil.reportAdvancedActionSelected(
+                AnalyticsParamValue.WIFI_DIRECT);
+
         Intent i = new Intent(getActivity(), CommCareWiFiDirectActivity.class);
         startActivityForResult(i, WIFI_DIRECT_ACTIVITY);
     }
@@ -346,6 +400,57 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
                 .edit()
                 .putString(ENABLE_MANUAL_FORM_QUARANTINE, enabled ? PrefValues.YES : PrefValues.NO)
                 .apply();
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        switch (requestCode){
+            case NEARBY_WIFI_PERM_REQUEST:
+                for(int i = 0; i < permissions.length; i++){
+                    if (permissions[i].equals(Manifest.permission.NEARBY_WIFI_DEVICES) &&
+                            grantResults[i] == PackageManager.PERMISSION_GRANTED){
+                        startWifiDirect();
+                        return;
+                    }
+                }
+                showingPermissionDialog.setValue(REJECT_FEATURE);
+        }
+    }
+
+    private boolean isMissingNearbyWifiPermission() {
+        return ContextCompat.checkSelfPermission(getActivity(),
+                Manifest.permission.NEARBY_WIFI_DEVICES) == PackageManager.PERMISSION_DENIED;
+    }
+
+    private void showNearbyWiFiPermissionRationale() {
+        StandardAlertDialog d = new StandardAlertDialog(getActivity(),
+                Localization.get("wifi.direct.permission.nearby.wifi.title"),
+                Localization.get("wifi.direct.permission.nearby.wifi.message"));
+        DialogInterface.OnClickListener listener = (dialog, which) -> {
+            showingPermissionDialog.setValue(NO_ACTION);
+            requestNearbyWifiPermission();
+            dialog.dismiss();
+        };
+        d.setPositiveButton(Localization.get("dialog.ok"), listener);
+        d.showNonPersistentDialog();
+    }
+
+    private void requestNearbyWifiPermission() {
+        this.requestPermissions(new String[]{Manifest.permission.NEARBY_WIFI_DEVICES},
+                NEARBY_WIFI_PERM_REQUEST);
+    }
+
+    private void informUserAboutFeatureUnavailability() {
+        StandardAlertDialog d = StandardAlertDialog.getBasicAlertDialog(
+                requireActivity(),
+                Localization.get("wifi.direct.permission.nearby.wifi.title"),
+                Localization.get("wifi.direct.permission.nearby.wifi.denial"),
+                (dialog, which) -> {
+                    showingPermissionDialog.setValue(NO_ACTION);
+                    dialog.dismiss();
+                });
+        d.showNonPersistentDialog();
     }
 }
 

--- a/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
+++ b/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
@@ -127,6 +127,21 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
         });
     }
 
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt(SHOW_PERMISSION_DIALOG, showingPermissionDialog.getValue().ordinal());
+    }
+
+    @Override
+    public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+        if (savedInstanceState!=null){
+            showingPermissionDialog.setValue(
+                    PermissionAction.values()[savedInstanceState.getInt(SHOW_PERMISSION_DIALOG)]);
+        }
+    }
+
     @NonNull
     @Override
     protected String getTitle() {

--- a/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
+++ b/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
@@ -84,11 +84,10 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
     /**
      * Responsible for showing a dialog to the user related with permissions acquisition and its
      * restoration in case of configuration changes, it can take:
-     *  NO_ACTION - No action
-     *  REJECT_FEATURE - Inform the user about feature unavailability when the permission was not
-     *                   granted
-     *  REQUEST_PERMISSION - Show the reason for requiring the permission
-     *
+     * NO_ACTION - No action
+     * REJECT_FEATURE - Inform the user about feature unavailability when the permission was not
+     * granted
+     * REQUEST_PERMISSION - Show the reason for requiring the permission
      */
     private MutableLiveData<PermissionAction> showingPermissionDialog = new MutableLiveData<>(NO_ACTION);
 
@@ -107,7 +106,7 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
         keyToTitleMap.put(ENABLE_MANUAL_FORM_QUARANTINE, "menu.enable.manual.form.quarantine");
     }
 
-    public enum PermissionAction{
+    public enum PermissionAction {
         NO_ACTION,
         INFORM_FEATURE_DEGRADATION,
         REQUEST_PERMISSION;
@@ -118,10 +117,9 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
         super.onCreatePreferences(savedInstanceState, rootKey);
 
         showingPermissionDialog.observe(this, value -> {
-            if (value == INFORM_FEATURE_DEGRADATION){
+            if (value == INFORM_FEATURE_DEGRADATION) {
                 informUserAboutFeatureUnavailability();
-            }
-            else if (value == REQUEST_PERMISSION){
+            } else if (value == REQUEST_PERMISSION) {
                 showNearbyWiFiPermissionRationale();
             }
         });
@@ -136,7 +134,7 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
     @Override
     public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
-        if (savedInstanceState!=null){
+        if (savedInstanceState != null) {
             showingPermissionDialog.setValue(
                     PermissionAction.values()[savedInstanceState.getInt(SHOW_PERMISSION_DIALOG)]);
         }
@@ -200,13 +198,13 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
         Preference wifiDirectButton = findPreference(WIFI_DIRECT);
         if (hasP2p()) {
             wifiDirectButton.setOnPreferenceClickListener(preference -> {
-                if (Build.VERSION.SDK_INT >=Build.VERSION_CODES.TIRAMISU){
-                    if (isMissingNearbyWifiPermission()){
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    if (isMissingNearbyWifiPermission()) {
                         if (this.shouldShowRequestPermissionRationale(
                                 Manifest.permission.NEARBY_WIFI_DEVICES)) {
                             showingPermissionDialog.setValue(REQUEST_PERMISSION);
                         } else {
-                           requestNearbyWifiPermission();
+                            requestNearbyWifiPermission();
                         }
                         return false;
                     }
@@ -361,14 +359,14 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
         d.showNonPersistentDialog();
     }
 
-    private static String getClearUserDataMessage(int numUnsentAndIncompleteForms){
+    private static String getClearUserDataMessage(int numUnsentAndIncompleteForms) {
         if (numUnsentAndIncompleteForms > 0)
-            return Localization.get("clear.user.data.warning.message.delete.forms",String.valueOf(numUnsentAndIncompleteForms));
+            return Localization.get("clear.user.data.warning.message.delete.forms", String.valueOf(numUnsentAndIncompleteForms));
         else
             return Localization.get("clear.user.data.warning.message");
     }
 
-    private static int getClearUserDataPositiveOption(int numUnsentAndIncompleteForms){
+    private static int getClearUserDataPositiveOption(int numUnsentAndIncompleteForms) {
         if (numUnsentAndIncompleteForms > 0)
             return R.string.clear_user_data_delete_form;
         else
@@ -420,11 +418,11 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        switch (requestCode){
+        switch (requestCode) {
             case NEARBY_WIFI_PERM_REQUEST:
-                for(int i = 0; i < permissions.length; i++){
+                for (int i = 0; i < permissions.length; i++) {
                     if (permissions[i].equals(Manifest.permission.NEARBY_WIFI_DEVICES) &&
-                            grantResults[i] == PackageManager.PERMISSION_GRANTED){
+                            grantResults[i] == PackageManager.PERMISSION_GRANTED) {
                         startWifiDirect();
                         return;
                     }

--- a/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
+++ b/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
@@ -1,7 +1,7 @@
 package org.commcare.preferences;
 
+import static org.commcare.preferences.AdvancedActionsPreferences.PermissionAction.INFORM_FEATURE_DEGRADATION;
 import static org.commcare.preferences.AdvancedActionsPreferences.PermissionAction.NO_ACTION;
-import static org.commcare.preferences.AdvancedActionsPreferences.PermissionAction.REJECT_FEATURE;
 import static org.commcare.preferences.AdvancedActionsPreferences.PermissionAction.REQUEST_PERMISSION;
 
 import android.Manifest;
@@ -90,7 +90,7 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
      *  REQUEST_PERMISSION - Show the reason for requiring the permission
      *
      */
-    private MutableLiveData<PermissionAction> showingPermissionDialog = new MutableLiveData<>();
+    private MutableLiveData<PermissionAction> showingPermissionDialog = new MutableLiveData<>(NO_ACTION);
 
     static {
         keyToTitleMap.put(REPORT_PROBLEM, "problem.report.menuitem");
@@ -109,7 +109,7 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
 
     public enum PermissionAction{
         NO_ACTION,
-        REJECT_FEATURE,
+        INFORM_FEATURE_DEGRADATION,
         REQUEST_PERMISSION;
     }
 
@@ -118,7 +118,7 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
         super.onCreatePreferences(savedInstanceState, rootKey);
 
         showingPermissionDialog.observe(this, value -> {
-            if (value == REJECT_FEATURE){
+            if (value == INFORM_FEATURE_DEGRADATION){
                 informUserAboutFeatureUnavailability();
             }
             else if (value == REQUEST_PERMISSION){
@@ -429,7 +429,7 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
                         return;
                     }
                 }
-                showingPermissionDialog.setValue(REJECT_FEATURE);
+                showingPermissionDialog.setValue(INFORM_FEATURE_DEGRADATION);
         }
     }
 

--- a/app/src/org/commcare/provider/ExternalApiReceiver.java
+++ b/app/src/org/commcare/provider/ExternalApiReceiver.java
@@ -133,7 +133,10 @@ public class ExternalApiReceiver extends BroadcastReceiver {
             }
         };
 
-        mProcess.addSubmissionListener(CommCareApplication.instance().getSession().getListenerForSubmissionNotification());
+        if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
+            mProcess.addSubmissionListener(
+                    CommCareApplication.instance().getSession().getListenerForSubmissionNotification());
+        }
         mProcess.connect(dummyconnector);
         mProcess.execute();
     }

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -236,7 +236,8 @@ public class CommCareSessionService extends Service {
             notificationBuilder.setContentText(contentText);
         }
 
-        //Send the notification.
+        // Send the notification. This will cause error messages if CommCare doesn't have
+        // permission to post notifications
         this.startForeground(NOTIFICATION, notificationBuilder.build());
     }
 
@@ -247,24 +248,26 @@ public class CommCareSessionService extends Service {
     private void showLoggedOutNotification() {
         this.stopForeground(true);
 
-        Intent i = new Intent(this, DispatchActivity.class);
-        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
+            Intent i = new Intent(this, DispatchActivity.class);
+            i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
-        PendingIntent contentIntent = null;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
-        else
-            contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT);
+            PendingIntent contentIntent = null;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+            else
+                contentIntent = PendingIntent.getActivity(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        Notification notification = new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_USER_SESSION_ID)
-                .setContentTitle(this.getString(R.string.expirenotification))
-                .setContentText("Click here to log back into your session")
-                .setSmallIcon(org.commcare.dalvik.R.drawable.notification)
-                .setContentIntent(contentIntent)
-                .build();
+            Notification notification = new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_USER_SESSION_ID)
+                    .setContentTitle(this.getString(R.string.expirenotification))
+                    .setContentText("Click here to log back into your session")
+                    .setSmallIcon(org.commcare.dalvik.R.drawable.notification)
+                    .setContentIntent(contentIntent)
+                    .build();
 
-        // Send the notification.
-        mNM.notify(NOTIFICATION, notification);
+            // Send the notification.
+            mNM.notify(NOTIFICATION, notification);
+        }
     }
 
     //Start CommCare Specific Functionality

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -165,7 +165,8 @@ public class CommCareSessionService extends Service {
                         decrypter.init(Cipher.DECRYPT_MODE, spec);
 
                         return decrypter;
-                    } catch (NoSuchPaddingException | NoSuchAlgorithmException | InvalidKeyException e) {
+                    } catch (NoSuchPaddingException | NoSuchAlgorithmException |
+                             InvalidKeyException e) {
                         e.printStackTrace();
                     }
                 }
@@ -211,7 +212,7 @@ public class CommCareSessionService extends Service {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
             contentIntent = PendingIntent.getActivity(this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
         else
-            contentIntent = PendingIntent.getActivity(this, 0, callable,0);
+            contentIntent = PendingIntent.getActivity(this, 0, callable, 0);
 
         String notificationText;
         if (AppUtils.getInstalledAppRecords().size() > 1) {
@@ -550,13 +551,13 @@ public class CommCareSessionService extends Service {
                 callable.setAction("android.intent.action.MAIN");
                 callable.addCategory("android.intent.category.LAUNCHER");
 
-               // The PendingIntent to launch our activity if the user selects this notification
-               //TODO: Put something here that will, I dunno, cancel submission or something? Maybe show it live?
-               PendingIntent contentIntent;
+                // The PendingIntent to launch our activity if the user selects this notification
+                //TODO: Put something here that will, I dunno, cancel submission or something? Maybe show it live?
+                PendingIntent contentIntent;
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
                     contentIntent = PendingIntent.getActivity(CommCareSessionService.this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
                 else
-                    contentIntent = PendingIntent.getActivity(CommCareSessionService.this, 0, callable,0);
+                    contentIntent = PendingIntent.getActivity(CommCareSessionService.this, 0, callable, 0);
 
                 submissionNotification = new NotificationCompat.Builder(CommCareSessionService.this,
                         CommCareNoficationManager.NOTIFICATION_CHANNEL_SERVER_COMMUNICATIONS_ID)

--- a/app/src/org/commcare/sync/FormSubmissionWorker.kt
+++ b/app/src/org/commcare/sync/FormSubmissionWorker.kt
@@ -23,7 +23,7 @@ class FormSubmissionWorker(appContext: Context, workerParams: WorkerParameters)
         formSubmissionHelper = FormSubmissionHelper(applicationContext, this, this)
         if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
             formSubmissionListeners.add(
-                CommCareApplication.instance().getSession().getListenerForSubmissionNotification()
+                    CommCareApplication.instance().getSession().getListenerForSubmissionNotification()
             )
         }
         val result = formSubmissionHelper.uploadForms()

--- a/app/src/org/commcare/sync/FormSubmissionWorker.kt
+++ b/app/src/org/commcare/sync/FormSubmissionWorker.kt
@@ -21,8 +21,11 @@ class FormSubmissionWorker(appContext: Context, workerParams: WorkerParameters)
 
     override suspend fun doWork(): Result {
         formSubmissionHelper = FormSubmissionHelper(applicationContext, this, this)
-        formSubmissionListeners.add(CommCareApplication.instance().getSession().getListenerForSubmissionNotification())
-
+        if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
+            formSubmissionListeners.add(
+                CommCareApplication.instance().getSession().getListenerForSubmissionNotification()
+            )
+        }
         val result = formSubmissionHelper.uploadForms()
 
         return when (result) {

--- a/app/src/org/commcare/tasks/LogSubmissionTask.java
+++ b/app/src/org/commcare/tasks/LogSubmissionTask.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import javax.annotation.Nullable;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
@@ -90,6 +91,7 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
         }
     }
 
+    @Nullable
     private final DataSubmissionListener listener;
     private final String submissionUrl;
     private final boolean forceLogs;

--- a/app/src/org/commcare/tasks/LogSubmissionTask.java
+++ b/app/src/org/commcare/tasks/LogSubmissionTask.java
@@ -103,7 +103,7 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
     }
 
     public LogSubmissionTask(String submissionUrl, boolean forceLogs) {
-        this (null, submissionUrl, forceLogs);
+        this(null, submissionUrl, forceLogs);
     }
 
     public static String getSubmissionUrl(SharedPreferences appPreferences) {
@@ -182,7 +182,7 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
             DeviceReportWriter reporter;
             try {
                 //Create a report writer
-                    reporter = new DeviceReportWriter(record);
+                reporter = new DeviceReportWriter(record);
             } catch (IOException e) {
                 //TODO: Bad local file (almost certainly). Throw a better message!
                 e.printStackTrace();
@@ -263,7 +263,7 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
     }
 
     private static LogSubmitOutcomes submitDeviceReportRecord(DeviceReportRecord slr, String submissionUrl,
-                                                    DataSubmissionListener listener, int index, boolean forceLogs) {
+                                                              DataSubmissionListener listener, int index, boolean forceLogs) {
         //Get our file pointer
         File f = new File(slr.getFilePath());
 

--- a/app/src/org/commcare/update/UpdateHelper.java
+++ b/app/src/org/commcare/update/UpdateHelper.java
@@ -225,11 +225,12 @@ public class UpdateHelper implements TableStateListener {
      * @param ctx For launching notification and localizing text.
      */
     public void startPinnedNotification(Context ctx) {
-        mPinnedNotificationProgress =
-                new PinnedNotificationWithProgress(ctx, "updates.pinned.download",
-                        "updates.pinned.progress", R.drawable.update_download_icon);
+        if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
+            mPinnedNotificationProgress =
+                    new PinnedNotificationWithProgress(ctx, "updates.pinned.download",
+                            "updates.pinned.progress", R.drawable.update_download_icon);
+        }
     }
-
 
     public void updateNotification(Integer... values) {
         if (mPinnedNotificationProgress != null) {
@@ -238,7 +239,6 @@ public class UpdateHelper implements TableStateListener {
     }
 
     public void OnUpdateCancelled() {
-
         if (mPinnedNotificationProgress != null) {
             mPinnedNotificationProgress.handleTaskCancellation();
         }

--- a/app/src/org/commcare/update/UpdateWorker.kt
+++ b/app/src/org/commcare/update/UpdateWorker.kt
@@ -59,7 +59,9 @@ class UpdateWorker(appContext: Context, workerParams: WorkerParameters)
                 CommCareApplication.instance().currentApp != null &&
                 CommCareApplication.instance().session.isActive) {
 
-            updateHelper.startPinnedNotification(CommCareApplication.instance())
+            if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
+                updateHelper.startPinnedNotification(CommCareApplication.instance())
+            }
             updateResult = updateHelper.update(ResourceInstallUtils.getDefaultProfileRef(),
                     ResourceInstallContext(InstallRequestSource.BACKGROUND_UPDATE))
         } else {

--- a/app/src/org/commcare/update/UpdateWorker.kt
+++ b/app/src/org/commcare/update/UpdateWorker.kt
@@ -59,9 +59,7 @@ class UpdateWorker(appContext: Context, workerParams: WorkerParameters)
                 CommCareApplication.instance().currentApp != null &&
                 CommCareApplication.instance().session.isActive) {
 
-            if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
-                updateHelper.startPinnedNotification(CommCareApplication.instance())
-            }
+            updateHelper.startPinnedNotification(CommCareApplication.instance())
             updateResult = updateHelper.update(ResourceInstallUtils.getDefaultProfileRef(),
                     ResourceInstallContext(InstallRequestSource.BACKGROUND_UPDATE))
         } else {

--- a/app/src/org/commcare/utils/CommCareUtil.java
+++ b/app/src/org/commcare/utils/CommCareUtil.java
@@ -95,8 +95,8 @@ public class CommCareUtil {
         LogSubmissionTask reportSubmitter;
         if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
             reportSubmitter = new LogSubmissionTask(
-                    CommCareApplication.instance().getSession().getListenerForSubmissionNotification(R.string.submission_logs_title),
-                    url,
+                    CommCareApplication.instance().getSession()
+                            .getListenerForSubmissionNotification(R.string.submission_logs_title), url,
                     forceLogs);
         } else {
             reportSubmitter = new LogSubmissionTask(url, forceLogs);

--- a/app/src/org/commcare/utils/CommCareUtil.java
+++ b/app/src/org/commcare/utils/CommCareUtil.java
@@ -92,10 +92,16 @@ public class CommCareUtil {
     }
 
     public static void executeLogSubmission(String url, boolean forceLogs) {
-        LogSubmissionTask reportSubmitter =
-                new LogSubmissionTask(CommCareApplication.instance().getSession().getListenerForSubmissionNotification(R.string.submission_logs_title),
-                        url,
-                        forceLogs);
+        LogSubmissionTask reportSubmitter;
+        if (CommCareApplication.notificationManager().areNotificationsEnabled()) {
+            reportSubmitter = new LogSubmissionTask(
+                    CommCareApplication.instance().getSession().getListenerForSubmissionNotification(R.string.submission_logs_title),
+                    url,
+                    forceLogs);
+        }
+        else {
+            reportSubmitter = new LogSubmissionTask(url, forceLogs);
+        }
         // Execute on a true multithreaded chain, since this is an asynchronous process
         reportSubmitter.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }

--- a/app/src/org/commcare/utils/CommCareUtil.java
+++ b/app/src/org/commcare/utils/CommCareUtil.java
@@ -98,8 +98,7 @@ public class CommCareUtil {
                     CommCareApplication.instance().getSession().getListenerForSubmissionNotification(R.string.submission_logs_title),
                     url,
                     forceLogs);
-        }
-        else {
+        } else {
             reportSubmitter = new LogSubmissionTask(url, forceLogs);
         }
         // Execute on a true multithreaded chain, since this is an asynchronous process

--- a/app/src/org/commcare/utils/Permissions.java
+++ b/app/src/org/commcare/utils/Permissions.java
@@ -105,7 +105,8 @@ public class Permissions {
                     Manifest.permission.READ_MEDIA_IMAGES,
                     Manifest.permission.READ_MEDIA_AUDIO,
                     Manifest.permission.READ_MEDIA_VIDEO,
-                    Manifest.permission.NEARBY_WIFI_DEVICES}));
+                    Manifest.permission.NEARBY_WIFI_DEVICES,
+                    Manifest.permission.POST_NOTIFICATIONS}));
         }
         else{
             appPermissions.addAll(Arrays.asList(new String[]{
@@ -125,7 +126,8 @@ public class Permissions {
                     Manifest.permission.READ_MEDIA_AUDIO,
                     Manifest.permission.READ_MEDIA_VIDEO};
         }
-        return new String[]{Manifest.permission.READ_EXTERNAL_STORAGE,
+        return new String[]{
+                Manifest.permission.READ_EXTERNAL_STORAGE,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE};
     }
 }

--- a/app/src/org/commcare/utils/Permissions.java
+++ b/app/src/org/commcare/utils/Permissions.java
@@ -105,7 +105,6 @@ public class Permissions {
                     Manifest.permission.READ_MEDIA_IMAGES,
                     Manifest.permission.READ_MEDIA_AUDIO,
                     Manifest.permission.READ_MEDIA_VIDEO,
-                    Manifest.permission.NEARBY_WIFI_DEVICES,
                     Manifest.permission.POST_NOTIFICATIONS}));
         } else {
             appPermissions.addAll(Arrays.asList(new String[]{

--- a/app/src/org/commcare/utils/Permissions.java
+++ b/app/src/org/commcare/utils/Permissions.java
@@ -13,6 +13,10 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Acquire Android permissions needed by CommCare.
  *
@@ -89,20 +93,36 @@ public class Permissions {
      * @return Permissions needed for _normal_ CommCare functionality
      */
     public static String[] getAppPermissions() {
-        return new String[]{Manifest.permission.READ_PHONE_STATE,
+        List<String> appPermissions = new ArrayList<>(Arrays.asList(new String[]{
+                Manifest.permission.READ_PHONE_STATE,
                 Manifest.permission.CALL_PHONE,
                 Manifest.permission.ACCESS_FINE_LOCATION,
                 Manifest.permission.ACCESS_COARSE_LOCATION,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                Manifest.permission.READ_EXTERNAL_STORAGE,
-                Manifest.permission.RECORD_AUDIO
-        };
+                Manifest.permission.RECORD_AUDIO}));
+
+        if (Build.VERSION.SDK_INT >=Build.VERSION_CODES.TIRAMISU){
+            appPermissions.addAll(Arrays.asList(new String[]{
+                    Manifest.permission.READ_MEDIA_IMAGES,
+                    Manifest.permission.READ_MEDIA_AUDIO,
+                    Manifest.permission.READ_MEDIA_VIDEO}));
+        }
+        else{
+            appPermissions.addAll(Arrays.asList(new String[]{
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_EXTERNAL_STORAGE}));
+        }
+        return appPermissions.toArray(new String[]{});
     }
 
     /**
      * @return Minimal set of permissions needed for CommCare to function
      */
     public static String[] getRequiredPerms() {
+        if (Build.VERSION.SDK_INT >=Build.VERSION_CODES.TIRAMISU) {
+            return new String[]{Manifest.permission.READ_MEDIA_IMAGES,
+                    Manifest.permission.READ_MEDIA_AUDIO,
+                    Manifest.permission.READ_MEDIA_VIDEO};
+        }
         return new String[]{Manifest.permission.READ_EXTERNAL_STORAGE,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE};
     }

--- a/app/src/org/commcare/utils/Permissions.java
+++ b/app/src/org/commcare/utils/Permissions.java
@@ -100,15 +100,14 @@ public class Permissions {
                 Manifest.permission.ACCESS_COARSE_LOCATION,
                 Manifest.permission.RECORD_AUDIO}));
 
-        if (Build.VERSION.SDK_INT >=Build.VERSION_CODES.TIRAMISU){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             appPermissions.addAll(Arrays.asList(new String[]{
                     Manifest.permission.READ_MEDIA_IMAGES,
                     Manifest.permission.READ_MEDIA_AUDIO,
                     Manifest.permission.READ_MEDIA_VIDEO,
                     Manifest.permission.NEARBY_WIFI_DEVICES,
                     Manifest.permission.POST_NOTIFICATIONS}));
-        }
-        else{
+        } else {
             appPermissions.addAll(Arrays.asList(new String[]{
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
                     Manifest.permission.READ_EXTERNAL_STORAGE}));
@@ -120,7 +119,7 @@ public class Permissions {
      * @return Minimal set of permissions needed for CommCare to function
      */
     public static String[] getRequiredPerms() {
-        if (Build.VERSION.SDK_INT >=Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             return new String[]{
                     Manifest.permission.READ_MEDIA_IMAGES,
                     Manifest.permission.READ_MEDIA_AUDIO,

--- a/app/src/org/commcare/utils/Permissions.java
+++ b/app/src/org/commcare/utils/Permissions.java
@@ -104,7 +104,8 @@ public class Permissions {
             appPermissions.addAll(Arrays.asList(new String[]{
                     Manifest.permission.READ_MEDIA_IMAGES,
                     Manifest.permission.READ_MEDIA_AUDIO,
-                    Manifest.permission.READ_MEDIA_VIDEO}));
+                    Manifest.permission.READ_MEDIA_VIDEO,
+                    Manifest.permission.NEARBY_WIFI_DEVICES}));
         }
         else{
             appPermissions.addAll(Arrays.asList(new String[]{
@@ -119,7 +120,8 @@ public class Permissions {
      */
     public static String[] getRequiredPerms() {
         if (Build.VERSION.SDK_INT >=Build.VERSION_CODES.TIRAMISU) {
-            return new String[]{Manifest.permission.READ_MEDIA_IMAGES,
+            return new String[]{
+                    Manifest.permission.READ_MEDIA_IMAGES,
                     Manifest.permission.READ_MEDIA_AUDIO,
                     Manifest.permission.READ_MEDIA_VIDEO};
         }

--- a/commcare-support-library/build.gradle
+++ b/commcare-support-library/build.gradle
@@ -43,7 +43,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -55,9 +55,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
 }

--- a/commcare-support-library/build.gradle
+++ b/commcare-support-library/build.gradle
@@ -39,10 +39,10 @@ afterEvaluate {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdk 33
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/commcare-support-library/src/main/res/layout/activity_main.xml
+++ b/commcare-support-library/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -16,4 +16,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.ConstraintLayout>


### PR DESCRIPTION
## Summary
This PR implements the changes required to support Android 13. The most relevant are:
- Nearby Wi-Fi devices permission - from Android 13, access to devices via Wi-Fi are no longer through the `ACCESS_FINE_LOCATION` permission. Apps that call any of [these Wi-Fi APIs](https://developer.android.com/guide/topics/connectivity/wifi-permissions#check-for-apis-that-require-permission) need to request the `NEARBY_WIFI_PERMISSION`;
- `POST_NOTIFICATION` permission - Google is invested in making sure users' wishes around notifications are respected, this means that users can now very easily revoke permissions around notifications. This motivated changes in places where notifications are triggered to skip them when the permission is not granted; 
- Stop Foreground services - this feature causes the system to remove the app from memory, which makes the app to stop, not just the Foreground service. CommCare seems to handle this elegantly, so no changes were done. The video below shows the behavior:
<table>
<tr>
<td>
<video  style="width:10%" controls src="https://github.com/dimagi/commcare-android/assets/19228119/5826f5ed-d5b1-4525-9719-ba39ebf5e774" />
</td>
</tr>
</table>

## Safety Assurance
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
I had the opportunity to run some smoke tests around the affected parts of the code and it ran well, however, some Instrumentation tests became flakier than usual, I think it's something to look into. 
A few questions for reviewers:
- Are there any concerns with the user stopping the Foreground Service, and subsequently CommCare, that we should account for?
- Regarding the approach when the `POST_NOTIFICATION` permission is revoked, it seems to me that the approach should be around preventing notifications from being triggered but I wonder if there are other options we should explore. 
- Android 13 introduces [Predictive back gesture](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture) and recommends its adoption as soon as possible, it seems fine to me to migrate later but happy to be persuaded otherwise. Any comments?

cross-request: https://github.com/dimagi/commcare-core/pull/1329

QA Note: Testing for Android 13