### PR TITLE
Changed compile SDK version to 33.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -226,7 +226,7 @@ static def getDate() {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     lintOptions {
         abortOnError false
@@ -249,7 +249,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         multiDexEnabled true
         applicationId "org.commcare.dalvik"
         testNamespace "org.commcare.dalvik.test"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -249,7 +249,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 31
         multiDexEnabled true
         applicationId "org.commcare.dalvik"
         testNamespace "org.commcare.dalvik.test"

--- a/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
+++ b/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
@@ -196,11 +196,12 @@ class DrawingBoundaryActivity : BaseMapboxActivity(), LocationListener, MapboxMa
     }
 
     override fun onLocationChanged(location: Location) {
+        val prevLocation = previousLocation;
         if (location != null && location.accuracy <= locationMinAccuracy) {
-            val addLocation = previousLocation == null ||
-                    (location.distanceTo(previousLocation) >= location.accuracy + previousLocation!!.accuracy &&
-                            location.time - previousLocation!!.time >= recordingIntervalMillis &&
-                            location.distanceTo(previousLocation) >= recordingIntervalMeters)
+            val addLocation = prevLocation == null ||
+                    (location.distanceTo(prevLocation) >= location.accuracy + prevLocation.accuracy &&
+                            location.time - prevLocation.time >= recordingIntervalMillis &&
+                            location.distanceTo(prevLocation) >= recordingIntervalMeters)
             if (addLocation && isRecording) {
                 previousLocation = location
                 val latLng = LatLng(location.latitude, location.longitude)

--- a/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
+++ b/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
@@ -1,22 +1,27 @@
 package org.commcare.gis
 
-import androidx.appcompat.app.AppCompatActivity
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.location.Location
 import android.location.LocationListener
-import android.os.Build
 import android.os.Bundle
 import android.view.View
+
+import androidx.appcompat.app.AppCompatActivity
 import androidx.viewbinding.ViewBinding
+
 import com.mapbox.geojson.Polygon
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
+
 import io.ona.kujaku.manager.DrawingManager
 import io.ona.kujaku.views.KujakuMapView
+
+import java.io.File
+
 import org.commcare.activities.components.FormEntryInstanceState
 import org.commcare.android.javarosa.IntentCallout
 import org.commcare.dalvik.R
@@ -25,9 +30,9 @@ import org.commcare.gis.EntityMapUtils.parseBoundaryCoords
 import org.commcare.utils.FileUtil
 import org.commcare.utils.ImageType
 import org.commcare.utils.StringUtils
+
 import org.javarosa.core.services.Logger
 import org.javarosa.core.services.locale.Localization
-import java.io.File
 
 /**
  * Used to draw or walk a boundary on mapbox based map
@@ -110,10 +115,10 @@ class DrawingBoundaryActivity : BaseMapboxActivity(), LocationListener, MapboxMa
     private fun freezeOrientation() {
         val orientation = resources.configuration.orientation
         requestedOrientation =
-            when (orientation) {
-                Configuration.ORIENTATION_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
-                else -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
-            }
+                when (orientation) {
+                    Configuration.ORIENTATION_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
+                    else -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
+                }
     }
 
     override fun onMapLoaded() {
@@ -262,21 +267,21 @@ class DrawingBoundaryActivity : BaseMapboxActivity(), LocationListener, MapboxMa
     }
 
     private fun initUI() {
-        viewBinding.startTrackingButton.text =  Localization.get("drawing.boundary.map.start.tracking")
+        viewBinding.startTrackingButton.text = Localization.get("drawing.boundary.map.start.tracking")
         viewBinding.startTrackingButton.setOnClickListener {
             startTracking()
         }
 
-        viewBinding.stopTrackingButton.text =  Localization.get("drawing.boundary.map.stop.tracking")
+        viewBinding.stopTrackingButton.text = Localization.get("drawing.boundary.map.stop.tracking")
         viewBinding.stopTrackingButton.setOnClickListener {
             stoppedUIState()
             stopTracking()
         }
-        viewBinding.okTrackingButton.text =  Localization.get("drawing.boundary.map.ok.tracking")
+        viewBinding.okTrackingButton.text = Localization.get("drawing.boundary.map.ok.tracking")
         viewBinding.okTrackingButton.setOnClickListener {
             finishTracking()
         }
-        viewBinding.redoTrackingButton.text =  Localization.get("drawing.boundary.map.redo.tracking")
+        viewBinding.redoTrackingButton.text = Localization.get("drawing.boundary.map.redo.tracking")
         viewBinding.redoTrackingButton.setOnClickListener {
             trackingUIState()
             redoTracking()

--- a/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
+++ b/app/src/org/commcare/gis/DrawingBoundaryActivity.kt
@@ -8,20 +8,15 @@ import android.location.Location
 import android.location.LocationListener
 import android.os.Bundle
 import android.view.View
-
 import androidx.appcompat.app.AppCompatActivity
 import androidx.viewbinding.ViewBinding
-
 import com.mapbox.geojson.Polygon
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Style
-
 import io.ona.kujaku.manager.DrawingManager
 import io.ona.kujaku.views.KujakuMapView
-
 import java.io.File
-
 import org.commcare.activities.components.FormEntryInstanceState
 import org.commcare.android.javarosa.IntentCallout
 import org.commcare.dalvik.R
@@ -30,7 +25,6 @@ import org.commcare.gis.EntityMapUtils.parseBoundaryCoords
 import org.commcare.utils.FileUtil
 import org.commcare.utils.ImageType
 import org.commcare.utils.StringUtils
-
 import org.javarosa.core.services.Logger
 import org.javarosa.core.services.locale.Localization
 
@@ -55,7 +49,6 @@ class DrawingBoundaryActivity : BaseMapboxActivity(), LocationListener, MapboxMa
 
         private const val LOCATION_MIN_MAX_ACCURACY = 50
         private const val LOCATION_MIN_MIN_ACCURACY = 10
-
     }
 
     private var mapSnapshotPath: String? = null
@@ -96,11 +89,13 @@ class DrawingBoundaryActivity : BaseMapboxActivity(), LocationListener, MapboxMa
     private fun initExtras() {
         val params = intent.extras
         if (params != null) {
-
             locationMinAccuracy = LOCATION_MIN_MIN_ACCURACY.coerceAtLeast(
-                    LOCATION_MIN_MAX_ACCURACY.coerceAtMost(
-                            Integer.valueOf(params.getString(EXTRA_KEY_ACCURACY, LOCATION_MIN_MIN_ACCURACY.toString()))))
-
+                LOCATION_MIN_MAX_ACCURACY.coerceAtMost(
+                        Integer.valueOf(params.getString(EXTRA_KEY_ACCURACY, LOCATION_MIN_MIN_ACCURACY.toString()
+                        )
+                        )
+                )
+            )
 
             recordingIntervalMeters = Integer.valueOf(params.getString(EXTRA_KEY_INTERVAL_METERS, "0"))
             recordingIntervalMillis = Integer.valueOf(params.getString(EXTRA_KEY_INTERVAL_MILLIS, "0"))
@@ -115,10 +110,10 @@ class DrawingBoundaryActivity : BaseMapboxActivity(), LocationListener, MapboxMa
     private fun freezeOrientation() {
         val orientation = resources.configuration.orientation
         requestedOrientation =
-                when (orientation) {
-                    Configuration.ORIENTATION_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
-                    else -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
-                }
+            when (orientation) {
+                Configuration.ORIENTATION_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
+                else -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
+            }
     }
 
     override fun onMapLoaded() {
@@ -201,12 +196,14 @@ class DrawingBoundaryActivity : BaseMapboxActivity(), LocationListener, MapboxMa
     }
 
     override fun onLocationChanged(location: Location) {
-        val prevLocation = previousLocation;
+        val prevLocation = previousLocation
         if (location != null && location.accuracy <= locationMinAccuracy) {
             val addLocation = prevLocation == null ||
-                    (location.distanceTo(prevLocation) >= location.accuracy + prevLocation.accuracy &&
-                            location.time - prevLocation.time >= recordingIntervalMillis &&
-                            location.distanceTo(prevLocation) >= recordingIntervalMeters)
+                (
+                location.distanceTo(prevLocation) >= location.accuracy + prevLocation.accuracy &&
+                location.time - prevLocation.time >= recordingIntervalMillis &&
+                location.distanceTo(prevLocation) >= recordingIntervalMeters
+                )
             if (addLocation && isRecording) {
                 previousLocation = location
                 val latLng = LatLng(location.latitude, location.longitude)


### PR DESCRIPTION
Fixed a new error in DrawingBoundaryActivity.kt handling a nullable Location.

## Summary
Changed from API 31 to 33 to support future work.

## Safety Assurance

- [ ] If the PR is high risk, "High Risk" label is set
- [x ] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
A new compile error appeared in DrawingBoundaryActivity.kt involving safe usage of a nullable Location, so the code was changed slightly to handle the error.