### PR TITLE
Dv/fingerprint options

### DIFF
--- a/app/src/org/commcare/activities/connect/ConnectIdLoginActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdLoginActivity.java
@@ -98,7 +98,9 @@ public class ConnectIdLoginActivity extends CommCareActivity<ConnectIdLoginActiv
 
     public void performFingerprintUnlock() {
         attemptingFingerprint = true;
-        BiometricsHelper.authenticateFingerprint(this, biometricManager, biometricPromptCallbacks);
+        boolean allowOtherOptions = BiometricsHelper.isPinConfigured(this, biometricManager) ||
+                allowPassword;
+        BiometricsHelper.authenticateFingerprint(this, biometricManager, allowOtherOptions, biometricPromptCallbacks);
     }
 
     public void performPasswordUnlock() {
@@ -118,7 +120,8 @@ public class ConnectIdLoginActivity extends CommCareActivity<ConnectIdLoginActiv
                 super.onAuthenticationError(errorCode, errString);
                 if (attemptingFingerprint) {
                     attemptingFingerprint = false;
-                    if (!BiometricsHelper.isPinConfigured(context, biometricManager)) {
+                    if (!BiometricsHelper.isPinConfigured(context, biometricManager) &&
+                            allowPassword) {
                         //Automatically try password, it's the only option
                         performPasswordUnlock();
                     } else {

--- a/app/src/org/commcare/utils/BiometricsHelper.java
+++ b/app/src/org/commcare/utils/BiometricsHelper.java
@@ -47,19 +47,25 @@ public class BiometricsHelper {
         return configureBiometric(activity, StrongBiometric);
     }
 
-    public static void authenticateFingerprint(FragmentActivity activity, BiometricManager biometricManager,
+    public static void authenticateFingerprint(FragmentActivity activity,
+                                               BiometricManager biometricManager,
+                                               boolean allowExtraOptions,
                                                BiometricPrompt.AuthenticationCallback biometricPromptCallback) {
         if (BiometricsHelper.isFingerprintConfigured(activity, biometricManager)) {
             BiometricPrompt prompt = new BiometricPrompt(activity,
                     ContextCompat.getMainExecutor(activity),
                     biometricPromptCallback);
 
-            prompt.authenticate(new BiometricPrompt.PromptInfo.Builder()
+            BiometricPrompt.PromptInfo.Builder builder = new BiometricPrompt.PromptInfo.Builder()
                     .setTitle(activity.getString(R.string.connect_unlock_fingerprint_title))
                     .setSubtitle(activity.getString(R.string.connect_unlock_fingerprint_message))
-                    .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
-                    .setNegativeButtonText(activity.getString(R.string.connect_unlock_other_options))
-                    .build());
+                    .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG);
+
+            if(allowExtraOptions) {
+                builder.setNegativeButtonText(activity.getString(R.string.connect_unlock_other_options));
+            }
+
+            prompt.authenticate(builder.build());
         }
     }
 


### PR DESCRIPTION
## Summary
Fix for [QA-5650](https://dimagi-dev.atlassian.net/browse/QA-5650). Not showing the "Other Options" button on the fingerprint unlock dialog when it is shown during ConnectID registration. This makes sense here because no other unlock methods (PIN or password) have been configured at this point in the app, and the user is provided the option to configure them instead.