### PR TITLE
Set audio recorder sample rate

### DIFF
--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -52,6 +52,9 @@ public class RecordingFragment extends DialogFragment {
 
     private static final String MIMETYPE_AUDIO_AAC = "audio/mp4a-latm";
 
+    private static final int HEAAC_SAMPLE_RATE = 44100;
+    private static final int AMRNB_SAMPLE_RATE = 8000;
+
     private String fileName;
     private static final String FILE_EXT = ".mp3";
 
@@ -192,10 +195,13 @@ public class RecordingFragment extends DialogFragment {
             recorder = new MediaRecorder();
         }
 
+        boolean isHeAacSupported = isHeAacEncoderSupported();
+
         recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
+        recorder.setAudioSamplingRate(isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE);
         recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
         recorder.setOutputFile(fileName);
-        if (isHeAacEncoderSupported()) {
+        if (isHeAacSupported) {
             recorder.setAudioEncoder(MediaRecorder.AudioEncoder.HE_AAC);
         } else {
             recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);


### PR DESCRIPTION
## Summary
Some users have reported having trouble recording audio, CommCare simple crashes with the following exception being thrown:
```
Fatal Exception: java.lang.IllegalStateException:
       at android.media.MediaRecorder.start(MediaRecorder.java)
       at org.commcare.views.widgets.RecordingFragment.startRecording(RecordingFragment.java:168)
       at org.commcare.views.widgets.RecordingFragment.lambda$prepareButtons$3(RecordingFragment.java:135)
       at org.commcare.views.widgets.RecordingFragment.$r8$lambda$_f4gpgcFmBpYAjMTw-zPR52rFnE(RecordingFragment.java)
       at org.commcare.views.widgets.RecordingFragment$$InternalSyntheticLambda$0$cc1961f5746e23f7491a3d6e1f5a06d308627bd6d301c3274e25a58d59953a04$1.onClick(RecordingFragment.java:2)
       at android.view.View.performClick(View.java:7522)
       at android.view.View.performClickInternal(View.java:7499)
       at android.view.View.access$3700(View.java:835)
       at android.view.View$PerformClick.run(View.java:29039)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:7952)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1022)
```
Initial findings led us to consider that maybe the devices stopped supporting the HE-AAC codec, but after some more investigation it was possible to identify another cause for `IllegalStateException` exceptions as not setting the Audio Sample Rate for the recorder. This PR changes that.
 

## Safety Assurance
- [X] I have confidence that this PR will not introduce a regression for the reasons below

cross-request: https://github.com/dimagi/commcare-core/pull/1154