### PR TITLE
Logs update failures to get more insight while debugging update resets

### DIFF
--- a/app/src/org/commcare/engine/resource/AndroidResourceManager.java
+++ b/app/src/org/commcare/engine/resource/AndroidResourceManager.java
@@ -190,6 +190,7 @@ public class AndroidResourceManager extends ResourceManager {
      */
     public void processUpdateFailure(AppInstallStatus result) {
         updateStats.registerUpdateFailure(result);
+        Logger.log(LogTypes.TYPE_CC_UPDATE, "Update Attempt failed due to error: " + result);
         FirebaseAnalyticsUtil.reportStageUpdateAttemptFailure(result.toString());
 
         if (result.shouldDiscardPartialUpdateTable()) {


### PR DESCRIPTION
## Summary

https://dimagi.atlassian.net/browse/SC-3427

Logs update failures to get more insight while debugging update resets

## Feature Flag
None

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

Not needed

### Safety story

Just adds a null safe simple log statement
