### PR TITLE
Change secondary phone

### DIFF
--- a/app/res/layout/screen_connect_message.xml
+++ b/app/res/layout/screen_connect_message.xml
@@ -30,5 +30,12 @@
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/content_start"
         android:paddingTop="@dimen/content_start" />
+    <Button
+        android:id="@+id/connect_message_button2"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="@dimen/content_start"
+        android:paddingTop="@dimen/content_start"
+        android:visibility="gone"/>
 
 </LinearLayout>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -573,6 +573,7 @@
     <string name="connect_recovery_alt_title">Alternate Phone</string>
     <string name="connect_recovery_alt_message">On the next screen, we\'ll send a code via SMS to the alternate phone number associated with your account.</string>
     <string name="connect_recovery_alt_button">Continue</string>
+    <string name="connect_recovery_alt_change_button">Change number</string>
 
     <string name="connect_recovery_success_title">Account Recovered</string>
     <string name="connect_recovery_success_message">You have successfully recovered your account and can now resume using your ConnectID.</string>

--- a/app/src/org/commcare/activities/connect/ConnectConstants.java
+++ b/app/src/org/commcare/activities/connect/ConnectConstants.java
@@ -19,6 +19,7 @@ public class ConnectConstants {
     public static final String TITLE = "TITLE";
     public static final String MESSAGE = "MESSAGE";
     public static final String BUTTON = "BUTTON";
+    public static final String BUTTON2 = "BUTTON2";
     public static final String SECRET = "SECRET";
 
     public static final String RECOVER = "RECOVER";

--- a/app/src/org/commcare/activities/connect/ConnectIdMessageActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdMessageActivity.java
@@ -19,6 +19,7 @@ public class ConnectIdMessageActivity extends CommCareActivity<ConnectIdMessageA
     private String title = null;
     private String message = null;
     private String button = null;
+    private String button2 = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,6 +31,10 @@ public class ConnectIdMessageActivity extends CommCareActivity<ConnectIdMessageA
         message = getString(getIntent().getIntExtra(ConnectConstants.MESSAGE, 0));
         button = getString(getIntent().getIntExtra(ConnectConstants.BUTTON, 0));
 
+        if(getIntent().hasExtra(ConnectConstants.BUTTON2)) {
+            button2 = getString(getIntent().getIntExtra(ConnectConstants.BUTTON2, 0));
+        }
+
         uiController.setupUI();
     }
 
@@ -40,6 +45,7 @@ public class ConnectIdMessageActivity extends CommCareActivity<ConnectIdMessageA
         uiController.setTitle(title);
         uiController.setMessage(message);
         uiController.setButtonText(button);
+        uiController.setButton2Text(button2);
     }
 
     @Override
@@ -57,14 +63,16 @@ public class ConnectIdMessageActivity extends CommCareActivity<ConnectIdMessageA
         uiController = new ConnectIdMessageActivityUiController(this);
     }
 
-    public void finish(boolean success) {
+    public void finish(boolean success, boolean secondButton) {
         Intent intent = new Intent(getIntent());
+
+        intent.putExtra(ConnectConstants.BUTTON2, secondButton);
 
         setResult(success ? RESULT_OK : RESULT_CANCELED, intent);
         finish();
     }
 
-    public void handleButtonPress() {
-        finish(true);
+    public void handleButtonPress(boolean secondButton) {
+        finish(true, secondButton);
     }
 }

--- a/app/src/org/commcare/activities/connect/ConnectIdMessageActivityUiController.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdMessageActivityUiController.java
@@ -1,5 +1,6 @@
 package org.commcare.activities.connect;
 
+import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
@@ -21,6 +22,8 @@ public class ConnectIdMessageActivityUiController implements CommCareActivityUIC
     private TextView messageTextView;
     @UiElement(value = R.id.connect_message_button)
     private Button button;
+    @UiElement(value = R.id.connect_message_button2)
+    private Button button2;
 
     protected final ConnectIdMessageActivity activity;
 
@@ -30,7 +33,8 @@ public class ConnectIdMessageActivityUiController implements CommCareActivityUIC
 
     @Override
     public void setupUI() {
-        button.setOnClickListener(v -> activity.handleButtonPress());
+        button.setOnClickListener(v -> activity.handleButtonPress(false));
+        button2.setOnClickListener(v -> activity.handleButtonPress(true));
     }
 
     @Override
@@ -48,5 +52,13 @@ public class ConnectIdMessageActivityUiController implements CommCareActivityUIC
 
     public void setButtonText(String buttonText) {
         button.setText(buttonText);
+    }
+
+    public void setButton2Text(String buttonText) {
+        boolean show = buttonText != null;
+        button2.setVisibility(show ? View.VISIBLE : View.GONE);
+        if(show) {
+            button2.setText(buttonText);
+        }
     }
 }

--- a/app/src/org/commcare/activities/connect/ConnectIdWorkflows.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdWorkflows.java
@@ -141,7 +141,9 @@ public class ConnectIdWorkflows {
                 params.put(ConnectConstants.RECOVER, false);
                 params.put(ConnectConstants.CHANGE, false);
             }
-            case CONNECT_REGISTRATION_ALTERNATE_PHONE -> {
+            case CONNECT_REGISTRATION_ALTERNATE_PHONE,
+                    CONNECT_VERIFY_ALT_PHONE_CHANGE,
+                    CONNECT_UNLOCK_ALT_PHONE_CHANGE-> {
                 params.put(ConnectConstants.METHOD, ConnectConstants.METHOD_CHANGE_ALTERNATE);
             }
             case CONNECT_REGISTRATION_SUCCESS -> {
@@ -177,13 +179,19 @@ public class ConnectIdWorkflows {
                 params.put(ConnectConstants.RECOVER, true);
                 params.put(ConnectConstants.CHANGE, true);
             }
-            case CONNECT_RECOVERY_ALT_PHONE_MESSAGE,
-                    CONNECT_VERIFY_ALT_PHONE_MESSAGE,
+            case CONNECT_RECOVERY_ALT_PHONE_MESSAGE -> {
+                //Show message screen indicating plan to use alt phone
+                params.put(ConnectConstants.TITLE, R.string.connect_recovery_alt_title);
+                params.put(ConnectConstants.MESSAGE, R.string.connect_recovery_alt_message);
+                params.put(ConnectConstants.BUTTON, R.string.connect_recovery_alt_button);
+            }
+            case CONNECT_VERIFY_ALT_PHONE_MESSAGE,
                     CONNECT_UNLOCK_ALT_PHONE_MESSAGE -> {
                 //Show message screen indicating plan to use alt phone
                 params.put(ConnectConstants.TITLE, R.string.connect_recovery_alt_title);
                 params.put(ConnectConstants.MESSAGE, R.string.connect_recovery_alt_message);
                 params.put(ConnectConstants.BUTTON, R.string.connect_recovery_alt_button);
+                params.put(ConnectConstants.BUTTON2, R.string.connect_recovery_alt_change_button);
             }
             case CONNECT_RECOVERY_VERIFY_ALT_PHONE -> {
                 params.put(ConnectConstants.METHOD, String.format(Locale.getDefault(), "%d",
@@ -428,12 +436,17 @@ public class ConnectIdWorkflows {
             }
             case CONNECT_VERIFY_ALT_PHONE_MESSAGE -> {
                 if (success) {
-                    nextRequestCode = ConnectTask.CONNECT_VERIFY_ALT_PHONE;
+                    boolean change = intent.getBooleanExtra(ConnectConstants.BUTTON2, false);
+
+                    nextRequestCode = change ? ConnectTask.CONNECT_VERIFY_ALT_PHONE_CHANGE : ConnectTask.CONNECT_VERIFY_ALT_PHONE;
                 }
             }
             case CONNECT_RECOVERY_VERIFY_ALT_PHONE -> {
                 nextRequestCode = success ? ConnectTask.CONNECT_RECOVERY_CHANGE_PIN :
                         ConnectTask.CONNECT_RECOVERY_VERIFY_PRIMARY_PHONE;
+            }
+            case CONNECT_VERIFY_ALT_PHONE_CHANGE -> {
+                nextRequestCode = success ? ConnectTask.CONNECT_VERIFY_ALT_PHONE : ConnectTask.CONNECT_VERIFY_ALT_PHONE_MESSAGE;
             }
             case CONNECT_VERIFY_ALT_PHONE -> {
                 if(success) {
@@ -511,8 +524,13 @@ public class ConnectIdWorkflows {
             }
             case CONNECT_UNLOCK_ALT_PHONE_MESSAGE -> {
                 if(success) {
-                    nextRequestCode = ConnectTask.CONNECT_UNLOCK_VERIFY_ALT_PHONE;
+                    boolean change = intent.getBooleanExtra(ConnectConstants.BUTTON2, false);
+
+                    nextRequestCode = change ? ConnectTask.CONNECT_UNLOCK_ALT_PHONE_CHANGE : ConnectTask.CONNECT_UNLOCK_VERIFY_ALT_PHONE;
                 }
+            }
+            case CONNECT_UNLOCK_ALT_PHONE_CHANGE -> {
+                nextRequestCode = ConnectTask.CONNECT_UNLOCK_VERIFY_ALT_PHONE;
             }
             case CONNECT_UNLOCK_VERIFY_ALT_PHONE -> {
                 if(success) {

--- a/app/src/org/commcare/activities/connect/ConnectTask.java
+++ b/app/src/org/commcare/activities/connect/ConnectTask.java
@@ -74,6 +74,10 @@ public enum ConnectTask {
             ConnectJobInfoActivity.class),
     CONNECT_REGISTRATION_CHANGE_PIN(ConnectConstants.ConnectIdTaskIdOffset + 35,
             ConnectIdPinActivity.class),
+    CONNECT_UNLOCK_ALT_PHONE_CHANGE(ConnectConstants.ConnectIdTaskIdOffset + 36,
+            ConnectIdPhoneActivity.class),
+    CONNECT_VERIFY_ALT_PHONE_CHANGE(ConnectConstants.ConnectIdTaskIdOffset + 37,
+            ConnectIdPhoneActivity.class),
     ;
 
     private final int requestCode;


### PR DESCRIPTION
Added functionality for user to change secondary phone during validation warning period. When the user attempts to perform secondary phone validation, a new button is shown with the initial message giving them the option to change the phone number. This additional option is not visible when the same message is shown during recovery (i.e. a user can't change their secondary phone number during recovery).