### PR TITLE
Add form load time metadata to Form submissions

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1089,6 +1089,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
 
         reportFormEntryTime();
+        mFormController.getFormDef().finilizeInitialization();
 
         formEntryRestoreSession.replaySession(this);
 


### PR DESCRIPTION
## Summary
This PR enhances the implementation of the XForms specification by adding support to [xforms-model-construct-done](https://www.w3.org/TR/xforms11/#evt-modelConstructDone) events. The `xforms-model-construct-done` event is to be triggered when the form is fully loaded and ready to be used, which in conjuction with `timeStarNumeric` (computed during [xforms-ready](https://www.w3.org/TR/xforms11/#evt-ready)) will in turn be used to calculate form load time.

### Changes in HQ
In order to add the `formLoadTime` metadata to form submissions, there are changes needed to the `XForm model` in HQ:
```
<model>
    <instance>
        <data>
            ...
            <orx:meta xmlns:cc="http://commcarehq.org/xforms">
                 ...
                 <cc:timeStartNumeric/>
                 <cc:formLoadTime/>
            </orx:meta>
        </data>
    </instance>
    ...
    <setvalue ref="/data/meta/timeStartNumeric" value="double(now())" event="xforms-ready"/>
    <setvalue ref="/data/meta/formLoadTime" value="int((double(now()) - /data/meta/timeStartNumeric)*24*60*60*10000)" event="xforms-model-construct-done"/>
</model>
...

```
Ticket: https://dimagi.atlassian.net/browse/SC-3590
cross-request: https://github.com/dimagi/commcare-core/pull/1412

### Note for reviewers
According to the [XForms Specification](https://www.w3.org/TR/xforms11/#rpm-events), `xforms-ready` event is dispatched as part of `xforms-model-contract-done`, so the order of execution proposed by this PR is inconsistent with the specification. The main problem is that the current implementation dispatches `xforms-ready` at the [beginning of the form initialization process](https://github.com/dimagi/commcare-core/blob/d09e72adeab33cff86a324da2fa0d542a62bf2c3/src/main/java/org/javarosa/core/model/FormDef.java#L1464), not when it's ready to be used and changing that would require changes to existing CommCare apps.

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
This feature makes use of existing functionality to run the calculations and update the form submission with the resulting values. 