### PR TITLE
Rearranged UI for biometric configuration to save vertical space

### DIFF
--- a/app/res/layout/screen_connect_verify.xml
+++ b/app/res/layout/screen_connect_verify.xml
@@ -12,7 +12,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_margin="@dimen/content_min_margin"
+        android:layout_marginTop="5dp"
+        android:layout_marginBottom="5dp"
         android:textColor="@color/cc_neutral_color"
         android:textSize="@dimen/text_larger"
         android:textAlignment="center"
@@ -23,7 +24,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_margin="@dimen/content_min_margin"
+        android:layout_marginBottom="10dp"
         android:textColor="@color/cc_neutral_color"
         android:textSize="@dimen/text_medium"
         android:textAlignment="center"
@@ -35,15 +36,6 @@
         android:layout_height="wrap_content"
         android:background="@color/cc_core_bg"
         android:orientation="vertical" >
-
-        <TextView
-            android:id="@+id/connect_verify_fingerprint_message"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:textColor="@color/cc_neutral_color"
-            android:textSize="@dimen/text_medium"
-            android:text="@string/connect_verify_use_fingerprint"/>
 
         <ImageView
             android:id="@+id/connect_verify_fingerprint_icon"
@@ -75,15 +67,6 @@
         android:layout_height="wrap_content"
         android:background="@color/cc_core_bg"
         android:orientation="vertical">
-
-        <TextView
-            android:id="@+id/connect_verify_pin_message"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:textColor="@color/cc_neutral_color"
-            android:textSize="@dimen/text_medium"
-            android:text="@string/connect_verify_use_pin"/>
 
         <ImageView
             android:id="@+id/connect_verify_pin_icon"

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -572,18 +572,15 @@
     <string name="connect_verify_title" cc:translatable="true">Unlock Options</string>
     <string name="connect_verify_message" cc:translatable="true">Please configure a method below to unlock both your device and ConnectID account</string>
 
-    <string name="connect_verify_use_fingerprint" cc:translatable="true">Use Fingerprint</string>
     <string name="connect_verify_use_fingerprint_long" cc:translatable="true">Use Fingerprint to Connect</string>
     <string name="connect_verify_fingerprint_configured" cc:translatable="true">Your fingerprint has already been configured and will be used to unlock ConnectID.</string>
     <string name="connect_verify_configure_fingerprint" cc:translatable="true">Configure Fingerprint</string>
-    <string name="connect_verify_use_pin" cc:translatable="true">Use PIN</string>
     <string name="connect_verify_use_pin_long" cc:translatable="true">Use PIN to Connect</string>
     <string name="connect_verify_pin_configured" cc:translatable="true">Your PIN has already been configured and will be used to unlock ConnectID.</string>
     <string name="connect_verify_configure_pin" cc:translatable="true">Configure PIN</string>
 
     <string name="connect_verify_agree" cc:translatable="true">Agree &amp; Continue</string>
     <string name="connect_verify_password_only" cc:translatable="true">Create a password instead</string>
-
 
     <string name="connect_verify_fingerprint" cc:translatable="true">Fingerprint</string>
     <string name="connect_verify_pin" cc:translatable="true">PIN</string>

--- a/app/src/org/commcare/activities/connect/ConnectIdVerificationActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdVerificationActivity.java
@@ -108,11 +108,8 @@ public class ConnectIdVerificationActivity extends CommCareActivity<ConnectIdVer
         boolean showFingerprint = fingerprintButtonText != null;
         boolean showPin = pinButtonText != null;
 
-        String fingerprintMessageText = showPin ? getString(R.string.connect_verify_use_fingerprint) : "";
-        String pinMessageText = showFingerprint ? getString(R.string.connect_verify_use_pin) : "";
-
-        uiController.updateFingerprint(fingerprintMessageText, fingerprintButtonText);
-        uiController.updatePin(pinMessageText, pinButtonText);
+        uiController.updateFingerprint(fingerprintButtonText);
+        uiController.updatePin(pinButtonText);
 
         uiController.setOrVisibility(showFingerprint && showPin);
     }

--- a/app/src/org/commcare/activities/connect/ConnectIdVerificationActivityUiController.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdVerificationActivityUiController.java
@@ -25,10 +25,6 @@ public class ConnectIdVerificationActivityUiController implements CommCareActivi
 
     @UiElement(value = R.id.connect_verify_fingerprint_container)
     private LinearLayout fingerprintContainer;
-    @UiElement(value = R.id.connect_verify_fingerprint_message)
-    private TextView fingerprintTextView;
-    @UiElement(value = R.id.connect_verify_fingerprint_icon)
-    private ImageView fingerprintIcon;
     @UiElement(value = R.id.connect_verify_fingerprint_button)
     private Button fingerprintButton;
 
@@ -37,10 +33,6 @@ public class ConnectIdVerificationActivityUiController implements CommCareActivi
 
     @UiElement(value = R.id.connect_verify_pin_container)
     private LinearLayout pinContainer;
-    @UiElement(value = R.id.connect_verify_pin_message)
-    private TextView pinTextView;
-    @UiElement(value = R.id.connect_verify_pin_icon)
-    private ImageView pinIcon;
     @UiElement(value = R.id.connect_verify_pin_button)
     private Button pinButton;
 
@@ -73,20 +65,18 @@ public class ConnectIdVerificationActivityUiController implements CommCareActivi
         messageTextView.setText(text);
     }
 
-    public void updateFingerprint(String fingerprintMessageText, String fingerprintButtonText) {
+    public void updateFingerprint(String fingerprintButtonText) {
         boolean showFingerprint = fingerprintButtonText != null;
         fingerprintContainer.setVisibility(showFingerprint ? View.VISIBLE : View.GONE);
         if (showFingerprint) {
-            fingerprintTextView.setText(fingerprintMessageText);
             fingerprintButton.setText(fingerprintButtonText);
         }
     }
 
-    public void updatePin(String pinMessageText, String pinButtonText) {
+    public void updatePin(String pinButtonText) {
         boolean showPin = pinButtonText != null;
         pinContainer.setVisibility(showPin ? View.VISIBLE : View.GONE);
         if (showPin) {
-            pinTextView.setText(pinMessageText);
             pinButton.setText(pinButtonText);
         }
     }


### PR DESCRIPTION
## Summary
On  some small Android devices, the link to choose password-only workflow in the biometric configuration page would fall off the bottom of the screen, making it unreachable for the user. I removed a couple unnecessary labels and reduced some white space to make the page take up less vertical space, and now everything is visible on the smaller screen size (1080x1920).

The UI now looks like this (screenshot on 1080x1920 device):
![image](https://github.com/dimagi/commcare-android/assets/1054894/25142a23-df90-49b2-a021-0124a6b5ff56)
