### PR TITLE
Improve audio recording configuration

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -444,6 +444,7 @@ custom.restore.file.not.set=Custom restore file path is not set in preferences
 custom.restore.error=Error loading custom sync
 
 start.recording=Start Recording
+start.recording.failed=Unable to start recording while another application is recording!
 stop.recording=Stop Recording
 recording.header=Record a sound
 before.recording=Tap to start recording

--- a/app/src/org/commcare/utils/MediaUtil.java
+++ b/app/src/org/commcare/utils/MediaUtil.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.media.AudioManager;
+import android.os.Build;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.Pair;
@@ -11,8 +13,6 @@ import android.view.WindowManager;
 
 import org.commcare.CommCareApplication;
 import org.commcare.engine.references.JavaFileReference;
-import org.commcare.google.services.analytics.AnalyticsParamValue;
-import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.util.LogTypes;
 import org.javarosa.core.reference.InvalidReferenceException;
@@ -27,6 +27,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 /**
  * @author ctsims
@@ -504,6 +505,12 @@ public class MediaUtil {
         } catch (OutOfMemoryError e) {
             return performSafeScaleDown(imageFilepath, scaleDownFactor + 1, depth + 1);
         }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public static boolean isRecordingActive(Context context){
+        return ((AudioManager) context.getSystemService(Context.AUDIO_SERVICE))
+                .getActiveRecordingConfigurations().size() > 0;
     }
 
 }

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -23,9 +23,11 @@ import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
 import org.commcare.dalvik.R;
+import org.commcare.utils.MediaUtil;
 import org.javarosa.core.services.locale.Localization;
 
 import java.io.File;
@@ -165,6 +167,13 @@ public class RecordingFragment extends DialogFragment {
     }
 
     private void startRecording() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            if (MediaUtil.isRecordingActive(getContext())) {
+                Toast.makeText(getContext(), Localization.get("start.recording.failed"), Toast.LENGTH_SHORT).show();
+                return;
+            }
+        }
+
         disableScreenRotation((AppCompatActivity)getContext());
         setCancelable(false);
         setupRecorder();

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -205,8 +205,11 @@ public class RecordingFragment extends DialogFragment {
         }
 
         boolean isHeAacSupported = isHeAacEncoderSupported();
-
-        recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            recorder.setAudioSource(MediaRecorder.AudioSource.VOICE_COMMUNICATION);
+       } else {
+            recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
+       }
         recorder.setAudioSamplingRate(isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE);
         recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
         recorder.setOutputFile(fileName);

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -210,6 +210,10 @@ public class RecordingFragment extends DialogFragment {
        } else {
             recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            recorder.setPrivacySensitive(true);
+        }
         recorder.setAudioSamplingRate(isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE);
         recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
         recorder.setOutputFile(fileName);


### PR DESCRIPTION
## Summary
This PR was motivated by an issue with the Audio Recording feature in which the resulting recording had no sound. The issue was replicated by audio recording with CommCare and another voice recorder app at the same time, it was noticed that navigating away from CommCare would cause the recording to go silence. A few options were entertained as potential solutions, but ultimately taking advantage of some recording configuration elements introduced in the latest versions of Android, proved to be sufficient to ensure that CommCare audio recording feature is handled with higher priority by the system. 
While the testing was able to, it's important to note that the actual conditions in which the issue occurred could not be established as access to the list of apps in the affected devices were not possible. 

## Product Description
There are a couple change visible to the user:
- CommCare now checks if there is an ongoing recording before initiating a new one, and informs the user with the necessary message when that's the case:
<img src="https://github.com/dimagi/commcare-android/assets/19228119/d591d867-5359-4351-9e05-fc40c8a6909f" width="256" height="455"/>

- During the recording, the user is advised not to leave CommCare:
<img src="https://github.com/dimagi/commcare-android/assets/19228119/39e30845-379f-4cb6-b5ae-2bcb4adce86d" width="256" height="455"/>

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
These changes were successfully tested on Android 9, 10, 11 and 12.
