### PR TITLE
Remove conscrypt-android

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,8 +125,6 @@ dependencies {
     implementation 'com.google.android.play:core:1.10.3'
     implementation 'android.arch.lifecycle:common-java8:1.1.1'
 
-    //Robust TLS 1.2 ciphers on Android 9-19
-    implementation "org.conscrypt:conscrypt-android:2.4.0"
     implementation('com.squareup.okhttp3:okhttp-tls:3.12.12') {
         exclude(group: 'org.bouncycastle', module: 'bcprov-jdk15on')
     }


### PR DESCRIPTION
## Summary

Remove dependency on conscrypt-android as it's no longer used with us having dropped support for Android 4 devices


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly


### Safety story
No Op
