### PR TITLE
Enable back button on connect activity

### DIFF
--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -320,6 +320,8 @@ public class DispatchActivity extends AppCompatActivity {
             i = new Intent(this, StandardHomeActivity.class);
         }
         i.putExtra(START_FROM_LOGIN, startFromLogin);
+        i.putExtra(CommCareLauncher.EXTRA_FROM_CONNECT,
+                getIntent().getBooleanExtra(CommCareLauncher.EXTRA_FROM_CONNECT, false));
         i.putExtra(LoginActivity.LOGIN_MODE, lastLoginMode);
         i.putExtra(LoginActivity.MANUAL_SWITCH_TO_PW_MODE, userManuallyEnteredPasswordMode);
         startFromLogin = false;

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -40,6 +40,7 @@ import org.commcare.android.logging.ReportingUtils;
 import org.commcare.appupdate.AppUpdateControllerFactory;
 import org.commcare.appupdate.AppUpdateState;
 import org.commcare.appupdate.FlexibleAppUpdateController;
+import org.commcare.commcaresupportlibrary.CommCareLauncher;
 import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
@@ -1464,6 +1465,9 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
     @Override
     public boolean isBackEnabled() {
+        if (getIntent().getBooleanExtra(CommCareLauncher.EXTRA_FROM_CONNECT, false)) {
+            return true;
+        }
         return false;
     }
 

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.appcompat.app.ActionBar;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.fragment.NavHostFragment;
 
@@ -35,6 +36,17 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.screen_connect);
         setTitle(getString(R.string.connect_title));
+        showBackButton();
+    }
+
+    private void showBackButton() {
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            if(isBackEnabled()){
+                actionBar.setDisplayShowHomeEnabled(true);
+                actionBar.setDisplayHomeAsUpEnabled(true);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

Shows back button on Connect Workflow Screens plus Home Screen for Connect Launches

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

None

### Safety story

Home Screen uses the connect launch flag to enable the back screen button to not affect normal CC workflow, other changes are limited to connect 
