### PR TITLE
Connect App verification

### DIFF
--- a/app/src/org/commcare/activities/CommCareVerificationActivity.java
+++ b/app/src/org/commcare/activities/CommCareVerificationActivity.java
@@ -43,6 +43,8 @@ public class CommCareVerificationActivity
     private static final String KEY_REQUIRE_REFRESH = "require_referesh";
     public static final String KEY_LAUNCH_FROM_SETTINGS = "from_settings";
 
+    public static final String KEY_LAUNCH_FROM_CONNECT = "from_connect";
+
     private static final int DIALOG_VERIFY_PROGRESS = 0;
     private static final String MISSING_MEDIA_TEXT_KEY = "missing-media-text-key";
     private static final String NEW_MEDIA_KEY = "new-media-to-validate";
@@ -68,6 +70,7 @@ public class CommCareVerificationActivity
      * CommCareHomeActivity
      */
     private boolean fromSettings;
+    private boolean fromConnect;
     private boolean isFirstLaunch;
 
     @Override
@@ -86,6 +89,8 @@ public class CommCareVerificationActivity
 
         this.fromSettings = this.getIntent().
                 getBooleanExtra(KEY_LAUNCH_FROM_SETTINGS, false);
+        this.fromConnect = this.getIntent().
+                getBooleanExtra(KEY_LAUNCH_FROM_CONNECT, false);
         this.fromManager = this.getIntent().
                 getBooleanExtra(AppManagerActivity.KEY_LAUNCH_FROM_MANAGER, false);
         if (fromManager) {
@@ -129,7 +134,7 @@ public class CommCareVerificationActivity
         // then something was done on the Manager screen that means we no longer want to be here --
         // VerificationActivity should be displayed to a user only if we were explicitly sent from
         // the manager, or if the state of installed apps calls for it
-        boolean shouldBeHere = fromManager || fromSettings || MultipleAppsUtil.shouldSeeMMVerification();
+        boolean shouldBeHere = fromManager || fromSettings || fromConnect || MultipleAppsUtil.shouldSeeMMVerification();
         if (!shouldBeHere) {
             // send back to dispatch activity
             setResult(RESULT_OK);

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -25,7 +25,7 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
                 if (result.getResultCode() == Activity.RESULT_OK) {
                     ConnectDownloadingFragment connectDownloadFragment = getConnectDownloadFragment();
                     if (connectDownloadFragment != null) {
-                        connectDownloadFragment.startLearning();
+                        connectDownloadFragment.onSuccessfulVerification();
                     }
                 }
             });

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -1,11 +1,16 @@
 package org.commcare.activities.connect;
 
+import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.fragment.NavHostFragment;
 
 import org.commcare.activities.CommCareActivity;
+import org.commcare.activities.CommCareVerificationActivity;
 import org.commcare.dalvik.R;
 import org.commcare.fragments.connect.ConnectDownloadingFragment;
 import org.commcare.tasks.ResourceEngineListener;
@@ -13,6 +18,17 @@ import org.commcare.tasks.ResourceEngineListener;
 import javax.annotation.Nullable;
 
 public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
+
+    ActivityResultLauncher<Intent> verificationLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            result -> {
+                if (result.getResultCode() == Activity.RESULT_OK) {
+                    ConnectDownloadingFragment connectDownloadFragment = getConnectDownloadFragment();
+                    if (connectDownloadFragment != null) {
+                        connectDownloadFragment.startLearning();
+                    }
+                }
+            });
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -41,5 +57,11 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
             return (ConnectDownloadingFragment)currentFragment;
         }
         return null;
+    }
+
+    public void startAppValidation() {
+        Intent i = new Intent(this, CommCareVerificationActivity.class);
+        i.putExtra(CommCareVerificationActivity.KEY_LAUNCH_FROM_SETTINGS, true);
+        verificationLauncher.launch(i);
     }
 }

--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -85,6 +85,10 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
     }
 
     private void onSuccessfulInstall() {
+        startLearning();
+    }
+
+    public void startLearning() {
         View view = getView();
         if (view != null) {
             NavDirections directions;

--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment;
 import androidx.navigation.NavDirections;
 import androidx.navigation.Navigation;
 
+import org.commcare.activities.connect.ConnectActivity;
 import org.commcare.android.database.connect.models.ConnectAppRecord;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
 import org.commcare.dalvik.R;
@@ -85,7 +86,7 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
     }
 
     private void onSuccessfulInstall() {
-        startLearning();
+        ((ConnectActivity)getActivity()).startAppValidation();
     }
 
     public void startLearning() {

--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -89,7 +89,7 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
         ((ConnectActivity)getActivity()).startAppValidation();
     }
 
-    public void startLearning() {
+    public void onSuccessfulVerification() {
         View view = getView();
         if (view != null) {
             NavDirections directions;


### PR DESCRIPTION
## Summary

Verifies Connect App after installing it and move to next sceeen only if verification is successful


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

None

### Safety story

Changes only touch connect screens, CC impact is limited to verification activity which adds a variable `fromConnect` to handle launch from connect but looks like a minimal safe change. 
