### PR TITLE
Safe starts session with error handling while handling activity result

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -548,7 +548,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     @Override
     public void onActivityResultSessionSafe(int requestCode, int resultCode, Intent intent) {
         if (resultCode == RESULT_RESTART) {
-            sessionNavigator.startNextSessionStep();
+            startNextSessionStepSafe();
         } else {
             // if handling new return code (want to return to home screen) but a return at the
             // end of your statement


### PR DESCRIPTION
## Summary

[Jira](https://dimagi-dev.atlassian.net/browse/QA-5457)

When a fixture instance used in case search prompts is not present, mobile crashes with no error handling. 

## Feature Flag

CASE_SEARCH

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

NA

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
Only error handling
