### PR TITLE
Intent for launching a specific App In CommCare 

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -452,4 +452,5 @@
     <string name="dependency_missing_dialog_playstore_not_found" cc:translatable="true">No Play Store found on your device</string>
     <string name="fcm_notification">FCM Notification</string>
     <string name="fcm_default_notification_channel">notification-channel-server-communications</string>
+    <string name="app_with_id_not_found">Required CommCare App is not installed on device</string>
 </resources>

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -207,7 +207,7 @@ public class DispatchActivity extends AppCompatActivity {
         if (sesssionEndpointAppID != null) {
             CommCareApp currentApp = CommCareApplication.instance().getCurrentApp();
             if (currentApp != null) {
-                return !currentApp.getUniqueId().contentEquals(sesssionEndpointAppID);
+                return !currentApp.getUniqueId().equals(sesssionEndpointAppID);
             }
         }
         return false;

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -1,5 +1,7 @@
 package org.commcare.activities;
 
+import static org.commcare.commcaresupportlibrary.CommCareLauncher.SESSION_ENDPOINT_APP_ID;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
@@ -35,7 +37,6 @@ public class DispatchActivity extends AppCompatActivity {
     private static final String TAG = DispatchActivity.class.getSimpleName();
     private static final String SESSION_REQUEST = "ccodk_session_request";
     public static final String SESSION_ENDPOINT_ID = "ccodk_session_endpoint_id";
-    public static final String SESSION_ENDPOINT_APP_ID = "ccodk_session_endpoint_app_id";
 
     // Args to session endpoints can be passed as a name to value bundle or more loosely as a list
     public static final String SESSION_ENDPOINT_ARGUMENTS_BUNDLE = "ccodk_session_endpoint_arguments_bundle";

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -72,6 +72,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         implements OnItemSelectedListener, DataPullController,
         RuntimePermissionRequester, WithUIController, PullTaskResultReceiver {
 
+    public static final String EXTRA_APP_ID = "extra_app_id";
     private static final String TAG = LoginActivity.class.getSimpleName();
 
     public static final int MENU_DEMO = Menu.FIRST;
@@ -101,6 +102,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
     private LoginActivityUIController uiController;
     private FormAndDataSyncer formAndDataSyncer;
+    private String presetAppID;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -116,6 +118,8 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
         uiController.setupUI();
         formAndDataSyncer = new FormAndDataSyncer();
+
+        presetAppID = getIntent().getStringExtra(EXTRA_APP_ID);
 
         if (savedInstanceState == null) {
             // Only restore last user on the initial creation
@@ -550,7 +554,10 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
         // Retrieve the app record corresponding to the app selected
         String appId = appIdDropdownList.get(position);
+        seatAppIfNeeded(appId);
+    }
 
+    protected void seatAppIfNeeded(String appId) {
         boolean selectedNewApp = !appId.equals(CommCareApplication.instance().getCurrentApp().getUniqueId());
         if (selectedNewApp) {
             // Set the id of the last selected app
@@ -739,5 +746,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
             uiController.setPasswordOrPin(appRestrictions.getString("password"));
             initiateLoginAttempt(false);
         }
+    }
+
+    protected String getPresetAppID() {
+        return presetAppID;
     }
 }

--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -233,7 +233,7 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         String presetAppId = activity.getPresetAppID();
         if (presetAppId != null) {
             for (ApplicationRecord readyApp : readyApps) {
-                if (readyApp.getUniqueId().contentEquals(presetAppId)) {
+                if (readyApp.getUniqueId().equals(presetAppId)) {
                     return readyApp;
                 }
             }

--- a/app/unit-tests/src/org/commcare/android/tests/navigation/ExternalLaunchTests.kt
+++ b/app/unit-tests/src/org/commcare/android/tests/navigation/ExternalLaunchTests.kt
@@ -6,18 +6,19 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.commcare.CommCareTestApplication
 import org.commcare.activities.DispatchActivity
 import org.commcare.activities.FormEntryActivity
+import org.commcare.activities.LoginActivity
 import org.commcare.activities.StandardHomeActivity
 import org.commcare.android.util.TestAppInstaller
 import org.commcare.android.util.TestUtils
-import org.junit.Assert
-import org.junit.Assert.assertEquals
+import org.commcare.util.screen.CommCareSessionException
+import org.commcare.utils.SessionUnavailableException
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
-import java.util.ArrayList
 
 
 @Config(application = CommCareTestApplication::class)
@@ -31,6 +32,39 @@ class ExternalLaunchTests {
                 "jr://resource/commcare-apps/index_and_cache_test/profile.ccpr",
                 "test", "123")
         TestUtils.processResourceTransactionIntoAppDb("/commcare-apps/case_list_lookup/restore.xml")
+    }
+
+    @Test
+    fun testLaunchWithAppId() {
+        // verify initial state
+        val indexAndCacheTestAppId = "000b3b9ecb0806331fbd1526616eb718"
+        assertEquals(indexAndCacheTestAppId, CommCareTestApplication.instance().currentApp.uniqueId)
+        assertEquals("test", CommCareTestApplication.instance().session.loggedInUser.username)
+
+        // Install another app, this will also seat this app as current app
+        TestAppInstaller.installApp("jr://resource/commcare-apps/archive_form_tests/profile.ccpr")
+        val archiveFormTestsAppId = "6a03772aedd992c9f2c9c2198a248184"
+        assertEquals(archiveFormTestsAppId, CommCareTestApplication.instance().currentApp.uniqueId)
+        assertEquals("test", CommCareTestApplication.instance().session.loggedInUser.username)
+
+        // Request launch for seated app, since user is logged in already we should end up on app home screen
+        launchAndVerifyCCWithAppId(archiveFormTestsAppId, StandardHomeActivity::class.java.name)
+
+        // Request launch for non seated app, this should cause user to log out and show user Login Screen
+        launchAndVerifyCCWithAppId(indexAndCacheTestAppId, LoginActivity::class.java.name)
+        assertThrows(SessionUnavailableException::class.java) {
+            CommCareTestApplication.instance().session.loggedInUser
+        }
+    }
+
+    private fun launchAndVerifyCCWithAppId(appId: String, nextScreen: String) {
+        val intent = Intent("org.commcare.dalvik.action.CommCareSession")
+        intent.putExtra(DispatchActivity.SESSION_ENDPOINT_APP_ID, appId)
+        var dispathActivity =
+            Robolectric.buildActivity(DispatchActivity::class.java, intent).create().resume().get()
+        var recordedNextIntent = Shadows.shadowOf(dispathActivity).nextStartedActivity
+        var intentActivityName: String = recordedNextIntent.component!!.className
+        assertEquals(nextScreen, intentActivityName)
     }
 
     @Test
@@ -67,7 +101,7 @@ class ExternalLaunchTests {
 
     private fun verifyNextIntent(nextIntent: Intent, header: String) {
         val intentActivityName: String = nextIntent.component!!.className
-        Assert.assertEquals(FormEntryActivity::class.java.name, intentActivityName)
+        assertEquals(FormEntryActivity::class.java.name, intentActivityName)
         assertEquals(nextIntent.extras!!.getString(FormEntryActivity.KEY_HEADER_STRING), header)
     }
 

--- a/app/unit-tests/src/org/commcare/android/tests/navigation/ExternalLaunchTests.kt
+++ b/app/unit-tests/src/org/commcare/android/tests/navigation/ExternalLaunchTests.kt
@@ -10,6 +10,8 @@ import org.commcare.activities.LoginActivity
 import org.commcare.activities.StandardHomeActivity
 import org.commcare.android.util.TestAppInstaller
 import org.commcare.android.util.TestUtils
+import org.commcare.commcaresupportlibrary.CommCareLauncher
+import org.commcare.commcaresupportlibrary.CommCareLauncher.SESSION_ENDPOINT_APP_ID
 import org.commcare.util.screen.CommCareSessionException
 import org.commcare.utils.SessionUnavailableException
 import org.junit.Assert.*
@@ -59,7 +61,7 @@ class ExternalLaunchTests {
 
     private fun launchAndVerifyCCWithAppId(appId: String, nextScreen: String) {
         val intent = Intent("org.commcare.dalvik.action.CommCareSession")
-        intent.putExtra(DispatchActivity.SESSION_ENDPOINT_APP_ID, appId)
+        intent.putExtra(SESSION_ENDPOINT_APP_ID, appId)
         var dispathActivity =
             Robolectric.buildActivity(DispatchActivity::class.java, intent).create().resume().get()
         var recordedNextIntent = Shadows.shadowOf(dispathActivity).nextStartedActivity

--- a/app/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
+++ b/app/unit-tests/src/org/commcare/android/util/TestAppInstaller.java
@@ -91,12 +91,15 @@ public class TestAppInstaller {
                 new ApplicationRecord(PropertyUtils.genUUID().replace("-", ""),
                         ApplicationRecord.STATUS_UNINITIALIZED);
 
+
         CommCareApp app = new CommCareTestApp(new CommCareApp(newRecord));
+
         ResourceEngineTask<Object> task =
                 new ResourceEngineTask<Object>(app, -1, false, false) {
                     @Override
                     protected void deliverResult(Object receiver,
                                                  AppInstallStatus result) {
+                        app.setMMResourcesValidated();
                     }
 
                     @Override

--- a/commcare-support-library/README.md
+++ b/commcare-support-library/README.md
@@ -58,3 +58,9 @@ Then retrieve the XML for a specific fixture from this list:
 
 `FixtureUtils.getFixtureXml(Context context, String fixtureId`
 
+#### CommCare Launch Helpers
+
+Launch CommCare with a specific CommCare App:
+
+`CommCareLauncher.launchCommCareForAppId(Context context, String appId)`
+

--- a/commcare-support-library/src/main/java/org/commcare/commcaresupportlibrary/CommCareLauncher.java
+++ b/commcare-support-library/src/main/java/org/commcare/commcaresupportlibrary/CommCareLauncher.java
@@ -1,0 +1,23 @@
+package org.commcare.commcaresupportlibrary;
+
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Utility class with methods to launch CommCare
+ */
+public class CommCareLauncher {
+    public static final String SESSION_ENDPOINT_APP_ID = "ccodk_session_endpoint_app_id";
+    private static final String CC_LAUNCH_ACTION = "org.commcare.dalvik.action.CommCareSession";
+
+    /**
+     *
+     * @param context Android context to launch the CommCare with
+     * @param appId Unique Id for CommCare App that CommCare should launch with
+     */
+    public static void launchCommCareForAppId(Context context, String appId) {
+        Intent intent = new Intent(CC_LAUNCH_ACTION);
+        intent.putExtra(SESSION_ENDPOINT_APP_ID, appId);
+        context.startActivity(intent);
+    }
+}


### PR DESCRIPTION
## Summary
Adds a way to launch a particular CC app using an intent as - 

````
val intent = Intent("org.commcare.dalvik.action.CommCareSession")
intent.putExtra(DispatchActivity.SESSION_ENDPOINT_APP_ID, appId)
startActivity(intent)
````

commit by commit

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

coverage for new functionality is in PR, installs and logins have ample tests. 

### Safety story

Tests should cover for any regressions on the dipatch and login pages. 
