### PR TITLE
Java 8+ API desugaring support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,6 +133,7 @@ dependencies {
 
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'com.google.guava:guava:31.1-jre'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 }
 
 ext {
@@ -308,6 +309,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }


### PR DESCRIPTION
## Summary

Enable desugaring to support Java 8 APIs like stream() for older devices (Android API 21 - 23) 

Reference: https://developer.android.com/studio/write/java8-support#library-desugaring

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story

Build level change to add support for Java 8+ APIs
