### PR TITLE
Implements heartbeat for Connect

### DIFF
--- a/app/src/org/commcare/activities/connect/ConnectManager.java
+++ b/app/src/org/commcare/activities/connect/ConnectManager.java
@@ -113,14 +113,15 @@ public class ConnectManager {
     }
 
     private static void scheduleHearbeat() {
-        if (isUnlocked()) {
+        if (AppManagerDeveloperPreferences.isConnectIdEnabled()) {
             Constraints constraints = new Constraints.Builder()
                     .setRequiredNetworkType(NetworkType.CONNECTED)
                     .setRequiresBatteryNotLow(true)
                     .build();
 
             PeriodicWorkRequest heartbeatRequest =
-                    new PeriodicWorkRequest.Builder(ConnectHeartbeatWorker.class, PERIODICITY_FOR_HEARTBEAT_IN_HOURS,
+                    new PeriodicWorkRequest.Builder(ConnectHeartbeatWorker.class,
+                            PERIODICITY_FOR_HEARTBEAT_IN_HOURS,
                             TimeUnit.HOURS)
                             .addTag(CONNECT_WORKER)
                             .setConstraints(constraints)
@@ -132,7 +133,7 @@ public class ConnectManager {
 
             WorkManager.getInstance(CommCareApplication.instance()).enqueueUniquePeriodicWork(
                     CONNECT_HEARTBEAT_REQUEST_NAME,
-                    ExistingPeriodicWorkPolicy.KEEP,
+                    ExistingPeriodicWorkPolicy.REPLACE,
                     heartbeatRequest
             );
         }

--- a/app/src/org/commcare/activities/connect/ConnectManager.java
+++ b/app/src/org/commcare/activities/connect/ConnectManager.java
@@ -5,6 +5,13 @@ import android.content.Context;
 import android.content.Intent;
 
 import org.commcare.AppUtils;
+import androidx.work.BackoffPolicy;
+import androidx.work.Constraints;
+import androidx.work.ExistingPeriodicWorkPolicy;
+import androidx.work.NetworkType;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
+
 import org.commcare.activities.CommCareActivity;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.activities.SettingsHelper;
@@ -12,6 +19,7 @@ import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
 import org.commcare.CommCareApplication;
 import org.commcare.android.database.global.models.ApplicationRecord;
+import org.commcare.connect.workers.ConnectHeartbeatWorker;
 import org.commcare.core.encryption.CryptUtil;
 import org.commcare.core.network.AuthInfo;
 import org.commcare.dalvik.R;
@@ -19,6 +27,8 @@ import org.commcare.google.services.analytics.AnalyticsParamValue;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.models.encryption.ByteEncrypter;
 import org.commcare.preferences.AppManagerDeveloperPreferences;
+import org.commcare.sync.FormSubmissionHelper;
+import org.commcare.sync.FormSubmissionWorker;
 import org.javarosa.core.util.PropertyUtils;
 
 import java.io.Serializable;
@@ -27,6 +37,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import javax.crypto.SecretKey;
 
@@ -38,6 +49,11 @@ import androidx.annotation.Nullable;
  * @author dviggiano
  */
 public class ConnectManager {
+    private static final String CONNECT_WORKER = "connect_worker";
+    private static final long PERIODICITY_FOR_HEARTBEAT_IN_HOURS = 4;
+    private static final long BACKOFF_DELAY_FOR_HEARTBEAT_RETRY = 5 * 60 * 1000L; // 5 mins
+    private static final String CONNECT_HEARTBEAT_REQUEST_NAME = "connect_hearbeat_periodic_request";
+
     /**
      * Enum representing the current state of ConnectID
      */
@@ -92,6 +108,33 @@ public class ConnectManager {
             } else if (manager.connectStatus == ConnectIdStatus.NotIntroduced) {
                 manager.connectStatus = ConnectIdStatus.LoggedOut;
             }
+        }
+        scheduleHearbeat();
+    }
+
+    private static void scheduleHearbeat() {
+        if (isUnlocked()) {
+            Constraints constraints = new Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .setRequiresBatteryNotLow(true)
+                    .build();
+
+            PeriodicWorkRequest heartbeatRequest =
+                    new PeriodicWorkRequest.Builder(ConnectHeartbeatWorker.class, PERIODICITY_FOR_HEARTBEAT_IN_HOURS,
+                            TimeUnit.HOURS)
+                            .addTag(CONNECT_WORKER)
+                            .setConstraints(constraints)
+                            .setBackoffCriteria(
+                                    BackoffPolicy.EXPONENTIAL,
+                                    BACKOFF_DELAY_FOR_HEARTBEAT_RETRY,
+                                    TimeUnit.MILLISECONDS)
+                            .build();
+
+            WorkManager.getInstance(CommCareApplication.instance()).enqueueUniquePeriodicWork(
+                    CONNECT_HEARTBEAT_REQUEST_NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    heartbeatRequest
+            );
         }
     }
 

--- a/app/src/org/commcare/connect/network/ConnectNetworkService.kt
+++ b/app/src/org/commcare/connect/network/ConnectNetworkService.kt
@@ -1,0 +1,14 @@
+package org.commcare.connect.network
+
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface ConnectNetworkService {
+
+    @POST("users/heartbeat")
+    fun makeHeartbeatRequest(
+        @Query("fcm_token") fcmToken: String
+    ): Call<ResponseBody?>?
+}

--- a/app/src/org/commcare/connect/network/ConnectNetworkServiceFactory.kt
+++ b/app/src/org/commcare/connect/network/ConnectNetworkServiceFactory.kt
@@ -12,12 +12,12 @@ object ConnectNetworkServiceFactory {
 
     private const val CONNECT_ID_BASE_URL = "https://connectid.dimagi.com/"
 
-    private val auth = HttpUtils.getCredential(ConnectManager.getConnectToken())
+    private val authInterceptor = AuthenticationInterceptor()
 
     private val httpClient = OkHttpClient.Builder()
         .connectTimeout(ModernHttpRequester.CONNECTION_TIMEOUT.toLong(), TimeUnit.MILLISECONDS)
         .readTimeout(ModernHttpRequester.CONNECTION_SO_TIMEOUT.toLong(), TimeUnit.MILLISECONDS)
-        .addInterceptor(AuthenticationInterceptor(auth))
+        .addInterceptor(authInterceptor)
 
     private val connectIdRetrofit = Retrofit.Builder()
         .baseUrl(CONNECT_ID_BASE_URL)
@@ -25,6 +25,7 @@ object ConnectNetworkServiceFactory {
         .build()
 
     fun createConnectIdNetworkSerive(): ConnectNetworkService {
+        authInterceptor.setCredential(HttpUtils.getCredential(ConnectManager.getConnectToken()))
         return connectIdRetrofit.create(ConnectNetworkService::class.java)
     }
 }

--- a/app/src/org/commcare/connect/network/ConnectNetworkServiceFactory.kt
+++ b/app/src/org/commcare/connect/network/ConnectNetworkServiceFactory.kt
@@ -1,0 +1,30 @@
+package org.commcare.connect.network
+
+import okhttp3.OkHttpClient
+import org.commcare.activities.connect.ConnectManager
+import org.commcare.core.network.AuthenticationInterceptor
+import org.commcare.core.network.ModernHttpRequester
+import org.commcare.network.HttpUtils
+import retrofit2.Retrofit
+import java.util.concurrent.TimeUnit
+
+object ConnectNetworkServiceFactory {
+
+    private const val CONNECT_BASE_URL = "https://connect.dimagi.com/"
+
+    private val auth = HttpUtils.getCredential(ConnectManager.getConnectToken())
+
+    private val httpClient = OkHttpClient.Builder()
+        .connectTimeout(ModernHttpRequester.CONNECTION_TIMEOUT.toLong(), TimeUnit.MILLISECONDS)
+        .readTimeout(ModernHttpRequester.CONNECTION_SO_TIMEOUT.toLong(), TimeUnit.MILLISECONDS)
+        .addInterceptor(AuthenticationInterceptor(auth))
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(CONNECT_BASE_URL)
+        .client(httpClient.build())
+        .build()
+
+    fun createConnectNetworkSerive(): ConnectNetworkService {
+        return retrofit.create(ConnectNetworkService::class.java)
+    }
+}

--- a/app/src/org/commcare/connect/network/ConnectNetworkServiceFactory.kt
+++ b/app/src/org/commcare/connect/network/ConnectNetworkServiceFactory.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit
 
 object ConnectNetworkServiceFactory {
 
-    private const val CONNECT_BASE_URL = "https://connect.dimagi.com/"
+    private const val CONNECT_ID_BASE_URL = "https://connectid.dimagi.com/"
 
     private val auth = HttpUtils.getCredential(ConnectManager.getConnectToken())
 
@@ -19,12 +19,12 @@ object ConnectNetworkServiceFactory {
         .readTimeout(ModernHttpRequester.CONNECTION_SO_TIMEOUT.toLong(), TimeUnit.MILLISECONDS)
         .addInterceptor(AuthenticationInterceptor(auth))
 
-    private val retrofit = Retrofit.Builder()
-        .baseUrl(CONNECT_BASE_URL)
+    private val connectIdRetrofit = Retrofit.Builder()
+        .baseUrl(CONNECT_ID_BASE_URL)
         .client(httpClient.build())
         .build()
 
-    fun createConnectNetworkSerive(): ConnectNetworkService {
-        return retrofit.create(ConnectNetworkService::class.java)
+    fun createConnectIdNetworkSerive(): ConnectNetworkService {
+        return connectIdRetrofit.create(ConnectNetworkService::class.java)
     }
 }

--- a/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
+++ b/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
@@ -13,7 +13,7 @@ class ConnectHeartbeatWorker(context: Context, workerParams: WorkerParameters) :
     CoroutineWorker(context, workerParams) {
 
     override suspend fun doWork(): Result {
-        withContext(Dispatchers.IO) {
+        return withContext(Dispatchers.IO) {
             if (!ConnectManager.isUnlocked()) {
                 return@withContext Result.failure()
             }
@@ -22,6 +22,5 @@ class ConnectHeartbeatWorker(context: Context, workerParams: WorkerParameters) :
             val response = connectNetworkService.makeHeartbeatRequest(fcmToken)!!.execute()
             return@withContext if (response.isSuccessful) Result.success() else Result.failure()
         }
-        return Result.failure()
     }
 }

--- a/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
+++ b/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
@@ -1,0 +1,27 @@
+package org.commcare.connect.workers
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.commcare.activities.connect.ConnectManager
+import org.commcare.connect.network.ConnectNetworkServiceFactory
+import org.commcare.utils.FirebaseMessagingUtil
+
+class ConnectHeartbeatWorker(context: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(context, workerParams) {
+
+    override suspend fun doWork(): Result {
+        withContext(Dispatchers.IO) {
+            if (!ConnectManager.isUnlocked()) {
+                return@withContext Result.failure()
+            }
+            val connectNetworkService = ConnectNetworkServiceFactory.createConnectNetworkSerive()
+            val fcmToken = FirebaseMessagingUtil.getFCMToken();
+            val response = connectNetworkService.makeHeartbeatRequest(fcmToken)!!.execute()
+            return@withContext if (response.isSuccessful) Result.success() else Result.failure()
+        }
+        return Result.failure()
+    }
+}

--- a/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
+++ b/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
@@ -17,7 +17,7 @@ class ConnectHeartbeatWorker(context: Context, workerParams: WorkerParameters) :
             if (!ConnectManager.isUnlocked()) {
                 return@withContext Result.failure()
             }
-            val connectNetworkService = ConnectNetworkServiceFactory.createConnectNetworkSerive()
+            val connectNetworkService = ConnectNetworkServiceFactory.createConnectIdNetworkSerive()
             val fcmToken = FirebaseMessagingUtil.getFCMToken();
             val response = connectNetworkService.makeHeartbeatRequest(fcmToken)!!.execute()
             return@withContext if (response.isSuccessful) Result.success() else Result.failure()


### PR DESCRIPTION
## Summary
Adds a heartbeat request to connect server that communicates the fcm_token to connect server to be used in push notifications. 

[HQ PR](https://github.com/dimagi/connect-id/pull/7)

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

None

### Safety story

Changes are isolated to Connect
Tested locally to make sure the request goes through to HQ with a 200 code