### PR TITLE
Connect: Download CC App 

### DIFF
--- a/app/res/navigation/nav_graph_connect.xml
+++ b/app/res/navigation/nav_graph_connect.xml
@@ -82,8 +82,8 @@
             android:name="title"
             app:argType="string" />
         <argument
-            android:name="appTitle"
-            app:argType="string" />
+            android:name="job"
+            app:argType="org.commcare.android.database.connect.models.ConnectJob" />
         <action
             android:id="@+id/action_connect_downloading_fragment_to_connect_job_learning_progress_fragment"
             app:destination="@id/connect_job_learning_progress_fragment" />

--- a/app/res/navigation/nav_graph_connect.xml
+++ b/app/res/navigation/nav_graph_connect.xml
@@ -84,6 +84,9 @@
         <argument
             android:name="appTitle"
             app:argType="string" />
+        <action
+            android:id="@+id/action_connect_downloading_fragment_to_connect_job_learning_progress_fragment"
+            app:destination="@id/connect_job_learning_progress_fragment" />
     </fragment>
 
 

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -659,4 +659,6 @@
     <string name="login_menu_connect_sign_in">Sign up for ConnectID</string>
     <string name="login_menu_connect_sign_out">Sign out of ConnectID</string>
     <string name="login_menu_connect_forget">Forget ConnectID user</string>
+    <string name="connect_app_install_unknown_error">App install failed due to an unknown error</string>
+    <string name="connect_app_installed">App installed</string>
 </resources>

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -1,5 +1,7 @@
 package org.commcare.activities;
 
+import static org.commcare.engine.resource.ResourceInstallUtils.showApkUpdatePrompt;
+
 import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
@@ -697,11 +699,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
     @Override
     public void failBadReqs(String versionRequired, String versionAvailable, boolean majorIsProblem) {
-        String versionMismatch = Localization.get("install.version.mismatch", new String[]{versionRequired, versionAvailable});
-        Intent intent = new Intent(this, PromptApkUpdateActivity.class);
-        intent.putExtra(PromptApkUpdateActivity.REQUIRED_VERSION, versionRequired);
-        intent.putExtra(PromptApkUpdateActivity.CUSTOM_PROMPT_TITLE, versionMismatch);
-        startActivity(intent);
+        showApkUpdatePrompt(this, versionRequired, versionAvailable);
     }
 
     @Override

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -1,8 +1,5 @@
 package org.commcare.activities;
 
-import static org.commcare.engine.resource.ResourceInstallUtils.showApkUpdatePrompt;
-import static org.commcare.engine.resource.ResourceInstallUtils.showTargetMismatchError;
-
 import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
@@ -700,7 +697,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
     @Override
     public void failBadReqs(String versionRequired, String versionAvailable, boolean majorIsProblem) {
-        showApkUpdatePrompt(this, versionRequired, versionAvailable);
+        ResourceInstallUtils.showApkUpdatePrompt(this, versionRequired, versionAvailable);
     }
 
     @Override
@@ -736,7 +733,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
     @Override
     public void failTargetMismatch() {
-        showTargetMismatchError(this);
+        ResourceInstallUtils.showTargetMismatchError(this);
     }
 
 

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -1,6 +1,7 @@
 package org.commcare.activities;
 
 import static org.commcare.engine.resource.ResourceInstallUtils.showApkUpdatePrompt;
+import static org.commcare.engine.resource.ResourceInstallUtils.showTargetMismatchError;
 
 import android.Manifest;
 import android.content.Context;
@@ -735,8 +736,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
     @Override
     public void failTargetMismatch() {
-        Intent intent = new Intent(this, TargetMismatchErrorActivity.class);
-        startActivity(intent);
+        showTargetMismatchError(this);
     }
 
 

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -2,18 +2,22 @@ package org.commcare.activities.connect;
 
 import android.os.Bundle;
 
+import androidx.fragment.app.Fragment;
+import androidx.navigation.fragment.NavHostFragment;
+
 import org.commcare.activities.CommCareActivity;
 import org.commcare.dalvik.R;
-import org.commcare.views.dialogs.CustomProgressDialog;
+import org.commcare.fragments.connect.ConnectDownloadingFragment;
+import org.commcare.tasks.ResourceEngineListener;
 
 import javax.annotation.Nullable;
 
-public class ConnectActivity extends CommCareActivity<ConnectActivity> {
+public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.screen_connect);
-
         setTitle(getString(R.string.connect_title));
     }
 
@@ -22,8 +26,24 @@ public class ConnectActivity extends CommCareActivity<ConnectActivity> {
         return false;
     }
 
-//    @Override
-//    public CustomProgressDialog generateProgressDialog(int taskId) {
-//        return CustomProgressDialog.newInstance(null, getString(R.string.please_wait), taskId);
-//    }
+    @Override
+    public ResourceEngineListener getReceiver() {
+        ConnectDownloadingFragment downloadFragment = getConnectDownloadFragment();
+        if (downloadFragment != null) {
+            return downloadFragment;
+        }
+        return null;
+    }
+
+    @Nullable
+    private ConnectDownloadingFragment getConnectDownloadFragment() {
+        NavHostFragment navHostFragment =
+                (NavHostFragment)getSupportFragmentManager().findFragmentById(R.id.nav_host_fragment_connect);
+        Fragment currentFragment =
+                navHostFragment.getChildFragmentManager().getPrimaryNavigationFragment();
+        if (currentFragment instanceof ConnectDownloadingFragment) {
+            return (ConnectDownloadingFragment)currentFragment;
+        }
+        return null;
+    }
 }

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -28,11 +28,7 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
 
     @Override
     public ResourceEngineListener getReceiver() {
-        ConnectDownloadingFragment downloadFragment = getConnectDownloadFragment();
-        if (downloadFragment != null) {
-            return downloadFragment;
-        }
-        return null;
+        return getConnectDownloadFragment();
     }
 
     @Nullable

--- a/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
+++ b/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences;
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.activities.PromptApkUpdateActivity;
+import org.commcare.activities.TargetMismatchErrorActivity;
 import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.core.network.CaptivePortalRedirectException;
 import org.commcare.engine.resource.installers.SingleAppInstallation;
@@ -159,6 +160,15 @@ public class ResourceInstallUtils {
         Intent intent = new Intent(context, PromptApkUpdateActivity.class);
         intent.putExtra(PromptApkUpdateActivity.REQUIRED_VERSION, versionRequired);
         intent.putExtra(PromptApkUpdateActivity.CUSTOM_PROMPT_TITLE, versionMismatch);
+        context.startActivity(intent);
+    }
+
+    /**
+     * Show target mismatch error during CC App installation
+     * @param context current context
+     */
+    public static void showTargetMismatchError(Context context) {
+        Intent intent = new Intent(context, TargetMismatchErrorActivity.class);
         context.startActivity(intent);
     }
 

--- a/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
+++ b/app/src/org/commcare/engine/resource/ResourceInstallUtils.java
@@ -1,9 +1,12 @@
 package org.commcare.engine.resource;
 
+import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
+import org.commcare.activities.PromptApkUpdateActivity;
 import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.core.network.CaptivePortalRedirectException;
 import org.commcare.engine.resource.installers.SingleAppInstallation;
@@ -26,6 +29,7 @@ import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.views.notifications.NotificationActionButtonInfo;
 import org.javarosa.core.services.Logger;
+import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.PropertyUtils;
 
 import java.net.MalformedURLException;
@@ -142,6 +146,20 @@ public class ResourceInstallUtils {
                 receiver.failUnknown(AppInstallStatus.UnknownFailure);
                 break;
         }
+    }
+
+    /**
+     * Shows Apk update prompt to user
+     * @param context current context
+     * @param versionRequired apk version required
+     * @param versionAvailable apk version available
+     */
+    public static void showApkUpdatePrompt(Context context, String versionRequired, String versionAvailable) {
+        String versionMismatch = Localization.get("install.version.mismatch", new String[]{versionRequired, versionAvailable});
+        Intent intent = new Intent(context, PromptApkUpdateActivity.class);
+        intent.putExtra(PromptApkUpdateActivity.REQUIRED_VERSION, versionRequired);
+        intent.putExtra(PromptApkUpdateActivity.CUSTOM_PROMPT_TITLE, versionMismatch);
+        context.startActivity(intent);
     }
 
     /**

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryDetailsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryDetailsFragment.java
@@ -63,7 +63,7 @@ public class ConnectDeliveryDetailsFragment extends Fragment {
         Button button = view.findViewById(R.id.connect_delivery_button);
         button.setOnClickListener(v -> {
             String title = getString(R.string.connect_downloading_delivery);
-            NavDirections directions = ConnectDeliveryDetailsFragmentDirections.actionConnectJobDeliveryDetailsFragmentToConnectDownloadingFragment(title, job.getTitle());
+            NavDirections directions = ConnectDeliveryDetailsFragmentDirections.actionConnectJobDeliveryDetailsFragmentToConnectDownloadingFragment(title, job);
             Navigation.findNavController(button).navigate(directions);
         });
 

--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -26,6 +26,9 @@ import org.javarosa.core.services.locale.LocaleTextException;
 import org.javarosa.core.services.locale.Localization;
 
 public class ConnectDownloadingFragment extends Fragment implements ResourceEngineListener {
+
+    private static final int APP_DOWNLOAD_TASK_ID = 4;
+
     private static String TEST_APP_LINK =
             "https://www.commcarehq.org/a/shubhamgoyaltest/apps/download/b4e4c3b0331b400badf490d7c188b103"
                     + "/media_profile.ccpr";
@@ -48,7 +51,7 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
     }
 
     private void startAppDownload() {
-        ResourceInstallUtils.startAppInstallAsync(false, 11, (CommCareTaskConnector)getActivity(), TEST_APP_LINK);
+        ResourceInstallUtils.startAppInstallAsync(false, APP_DOWNLOAD_TASK_ID, (CommCareTaskConnector)getActivity(), TEST_APP_LINK);
     }
 
     @Override

--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -1,7 +1,5 @@
 package org.commcare.fragments.connect;
 
-import static org.commcare.engine.resource.ResourceInstallUtils.showTargetMismatchError;
-
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -152,6 +150,6 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
 
     @Override
     public void failTargetMismatch() {
-        showTargetMismatchError(getActivity());
+        ResourceInstallUtils.showTargetMismatchError(getActivity());
     }
 }

--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -63,8 +63,8 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
 
         View view = inflater.inflate(R.layout.fragment_connect_downloading, container, false);
 
-        statusText = view.findViewById(R.id.connect_downloading_title);
-        statusText.setText(args.getTitle());
+        TextView titleTv = view.findViewById(R.id.connect_downloading_title);
+        titleTv.setText(args.getTitle());
 
         statusText = view.findViewById(R.id.connect_downloading_status);
         statusText.setText(getString(R.string.connect_downloading_status, 0));

--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -33,6 +33,7 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
                     + "/media_profile.ccpr";
     private ProgressBar progressBar;
     private TextView statusText;
+    private ConnectJob job;
 
     public ConnectDownloadingFragment() {
         // Required empty public constructor
@@ -56,7 +57,8 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
         ConnectDownloadingFragmentArgs args = ConnectDownloadingFragmentArgs.fromBundle(getArguments());
-        getActivity().setTitle(args.getAppTitle());
+        job = args.getJob();
+        getActivity().setTitle(job.getTitle());
 
         View view = inflater.inflate(R.layout.fragment_connect_downloading, container, false);
 

--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -1,24 +1,39 @@
 package org.commcare.fragments.connect;
 
+import static org.commcare.engine.resource.ResourceInstallUtils.showTargetMismatchError;
+
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.commcare.android.database.connect.models.ConnectJob;
-import org.commcare.android.database.connect.models.ConnectJobLearningModule;
-import org.commcare.dalvik.R;
-
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Locale;
-
 import androidx.fragment.app.Fragment;
+import androidx.navigation.NavDirections;
+import androidx.navigation.Navigation;
 
-public class ConnectDownloadingFragment extends Fragment {
+import org.commcare.android.database.connect.models.ConnectJob;
+import org.commcare.dalvik.R;
+import org.commcare.engine.resource.AppInstallStatus;
+import org.commcare.engine.resource.ResourceInstallUtils;
+import org.commcare.resources.model.InvalidResourceException;
+import org.commcare.resources.model.UnresolvedResourceException;
+import org.commcare.tasks.ResourceEngineListener;
+import org.commcare.tasks.templates.CommCareTaskConnector;
+import org.commcare.views.notifications.NotificationActionButtonInfo;
+import org.javarosa.core.reference.InvalidReferenceException;
+import org.javarosa.core.services.locale.LocaleTextException;
+import org.javarosa.core.services.locale.Localization;
+
+public class ConnectDownloadingFragment extends Fragment implements ResourceEngineListener {
+    private static String TEST_APP_LINK =
+            "https://www.commcarehq.org/a/shubhamgoyaltest/apps/download/b4e4c3b0331b400badf490d7c188b103"
+                    + "/media_profile.ccpr";
+    private ProgressBar progressBar;
+    private TextView statusText;
+
     public ConnectDownloadingFragment() {
         // Required empty public constructor
     }
@@ -30,22 +45,111 @@ public class ConnectDownloadingFragment extends Fragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        startAppDownload();
+    }
+
+    private void startAppDownload() {
+        ResourceInstallUtils.startAppInstallAsync(false, 11, (CommCareTaskConnector)getActivity(), TEST_APP_LINK);
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                             Bundle savedInstanceState) {
+            Bundle savedInstanceState) {
         ConnectDownloadingFragmentArgs args = ConnectDownloadingFragmentArgs.fromBundle(getArguments());
         getActivity().setTitle(args.getAppTitle());
 
         View view = inflater.inflate(R.layout.fragment_connect_downloading, container, false);
 
-        TextView textView = view.findViewById(R.id.connect_downloading_title);
-        textView.setText(args.getTitle());
+        statusText = view.findViewById(R.id.connect_downloading_title);
+        statusText.setText(args.getTitle());
 
-        textView = view.findViewById(R.id.connect_downloading_status);
-        textView.setText(getString(R.string.connect_downloading_status, 0));
+        statusText = view.findViewById(R.id.connect_downloading_status);
+        statusText.setText(getString(R.string.connect_downloading_status, 0));
+
+        progressBar = view.findViewById(R.id.connect_downloading_progress);
 
         return view;
+    }
+
+    @Override
+    public void reportSuccess(boolean isNewInstall) {
+        Toast.makeText(getActivity(), R.string.connect_app_installed, Toast.LENGTH_SHORT).show();
+        onSuccessfulInstall();
+    }
+
+    private void onSuccessfulInstall() {
+        ConnectJob job = ConnectJobIntroFragmentArgs.fromBundle(getArguments()).getJob();
+        NavDirections directions =
+                ConnectDownloadingFragmentDirections.actionConnectDownloadingFragmentToConnectJobLearningProgressFragment(
+                        job);
+        View view = getView();
+        if (view != null) {
+            Navigation.findNavController(view).navigate(directions);
+        }
+    }
+
+    @Override
+    public void failMissingResource(UnresolvedResourceException ure, AppInstallStatus statusmissing) {
+        showInstallFailError(statusmissing);
+    }
+
+    private void showInstallFailError(AppInstallStatus statusmissing) {
+        String installError = getString(R.string.connect_app_install_unknown_error);
+        try {
+            installError = Localization.get(statusmissing.getLocaleKeyBase() + ".title");
+        } catch (LocaleTextException e) {
+            // do nothing
+        }
+        showInstallFailError(installError);
+    }
+
+    private void showInstallFailError(String error) {
+        statusText.setText(error);
+    }
+
+    @Override
+    public void failInvalidResource(InvalidResourceException e, AppInstallStatus statusmissing) {
+        showInstallFailError(statusmissing);
+    }
+
+    @Override
+    public void failInvalidReference(InvalidReferenceException e, AppInstallStatus status) {
+        showInstallFailError(status);
+    }
+
+    @Override
+    public void failBadReqs(String vReq, String vAvail, boolean majorIsProblem) {
+        ResourceInstallUtils.showApkUpdatePrompt(getActivity(), vReq, vAvail);
+    }
+
+    @Override
+    public void failUnknown(AppInstallStatus statusfailunknown) {
+        showInstallFailError(statusfailunknown);
+    }
+
+    @Override
+    public void updateResourceProgress(int done, int pending, int phase) {
+        progressBar.setMax(pending);
+        progressBar.setProgress(done);
+    }
+
+    @Override
+    public void failWithNotification(AppInstallStatus statusfailstate) {
+        if (statusfailstate == AppInstallStatus.DuplicateApp) {
+            onSuccessfulInstall();
+        } else {
+            showInstallFailError(statusfailstate);
+        }
+    }
+
+    @Override
+    public void failWithNotification(AppInstallStatus statusfailstate,
+            NotificationActionButtonInfo.ButtonAction buttonAction) {
+        showInstallFailError(statusfailstate);
+    }
+
+    @Override
+    public void failTargetMismatch() {
+        showTargetMismatchError(getActivity());
     }
 }

--- a/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
@@ -73,7 +73,7 @@ public class ConnectJobIntroFragment extends Fragment {
         Button button = view.findViewById(R.id.connect_job_intro_start_button);
         button.setOnClickListener(v -> {
             String title = getString(R.string.connect_downloading_learn);
-            NavDirections directions = ConnectJobIntroFragmentDirections.actionConnectJobIntroFragmentToConnectDownloadingFragment(title, job.getTitle());
+            NavDirections directions = ConnectJobIntroFragmentDirections.actionConnectJobIntroFragmentToConnectDownloadingFragment(title, job);
             Navigation.findNavController(button).navigate(directions);
         });
 


### PR DESCRIPTION
## Summary

Implements Download CC App from Connect Fragment

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

No coverage for Connect UI but all our tests run through normal CC app installs to protect against any regressions. 

### Safety story

Tests and QA

Best reviewed commit by commit. 