### PR TITLE
Remove dispatched Session Endpoint request

### DIFF
--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -350,6 +350,10 @@ public class DispatchActivity extends AppCompatActivity {
                         i.putExtra(SESSION_ENDPOINT_ID, sessionEndpointId);
                         i.putExtra(SESSION_ENDPOINT_ARGUMENTS_BUNDLE, args);
                         i.putStringArrayListExtra(SESSION_ENDPOINT_ARGUMENTS_LIST, argsList);
+
+                        // Session Endpoint extra is no longer needed. If not removed, it triggers
+                        // the external launch logic in subsequent logins
+                        getIntent().removeExtra(SESSION_ENDPOINT_ID);
                     }
                     if (i != null) {
                         i.putExtra(WAS_EXTERNAL, true);


### PR DESCRIPTION
## Summary
This PR fixes an issue affecting the Reminders app where an already dispatched Session Endpoint request would be resubmitted in subsequent logins. 

## Safety Assurance
- [X] I have confidence that this PR will not introduce a regression for the reasons below
