### PR TITLE
remove timezone offsetting from date range methods

### DIFF
--- a/app/src/org/commcare/utils/DateRangeUtils.java
+++ b/app/src/org/commcare/utils/DateRangeUtils.java
@@ -33,14 +33,10 @@ public class DateRangeUtils {
                 SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT, Locale.US);
                 Date startDate = sdf.parse(humanReadableDateRangeSplit[0]);
                 Date endDate = sdf.parse(humanReadableDateRangeSplit[1]);
-                return new Pair<>(getTimeFromDateOffsettingTz(startDate), getTimeFromDateOffsettingTz(endDate));
+                return new Pair<>(startDate.getTime(), endDate.getTime());
             }
         }
         throw new ParseException("Argument " + humanReadableDateRange + " should be formatted as 'yyyy-mm-dd to yyyy-mm-dd'", 0);
-    }
-
-    private static Long getTimeFromDateOffsettingTz(Date date) {
-        return date.getTime() - date.getTimezoneOffset() * 60 * 1000;
     }
 
     /**


### PR DESCRIPTION
## Summary

This is to fix [DateRangeUtilsTest](https://github.com/dimagi/commcare-android/blob/master/app/unit-tests/src/org/commcare/utils/DateRangeUtilsTest.java) which fails in certain timezones. 

The date range method `parseHumanReadableDate` is used in case search date range widget to convert a text date range like `12-07-2023 to 14-07-2023` to time in milliseconds to  set the range to the date widget. This method currently offsets the time in milliseconds for the current timezone. That doesn't seem correct to me as that can lead to dates being different on date widget in comparison to what is provided in the String. Instead we should just be returning the dates in current time zone so that they are consistent between their string manipulation and date widget. 

This method itself was added in [this PR](https://github.com/dimagi/commcare-android/pull/2508/files) for context and I can't seem to remember why I decided to offset the timezone earlier. 

## Feature Flag

CASE_SEARCH


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

Change itself is to fix a test

### Safety story

Change is Limited to date range widget used in case search

QA note: Check for date range widget in case search working correctly across a few different timezones. 
