### PR TITLE
Trims location attributes before formatting as a string

### DIFF
--- a/app/src/org/commcare/utils/GeoUtils.java
+++ b/app/src/org/commcare/utils/GeoUtils.java
@@ -47,7 +47,11 @@ public class GeoUtils {
      * @return String in format "<latitude> <longitude> <altitude> <accuracy>"
      */
     public static String locationToString(Location location) {
-        return String.format("%s %s %s %s", location.getLatitude(), location.getLongitude(), location.getAltitude(), location.getAccuracy());
+        String latitude = String.valueOf(location.getLatitude()).trim();
+        String longitude = String.valueOf(location.getLongitude()).trim();
+        String altitude = String.valueOf(location.getAltitude()).trim();
+        String accuracy = String.valueOf(location.getAccuracy()).trim();
+        return String.format("%s %s %s %s", latitude, longitude, altitude, accuracy);
     }
 
     /**


### PR DESCRIPTION
## Summary

[JIRA](https://dimagi-dev.atlassian.net/browse/SAAS-14313)
[Related HQ PR](https://github.com/dimagi/commcare-hq/pull/33338)

@mjriley  noticed that some of the location strings has leading spaces into the location string like - ` lat    lng alt acc`. This PR trims the location attributes to make sure we keep the formatting consistent on mobile side. 

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

None, but covered in manual QA tests


### Safety story

Very minor change, will go through mobile release QA