### PR TITLE
Adds wait in Async Restore Instrumentation Tests

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/androidTests/AsyncRestoreTest.java
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/AsyncRestoreTest.java
@@ -68,7 +68,7 @@ public class AsyncRestoreTest extends BaseTest {
 
         // Make sure user is present in the group.
         HQApi.addUserInGroup(userId, groupId);
-        InstrumentationUtility.sleep(5);
+        InstrumentationUtility.sleep(30);
 
         installAppAndClearCache();
 
@@ -98,7 +98,7 @@ public class AsyncRestoreTest extends BaseTest {
 
         // Make sure user is not present in the group.
         HQApi.removeUserFromGroup(userId, groupId);
-        InstrumentationUtility.sleep(5);
+        InstrumentationUtility.sleep(30);
 
         installAppAndClearCache();
 
@@ -112,10 +112,9 @@ public class AsyncRestoreTest extends BaseTest {
         // Confirm No Restore happened during login.
         assertFalse(AsyncRestoreHelperMock.isRetryCalled());
         assertFalse(AsyncRestoreHelperMock.isServerProgressReportingStarted());
-
         // Add user to the group.
         HQApi.addUserInGroup(userId, groupId);
-        InstrumentationUtility.sleep(5);
+        InstrumentationUtility.sleep(30);
 
         // Sync with server.
         onView(withText("Sync with Server"))

--- a/app/instrumentation-tests/src/org/commcare/androidTests/AsyncRestoreTest.java
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/AsyncRestoreTest.java
@@ -68,6 +68,7 @@ public class AsyncRestoreTest extends BaseTest {
 
         // Make sure user is present in the group.
         HQApi.addUserInGroup(userId, groupId);
+        InstrumentationUtility.sleep(5);
 
         installAppAndClearCache();
 
@@ -97,6 +98,7 @@ public class AsyncRestoreTest extends BaseTest {
 
         // Make sure user is not present in the group.
         HQApi.removeUserFromGroup(userId, groupId);
+        InstrumentationUtility.sleep(5);
 
         installAppAndClearCache();
 
@@ -113,6 +115,7 @@ public class AsyncRestoreTest extends BaseTest {
 
         // Add user to the group.
         HQApi.addUserInGroup(userId, groupId);
+        InstrumentationUtility.sleep(5);
 
         // Sync with server.
         onView(withText("Sync with Server"))


### PR DESCRIPTION
Adds wait after making HQ API calls to make sure HQ registers those changes well before we do login. 

Only a test change and therefore skipping the PR template. 
