### PR TITLE
Dv/phone number fix

### DIFF
--- a/app/src/org/commcare/activities/connect/ConnectIdPhoneActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdPhoneActivity.java
@@ -72,8 +72,8 @@ public class ConnectIdPhoneActivity extends CommCareActivity<ConnectIdPhoneActiv
             codeText = String.format(Locale.getDefault(), "%d", code);
         }
 
-        if (existing != null && existing.startsWith(codeText)) {
-            existing = existing.substring(codeText.length());
+        if (existing != null && existing.startsWith("+" + codeText)) {
+            existing = existing.substring(codeText.length() + 1);
         }
 
         uiController.setPhoneNumber(existing);


### PR DESCRIPTION
## Summary
Fixed error (see [QA-5636](https://dimagi-dev.atlassian.net/browse/QA-5636)) populating phone number UI input from existing phone number. We recently changed the UX so that the "+" in the country code is no longer inside the user input for country code (instead it is displayed in a static label next to the input). The code to populate the phone number input didn't take into account that the country code text would no longer contain the "+".