### PR TITLE
Better UX for transitioning from learn to deliver

### DIFF
--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -12,6 +12,7 @@ import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.android.database.user.models.SessionStateDescriptor;
+import org.commcare.connect.ConnectManager;
 import org.commcare.dalvik.R;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.recovery.measures.ExecuteRecoveryMeasuresActivity;
@@ -63,6 +64,7 @@ public class DispatchActivity extends AppCompatActivity {
     private boolean startFromLogin;
     private LoginMode lastLoginMode;
     private boolean userManuallyEnteredPasswordMode;
+    private boolean shouldGoToConnectJobStatus;
 
     private boolean shouldFinish;
     private boolean userTriggeredLogout;
@@ -193,8 +195,11 @@ public class DispatchActivity extends AppCompatActivity {
                         !shortcutExtraWasConsumed) {
                     // CommCare was launched from a shortcut
                     handleShortcutLaunch();
-                }
-                else {
+                } else if(shouldGoToConnectJobStatus) {
+                    CommCareApplication.instance().closeUserSession();
+                    ConnectManager.goToActiveInfoForJob(this, true);
+                    shouldGoToConnectJobStatus = false;
+                } else {
                     launchHomeScreen();
                 }
             } catch (SessionUnavailableException sue) {
@@ -458,6 +463,7 @@ public class DispatchActivity extends AppCompatActivity {
                     lastLoginMode = (LoginMode)intent.getSerializableExtra(LoginActivity.LOGIN_MODE);
                     userManuallyEnteredPasswordMode =
                             intent.getBooleanExtra(LoginActivity.MANUAL_SWITCH_TO_PW_MODE, false);
+                    shouldGoToConnectJobStatus = intent.getBooleanExtra(LoginActivity.GO_TO_CONNECT_JOB_STATUS, false);
                     startFromLogin = true;
                 }
                 return;

--- a/app/src/org/commcare/activities/HomeButtons.java
+++ b/app/src/org/commcare/activities/HomeButtons.java
@@ -210,7 +210,7 @@ public class HomeButtons {
     private static View.OnClickListener getConnectButtonListener(final StandardHomeActivity activity) {
         return v -> {
             reportButtonClick(AnalyticsParamValue.CONNECT_BUTTON);
-            ConnectManager.goToActiveInfoForJob(activity);
+            ConnectManager.goToActiveInfoForJob(activity, false);
         };
     }
 

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -29,6 +29,7 @@ import java.util.Date;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.connect.models.ConnectJobRecord;
 import org.commcare.connect.ConnectManager;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.global.models.ApplicationRecord;
@@ -95,6 +96,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
     public static final String LOGIN_MODE = "login-mode";
     public static final String MANUAL_SWITCH_TO_PW_MODE = "manually-swithced-to-password-mode";
+    public static final String GO_TO_CONNECT_JOB_STATUS = "go-to-connect-job-status";
 
     private static final int TASK_KEY_EXCHANGE = 1;
     private static final int TASK_UPGRADE_INSTALL = 2;
@@ -452,14 +454,15 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         CommCareApplication.notificationManager().clearNotifications(NOTIFICATION_MESSAGE_LOGIN);
 
         if(handleConnectSignIn()) {
-            goToAppHomeAndFinish();
+            setResultAndFinish(false);
         }
     }
 
-    private void goToAppHomeAndFinish() {
+    private void setResultAndFinish(boolean goToJobInfo) {
         Intent i = new Intent();
         i.putExtra(LOGIN_MODE, uiController.getLoginMode());
         i.putExtra(MANUAL_SWITCH_TO_PW_MODE, uiController.userManuallySwitchedToPasswordMode());
+        i.putExtra(GO_TO_CONNECT_JOB_STATUS, goToJobInfo);
         setResult(RESULT_OK, i);
         finish();
     }
@@ -476,16 +479,23 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     }
 
     public boolean handleConnectSignIn() {
-        if (!appLaunchedFromConnect && ConnectManager.isConnectIdIntroduced()) {
+        if(ConnectManager.isConnectIdIntroduced()) {
             String appId = CommCareApplication.instance().getCurrentApp().getUniqueId();
-            String username = uiController.getEnteredUsername();
-            String pass = uiController.getEnteredPasswordOrPin();
-
-            ConnectManager.checkConnectIdLink(this, uiController.loginManagedByConnectId(), appId, username, pass, success -> {
-                goToAppHomeAndFinish();
-            });
-
-            ConnectManager.setConnectJobForApp(this, appId);
+            ConnectJobRecord job = ConnectManager.setConnectJobForApp(this, appId);
+            if(job != null) {
+                //Update job status
+                ConnectManager.updateJobProgress(this, job, success -> {
+                    setResultAndFinish(job.readyToTransitionToDelivery());
+                });
+            } else {
+                //Possibly offer to link or de-link ConnectId-managed login
+                ConnectManager.checkConnectIdLink(this,
+                        uiController.loginManagedByConnectId(), appId,
+                        uiController.getEnteredUsername(),
+                        uiController.getEnteredPasswordOrPin(), success -> {
+                    setResultAndFinish(false);
+                });
+            }
 
             return false;
         }

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -60,8 +60,10 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
                     R.id.connect_job_delivery_progress_fragment :
                     R.id.connect_job_learning_progress_fragment;
 
+            boolean buttons = getIntent().getBooleanExtra("buttons", true);
+
             Bundle bundle = new Bundle();
-            bundle.putBoolean("showLaunch", false);
+            bundle.putBoolean("showLaunch", buttons);
 
             NavOptions options = new NavOptions.Builder()
                     .setPopUpTo(navController.getGraph().getStartDestinationId(), true)

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -275,6 +275,9 @@ public class ConnectJobRecord extends Persisted implements Serializable {
     public String getCurrency() { return currency; }
     public int getNumLearningModules() { return numLearningModules; }
     public int getCompletedLearningModules() { return learningModulesCompleted; }
+    public int getLearningPercentComplete() {
+        return numLearningModules > 0 ? (100 * learningModulesCompleted / numLearningModules) : 100;
+    }
     public void setComletedLearningModules(int numCompleted) { this.learningModulesCompleted = numCompleted; }
     public ConnectAppRecord getLearnAppInfo() { return learnAppInfo; }
     public void setLearnAppInfo(ConnectAppRecord appInfo) { this.learnAppInfo = appInfo; }
@@ -414,6 +417,9 @@ public class ConnectJobRecord extends Persisted implements Serializable {
         paymentUnits = units;
     }
 
+    public boolean readyToTransitionToDelivery() {
+        return status == STATUS_LEARNING && getLearningPercentComplete() >= 100;
+    }
 
     /**
      * Used for app db migration only

--- a/app/src/org/commcare/connect/network/ConnectNetworkHelper.java
+++ b/app/src/org/commcare/connect/network/ConnectNetworkHelper.java
@@ -177,7 +177,7 @@ public class ConnectNetworkHelper {
                     stream = requester.getResponseStream(response);
                 } else if (response.errorBody() != null) {
                     String error = response.errorBody().string();
-                    Logger.log("DAVE", error);
+                    Logger.log("Netowrk Error", error);
                 }
             } catch (IOException e) {
                 exception = e;

--- a/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
@@ -13,6 +13,7 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.commcare.connect.ConnectDatabaseHelper;
 import org.commcare.connect.ConnectManager;
 import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
@@ -96,6 +97,10 @@ public class ConnectJobIntroFragment extends Fragment {
                     public void processSuccess(int responseCode, InputStream responseData) {
                         reportApiCall(true);
                         //TODO: Expecting to eventually get HQ username from server here
+
+                        job.setStatus(ConnectJobRecord.STATUS_LEARNING);
+                        ConnectDatabaseHelper.upsertJob(getContext(), job);
+
                         NavDirections directions;
                         if (appInstalled) {
                             directions = ConnectJobIntroFragmentDirections.actionConnectJobIntroFragmentToConnectJobLearningProgressFragment();


### PR DESCRIPTION
Auto-syncing job status when logging into any app related to Connect.
Redirecting to Learn Progress page (showing learning certificate) when user attempts to login to learn app and ready to transition to delivery.