### PR TITLE
Fix barcode screen glitch

### DIFF
--- a/app/res/layout/entity_select_layout.xml
+++ b/app/res/layout/entity_select_layout.xml
@@ -111,7 +111,8 @@
         android:id="@+id/searchfooter"
         android:orientation="horizontal"
         android:background="@drawable/border_top_black"
-        android:paddingTop="1dp">
+        android:paddingTop="1dp"
+        android:visibility="gone">
 
         <TextView
             android:id="@+id/screen_entity_select_search_label"


### PR DESCRIPTION
## Summary
This PR fixes an issue with the Case List screen in which a barcode search view is shown momentarily when the case list is being rendered (see image below).
![image](https://github.com/dimagi/commcare-android/assets/19228119/f1a686b9-afd7-42d7-80f8-71811865efd9)


## Safety Assurance
- [ X ] I have confidence that this PR will not introduce a regression for the reasons below
