### PR TITLE
Test fix and API changes 

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -76,6 +76,7 @@ import org.commcare.models.database.global.DatabaseGlobalOpenHelper;
 import org.commcare.models.database.user.models.EntityStorageCache;
 import org.commcare.models.legacy.LegacyInstallUtils;
 import org.commcare.modern.database.Table;
+import org.commcare.modern.session.SessionWrapper;
 import org.commcare.modern.util.PerformanceTuningUtil;
 import org.commcare.network.DataPullRequester;
 import org.commcare.network.DataPullResponseFactory;
@@ -86,7 +87,6 @@ import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.preferences.LocalePreferences;
 import org.commcare.services.CommCareSessionService;
-import org.commcare.session.CommCareSession;
 import org.commcare.sync.FormSubmissionHelper;
 import org.commcare.sync.FormSubmissionWorker;
 import org.commcare.tasks.AsyncRestoreHelper;
@@ -435,7 +435,7 @@ public class CommCareApplication extends MultiDexApplication {
     /**
      * Get the current CommCare session that's being executed
      */
-    public CommCareSession getCurrentSession() {
+    public SessionWrapper getCurrentSession() {
         return getCurrentSessionWrapper().getSession();
     }
 

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -1,13 +1,9 @@
 package org.commcare.activities;
 
-import androidx.annotation.StringDef;
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.database.DataSetObserver;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -23,6 +19,9 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
+
 import com.jakewharton.rxbinding2.widget.AdapterViewItemClickEvent;
 import com.jakewharton.rxbinding2.widget.RxAdapterView;
 
@@ -36,15 +35,15 @@ import org.commcare.cases.entity.Entity;
 import org.commcare.cases.entity.NodeEntityFactory;
 import org.commcare.dalvik.R;
 import org.commcare.fragments.ContainerFragment;
-import org.commcare.gis.EntityMapboxActivity;
 import org.commcare.gis.EntityMapActivity;
+import org.commcare.gis.EntityMapboxActivity;
 import org.commcare.google.services.ads.AdLocation;
 import org.commcare.google.services.ads.AdMobManager;
 import org.commcare.models.AndroidSessionWrapper;
+import org.commcare.modern.session.SessionWrapper;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.provider.IdentityCalloutHandler;
 import org.commcare.provider.SimprintsCalloutProcessing;
-import org.commcare.session.CommCareSession;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.Action;
 import org.commcare.suite.model.Callout;
@@ -79,7 +78,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import androidx.fragment.app.FragmentManager;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.functions.Consumer;
 
@@ -88,7 +86,7 @@ import io.reactivex.functions.Consumer;
  */
 public class EntitySelectActivity extends SaveSessionCommCareActivity
         implements EntityLoaderListener, HereFunctionHandlerListener {
-    private CommCareSession session;
+    private SessionWrapper session;
     private AndroidSessionWrapper asw;
 
     private static final String ICDS_DOMAIN_NAME = "icds-cas.commcarehq.org";

--- a/app/src/org/commcare/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/models/AndroidSessionWrapper.java
@@ -242,11 +242,9 @@ public class AndroidSessionWrapper implements SessionWrapperInterface {
     }
 
     @Override
-    public void prepareExternalSources(RemoteInstanceFetcher fetcher)
-            throws RemoteInstanceFetcher.RemoteInstanceException {
-        for(StackFrameStep step : session.getFrame().getSteps()) {
-            step.initDataInstanceSources(fetcher);
-        }
+    public void prepareExternalSources() {
+        throw new RuntimeException(
+                "This method is not yet implemented and only here to maintain parity with core interface");
     }
 
     /**

--- a/app/src/org/commcare/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/models/AndroidSessionWrapper.java
@@ -6,7 +6,9 @@ import org.commcare.CommCareApplication;
 import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.android.database.user.models.SessionStateDescriptor;
 import org.commcare.core.interfaces.RemoteInstanceFetcher;
+import org.commcare.models.database.AndroidSandbox;
 import org.commcare.models.database.SqlStorage;
+import org.commcare.modern.session.SessionWrapper;
 import org.commcare.modern.session.SessionWrapperInterface;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.session.CommCareSession;
@@ -47,15 +49,15 @@ import javax.crypto.SecretKey;
 public class AndroidSessionWrapper implements SessionWrapperInterface {
     private static final String TAG = AndroidSessionWrapper.class.getSimpleName();
     //The state descriptor will need these 
-    private final CommCareSession session;
+    private final SessionWrapper session;
     private int formRecordId = -1;
     private int sessionStateRecordId = -1;
 
     public AndroidSessionWrapper(CommCarePlatform platform) {
-        session = new CommCareSession(platform);
+        session = new SessionWrapper(new CommCareSession(platform), platform, new AndroidSandbox(CommCareApplication.instance()));
     }
 
-    public AndroidSessionWrapper(CommCareSession session) {
+    public AndroidSessionWrapper(SessionWrapper session) {
         this.session = session;
     }
 
@@ -87,7 +89,7 @@ public class AndroidSessionWrapper implements SessionWrapperInterface {
         initializer = null;
     }
 
-    public CommCareSession getSession() {
+    public SessionWrapper getSession() {
         return session;
     }
 

--- a/app/src/org/commcare/preferences/DevSessionRestorer.java
+++ b/app/src/org/commcare/preferences/DevSessionRestorer.java
@@ -1,15 +1,18 @@
 package org.commcare.preferences;
 
 import android.content.SharedPreferences;
-import androidx.core.util.Pair;
 import android.util.Base64;
 import android.util.Log;
+
+import androidx.core.util.Pair;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.activities.FormEntryActivity;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.models.AndroidSessionWrapper;
+import org.commcare.models.database.AndroidSandbox;
+import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.CommCareSession;
 import org.commcare.util.CommCarePlatform;
 import org.commcare.utils.SessionStateUninitException;
@@ -113,7 +116,8 @@ public class DevSessionRestorer {
                         CommCareSession.restoreSessionFromStream(platform, stream);
 
                 Log.i(TAG, "Restoring session from storage");
-                return new AndroidSessionWrapper(restoredSession);
+                return new AndroidSessionWrapper(new SessionWrapper(restoredSession, platform,
+                        new AndroidSandbox(CommCareApplication.instance())));
             } catch (Exception e) {
                 clearSession(prefs);
                 Log.w(TAG, "Restoring session from serialized file failed");

--- a/app/src/org/commcare/utils/AndroidInstanceInitializer.java
+++ b/app/src/org/commcare/utils/AndroidInstanceInitializer.java
@@ -15,7 +15,6 @@ import org.commcare.models.database.AndroidSandbox;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.user.models.AndroidCaseIndexTable;
 import org.commcare.modern.session.SessionWrapper;
-import org.commcare.session.CommCareSession;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.ConcreteInstanceRoot;
@@ -35,12 +34,12 @@ public class AndroidInstanceInitializer extends CommCareInstanceInitializer {
         this(null, null, null);
     }
 
-    public AndroidInstanceInitializer(CommCareSession session) {
+    public AndroidInstanceInitializer(SessionWrapper session) {
         this(session, new AndroidSandbox(CommCareApplication.instance()), CommCareApplication.instance().getCommCarePlatform());
     }
 
-    public AndroidInstanceInitializer(CommCareSession session, UserSandbox sandbox, CommCarePlatform platform) {
-        super(new SessionWrapper(session, platform, sandbox), sandbox, platform);
+    public AndroidInstanceInitializer(SessionWrapper session, UserSandbox sandbox, CommCarePlatform platform) {
+        super(session, sandbox, platform);
     }
 
     @Override

--- a/app/src/org/commcare/utils/AndroidInstanceInitializer.java
+++ b/app/src/org/commcare/utils/AndroidInstanceInitializer.java
@@ -14,6 +14,7 @@ import org.commcare.engine.cases.AndroidLedgerInstanceTreeElement;
 import org.commcare.models.database.AndroidSandbox;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.user.models.AndroidCaseIndexTable;
+import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.CommCareSession;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.model.instance.AbstractTreeElement;
@@ -39,7 +40,7 @@ public class AndroidInstanceInitializer extends CommCareInstanceInitializer {
     }
 
     public AndroidInstanceInitializer(CommCareSession session, UserSandbox sandbox, CommCarePlatform platform) {
-        super(session, sandbox, platform);
+        super(new SessionWrapper(session, platform, sandbox), sandbox, platform);
     }
 
     @Override

--- a/app/unit-tests/src/org/commcare/android/database/user/models/SessionStateDescriptorTests.java
+++ b/app/unit-tests/src/org/commcare/android/database/user/models/SessionStateDescriptorTests.java
@@ -45,7 +45,7 @@ public class SessionStateDescriptorTests {
         serializeSessionOutToDescriptor(session);
     }
 
-    private static void serializeSessionOutToDescriptor(CommCareSession session) {
+    private static void serializeSessionOutToDescriptor(SessionWrapper session) {
         AndroidSessionWrapper originalSessionWrapper = new AndroidSessionWrapper(session);
         SessionStateDescriptor oldDescriptor = SessionStateDescriptor.buildFromSessionWrapper(originalSessionWrapper);
 

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -351,6 +351,7 @@ public class FormStorageTest {
             , "org.javarosa.core.util.externalizable.ExtWrapMultiMap"
             , "org.javarosa.core.model.instance.ExternalDataInstanceSource"
             , "org.commcare.suite.model.DetailGroup"
+            , "org.commcare.suite.model.EndpointArgument"
     );
 
 


### PR DESCRIPTION
## Summary
Changes for https://github.com/dimagi/commcare-core/pull/1322 

Changes `CommCareSession` to `SessionWrapper` in a few places to align with the [core commit](https://github.com/dimagi/commcare-core/pull/1322/commits/4880a84783e7b1222e02c76b91263e373d70731a)


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

No functional change

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
Ensuring through existing tests. 

cross-request: https://github.com/dimagi/commcare-core/pull/1322
