### PR TITLE
Use a fixed CC launch action for all CC build types

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -131,7 +131,7 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
             <intent-filter>
-                <action android:name="${applicationId}.action.CommCareSession"/>
+                <action android:name="org.commcare.dalvik.action.CommCareSession"/>
 
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>


### PR DESCRIPTION
## Summary

There is no reason for us to use different action names depending on the build types as we only expect one CC build type to be installed on a device. The change is prompted by the fact that we don't need to use different intent action while developing locally with CC debug builds. 


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

Not needed 
### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 

Safe as there is no change for release builds
