### PR TITLE
Adds a new notification channel for push notifications

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -393,6 +393,8 @@
     <string name="notification_channel_user_session_description" cc:translatable="true">Notification containing information around current user session like when the current session is scheduled to expire</string>
     <string name="notification_channel_server_communication_title" cc:translatable="true">Server Communications</string>
     <string name="notification_channel_server_communication_description" cc:translatable="true">Notifications for status of any background server communication happening at the moment like CommCare App updates, log submission etc.</string>
+    <string name="notification_channel_push_notfications_title" cc:translatable="true">Priority notifications from Server</string>
+    <string name="notification_channel_push_notfications_description" cc:translatable="true">Notifications sent from server directly to notify user of priority tasks</string>
 
     <!--Recovery Measures-->
     <string name="recovery_measure_reinstall_method" cc:translatable="true">Choose Reinstall Method</string>
@@ -451,6 +453,6 @@
     <string name="dependency_missing_dialog_go_to_store" cc:translatable="true">Install from Store</string>
     <string name="dependency_missing_dialog_playstore_not_found" cc:translatable="true">No Play Store found on your device</string>
     <string name="fcm_notification">FCM Notification</string>
-    <string name="fcm_default_notification_channel">notification-channel-server-communications</string>
+    <string name="fcm_default_notification_channel">notification-channel-push-notifications</string>
     <string name="app_with_id_not_found">Required CommCare App is not installed on device</string>
 </resources>

--- a/app/src/org/commcare/CommCareNoficationManager.java
+++ b/app/src/org/commcare/CommCareNoficationManager.java
@@ -38,6 +38,7 @@ public class CommCareNoficationManager {
     public static final String NOTIFICATION_CHANNEL_ERRORS_ID = "notification-channel-errors";
     public static final String NOTIFICATION_CHANNEL_USER_SESSION_ID = "notification-channel-user-session";
     public static final String NOTIFICATION_CHANNEL_SERVER_COMMUNICATIONS_ID = "notification-channel-server-communications";
+    public static final String NOTIFICATION_CHANNEL_PUSH_NOTIFICATIONS_ID = "notification-channel-push-notifications";
 
     /**
      * Handler to receive notifications and show them the user using toast.
@@ -188,6 +189,11 @@ public class CommCareNoficationManager {
                 R.string.notification_channel_server_communication_title,
                 R.string.notification_channel_server_communication_description,
                 NotificationManager.IMPORTANCE_LOW);
+
+        createNotificationChannel(NOTIFICATION_CHANNEL_PUSH_NOTIFICATIONS_ID,
+                R.string.notification_channel_push_notfications_title,
+                R.string.notification_channel_push_notfications_description,
+                NotificationManager.IMPORTANCE_DEFAULT);
     }
 
     @TargetApi(Build.VERSION_CODES.O)

--- a/app/src/org/commcare/services/CommCareFirebaseMessagingService.java
+++ b/app/src/org/commcare/services/CommCareFirebaseMessagingService.java
@@ -99,7 +99,7 @@ public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
             contentIntent = PendingIntent.getActivity(this, 0, i, 0);
 
         NotificationCompat.Builder fcmNotification = new NotificationCompat.Builder(this,
-                CommCareNoficationManager.NOTIFICATION_CHANNEL_SERVER_COMMUNICATIONS_ID)
+                CommCareNoficationManager.NOTIFICATION_CHANNEL_PUSH_NOTIFICATIONS_ID)
                 .setContentTitle(notificationTitle)
                 .setContentText(notificationText)
                 .setContentIntent(contentIntent)


### PR DESCRIPTION
## Summary

Simple change to direct firebase notifications to a new notification channel with default priority (instead of non obstructive min priority for server notifications) 

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story

Small change, almost no-op. Should be tested by QA before release. 

