### PR TITLE
Allow Unsynced Time Limit to be set in hours

### DIFF
--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -153,12 +153,11 @@ public class SyncDetailCalculations {
     private static boolean unsentFormTimeLimitExceeded(long lastSyncTime) {
         SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
         double unsentFormTimeLimitInDays = Double.parseDouble(prefs.getString(UNSENT_FORM_TIME_KEY, "5"));
-        int unsentFormTimeLimitInMinutes = (int)(unsentFormTimeLimitInDays * 24 * 60);
+        long unsentFormTimeLimitInMsecs = (int)(unsentFormTimeLimitInDays * 24 * 60 * 60 * 1000);
 
         long now = new Date().getTime();
-        int secsSinceLastSync = (int)((now - lastSyncTime) / 1000);
-        int minutesSinceLastSync = (int)(secsSinceLastSync / 60);
+        long msecsSinceLastSync = (now - lastSyncTime);
 
-        return minutesSinceLastSync > unsentFormTimeLimitInMinutes;
+        return msecsSinceLastSync > unsentFormTimeLimitInMsecs;
     }
 }

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -152,12 +152,13 @@ public class SyncDetailCalculations {
 
     private static boolean unsentFormTimeLimitExceeded(long lastSyncTime) {
         SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        int unsentFormTimeLimit = Integer.parseInt(prefs.getString(UNSENT_FORM_TIME_KEY, "5"));
+        double unsentFormTimeLimitInDays = Double.parseDouble(prefs.getString(UNSENT_FORM_TIME_KEY, "5"));
+        int unsentFormTimeLimitInMinutes = (int)(unsentFormTimeLimitInDays * 24 * 60);
 
         long now = new Date().getTime();
-        int secs_ago = (int)((lastSyncTime - now) / 1000);
-        int days_ago = secs_ago / 86400;
+        int secsSinceLastSync = (int)((now - lastSyncTime) / 1000);
+        int minutesSinceLastSync = (int)(secsSinceLastSync / 60);
 
-        return (-days_ago) > unsentFormTimeLimit;
+        return minutesSinceLastSync > unsentFormTimeLimitInMinutes;
     }
 }

--- a/app/src/org/commcare/utils/SyncDetailCalculations.java
+++ b/app/src/org/commcare/utils/SyncDetailCalculations.java
@@ -11,10 +11,9 @@ import org.commcare.CommCareApplication;
 import org.commcare.activities.StandardHomeActivity;
 import org.commcare.adapters.HomeCardDisplayData;
 import org.commcare.adapters.SquareButtonViewHolder;
-import org.commcare.android.logging.ReportingUtils;
+import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.dalvik.R;
 import org.commcare.models.database.SqlStorage;
-import org.commcare.android.database.user.models.FormRecord;
 import org.commcare.modern.util.Pair;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.util.LogTypes;
@@ -32,19 +31,23 @@ import java.util.Date;
  * @author Phillip Mates (pmates@dimagi.com).
  */
 public class SyncDetailCalculations {
-    private final static String UNSENT_FORM_NUMBER_KEY = "unsent-number-limit";
-    private final static String UNSENT_FORM_TIME_KEY = "unsent-time-limit";
-    private final static String LAST_SYNC_KEY_BASE = "last-succesful-sync-";
+    private static final String UNSENT_FORM_NUMBER_KEY = "unsent-number-limit";
+    private static final String UNSENT_FORM_TIME_KEY = "unsent-time-limit";
+    private static final String LAST_SYNC_KEY_BASE = "last-succesful-sync-";
 
-    public static void updateSubText(final StandardHomeActivity activity,
-                                     SquareButtonViewHolder squareButtonViewHolder,
-                                     HomeCardDisplayData cardDisplayData, String notificationText) {
+    public static void updateSubText(
+            final StandardHomeActivity activity,
+            SquareButtonViewHolder squareButtonViewHolder,
+            HomeCardDisplayData cardDisplayData,
+            String notificationText) {
 
         int numUnsentForms = getNumUnsentForms();
         Pair<Long, String> lastSyncTimeAndMessage = getLastSyncTimeAndMessage();
 
-        Spannable syncIndicator = (activity.localize("home.unsent.forms.indicator",
-                new String[]{String.valueOf(numUnsentForms)}));
+        Spannable syncIndicator =
+                (activity.localize(
+                        "home.unsent.forms.indicator",
+                        new String[] {String.valueOf(numUnsentForms)}));
 
         String syncStatus = "";
 
@@ -53,7 +56,6 @@ public class SyncDetailCalculations {
         } else if (numUnsentForms == 0) {
             syncStatus = lastSyncTimeAndMessage.second;
         }
-
 
         if (numUnsentForms != 0 || HiddenPreferences.shouldShowUnsentFormsWhenZero()) {
             if (!TextUtils.isEmpty(syncStatus)) {
@@ -65,13 +67,16 @@ public class SyncDetailCalculations {
         squareButtonViewHolder.subTextView.setText(syncStatus);
 
         setSyncSubtextColor(
-                squareButtonViewHolder.subTextView, numUnsentForms, lastSyncTimeAndMessage.first,
+                squareButtonViewHolder.subTextView,
+                numUnsentForms,
+                lastSyncTimeAndMessage.first,
                 activity.getResources().getColor(cardDisplayData.subTextColor),
                 activity.getResources().getColor(R.color.cc_dark_warm_accent_color));
     }
 
     public static int getNumUnsentForms() {
-        SqlStorage<FormRecord> formsStorage = CommCareApplication.instance().getUserStorage(FormRecord.class);
+        SqlStorage<FormRecord> formsStorage =
+                CommCareApplication.instance().getUserStorage(FormRecord.class);
         try {
             return StorageUtils.getUnsentRecordsForCurrentApp(formsStorage).length;
         } catch (SessionUnavailableException e) {
@@ -87,16 +92,24 @@ public class SyncDetailCalculations {
         if (lastSyncTime == 0) {
             syncTimeMessage = Localization.get("home.sync.message.last.never");
         } else {
-            syncTimeMessage = DateUtils.formatSameDayTime(lastSyncTime, new Date().getTime(), DateFormat.DEFAULT, DateFormat.DEFAULT);
+            syncTimeMessage =
+                    DateUtils.formatSameDayTime(
+                            lastSyncTime,
+                            new Date().getTime(),
+                            DateFormat.DEFAULT,
+                            DateFormat.DEFAULT);
         }
-        return new Pair<>(lastSyncTime, Localization.get("home.sync.message.last", new String[]{syncTimeMessage.toString()}));
+        return new Pair<>(
+                lastSyncTime,
+                Localization.get(
+                        "home.sync.message.last", new String[] {syncTimeMessage.toString()}));
     }
 
-
     /**
-     * @return The number of days since the user has last synced, as calculated by the difference
-     * between the current date and the date of the last sync. -1 if the user hasn't ever synced
-     * or if the last date of sync is unavailable
+     * Calculates the number of days synce the user last synced
+     *
+     * @return the difference between the current date and the date of the last sync. -1 if the user
+     *     hasn't ever synced or if the last date of sync is unavailable
      */
     public static int getDaysSinceLastSync() {
         try {
@@ -105,10 +118,11 @@ public class SyncDetailCalculations {
                 return -1;
             }
             return getDaysBetweenJavaDatetimes(new Date(lastSync), new Date());
-        } catch(Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
-            Logger.log(LogTypes.SOFT_ASSERT,"Error Generating Days since last sync: " +
-                    e.getMessage());
+            Logger.log(
+                    LogTypes.SOFT_ASSERT,
+                    "Error Generating Days since last sync: " + e.getMessage());
             return -1;
         }
     }
@@ -122,7 +136,8 @@ public class SyncDetailCalculations {
     }
 
     public static long getLastSyncTime(String username) {
-        SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        SharedPreferences prefs =
+                CommCareApplication.instance().getCurrentApp().getAppPreferences();
         return prefs.getLong(getLastSyncKey(username), 0);
     }
 
@@ -130,8 +145,12 @@ public class SyncDetailCalculations {
         return LAST_SYNC_KEY_BASE + username;
     }
 
-    private static void setSyncSubtextColor(TextView subtext, int numUnsentForms, long lastSyncTime,
-                                            int normalColor, int warningColor) {
+    private static void setSyncSubtextColor(
+            TextView subtext,
+            int numUnsentForms,
+            long lastSyncTime,
+            int normalColor,
+            int warningColor) {
         if (isSyncStronglyNeeded(numUnsentForms, lastSyncTime)) {
             subtext.setTextColor(warningColor);
         } else {
@@ -140,20 +159,23 @@ public class SyncDetailCalculations {
     }
 
     private static boolean isSyncStronglyNeeded(int numUnsentForms, long lastSyncTime) {
-        return unsentFormNumberLimitExceeded(numUnsentForms) ||
-                unsentFormTimeLimitExceeded(lastSyncTime);
+        return unsentFormNumberLimitExceeded(numUnsentForms)
+                || unsentFormTimeLimitExceeded(lastSyncTime);
     }
 
     private static boolean unsentFormNumberLimitExceeded(int numUnsentForms) {
-        SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        SharedPreferences prefs =
+                CommCareApplication.instance().getCurrentApp().getAppPreferences();
         int unsentFormNumberLimit = Integer.parseInt(prefs.getString(UNSENT_FORM_NUMBER_KEY, "5"));
         return numUnsentForms > unsentFormNumberLimit;
     }
 
     private static boolean unsentFormTimeLimitExceeded(long lastSyncTime) {
-        SharedPreferences prefs = CommCareApplication.instance().getCurrentApp().getAppPreferences();
-        double unsentFormTimeLimitInDays = Double.parseDouble(prefs.getString(UNSENT_FORM_TIME_KEY, "5"));
-        long unsentFormTimeLimitInMsecs = (int)(unsentFormTimeLimitInDays * 24 * 60 * 60 * 1000);
+        SharedPreferences prefs =
+                CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        double unsentFormTimeLimitInDays =
+                Double.parseDouble(prefs.getString(UNSENT_FORM_TIME_KEY, "5"));
+        long unsentFormTimeLimitInMsecs = (int) (unsentFormTimeLimitInDays * 24 * 60 * 60 * 1000);
 
         long now = new Date().getTime();
         long msecsSinceLastSync = (now - lastSyncTime);


### PR DESCRIPTION
## Summary
Currently, the minimum frequency for CommCare to warn users that a sync is needed is daily, this PR allows setting time limits shorter than that. The property `Unsynced Time Limit` is expressed in days, so this change makes it possible to pass down a decimal number resulting in frequencies lower than 24 hours, when the value is lower than `1`.

Ticket: https://dimagi.atlassian.net/browse/SC-3223

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Unit tests don't cover this logic. I was tempted to add some, but this code lives in a private method so I would need to broaden the scope of the test.
