### PR TITLE
Going directly to Connect jobs list after user unlocks CID

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -455,7 +455,9 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     public void handleConnectButtonPress() {
         selectedAppIndex = -1;
         ConnectManager.handleConnectButtonPress(success -> {
-            updateConnectButton();
+            if(success) {
+                ConnectManager.goToConnectJobsList();
+            }
         });
     }
 

--- a/app/src/org/commcare/activities/connect/ConnectManager.java
+++ b/app/src/org/commcare/activities/connect/ConnectManager.java
@@ -197,9 +197,7 @@ public class ConnectManager {
                 }
             }
             case LoggedIn -> {
-                ConnectTask task = ConnectTask.CONNECT_MAIN;
-                Intent i = new Intent(manager.parentActivity, task.getNextActivity());
-                manager.parentActivity.startActivityForResult(i, task.getRequestCode());
+                goToConnectJobsList();
             }
         }
 
@@ -207,6 +205,12 @@ public class ConnectManager {
             manager.phase = requestCode;
             manager.continueWorkflow();
         }
+    }
+
+    public static void goToConnectJobsList() {
+        ConnectTask task = ConnectTask.CONNECT_MAIN;
+        Intent i = new Intent(manager.parentActivity, task.getNextActivity());
+        manager.parentActivity.startActivityForResult(i, task.getRequestCode());
     }
 
     private void continueWorkflow() {


### PR DESCRIPTION
Once the user chooses to unlock ConnectID on the login page, we'll go straight to the jobs list instead of back to the login page. This is a user request.