### PR TITLE
Not showing apps managed by Connect in LoginActivity selector

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -112,7 +112,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
     private LoginActivityUiController uiController;
     private FormAndDataSyncer formAndDataSyncer;
-    private String presetAppID;
+    private String presetAppId;
     private boolean appLaunchedFromConnect;
 
     @Override
@@ -133,7 +133,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         ConnectManager.init(this);
         updateConnectButton();
 
-        presetAppID = getIntent().getStringExtra(EXTRA_APP_ID);
+        presetAppId = getIntent().getStringExtra(EXTRA_APP_ID);
         appLaunchedFromConnect = getIntent().getBooleanExtra(CommCareLauncher.EXTRA_FROM_CONNECT, false);
 
         if (savedInstanceState == null) {
@@ -282,7 +282,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         return false;
     }
 
-
     // cancels all worker tasks for previously seated app
     private static void disableWorkForLastSeatedApp() {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(CommCareApplication.instance());
@@ -384,9 +383,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
             if (ConnectManager.isUnlocked() && appLaunchedFromConnect) {
                 //Configure some things if we haven't already
                 ConnectLinkedAppRecord record = ConnectDatabaseHelper.getAppData(this,
-                        presetAppID, username);
+                        presetAppId, username);
                 if (record == null) {
-                    record = ConnectManager.prepareConnectManagedApp(this, presetAppID, username);
+                    record = ConnectManager.prepareConnectManagedApp(this, presetAppId, username);
                 }
 
                 passwordOrPin = record.getPassword();
@@ -896,7 +895,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         }
     }
 
-    protected String getPresetAppID() {
-        return presetAppID;
+    protected String getPresetAppId() {
+        return presetAppId;
     }
 }

--- a/app/src/org/commcare/activities/LoginActivityUiController.java
+++ b/app/src/org/commcare/activities/LoginActivityUiController.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 import androidx.preference.PreferenceManager;
 
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Vector;
 
 import org.commcare.CommCareApplication;
@@ -28,6 +29,7 @@ import org.commcare.activities.connect.ConnectDatabaseHelper;
 import org.commcare.activities.connect.ConnectManager;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.global.models.ApplicationRecord;
+import org.commcare.core.network.AuthInfo;
 import org.commcare.dalvik.R;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.interfaces.CommCareActivityUIController;
@@ -221,9 +223,28 @@ public class LoginActivityUiController implements CommCareActivityUIController {
 
         // Decide whether or not to show the app selection spinner based upon # of usable apps
         ArrayList<ApplicationRecord> readyApps = MultipleAppsUtil.getUsableAppRecords();
+        if(ConnectManager.isConnectIdIntroduced()) {
+            //We need to remove any apps that are managed by Connect
+            String username = ConnectManager.getUser(activity).getUserId().toLowerCase(Locale.getDefault());
+            for(int i= readyApps.size()-1; i>=0; i--) {
+                String appId = readyApps.get(i).getUniqueId();
+                //Preset app needs to be in the list if set
+                if(!appId.equals(activity.getPresetAppId())) {
+                    AuthInfo.ProvidedAuth auth = ConnectManager.getCredentialsForApp(appId, username);
+                    if (auth != null) {
+                        //Creds stored for the CID username indicates this app is managed by Connect
+                        readyApps.remove(i);
+                    }
+                }
+            }
+        }
+
         boolean promptIncluded = false;
         ApplicationRecord presetAppRecord = getPresetAppRecord(readyApps);
-        if ((readyApps.size() == 1 && (!ConnectManager.isConnectIdIntroduced() || ConnectManager.isUnlocked()))
+        if(readyApps.isEmpty()) {
+            appLabel.setVisibility(View.GONE);
+            setLoginInputsVisibility(false);
+        } else if ((readyApps.size() == 1 && (!ConnectManager.isConnectIdIntroduced() || ConnectManager.isUnlocked()))
                 || presetAppRecord != null) {
             setLoginInputsVisibility(true);
 
@@ -298,7 +319,7 @@ public class LoginActivityUiController implements CommCareActivityUIController {
 
     @Nullable
     private ApplicationRecord getPresetAppRecord(ArrayList<ApplicationRecord> readyApps) {
-        String presetAppId = activity.getPresetAppID();
+        String presetAppId = activity.getPresetAppId();
         if (presetAppId != null) {
             for (ApplicationRecord readyApp : readyApps) {
                 if (readyApp.getUniqueId().equals(presetAppId)) {

--- a/app/src/org/commcare/activities/LoginActivityUiController.java
+++ b/app/src/org/commcare/activities/LoginActivityUiController.java
@@ -223,21 +223,7 @@ public class LoginActivityUiController implements CommCareActivityUIController {
 
         // Decide whether or not to show the app selection spinner based upon # of usable apps
         ArrayList<ApplicationRecord> readyApps = MultipleAppsUtil.getUsableAppRecords();
-        if(ConnectManager.isConnectIdIntroduced()) {
-            //We need to remove any apps that are managed by Connect
-            String username = ConnectManager.getUser(activity).getUserId().toLowerCase(Locale.getDefault());
-            for(int i= readyApps.size()-1; i>=0; i--) {
-                String appId = readyApps.get(i).getUniqueId();
-                //Preset app needs to be in the list if set
-                if(!appId.equals(activity.getPresetAppId())) {
-                    AuthInfo.ProvidedAuth auth = ConnectManager.getCredentialsForApp(appId, username);
-                    if (auth != null) {
-                        //Creds stored for the CID username indicates this app is managed by Connect
-                        readyApps.remove(i);
-                    }
-                }
-            }
-        }
+        ConnectManager.filterConnectManagedApps(activity, readyApps, activity.getPresetAppId());
 
         boolean promptIncluded = false;
         ApplicationRecord presetAppRecord = getPresetAppRecord(readyApps);

--- a/app/src/org/commcare/activities/connect/ConnectManager.java
+++ b/app/src/org/commcare/activities/connect/ConnectManager.java
@@ -588,12 +588,10 @@ public class ConnectManager {
     }
 
     public static AuthInfo.ProvidedAuth getCredentialsForApp(String appId, String userId) {
-        if (isUnlocked()) {
-            ConnectLinkedAppRecord record = ConnectDatabaseHelper.getAppData(manager.parentActivity, appId,
-                    userId);
-            if (record != null && record.getPassword().length() > 0) {
-                return new AuthInfo.ProvidedAuth(record.getUserId(), record.getPassword(), false);
-            }
+        ConnectLinkedAppRecord record = ConnectDatabaseHelper.getAppData(manager.parentActivity, appId,
+                userId);
+        if (record != null && record.getPassword().length() > 0) {
+            return new AuthInfo.ProvidedAuth(record.getUserId(), record.getPassword(), false);
         }
 
         return null;

--- a/app/src/org/commcare/activities/connect/ConnectManager.java
+++ b/app/src/org/commcare/activities/connect/ConnectManager.java
@@ -5,11 +5,13 @@ import android.content.Context;
 import android.content.Intent;
 
 import org.commcare.activities.CommCareActivity;
+import org.commcare.activities.LoginActivity;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.activities.SettingsHelper;
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.core.encryption.CryptUtil;
 import org.commcare.core.network.AuthInfo;
 import org.commcare.dalvik.R;
@@ -20,12 +22,15 @@ import org.commcare.preferences.AppManagerDeveloperPreferences;
 import org.javarosa.core.util.PropertyUtils;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
 import javax.crypto.SecretKey;
+
+import androidx.annotation.Nullable;
 
 /**
  * Manager class for ConnectID, handles workflow navigation and user management
@@ -173,6 +178,24 @@ public class ConnectManager {
         manager.recoveryPhone = null;
         manager.recoverySecret = null;
         manager.forgotPassword = false;
+    }
+
+    public static void filterConnectManagedApps(Context context, ArrayList<ApplicationRecord> readyApps, String presetAppId) {
+        if(ConnectManager.isConnectIdIntroduced()) {
+            //We need to remove any apps that are managed by Connect
+            String username = ConnectManager.getUser(context).getUserId().toLowerCase(Locale.getDefault());
+            for(int i= readyApps.size()-1; i>=0; i--) {
+                String appId = readyApps.get(i).getUniqueId();
+                //Preset app needs to remain in the list if set
+                if(!appId.equals(presetAppId)) {
+                    AuthInfo.ProvidedAuth auth = ConnectManager.getCredentialsForApp(appId, username);
+                    if (auth != null) {
+                        //Creds stored for the CID username indicates this app is managed by Connect
+                        readyApps.remove(i);
+                    }
+                }
+            }
+        }
     }
 
     public static void handleConnectButtonPress(ConnectActivityCompleteListener listener) {
@@ -587,6 +610,7 @@ public class ConnectManager {
         }
     }
 
+    @Nullable
     public static AuthInfo.ProvidedAuth getCredentialsForApp(String appId, String userId) {
         ConnectLinkedAppRecord record = ConnectDatabaseHelper.getAppData(manager.parentActivity, appId,
                 userId);


### PR DESCRIPTION
This is to address [CCPC-141](https://dimagi-dev.atlassian.net/browse/CCPC-141). Hiding apps that are managed by Connect in the selector on the login page, so there's no way for the user to access those apps from there.

"Apps managed by Connect" are identified as having a stored ConnectLinkedAppRecord with a username equal to the ConnectID username (a long random alphanumeric string).

The code allows the presetAppId to remain in the list (i.e. when launched from Connect), since it needs to be included in order for the traditional login functionality to work.

I also renamed the presetAppID and getter to Id since the linter doesn't like acronyms to be in all caps.