### PR TITLE
Improved biometric enrollment for Android versions before API 30

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -542,6 +542,10 @@
     <string name="connect_recovery_success_message" cc:translatable="true">You have successfully recovered your account and can now resume using your ConnectID.</string>
     <string name="connect_recovery_success_button" cc:translatable="true">OK</string>
 
+    <string name="connect_biometric_enroll_fail_title">Biometric Issue</string>
+    <string name="connect_biometric_enroll_fail_message">You will need to configure this biometric manually in the Android settings.</string>
+    <string name="connect_biometric_enroll_fail_button">Go to Settings</string>
+
     <string name="connect_unlock_title" cc:translatable="true">Unlock ConnectID</string>
     <string name="connect_unlock_message" cc:translatable="true">Please unlock to continue</string>
     <string name="connect_unlock_button_pin" cc:translatable="true">Unlock with PIN</string>

--- a/app/src/org/commcare/activities/SettingsHelper.java
+++ b/app/src/org/commcare/activities/SettingsHelper.java
@@ -2,9 +2,14 @@ package org.commcare.activities;
 
 import android.content.Context;
 import android.content.Intent;
+import android.provider.Settings;
 
 public class SettingsHelper {
     public static void launchDateSettings(Context context) {
         context.startActivity(new Intent(android.provider.Settings.ACTION_DATE_SETTINGS));
+    }
+
+    public static void launchSecuritySettings(Context context) {
+        context.startActivity(new Intent(android.provider.Settings.ACTION_SECURITY_SETTINGS));
     }
 }

--- a/app/src/org/commcare/activities/connect/ConnectIdConstants.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdConstants.java
@@ -22,6 +22,7 @@ public class ConnectIdConstants {
 
     public static final String RECOVER = "RECOVER";
     public static final String CONFIGURED = "CONFIGURED";
+    public static final String ENROLL_FAIL = "ENROLL_FAIL";
     public static final String CHANGE = "CHANGE";
     public static final String FORGOT = "FORGOT";
     public static final String ALLOW_PASSWORD = "ALLOW_PASSWORD";

--- a/app/src/org/commcare/activities/connect/ConnectIdManager.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdManager.java
@@ -365,10 +365,9 @@ public class ConnectIdManager {
                     boolean configured = intent.getBooleanExtra(ConnectIdConstants.CONFIGURED, false);
                     manager.passwordOnlyWorkflow = intent.getBooleanExtra(ConnectIdConstants.PASSWORD, false);
                     boolean failedEnrollment = intent.getBooleanExtra(ConnectIdConstants.ENROLL_FAIL, false);
-                    if(failedEnrollment) {
+                    if (failedEnrollment) {
                         nextRequestCode = ConnectIdTask.CONNECT_BIOMETRIC_ENROLL_FAIL;
-                    }
-                    else {
+                    } else {
                         nextRequestCode = configured && !manager.passwordOnlyWorkflow ?
                                 ConnectIdTask.CONNECT_REGISTRATION_UNLOCK_BIOMETRIC :
                                 ConnectIdTask.CONNECT_REGISTRATION_VERIFY_PRIMARY_PHONE;
@@ -544,7 +543,7 @@ public class ConnectIdManager {
             }
             case CONNECT_BIOMETRIC_ENROLL_FAIL -> {
                 nextRequestCode = ConnectIdTask.CONNECT_REGISTRATION_CONFIGURE_BIOMETRICS;
-                if(success) {
+                if (success) {
                     //Go to settings
                     launchSecuritySettings = true;
                 }
@@ -562,7 +561,7 @@ public class ConnectIdManager {
 
         manager.continueWorkflow();
 
-        if(launchSecuritySettings) {
+        if (launchSecuritySettings) {
             //Launch after continuing workflow so previous activity is still there when user returns
             SettingsHelper.launchSecuritySettings(manager.parentActivity);
         }

--- a/app/src/org/commcare/activities/connect/ConnectIdManager.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdManager.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.widget.Toast;
 
 import org.commcare.activities.CommCareActivity;
+import org.commcare.activities.SettingsHelper;
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
 import org.commcare.core.network.AuthInfo;
@@ -283,6 +284,11 @@ public class ConnectIdManager {
             case CONNECT_REGISTRATION_UNLOCK_BIOMETRIC -> {
                 params.put(ConnectIdConstants.ALLOW_PASSWORD, "false");
             }
+            case CONNECT_BIOMETRIC_ENROLL_FAIL -> {
+                params.put(ConnectIdConstants.TITLE, R.string.connect_biometric_enroll_fail_title);
+                params.put(ConnectIdConstants.MESSAGE, R.string.connect_biometric_enroll_fail_message);
+                params.put(ConnectIdConstants.BUTTON, R.string.connect_biometric_enroll_fail_button);
+            }
         }
 
         if (nextActivity != null) {
@@ -301,6 +307,7 @@ public class ConnectIdManager {
         boolean success = resultCode == Activity.RESULT_OK;
         ConnectIdTask nextRequestCode = ConnectIdTask.CONNECT_NO_ACTIVITY;
         boolean rememberPhase = false;
+        boolean launchSecuritySettings = false;
 
         ConnectIdTask task = ConnectIdTask.fromRequestCode(requestCode);
         switch (task) {
@@ -357,9 +364,15 @@ public class ConnectIdManager {
                     //If no biometric configured, proceed with password only
                     boolean configured = intent.getBooleanExtra(ConnectIdConstants.CONFIGURED, false);
                     manager.passwordOnlyWorkflow = intent.getBooleanExtra(ConnectIdConstants.PASSWORD, false);
-                    nextRequestCode = !manager.passwordOnlyWorkflow && configured ?
-                            ConnectIdTask.CONNECT_REGISTRATION_UNLOCK_BIOMETRIC :
-                            ConnectIdTask.CONNECT_REGISTRATION_VERIFY_PRIMARY_PHONE;
+                    boolean failedEnrollment = intent.getBooleanExtra(ConnectIdConstants.ENROLL_FAIL, false);
+                    if(failedEnrollment) {
+                        nextRequestCode = ConnectIdTask.CONNECT_BIOMETRIC_ENROLL_FAIL;
+                    }
+                    else {
+                        nextRequestCode = configured && !manager.passwordOnlyWorkflow ?
+                                ConnectIdTask.CONNECT_REGISTRATION_UNLOCK_BIOMETRIC :
+                                ConnectIdTask.CONNECT_REGISTRATION_VERIFY_PRIMARY_PHONE;
+                    }
                 }
             }
             case CONNECT_REGISTRATION_UNLOCK_BIOMETRIC -> {
@@ -529,6 +542,13 @@ public class ConnectIdManager {
                     }
                 }
             }
+            case CONNECT_BIOMETRIC_ENROLL_FAIL -> {
+                nextRequestCode = ConnectIdTask.CONNECT_REGISTRATION_CONFIGURE_BIOMETRICS;
+                if(success) {
+                    //Go to settings
+                    launchSecuritySettings = true;
+                }
+            }
             default -> {
                 return;
             }
@@ -541,6 +561,11 @@ public class ConnectIdManager {
         }
 
         manager.continueWorkflow();
+
+        if(launchSecuritySettings) {
+            //Launch after continuing workflow so previous activity is still there when user returns
+            SettingsHelper.launchSecuritySettings(manager.parentActivity);
+        }
     }
 
     public static void rememberAppCredentials(String appId, String userId, String passwordOrPin) {

--- a/app/src/org/commcare/activities/connect/ConnectIdTask.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdTask.java
@@ -51,7 +51,7 @@ public enum ConnectIdTask {
     CONNECT_UNLOCK_PIN(ConnectIdConstants.ConnectIdTaskIdOffset + 21,
             null),
     CONNECT_BIOMETRIC_ENROLL_FAIL(ConnectIdConstants.ConnectIdTaskIdOffset + 22,
-                             ConnectIdMessageActivity.class);
+            ConnectIdMessageActivity.class);
 
     private final int requestCode;
     private final Class<?> nextActivity;

--- a/app/src/org/commcare/activities/connect/ConnectIdTask.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdTask.java
@@ -49,7 +49,9 @@ public enum ConnectIdTask {
     CONNECT_UNLOCK_PASSWORD(ConnectIdConstants.ConnectIdTaskIdOffset + 20,
             ConnectIdPasswordVerificationActivity.class),
     CONNECT_UNLOCK_PIN(ConnectIdConstants.ConnectIdTaskIdOffset + 21,
-            null);
+            null),
+    CONNECT_BIOMETRIC_ENROLL_FAIL(ConnectIdConstants.ConnectIdTaskIdOffset + 22,
+                             ConnectIdMessageActivity.class);
 
     private final int requestCode;
     private final Class<?> nextActivity;

--- a/app/src/org/commcare/activities/connect/ConnectIdVerificationActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdVerificationActivity.java
@@ -38,7 +38,7 @@ public class ConnectIdVerificationActivity extends CommCareActivity<ConnectIdVer
         if (fingerprint == BiometricsHelper.ConfigurationStatus.NotAvailable &&
                 pin == BiometricsHelper.ConfigurationStatus.NotAvailable) {
             //Skip to password-only workflow
-            finish(true, true);
+            finish(true, true, false);
         } else {
             updateState(fingerprint, pin);
         }
@@ -121,26 +121,26 @@ public class ConnectIdVerificationActivity extends CommCareActivity<ConnectIdVer
         BiometricsHelper.ConfigurationStatus fingerprint = BiometricsHelper.checkFingerprintStatus(this,
                 biometricManager);
         if (fingerprint == BiometricsHelper.ConfigurationStatus.Configured) {
-            finish(true, false);
-        } else {
-            BiometricsHelper.configureFingerprint(this);
+            finish(true, false, false);
+        } else if(!BiometricsHelper.configureFingerprint(this)) {
+            finish(true, false, true);
         }
     }
 
     public void handlePinButton() {
         BiometricsHelper.ConfigurationStatus pin = BiometricsHelper.checkPinStatus(this, biometricManager);
         if (pin == BiometricsHelper.ConfigurationStatus.Configured) {
-            finish(true, false);
-        } else {
-            BiometricsHelper.configurePin(this);
+            finish(true, false, false);
+        } else if(!BiometricsHelper.configurePin(this)) {
+            finish(true, false, true);
         }
     }
 
     public void handlePasswordButton() {
-        finish(true, true);
+        finish(true, true, false);
     }
 
-    public void finish(boolean success, boolean passwordOnly) {
+    public void finish(boolean success, boolean passwordOnly, boolean failedEnrollment) {
         Intent intent = new Intent(getIntent());
 
         BiometricsHelper.ConfigurationStatus fingerprint = BiometricsHelper.checkFingerprintStatus(this,
@@ -151,6 +151,7 @@ public class ConnectIdVerificationActivity extends CommCareActivity<ConnectIdVer
         intent.putExtra(ConnectIdConstants.CONFIGURED, configured);
 
         intent.putExtra(ConnectIdConstants.PASSWORD, passwordOnly);
+        intent.putExtra(ConnectIdConstants.ENROLL_FAIL, failedEnrollment);
 
         setResult(success ? RESULT_OK : RESULT_CANCELED, intent);
         finish();

--- a/app/src/org/commcare/activities/connect/ConnectIdVerificationActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdVerificationActivity.java
@@ -122,7 +122,7 @@ public class ConnectIdVerificationActivity extends CommCareActivity<ConnectIdVer
                 biometricManager);
         if (fingerprint == BiometricsHelper.ConfigurationStatus.Configured) {
             finish(true, false, false);
-        } else if(!BiometricsHelper.configureFingerprint(this)) {
+        } else if (!BiometricsHelper.configureFingerprint(this)) {
             finish(true, false, true);
         }
     }
@@ -131,7 +131,7 @@ public class ConnectIdVerificationActivity extends CommCareActivity<ConnectIdVer
         BiometricsHelper.ConfigurationStatus pin = BiometricsHelper.checkPinStatus(this, biometricManager);
         if (pin == BiometricsHelper.ConfigurationStatus.Configured) {
             finish(true, false, false);
-        } else if(!BiometricsHelper.configurePin(this)) {
+        } else if (!BiometricsHelper.configurePin(this)) {
             finish(true, false, true);
         }
     }

--- a/app/src/org/commcare/utils/BiometricsHelper.java
+++ b/app/src/org/commcare/utils/BiometricsHelper.java
@@ -159,8 +159,7 @@ public class BiometricsHelper {
             enrollIntent = new Intent(Settings.ACTION_BIOMETRIC_ENROLL);
             enrollIntent.putExtra(Settings.EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED,
                     authenticator);
-        }
-        else if(authenticator == StrongBiometric && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        } else if (authenticator == StrongBiometric && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             //An alternative for fingerprint enroll that might be available
             enrollIntent = new Intent(Settings.ACTION_FINGERPRINT_ENROLL);
         } else {

--- a/app/src/org/commcare/utils/BiometricsHelper.java
+++ b/app/src/org/commcare/utils/BiometricsHelper.java
@@ -43,8 +43,8 @@ public class BiometricsHelper {
         return checkStatus(context, biometricManager, StrongBiometric) == ConfigurationStatus.Configured;
     }
 
-    public static void configureFingerprint(Activity activity) {
-        configureBiometric(activity, StrongBiometric);
+    public static boolean configureFingerprint(Activity activity) {
+        return configureBiometric(activity, StrongBiometric);
     }
 
     public static void authenticateFingerprint(FragmentActivity activity, BiometricManager biometricManager,
@@ -81,8 +81,8 @@ public class BiometricsHelper {
         return checkStatus(context, biometricManager, PinBiometric) == ConfigurationStatus.Configured;
     }
 
-    public static void configurePin(Activity activity) {
-        configureBiometric(activity, PinBiometric);
+    public static boolean configurePin(Activity activity) {
+        return configureBiometric(activity, PinBiometric);
     }
 
     private static BiometricPrompt.AuthenticationCallback biometricPromptCallbackHolder;
@@ -151,11 +151,24 @@ public class BiometricsHelper {
         return biometricManager.canAuthenticate(authenticator);
     }
 
-    private static void configureBiometric(Activity activity, int authenticator) {
+    private static boolean configureBiometric(Activity activity, int authenticator) {
         // Prompts the user to create credentials that your app accepts.
-        final Intent enrollIntent = new Intent(Settings.ACTION_BIOMETRIC_ENROLL);
-        enrollIntent.putExtra(Settings.EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED,
-                authenticator);
+        Intent enrollIntent;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            //Best case, handles both fingerprint and PIN
+            enrollIntent = new Intent(Settings.ACTION_BIOMETRIC_ENROLL);
+            enrollIntent.putExtra(Settings.EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED,
+                    authenticator);
+        }
+        else if(authenticator == StrongBiometric && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            //An alternative for fingerprint enroll that might be available
+            enrollIntent = new Intent(Settings.ACTION_FINGERPRINT_ENROLL);
+        } else {
+            //No way to enroll, have to fail
+            return false;
+        }
+
         activity.startActivityForResult(enrollIntent, IntentIntegrator.REQUEST_CODE);
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
Added checks for the API level when the user chooses to enroll in a biometric (fingerprint or PIN). When the API is less than 30, there's one additional check to see if it is >=28 and if so the fingerprint enrollment can still be launched. Otherwise, a message is shown to the user indicating that they will need to configure the biometric manually in Android settings, and a button is shown that will take them directly to the Security page in Android settings.

## Product Description
For users with API 28 or 29, a new fingerprint enrollment will now appear. Otherwise, any enrollment with API <30 now exhibits the behavior described above.

New enrollment when user chooses to enroll fingerprint using API 28 or 29:
![image](https://github.com/dimagi/commcare-android/assets/1054894/d4dc91ec-560b-49ef-ade6-8e99da1db610)

New message shown when app can't auto-direct user all the way to Android enrollment:
![image](https://github.com/dimagi/commcare-android/assets/1054894/1aad23d3-fd16-4227-92d0-531598a2a1e8)

