### PR TITLE
Adjust case detail display text column when empty

### DIFF
--- a/app/src/org/commcare/views/EntityDetailView.java
+++ b/app/src/org/commcare/views/EntityDetailView.java
@@ -210,7 +210,7 @@ public class EntityDetailView extends FrameLayout {
         } else {
             if (isLabelEmpty(labelText)) {
                 origLabel.weight = 0;
-                origValue.weight = 10;
+                origValue.weight = detailRow.getWeightSum();
             }
             if (detailRow.getOrientation() != LinearLayout.HORIZONTAL) {
                 detailRow.setOrientation(LinearLayout.HORIZONTAL);


### PR DESCRIPTION
## Summary
This PR introduces minor changes to the layout of case detail items to better handle empty display texts.

Ticket: https://dimagi.atlassian.net/browse/SAAS-12631

## Product Description
For horizontal orientation:
<table>
<tr>
<th>Before</td>
<th>After</td>
</tr>
<tr >
<td valign="top">
<img src=https://github.com/dimagi/commcare-android/assets/19228119/887fdbc0-9212-4edc-ae7f-7f63a2abe7cd />
</td>
<td valign="top">
<img src=https://github.com/dimagi/commcare-android/assets/19228119/fe0afe46-3f5b-4df1-96c2-6cdccad036fd />
</td>
</tr>
</table>

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below
