### PR TITLE
Create lockout message for mobile users

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -511,6 +511,9 @@ refresh.build.settings.error=No refresh occurred. In order to use this utility, 
 login.attempt.fail.auth.title=Invalid Username or Password
 login.attempt.fail.auth.detail=Your username or password was not recognized, please type them again and retry.
 
+login.attempts.exceeded.auth.title=Maximum password attempts exceeded
+login.attempts.exceeded.auth.detail=Your user account has been locked due to too many attempts. Please contact your supervisor or CommCare Support.
+
 login.attempt.fail.empty.url.title=Url not set
 login.attempt.fail.empty.url.detail=Sync url is empty. Please contact CommCare Support.
 

--- a/app/src/org/commcare/engine/references/JavaHttpReference.java
+++ b/app/src/org/commcare/engine/references/JavaHttpReference.java
@@ -78,7 +78,7 @@ public class JavaHttpReference implements Reference, ReleasedOnTimeSupportedRefe
             return response.body().byteStream();
         } else {
             if (response.code() == 406) {
-                throw new IOException(HttpUtils.parseUserVisibleError(response));
+                throw new IOException(HttpUtils.parseUserVisibleError(response, true));
             } else if (response.code() == 503) {
                 throw new RateLimitedException();
             }

--- a/app/src/org/commcare/network/HttpCalloutTask.java
+++ b/app/src/org/commcare/network/HttpCalloutTask.java
@@ -44,6 +44,7 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, Ht
         NetworkFailureBadPassword,
         IncorrectPin,
         AuthOverHttp,
+        LockedOutUser,
         CaptivePortal
     }
 

--- a/app/src/org/commcare/network/HttpCalloutTask.java
+++ b/app/src/org/commcare/network/HttpCalloutTask.java
@@ -2,6 +2,8 @@ package org.commcare.network;
 
 import android.content.Context;
 
+import okhttp3.ResponseBody;
+
 import org.commcare.core.network.AuthenticationInterceptor;
 import org.commcare.core.network.CaptivePortalRedirectException;
 import org.commcare.core.network.ModernHttpRequester;
@@ -18,15 +20,14 @@ import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.xmlpull.v1.XmlPullParserException;
 
+import retrofit2.Response;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.UnknownHostException;
 
 import javax.net.ssl.SSLException;
-
-import okhttp3.ResponseBody;
-import retrofit2.Response;
 
 /**
  * @author ctsims

--- a/app/src/org/commcare/network/HttpCalloutTask.java
+++ b/app/src/org/commcare/network/HttpCalloutTask.java
@@ -47,6 +47,25 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, Ht
         CaptivePortal
     }
 
+    // Stores HTTP response body error messages associated with 401s
+    public enum ResponseBodyErrorMessages {
+        Max_Login_Attempts_Exceeded("maximum password attempts exceeded"),
+        No_Error_Message("");
+        private final String errorMessage;
+
+        ResponseBodyErrorMessages(String errorMessage) {
+            this.errorMessage = errorMessage;
+        }
+        public static ResponseBodyErrorMessages retrieveErrorMessageValue(String errorMessage){
+            for (ResponseBodyErrorMessages msgs : ResponseBodyErrorMessages.values()){
+                if (msgs.errorMessage.equals(errorMessage)){
+                    return msgs;
+                }
+            }
+            throw new IllegalArgumentException("HTTP Response body error message not recognized: "+ errorMessage);
+        }
+    }
+
     private final Context c;
 
     public HttpCalloutTask(Context c) {

--- a/app/src/org/commcare/network/HttpCalloutTask.java
+++ b/app/src/org/commcare/network/HttpCalloutTask.java
@@ -1,5 +1,8 @@
 package org.commcare.network;
 
+import static org.commcare.network.HttpCalloutTask.ResponseBodyErrorMessages.retrieveErrorMessageValue;
+import static org.commcare.network.HttpUtils.parseUserVisibleError;
+
 import android.content.Context;
 
 import okhttp3.ResponseBody;
@@ -200,7 +203,13 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, Ht
     }
 
     protected HttpCalloutOutcomes doResponseAuthFailed(Response response) {
-        return HttpCalloutOutcomes.AuthFailed;
+        switch (retrieveErrorMessageValue(parseUserVisibleError(response, false))){
+            case Max_Login_Attempts_Exceeded:
+                return HttpCalloutOutcomes.LockedOutUser;
+            default:
+                return HttpCalloutOutcomes.AuthFailed;
+        }
+
     }
 
     protected abstract HttpCalloutOutcomes doResponseOther(Response response);

--- a/app/src/org/commcare/network/HttpUtils.java
+++ b/app/src/org/commcare/network/HttpUtils.java
@@ -26,6 +26,10 @@ import retrofit2.Response;
  */
 public class HttpUtils {
 
+
+    private static final String ERROR_BODY_DEFAULT_RESPONSE_KEY = "default_response";
+    private static final String ERROR_BODY_ERROR_MESSAGE_KEY = "error";
+
     public static String getCredential(AuthInfo authInfo) {
         if (authInfo instanceof AuthInfo.ProvidedAuth) {
             return getCredential(buildDomainUser(authInfo.username), authInfo.password);
@@ -80,8 +84,8 @@ public class HttpUtils {
             responseStr = response.errorBody().string();
             JSONObject errorKeyAndDefault = new JSONObject(responseStr);
             message = Localization.getWithDefault(
-                    errorKeyAndDefault.getString("error"),
-                    errorKeyAndDefault.getString("default_response"));
+                    errorKeyAndDefault.getString(ERROR_BODY_ERROR_MESSAGE_KEY),
+                    errorKeyAndDefault.getString(ERROR_BODY_DEFAULT_RESPONSE_KEY));
         } catch (JSONException | IOException e) {
             message = responseStr != null ? responseStr : "Unknown issue";
         }

--- a/app/src/org/commcare/network/HttpUtils.java
+++ b/app/src/org/commcare/network/HttpUtils.java
@@ -77,15 +77,19 @@ public class HttpUtils {
         }
     }
 
-    public static String parseUserVisibleError(Response<ResponseBody> response) {
+    public static String parseUserVisibleError(Response<ResponseBody> response, boolean isMessageLocalized) {
         String message;
         String responseStr = null;
         try {
             responseStr = response.errorBody().string();
             JSONObject errorKeyAndDefault = new JSONObject(responseStr);
-            message = Localization.getWithDefault(
-                    errorKeyAndDefault.getString(ERROR_BODY_ERROR_MESSAGE_KEY),
-                    errorKeyAndDefault.getString(ERROR_BODY_DEFAULT_RESPONSE_KEY));
+            if (isMessageLocalized) {
+                message = Localization.getWithDefault(
+                        errorKeyAndDefault.getString(ERROR_BODY_ERROR_MESSAGE_KEY),
+                        errorKeyAndDefault.getString(ERROR_BODY_DEFAULT_RESPONSE_KEY));
+            } else {
+                message = errorKeyAndDefault.getString(ERROR_BODY_ERROR_MESSAGE_KEY);
+            }
         } catch (JSONException | IOException e) {
             message = responseStr != null ? responseStr : "Unknown issue";
         }

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -337,7 +337,7 @@ public abstract class DataPullTask<R>
     }
 
     private ResultAndError<PullTaskResult> processErrorResponseWithMessage(RemoteDataPullResponse pullResponse) {
-        return new ResultAndError<>(PullTaskResult.ACTIONABLE_FAILURE, HttpUtils.parseUserVisibleError(pullResponse.getResponse()));
+        return new ResultAndError<>(PullTaskResult.ACTIONABLE_FAILURE, HttpUtils.parseUserVisibleError(pullResponse.getResponse(), true));
     }
 
     private ResultAndError<PullTaskResult> handleAuthFailed() {

--- a/app/src/org/commcare/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/tasks/ManageKeyRecordTask.java
@@ -207,6 +207,10 @@ public abstract class ManageKeyRecordTask<R extends DataPullController> extends 
                 Logger.log(LogTypes.TYPE_USER, "ManageKeyRecordTask error|captive portal detected");
                 receiver.raiseLoginMessage(StockMessages.Sync_CaptivePortal, true);
                 break;
+            case LockedOutUser:
+                Logger.log(LogTypes.TYPE_USER, "ManageKeyRecordTask error|maximum login attempts exceeded");
+                receiver.raiseLoginMessage(StockMessages.Auth_UserLockedOut, false);
+                break;
             default:
                 break;
         }

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -226,7 +226,7 @@ public class FormUploadUtil {
     }
 
     private static FormUploadResult processActionableFaiure(Response<ResponseBody> response) {
-        String message = parseUserVisibleError(response);
+        String message = parseUserVisibleError(response, true);
         FormUploadResult result = FormUploadResult.ACTIONABLE_FAILURE;
         result.setErrorMessage(message);
         return result;

--- a/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
+++ b/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
@@ -162,7 +162,12 @@ public class NotificationMessageFactory {
         /**
          * Bad SSL Certificate *
          */
-        BadSslCertificate("notification.bad.certificate");
+        BadSslCertificate("notification.bad.certificate"),
+
+        /**
+         * Exceeded the maximum number of login attempts *
+         */
+        Auth_UserLockedOut("login.attempts.exceeded.auth");
 
         StockMessages(String root) {
             this.root = root;


### PR DESCRIPTION
## Summary
This PR presents an appropriate message to users that have been locked out of CommCare due to exceeding the maximum number of login attempts allowed. To restore the account, users need to reach out to a Supervisor or Administrator.
Another design considered during this work, involved receiving a `406` response code to let the [User Actionable errors](https://github.com/dimagi/commcare-core/wiki/HTTP-Requests-and-Responses-%28Submission-and-Syncs%29#user-actionable-errors) feature handle the error message, this option was later disfavoured over a `401` response code with specific error messages but it can always be revisited if needed. 
Ticket: https://dimagi.atlassian.net/browse/SAAS-13154

## Product Description
Currently, when an user is locked out, they get an `Invalid Username or Password` message. With this change, the message will be:
![Screenshot_20240611-141106_CommCare Debug](https://github.com/dimagi/commcare-android/assets/19228119/03b07c6e-ee2a-477c-ba88-e2770233b479)

## Safety Assurance
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
This PR only improves error message handling on the client side, instead of having a catch-all message for all authentication failure events. 
