### PR TITLE
Fixed bug when trying to show rate limiting error message.

### DIFF
--- a/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
+++ b/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
@@ -273,7 +273,7 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
 
     public void showRateLimitError(boolean userTriggered) {
         if (HiddenPreferences.isRateLimitPopupDisabled() || !userTriggered) {
-            handleFormUploadResult(FormUploadResult.RATE_LIMITED, null, userTriggered);
+            handleFormSendResult(Localization.get(FormUploadResult.RATE_LIMITED.getLocaleKeyBase()), false);
             return;
         }
         String title = Localization.get("form.send.rate.limit.error.title");

--- a/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
+++ b/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
@@ -232,23 +232,23 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
     public void handleFormUploadResult(FormUploadResult result, String formLabel, boolean userTriggered) {
         switch (result) {
             case FULL_SUCCESS:
-                handleFormSendResult(formLabel, true);
+                updateUiForFormUploadResult(formLabel, true);
                 break;
             case BAD_CERTIFICATE:
                 CommCareApplication.notificationManager().reportNotificationMessage(
                         NotificationMessageFactory.message(NotificationMessageFactory.StockMessages.BadSslCertificate,
                                 NotificationActionButtonInfo.ButtonAction.LAUNCH_DATE_SETTINGS));
 
-                handleFormSendResult(Localization.get(result.getLocaleKeyBase()), false);
+                updateUiForFormUploadResult(Localization.get(result.getLocaleKeyBase()), false);
                 break;
             case ACTIONABLE_FAILURE:
-                handleFormSendResult(result.getErrorMessage(), false);
+                updateUiForFormUploadResult(result.getErrorMessage(), false);
                 break;
             case RATE_LIMITED:
                 showRateLimitError(userTriggered);
                 break;
             case CANCELLED:
-                handleFormSendResult(Localization.get(result.getLocaleKeyBase())
+                updateUiForFormUploadResult(Localization.get(result.getLocaleKeyBase())
                         + " " + formLabel, false);
                 break;
             case AUTH_FAILURE:
@@ -258,12 +258,12 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
             case INVALID_CASE_GRAPH:
             case FAILURE:
             default:
-                handleFormSendResult(Localization.get(result.getLocaleKeyBase()), false);
+                updateUiForFormUploadResult(Localization.get(result.getLocaleKeyBase()), false);
                 break;
         }
     }
 
-    public void handleFormSendResult(String message, boolean success) {
+    public void updateUiForFormUploadResult(String message, boolean success) {
         updateUiAfterDataPullOrSend(message, success);
         if (success) {
             // Since we know that we just had connectivity, now is a great time to try this
@@ -273,7 +273,7 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
 
     public void showRateLimitError(boolean userTriggered) {
         if (HiddenPreferences.isRateLimitPopupDisabled() || !userTriggered) {
-            handleFormSendResult(Localization.get(FormUploadResult.RATE_LIMITED.getLocaleKeyBase()), false);
+            updateUiForFormUploadResult(Localization.get(FormUploadResult.RATE_LIMITED.getLocaleKeyBase()), false);
             return;
         }
         String title = Localization.get("form.send.rate.limit.error.title");


### PR DESCRIPTION
## Summary
Step 6 [here](https://dimagi-dev.atlassian.net/browse/CCPC-184), the crash. The error-handling code for rate limiting was calling handleFormUploadResult when it should have called handleFormSendResult. Fixed the error and renamed the latter method to avoid future confusion.

## Safety Assurance

- [ ] If the PR is high risk, "High Risk" label is set
- [x ] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
