### PR TITLE
Connect DB passphrase managed by ConnectID server

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -11,6 +11,7 @@
 
     <string name="ConnectTokenURL">https://connectid.dimagi.com/o/token/</string>
     <string name="ConnectHeartbeatURL">https://connectid.dimagi.com/users/heartbeat</string>
+    <string name="ConnectFetchDbKeyURL">https://connectid.dimagi.com/users/fetch_db_key</string>
     <string name="ConnectChangePasswordURL">https://connectid.dimagi.com/users/change_password</string>
     <string name="ConnectResetPasswordURL">https://connectid.dimagi.com/users/recover/reset_password</string>
     <string name="ConnectConfirmPasswordURL">https://connectid.dimagi.com/users/recover/confirm_password</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -503,6 +503,7 @@
     <string name="busy_message">We are still busy processing your previous request. Please try again in some time.</string>
 
     <string name="connect_button_logged_in">Go to Connect menu</string>
+    <string name="connect_db_corrupt">A problem occurred with the database, please recover your account.</string>
 
     <string name="connect_consent_title">Consent</string>
     <string name="connect_consent_message_1">I have read and agree to Dimagi\'s <a href="https://www.dimagi.com/terms/latest/privacy/">Privacy Policy</a>, <a href="https://www.dimagi.com/terms/latest/tos/">Terms of Service</a>, <a href="https://www.dimagi.com/terms/latest/ba/">Business Agreement</a> and <a href="https://www.dimagi.com/terms/latest/aup/">Acceptable Use Policy</a>.</string>

--- a/app/src/org/commcare/activities/connect/ConnectIdPasswordVerificationActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdPasswordVerificationActivity.java
@@ -9,6 +9,7 @@ import org.commcare.activities.CommCareActivity;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
 import org.commcare.connect.ConnectConstants;
 import org.commcare.connect.ConnectDatabaseHelper;
+import org.commcare.connect.ConnectManager;
 import org.commcare.connect.network.ApiConnectId;
 import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.connect.network.IApiCallback;
@@ -17,6 +18,7 @@ import org.commcare.google.services.analytics.AnalyticsParamValue;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.interfaces.CommCareActivityUIController;
 import org.commcare.interfaces.WithUIController;
+import org.commcare.util.Base64;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.services.Logger;
@@ -167,8 +169,7 @@ public class ConnectIdPasswordVerificationActivity extends CommCareActivity<Conn
 
                             key = ConnectConstants.CONNECT_KEY_DB_KEY;
                             if (json.has(key)) {
-                                //TODO: Use the passphrase from the DB
-                                //json.getString(key);
+                                ConnectDatabaseHelper.handleReceivedDbPassphrase(context, json.getString(key));
                             }
 
                             ConnectUserRecord user = new ConnectUserRecord(phone, username,

--- a/app/src/org/commcare/activities/connect/ConnectIdPhoneVerificationActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdPhoneVerificationActivity.java
@@ -255,8 +255,7 @@ public class ConnectIdPhoneVerificationActivity extends CommCareActivity<Connect
 
                         key = ConnectConstants.CONNECT_KEY_DB_KEY;
                         if (json.has(key)) {
-                            //TODO: Use the passphrase from the DB
-                            //json.getString(key);
+                            ConnectDatabaseHelper.handleReceivedDbPassphrase(context, json.getString(key));
                         }
 
                         key = ConnectConstants.CONNECT_KEY_NAME;

--- a/app/src/org/commcare/activities/connect/ConnectIdPhoneVerificationActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdPhoneVerificationActivity.java
@@ -267,7 +267,7 @@ public class ConnectIdPhoneVerificationActivity extends CommCareActivity<Connect
                                 secondaryPhone = json.has(key) ? json.getString(key) : null;
                             }
 
-                            ConnectDatabaseHelper.handleReceivedDbPassphrase(context, json.getString(key));
+                            finish(true, false, secondaryPhone);
                         }
                         case MethodRecoveryAlternate -> {
                             String responseAsString = new String(
@@ -282,8 +282,7 @@ public class ConnectIdPhoneVerificationActivity extends CommCareActivity<Connect
 
                             key = ConnectConstants.CONNECT_KEY_DB_KEY;
                             if (json.has(key)) {
-                                //TODO: Use the passphrase from the DB
-                                //json.getString(key);
+                                ConnectDatabaseHelper.handleReceivedDbPassphrase(context, json.getString(key));
                             }
 
                             resetPassword(context, phone, password, username, displayName);

--- a/app/src/org/commcare/activities/connect/ConnectIdPinActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdPinActivity.java
@@ -199,8 +199,7 @@ public class ConnectIdPinActivity extends CommCareActivity<ConnectIdPinActivity>
 
                                     key = ConnectConstants.CONNECT_KEY_DB_KEY;
                                     if (json.has(key)) {
-                                        //TODO: Use the passphrase from the DB
-                                        //json.getString(key);
+                                        ConnectDatabaseHelper.handleReceivedDbPassphrase(context, json.getString(key));
                                     }
 
                                     ConnectUserRecord user = new ConnectUserRecord(phone, username,

--- a/app/src/org/commcare/activities/connect/ConnectIdRegistrationActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdRegistrationActivity.java
@@ -132,8 +132,7 @@ public class ConnectIdRegistrationActivity extends CommCareActivity<ConnectIdReg
                             JSONObject json = new JSONObject(responseAsString);
                             String key = ConnectConstants.CONNECT_KEY_DB_KEY;
                             if (json.has(key)) {
-                                //TODO: Use the passphrase from the DB
-                                //json.getString(key);
+                                ConnectDatabaseHelper.handleReceivedDbPassphrase(context, json.getString(key));
                             }
 
                             key = ConnectConstants.CONNECT_KEY_VALIDATE_SECONDARY_PHONE_BY;

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -3,6 +3,9 @@ package org.commcare.android.database.global.models;
 import org.commcare.android.storage.framework.Persisted;
 import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
+import org.commcare.modern.models.MetaField;
+
+import kotlin.Metadata;
 
 /**
  * DB model for storing the encrypted/encoded Connect DB passphrase
@@ -12,17 +15,30 @@ import org.commcare.modern.database.Table;
 @Table(ConnectKeyRecord.STORAGE_KEY)
 public class ConnectKeyRecord extends Persisted {
     public static final String STORAGE_KEY = "connect_key";
+    public static final String IS_LOCAL = "is_local";
     @Persisting(1)
     String encryptedPassphrase;
+
+    @Persisting(2)
+    @MetaField(IS_LOCAL)
+    boolean isLocal;
 
     public ConnectKeyRecord() {
     }
 
-    public ConnectKeyRecord(String encryptedPassphrase) {
+    public ConnectKeyRecord(String encryptedPassphrase, boolean isLocal) {
         this.encryptedPassphrase = encryptedPassphrase;
+        this.isLocal = isLocal;
     }
 
     public String getEncryptedPassphrase() {
         return encryptedPassphrase;
+    }
+    public boolean getIsLocal() {
+        return isLocal;
+    }
+
+    public static ConnectKeyRecord fromV6(ConnectKeyRecordV6 oldVersion) {
+        return new ConnectKeyRecord(oldVersion.getEncryptedPassphrase(), true);
     }
 }

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -34,6 +34,9 @@ public class ConnectKeyRecord extends Persisted {
     public String getEncryptedPassphrase() {
         return encryptedPassphrase;
     }
+    public void setEncryptedPassphrase(String passphrase) {
+        encryptedPassphrase = passphrase;
+    }
     public boolean getIsLocal() {
         return isLocal;
     }

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecordV6.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecordV6.java
@@ -1,0 +1,29 @@
+package org.commcare.android.database.global.models;
+
+import org.commcare.android.storage.framework.Persisted;
+import org.commcare.models.framework.Persisting;
+import org.commcare.modern.database.Table;
+
+/**
+ * DB model for storing the encrypted/encoded Connect DB passphrase
+ * Used up to global DB V6
+ *
+ * @author dviggiano
+ */
+@Table(ConnectKeyRecordV6.STORAGE_KEY)
+public class ConnectKeyRecordV6 extends Persisted {
+    public static final String STORAGE_KEY = "connect_key";
+    @Persisting(1)
+    String encryptedPassphrase;
+
+    public ConnectKeyRecordV6() {
+    }
+
+    public ConnectKeyRecordV6(String encryptedPassphrase) {
+        this.encryptedPassphrase = encryptedPassphrase;
+    }
+
+    public String getEncryptedPassphrase() {
+        return encryptedPassphrase;
+    }
+}

--- a/app/src/org/commcare/connect/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/ConnectDatabaseHelper.java
@@ -61,12 +61,8 @@ public class ConnectDatabaseHelper {
         }
     }
 
-    public static void init(Context context) {
-        synchronized (connectDbHandleLock) {
-            byte[] passphrase = getConnectDbPassphrase(context);
-            SQLiteDatabase database = new DatabaseConnectOpenHelper(context).getWritableDatabase(passphrase);
-            database.close();
-        }
+    public static boolean dbExists(Context context) {
+        return DatabaseConnectOpenHelper.dbExists(context);
     }
 
     private static <T extends Persistable> SqlStorage<T> getConnectStorage(Context context, Class<T> c) {
@@ -96,9 +92,11 @@ public class ConnectDatabaseHelper {
 
     public static ConnectUserRecord getUser(Context context) {
         ConnectUserRecord user = null;
-        for (ConnectUserRecord r : getConnectStorage(context, ConnectUserRecord.class)) {
-            user = r;
-            break;
+        if(dbExists(context)) {
+            for (ConnectUserRecord r : getConnectStorage(context, ConnectUserRecord.class)) {
+                user = r;
+                break;
+            }
         }
 
         return user;
@@ -597,9 +595,9 @@ public class ConnectDatabaseHelper {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 modules.sort(Comparator.comparingInt(ConnectLearnModuleSummaryRecord::getModuleIndex));
             }
-            else {
+            //else {
                 //TODO: Brute force sort
-            }
+            //}
 
             if(job.getLearnAppInfo() != null) {
                 job.getLearnAppInfo().setLearnModules(modules);

--- a/app/src/org/commcare/connect/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/ConnectDatabaseHelper.java
@@ -49,10 +49,11 @@ public class ConnectDatabaseHelper {
             String localPassphrase = getConnectDbEncodedPassphrase(true);
 
             if(!remotePassphrase.equals(localPassphrase)) {
-                //Migrate DB
+                DatabaseConnectOpenHelper.rekeyDB(context, localPassphrase, remotePassphrase);
+                storeConnectDbPassphrase(context, remotePassphrase, true);
             }
         } catch (Exception e) {
-            Logger.exception("Getting DB passphrase", e);
+            Logger.exception("Handling received DB passphrase", e);
             throw new RuntimeException(e);
         }
     }

--- a/app/src/org/commcare/connect/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/ConnectDatabaseHelper.java
@@ -51,7 +51,7 @@ public class ConnectDatabaseHelper {
             byte[] passphrase = EncryptionUtils.generatePassphrase();
 
             String encoded = EncryptionUtils.encryptToBase64String(context, passphrase);
-            ConnectKeyRecord record = new ConnectKeyRecord(encoded);
+            ConnectKeyRecord record = new ConnectKeyRecord(encoded, true);
             CommCareApplication.instance().getGlobalStorage(ConnectKeyRecord.class).write(record);
 
             return passphrase;

--- a/app/src/org/commcare/connect/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/ConnectDatabaseHelper.java
@@ -18,6 +18,7 @@ import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
 import org.commcare.android.database.connect.models.ConnectPaymentUnitRecord;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
 import org.commcare.android.database.global.models.ConnectKeyRecord;
+import org.commcare.dalvik.R;
 import org.commcare.models.database.AndroidDbHelper;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.connect.DatabaseConnectOpenHelper;
@@ -57,8 +58,7 @@ public class ConnectDatabaseHelper {
             }
         } catch (Exception e) {
             Logger.exception("Handling received DB passphrase", e);
-            ConnectDatabaseHelper.forgetUser(context);
-            Toast.makeText(context, "Corrupt DB, please recover account", Toast.LENGTH_LONG).show();
+            handleCorruptDb(context);
         }
     }
 
@@ -178,6 +178,11 @@ public class ConnectDatabaseHelper {
                 connectDatabase = null;
             }
         }
+    }
+
+    public static void handleCorruptDb(Context context) {
+        ConnectDatabaseHelper.forgetUser(context);
+        Toast.makeText(context, context.getString(R.string.connect_db_corrupt), Toast.LENGTH_LONG).show();
     }
 
     public static ConnectUserRecord getUser(Context context) {

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -31,6 +31,7 @@ import org.commcare.CommCareApplication;
 import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.commcaresupportlibrary.CommCareLauncher;
 import org.commcare.connect.network.ApiConnect;
+import org.commcare.connect.network.ApiConnectId;
 import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.connect.network.ConnectSsoHelper;
 import org.commcare.connect.network.IApiCallback;
@@ -127,6 +128,10 @@ public class ConnectManager {
             if (user != null) {
                 boolean registering = user.getRegistrationPhase() != ConnectTask.CONNECT_NO_ACTIVITY;
                 manager.connectStatus = registering ? ConnectIdStatus.Registering : ConnectIdStatus.LoggedIn;
+
+                if(ConnectDatabaseHelper.getConnectDbEncodedPassphrase(false) == null) {
+                    getRemoteDbPassphrase(parent, user);
+                }
             }
         }
     }
@@ -657,6 +662,42 @@ public class ConnectManager {
         CommCareApplication.instance().getCurrentApp().getStorage(UserKeyRecord.class).write(ukr);
 
         return appRecord;
+    }
+
+    public static void getRemoteDbPassphrase(Context context, ConnectUserRecord user) {
+        ApiConnectId.fetchDbPassphrase(context, user, new IApiCallback() {
+            @Override
+            public void processSuccess(int responseCode, InputStream responseData) {
+                try {
+                    String responseAsString = new String(
+                            StreamsUtil.inputStreamToByteArray(responseData));
+                    if (responseAsString.length() > 0) {
+                        JSONObject json = new JSONObject(responseAsString);
+                        String key = ConnectConstants.CONNECT_KEY_DB_KEY;
+                        if (json.has(key)) {
+                            ConnectDatabaseHelper.handleReceivedDbPassphrase(context, json.getString(key));
+                        }
+                    }
+                } catch (IOException | JSONException e) {
+                    Logger.exception("Parsing return from DB key request", e);
+                }
+            }
+
+            @Override
+            public void processFailure(int responseCode, IOException e) {
+                Logger.log("ERROR", String.format(Locale.getDefault(), "Failed: %d", responseCode));
+            }
+
+            @Override
+            public void processNetworkFailure() {
+                Logger.log("ERROR", "Failed (network)");
+            }
+
+            @Override
+            public void processOldApiError() {
+                ConnectNetworkHelper.showOutdatedApiError(context);
+            }
+        });
     }
 
     public static void updateJobProgress(Context context, ConnectJobRecord job, ConnectActivityCompleteListener listener) {

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -135,8 +135,7 @@ public class ConnectManager {
                 }
             } else if(ConnectDatabaseHelper.isDbBroken()) {
                 //Corrupt DB, inform user to recover
-                ConnectDatabaseHelper.forgetUser(parent);
-                Toast.makeText(parent, "Corrupt DB, please recover account", Toast.LENGTH_LONG).show();
+                ConnectDatabaseHelper.handleCorruptDb(parent);
             }
         }
     }

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -135,6 +135,10 @@ public class ConnectManager {
                 } else {
                     ConnectDatabaseHelper.handleReceivedDbPassphrase(parent, remotePassphrase);
                 }
+            } else if(ConnectDatabaseHelper.isDbBroken()) {
+                //Corrupt DB, inform user to recover
+                ConnectDatabaseHelper.forgetUser(parent);
+                Toast.makeText(parent, "Corrupt DB, please recover account", Toast.LENGTH_LONG).show();
             }
         }
     }

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -121,7 +121,6 @@ public class ConnectManager {
     public static void init(CommCareActivity<?> parent) {
         ConnectManager manager = getInstance();
         manager.parentActivity = parent;
-        ConnectDatabaseHelper.init(parent);
 
         if(manager.connectStatus == ConnectIdStatus.NotIntroduced) {
             ConnectUserRecord user = ConnectDatabaseHelper.getUser(manager.parentActivity);
@@ -164,11 +163,8 @@ public class ConnectManager {
     }
 
     public static boolean isConnectIdIntroduced() {
-        if (!AppManagerDeveloperPreferences.isConnectIdEnabled()) {
-            return false;
-        }
-
-        return getInstance().connectStatus == ConnectIdStatus.LoggedIn;
+        return AppManagerDeveloperPreferences.isConnectIdEnabled()
+                && getInstance().connectStatus == ConnectIdStatus.LoggedIn;
     }
 
     public static boolean isUnlocked() {

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -132,8 +132,6 @@ public class ConnectManager {
                 String remotePassphrase = ConnectDatabaseHelper.getConnectDbEncodedPassphrase(parent, false);
                 if(remotePassphrase == null) {
                     getRemoteDbPassphrase(parent, user);
-                } else {
-                    ConnectDatabaseHelper.handleReceivedDbPassphrase(parent, remotePassphrase);
                 }
             } else if(ConnectDatabaseHelper.isDbBroken()) {
                 //Corrupt DB, inform user to recover

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -129,8 +129,11 @@ public class ConnectManager {
                 boolean registering = user.getRegistrationPhase() != ConnectTask.CONNECT_NO_ACTIVITY;
                 manager.connectStatus = registering ? ConnectIdStatus.Registering : ConnectIdStatus.LoggedIn;
 
-                if(ConnectDatabaseHelper.getConnectDbEncodedPassphrase(false) == null) {
+                String remotePassphrase = ConnectDatabaseHelper.getConnectDbEncodedPassphrase(parent, false);
+                if(remotePassphrase == null) {
                     getRemoteDbPassphrase(parent, user);
+                } else {
+                    ConnectDatabaseHelper.handleReceivedDbPassphrase(parent, remotePassphrase);
                 }
             }
         }

--- a/app/src/org/commcare/connect/network/ApiConnect.java
+++ b/app/src/org/commcare/connect/network/ApiConnect.java
@@ -42,7 +42,7 @@ public class ApiConnect {
 
             try {
                 ConnectNetworkHelper.PostResult postResult = ConnectNetworkHelper.postSync(context, url,
-                        API_VERSION_NONE, new AuthInfo.ProvidedAuth(hqUsername, hqPassword), params, true);
+                        API_VERSION_NONE, new AuthInfo.ProvidedAuth(hqUsername, hqPassword), params, true, false);
                 if (postResult.e == null && postResult.responseCode == 200) {
                     postResult.responseStream.close();
 
@@ -74,7 +74,7 @@ public class ApiConnect {
         String url = "https://" + host + "/oauth/token/";
 
         ConnectNetworkHelper.PostResult postResult = ConnectNetworkHelper.postSync(context, url,
-                API_VERSION_NONE, new AuthInfo.NoAuth(), params, true);
+                API_VERSION_NONE, new AuthInfo.NoAuth(), params, true, false);
         if (postResult.responseCode == 200) {
             try {
                 String responseAsString = new String(StreamsUtil.inputStreamToByteArray(
@@ -114,7 +114,7 @@ public class ApiConnect {
             String url = context.getString(R.string.ConnectOpportunitiesURL, BuildConfig.CCC_HOST);
             Multimap<String, String> params = ArrayListMultimap.create();
 
-            ConnectNetworkHelper.get(context, url, API_VERSION_CONNECT, token, params, handler);
+            ConnectNetworkHelper.get(context, url, API_VERSION_CONNECT, token, params, false, handler);
         });
 
         return true;
@@ -134,7 +134,7 @@ public class ApiConnect {
             HashMap<String, String> params = new HashMap<>();
             params.put("opportunity", String.format(Locale.getDefault(), "%d", jobId));
 
-            ConnectNetworkHelper.post(context, url, API_VERSION_CONNECT, token, params, true, handler);
+            ConnectNetworkHelper.post(context, url, API_VERSION_CONNECT, token, params, true, false, handler);
         });
 
         return true;
@@ -153,7 +153,7 @@ public class ApiConnect {
             String url = context.getString(R.string.ConnectLearnProgressURL, BuildConfig.CCC_HOST, jobId);
             Multimap<String, String> params = ArrayListMultimap.create();
 
-            ConnectNetworkHelper.get(context, url, API_VERSION_CONNECT, token, params, handler);
+            ConnectNetworkHelper.get(context, url, API_VERSION_CONNECT, token, params, false, handler);
         });
 
         return true;
@@ -172,7 +172,7 @@ public class ApiConnect {
             String url = context.getString(R.string.ConnectClaimJobURL, BuildConfig.CCC_HOST, jobId);
             HashMap<String, String> params = new HashMap<>();
 
-            ConnectNetworkHelper.post(context, url, API_VERSION_CONNECT, token, params, false, handler);
+            ConnectNetworkHelper.post(context, url, API_VERSION_CONNECT, token, params, false, false, handler);
         });
 
         return true;
@@ -191,7 +191,7 @@ public class ApiConnect {
             String url = context.getString(R.string.ConnectDeliveriesURL, BuildConfig.CCC_HOST, jobId);
             Multimap<String, String> params = ArrayListMultimap.create();
 
-            ConnectNetworkHelper.get(context, url, API_VERSION_CONNECT, token, params, handler);
+            ConnectNetworkHelper.get(context, url, API_VERSION_CONNECT, token, params, false, handler);
         });
 
         return true;
@@ -212,7 +212,7 @@ public class ApiConnect {
             HashMap<String, String> params = new HashMap<>();
             params.put("confirmed", confirmed ? "true" : "false");
 
-            ConnectNetworkHelper.post(context, url, API_VERSION_CONNECT, token, params, true, handler);
+            ConnectNetworkHelper.post(context, url, API_VERSION_CONNECT, token, params, true, false, handler);
         });
 
         return true;

--- a/app/src/org/commcare/connect/network/ApiConnectId.java
+++ b/app/src/org/commcare/connect/network/ApiConnectId.java
@@ -31,7 +31,7 @@ public class ApiConnectId {
         if(token != null) {
             params.put("fcm_token", token);
             boolean useFormEncoding = true;
-            return ConnectNetworkHelper.postSync(context, url, API_VERSION_CONNECT_ID, ConnectManager.getConnectToken(), params, useFormEncoding);
+            return ConnectNetworkHelper.postSync(context, url, API_VERSION_CONNECT_ID, ConnectManager.getConnectToken(), params, useFormEncoding, true);
         }
 
         return new ConnectNetworkHelper.PostResult(-1, null, null);
@@ -56,7 +56,7 @@ public class ApiConnectId {
             String url = context.getString(R.string.ConnectTokenURL);
 
             ConnectNetworkHelper.PostResult postResult = ConnectNetworkHelper.postSync(context, url,
-                    API_VERSION_CONNECT_ID, new AuthInfo.NoAuth(), params, true);
+                    API_VERSION_CONNECT_ID, new AuthInfo.NoAuth(), params, true, false);
             if (postResult.responseCode == 200) {
                 try {
                     String responseAsString = new String(StreamsUtil.inputStreamToByteArray(
@@ -84,6 +84,13 @@ public class ApiConnectId {
         return null;
     }
 
+    public static void fetchDbPassphrase(Context context, ConnectUserRecord user, IApiCallback callback) {
+        ConnectNetworkHelper.get(context,
+                context.getString(R.string.ConnectFetchDbKeyURL),
+                API_VERSION_CONNECT_ID, new AuthInfo.ProvidedAuth(user.getUserId(), user.getPassword(), false),
+                ArrayListMultimap.create(), true, callback);
+    }
+
     public static boolean checkPassword(Context context, String phone, String secret,
                                         String password, IApiCallback callback) {
         HashMap<String, String> params = new HashMap<>();
@@ -92,7 +99,7 @@ public class ApiConnectId {
         params.put("password", password);
 
         return ConnectNetworkHelper.post(context, context.getString(R.string.ConnectConfirmPasswordURL),
-                API_VERSION_CONNECT_ID, new AuthInfo.NoAuth(), params, false, callback);
+                API_VERSION_CONNECT_ID, new AuthInfo.NoAuth(), params, false, false, callback);
     }
 
     public static boolean changePassword(Context context, String username, String oldPassword,
@@ -107,7 +114,7 @@ public class ApiConnectId {
         HashMap<String, String> params = new HashMap<>();
         params.put("password", newPassword);
 
-        return ConnectNetworkHelper.post(context, context.getString(urlId), API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+        return ConnectNetworkHelper.post(context, context.getString(urlId), API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean resetPassword(Context context, String phoneNumber, String recoverySecret,
@@ -124,7 +131,7 @@ public class ApiConnectId {
         params.put("secret_key", recoverySecret);
         params.put("password", newPassword);
 
-        return ConnectNetworkHelper.post(context, context.getString(urlId), API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+        return ConnectNetworkHelper.post(context, context.getString(urlId), API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean checkPin(Context context, String phone, String secret,
@@ -141,7 +148,7 @@ public class ApiConnectId {
         params.put("secret_key", secret);
         params.put("recovery_pin", pin);
 
-        return ConnectNetworkHelper.post(context, context.getString(urlId), API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+        return ConnectNetworkHelper.post(context, context.getString(urlId), API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean changePin(Context context, String username, String password,
@@ -156,7 +163,7 @@ public class ApiConnectId {
         HashMap<String, String> params = new HashMap<>();
         params.put("recovery_pin", pin);
 
-        return ConnectNetworkHelper.post(context, context.getString(urlId), API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+        return ConnectNetworkHelper.post(context, context.getString(urlId), API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean checkPhoneAvailable(Context context, String phone, IApiCallback callback) {
@@ -165,7 +172,7 @@ public class ApiConnectId {
 
         return ConnectNetworkHelper.get(context,
                 context.getString(R.string.ConnectPhoneAvailableURL),
-                API_VERSION_CONNECT_ID, new AuthInfo.NoAuth(), params, callback);
+                API_VERSION_CONNECT_ID, new AuthInfo.NoAuth(), params, false, callback);
     }
 
     public static boolean registerUser(Context context, String username, String password, String displayName,
@@ -179,7 +186,7 @@ public class ApiConnectId {
 
         return ConnectNetworkHelper.post(context,
                 context.getString(R.string.ConnectRegisterURL),
-                API_VERSION_CONNECT_ID, new AuthInfo.NoAuth(), params, false, callback);
+                API_VERSION_CONNECT_ID, new AuthInfo.NoAuth(), params, false, false, callback);
     }
 
     public static boolean changePhone(Context context, String username, String password,
@@ -192,7 +199,7 @@ public class ApiConnectId {
         params.put("new_phone_number", newPhone);
 
         return ConnectNetworkHelper.post(context, context.getString(urlId), API_VERSION_CONNECT_ID,
-                new AuthInfo.ProvidedAuth(username, password, false), params, false,
+                new AuthInfo.ProvidedAuth(username, password, false), params, false, false,
                 callback);
     }
 
@@ -212,7 +219,7 @@ public class ApiConnectId {
         }
 
         return ConnectNetworkHelper.post(context, context.getString(urlId), API_VERSION_CONNECT_ID,
-                new AuthInfo.ProvidedAuth(username, password, false), params, false,
+                new AuthInfo.ProvidedAuth(username, password, false), params, false, false,
                 callback);
     }
 
@@ -224,7 +231,7 @@ public class ApiConnectId {
         HashMap<String, String> params = new HashMap<>();
 
         return ConnectNetworkHelper.post(context, context.getString(urlId),
-                API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+                API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean requestRecoveryOtpPrimary(Context context, String phone, IApiCallback callback) {
@@ -235,7 +242,7 @@ public class ApiConnectId {
         params.put("phone", phone);
 
         return ConnectNetworkHelper.post(context, context.getString(urlId),
-                API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+                API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean requestRecoveryOtpSecondary(Context context, String phone, String secret,
@@ -248,7 +255,7 @@ public class ApiConnectId {
         params.put("secret_key", secret);
 
         return ConnectNetworkHelper.post(context, context.getString(urlId),
-                API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+                API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean requestVerificationOtpSecondary(Context context, String username, String password,
@@ -259,7 +266,7 @@ public class ApiConnectId {
         HashMap<String, String> params = new HashMap<>();
 
         return ConnectNetworkHelper.post(context, context.getString(urlId),
-                API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+                API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean confirmRegistrationOtpPrimary(Context context, String username, String password,
@@ -271,7 +278,7 @@ public class ApiConnectId {
         params.put("token", token);
 
         return ConnectNetworkHelper.post(context, context.getString(urlId),
-                API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+                API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean confirmRecoveryOtpPrimary(Context context, String phone, String secret,
@@ -285,7 +292,7 @@ public class ApiConnectId {
         params.put("token", token);
 
         return ConnectNetworkHelper.post(context, context.getString(urlId),
-                API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+                API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean confirmRecoveryOtpSecondary(Context context, String phone, String secret,
@@ -299,7 +306,7 @@ public class ApiConnectId {
         params.put("token", token);
 
         return ConnectNetworkHelper.post(context, context.getString(urlId),
-                API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+                API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 
     public static boolean confirmVerificationOtpSecondary(Context context, String username, String password,
@@ -311,6 +318,6 @@ public class ApiConnectId {
         params.put("token", token);
 
         return ConnectNetworkHelper.post(context, context.getString(urlId),
-                API_VERSION_CONNECT_ID, authInfo, params, false, callback);
+                API_VERSION_CONNECT_ID, authInfo, params, false, false, callback);
     }
 }

--- a/app/src/org/commcare/connect/network/ConnectNetworkHelper.java
+++ b/app/src/org/commcare/connect/network/ConnectNetworkHelper.java
@@ -114,13 +114,14 @@ public class ConnectNetworkHelper {
 
     public static boolean post(Context context, String url, String version, AuthInfo authInfo,
                                HashMap<String, String> params, boolean useFormEncoding,
-                               IApiCallback handler) {
-        return getInstance().postInternal(context, url, version, authInfo, params, useFormEncoding, handler);
+                               boolean background, IApiCallback handler) {
+        return getInstance().postInternal(context, url, version, authInfo, params, useFormEncoding,
+                background, handler);
     }
 
     public static boolean get(Context context, String url, String version, AuthInfo authInfo,
-                              Multimap<String, String> params, IApiCallback handler) {
-        return getInstance().getInternal(context, url, version, authInfo, params, handler);
+                              Multimap<String, String> params, boolean background, IApiCallback handler) {
+        return getInstance().getInternal(context, url, version, authInfo, params, background, handler);
     }
 
     private static void addVersionHeader(HashMap<String, String> headers, String version) {
@@ -130,12 +131,16 @@ public class ConnectNetworkHelper {
     }
 
     public static PostResult postSync(Context context, String url, String version, AuthInfo authInfo,
-                                        HashMap<String, String> params, boolean useFormEncoding) {
-        setCallInProgress(url);
+                                      HashMap<String, String> params, boolean useFormEncoding,
+                                      boolean background) {
         ConnectNetworkHelper instance = getInstance();
 
-        try {
+        if(!background) {
+            setCallInProgress(url);
             instance.showProgressDialog(context);
+        }
+
+        try {
             HashMap<String, String> headers = new HashMap<>();
             RequestBody requestBody;
 
@@ -183,25 +188,29 @@ public class ConnectNetworkHelper {
                 exception = e;
             }
 
-            instance.onFinishProcessing(context);
+            instance.onFinishProcessing(context, background);
 
             return new PostResult(responseCode, stream, exception);
         }
         catch(Exception e) {
-            setCallInProgress(null);
+            if(!background) {
+                setCallInProgress(null);
+            }
             return new PostResult(-1, null, null);
         }
     }
 
     private boolean postInternal(Context context, String url, String version, AuthInfo authInfo,
                                  HashMap<String, String> params, boolean useFormEncoding,
-                                 IApiCallback handler) {
-        if (isBusy()) {
-            return false;
-        }
-        setCallInProgress(url);
+                                 boolean background, IApiCallback handler) {
+        if(!background) {
+            if (isBusy()) {
+                return false;
+            }
+            setCallInProgress(url);
 
-        showProgressDialog(context);
+            showProgressDialog(context);
+        }
 
         HashMap<String, String> headers = new HashMap<>();
         RequestBody requestBody;
@@ -229,7 +238,7 @@ public class ConnectNetworkHelper {
                         requestBody,
                         HTTPMethod.POST,
                         authInfo);
-        postTask.connect(getResponseProcessor(context, url, handler));
+        postTask.connect(getResponseProcessor(context, url, background, handler));
 
         postTask.executeParallel();
 
@@ -247,10 +256,13 @@ public class ConnectNetworkHelper {
         return headers;
     }
 
-    public PostResult getSync(Context context, String url, AuthInfo authInfo,
+    public PostResult getSync(Context context, String url, AuthInfo authInfo, boolean background,
                                         Multimap<String, String> params) {
-        setCallInProgress(url);
-        showProgressDialog(context);
+        if(!background) {
+            setCallInProgress(url);
+            showProgressDialog(context);
+        }
+
         HashMap<String, String> headers = new HashMap<>();
 
         //TODO: Figure out how to send GET request the right way
@@ -292,19 +304,21 @@ public class ConnectNetworkHelper {
             exception = e;
         }
 
-        onFinishProcessing(context);
+        onFinishProcessing(context, background);
 
         return new PostResult(responseCode, stream, exception);
     }
 
     private boolean getInternal(Context context, String url, String version, AuthInfo authInfo,
-                                Multimap<String, String> params, IApiCallback handler) {
-        if (isBusy()) {
-            return false;
-        }
-        setCallInProgress(url);
+                                Multimap<String, String> params, boolean background, IApiCallback handler) {
+        if(!background) {
+            if (isBusy()) {
+                return false;
+            }
+            setCallInProgress(url);
 
-        showProgressDialog(context);
+            showProgressDialog(context);
+        }
 
         //TODO: Figure out how to send GET request the right way
         StringBuilder getUrl = new StringBuilder(url);
@@ -328,24 +342,24 @@ public class ConnectNetworkHelper {
                         ArrayListMultimap.create(),
                         headers,
                         authInfo);
-        getTask.connect(getResponseProcessor(context, url, handler));
+        getTask.connect(getResponseProcessor(context, url, background, handler));
         getTask.executeParallel();
 
         return true;
     }
 
     private ConnectorWithHttpResponseProcessor<HttpResponseProcessor> getResponseProcessor(
-            Context context, String url, IApiCallback handler) {
+            Context context, String url, boolean background, IApiCallback handler) {
         return new ConnectorWithHttpResponseProcessor<>() {
             @Override
             public void processSuccess(int responseCode, InputStream responseData) {
-                onFinishProcessing(context);
+                onFinishProcessing(context, background);
                 handler.processSuccess(responseCode, responseData);
             }
 
             @Override
             public void processClientError(int responseCode) {
-                onFinishProcessing(context);
+                onFinishProcessing(context, background);
 
                 String message = String.format(Locale.getDefault(), "Call:%s\nResponse code:%d", url, responseCode);
                 CrashUtil.reportException(new Exception(message));
@@ -361,7 +375,7 @@ public class ConnectNetworkHelper {
 
             @Override
             public void processServerError(int responseCode) {
-                onFinishProcessing(context);
+                onFinishProcessing(context, background);
 
                 String message = String.format(Locale.getDefault(), "Call:%s\nResponse code:%d", url, responseCode);
                 CrashUtil.reportException(new Exception(message));
@@ -372,7 +386,7 @@ public class ConnectNetworkHelper {
 
             @Override
             public void processOther(int responseCode) {
-                onFinishProcessing(context);
+                onFinishProcessing(context, background);
 
                 String message = String.format(Locale.getDefault(), "Call:%s\nResponse code:%d", url, responseCode);
                 CrashUtil.reportException(new Exception(message));
@@ -382,7 +396,7 @@ public class ConnectNetworkHelper {
 
             @Override
             public void handleIOException(IOException exception) {
-                onFinishProcessing(context);
+                onFinishProcessing(context, background);
                 if (exception instanceof UnknownHostException) {
                     handler.processNetworkFailure();
                 } else {
@@ -425,9 +439,11 @@ public class ConnectNetworkHelper {
         };
     }
 
-    private void onFinishProcessing(Context context) {
-        setCallInProgress(null);
-        dismissProgressDialog(context);
+    private void onFinishProcessing(Context context, boolean background) {
+        if(!background) {
+            setCallInProgress(null);
+            dismissProgressDialog(context);
+        }
     }
 
     public static void showNetworkError(Context context) {

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -65,30 +65,14 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
         getDbFile(context).delete();
     }
 
-    public static void rekeyDB(Context context, SQLiteDatabase db, String oldPassphrase, String newPassphrase) throws Base64DecoderException {
-        byte[] newBytes = Base64.decode(newPassphrase);
-        String newKeyEncoded = UserSandboxUtils.getSqlCipherEncodedKey(newBytes);
+    public static void rekeyDB(SQLiteDatabase db, String newPassphrase) throws Base64DecoderException {
+        if(db != null) {
+            byte[] newBytes = Base64.decode(newPassphrase);
+            String newKeyEncoded = UserSandboxUtils.getSqlCipherEncodedKey(newBytes);
 
-        //Multiple options for getting the DB handle
-        //1: Passed-in handle
-        SQLiteDatabase rawDbHandle = db;
-        //2: Standard open method
-        //SQLiteDatabase rawDbHandle = new DatabaseConnectOpenHelper(context).getWritableDatabase(oldBytes);
-        //3: Method from UserSandboxUtils
-        byte[] oldBytes = Base64.decode(oldPassphrase);
-        String oldKeyEncoded = UserSandboxUtils.getSqlCipherEncodedKey(oldBytes);
-        oldKeyEncoded = oldKeyEncoded.substring(2, oldKeyEncoded.length() - 1);
-        //SQLiteDatabase rawDbHandle = SQLiteDatabase.openDatabase(dbFile.getAbsolutePath(), oldKeyEncoded, null,
-                //SQLiteDatabase.OPEN_READWRITE);
-
-        //Multiple options for changing DB passphrase
-        //1: Takes a String or char[]
-        rawDbHandle.changePassword(newKeyEncoded);
-        //2: Requires String (sounds like first line isn't needed)
-        //rawDbHandle.query("PRAGMA key = '" + oldKeyEncoded + "';");
-        //rawDbHandle.query("PRAGMA rekey  = '" + newKeyEncoded + "';");
-
-        rawDbHandle.close();
+            db.query("PRAGMA rekey = '" + newKeyEncoded + "';");
+            db.close();
+        }
     }
 
     @Override

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -58,23 +58,24 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
     }
 
     public static boolean dbExists(Context context) {
-        return getDbFile(context).exists();
+        //return getDbFile(context).exists();
+        String path = context.getDatabasePath(CONNECT_DB_LOCATOR).getPath();
+        File dbPathFile = new File(path);
+        return dbPathFile.exists();
     }
 
-    public static void rekeyDB(Context context, String oldPassphrase, String newPassphrase) throws Base64DecoderException {
-        File dbFile = getDbFile(context);
-
+    public static void rekeyDB(Context context, SQLiteDatabase db, String oldPassphrase, String newPassphrase) throws Base64DecoderException {
         byte[] oldBytes = Base64.decode(oldPassphrase);
         byte[] newBytes = Base64.decode(newPassphrase);
 
         String oldKeyEncoded = UserSandboxUtils.getSqlCipherEncodedKey(oldBytes);
         String newKeyEncoded = UserSandboxUtils.getSqlCipherEncodedKey(newBytes);
-        SQLiteDatabase rawDbHandle = SQLiteDatabase.openDatabase(dbFile.getAbsolutePath(), oldKeyEncoded, null,
-                SQLiteDatabase.OPEN_READWRITE);
+        //SQLiteDatabase rawDbHandle = new DatabaseConnectOpenHelper(context).getWritableDatabase(oldBytes);// SQLiteDatabase.openDatabase(dbFile.getAbsolutePath(), oldKeyEncoded, null,
+                //SQLiteDatabase.OPEN_READWRITE);
 
-        rawDbHandle.execSQL("PRAGMA key = '" + oldKeyEncoded + "';");
-        rawDbHandle.execSQL("PRAGMA rekey  = '" + newKeyEncoded + "';");
-        rawDbHandle.close();
+        db.query("PRAGMA key = '" + oldKeyEncoded + "';");
+        db.query("PRAGMA rekey  = '" + newKeyEncoded + "';");
+        db.close();
     }
 
     @Override

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -21,6 +21,8 @@ import org.commcare.logging.DataChangeLogger;
 import org.commcare.models.database.DbUtil;
 import org.commcare.modern.database.TableBuilder;
 
+import java.io.File;
+
 /**
  * The helper for opening/updating the Connect (encrypted) db space for CommCare.
  *
@@ -46,6 +48,12 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
     public DatabaseConnectOpenHelper(Context context) {
         super(context, CONNECT_DB_LOCATOR, null, CONNECT_DB_VERSION);
         this.mContext = context;
+    }
+
+    public static boolean dbExists(Context context) {
+        String path = context.getDatabasePath(CONNECT_DB_LOCATOR).getPath();
+        File dbPathFile = new File(path);
+        return dbPathFile.exists();
     }
 
     @Override

--- a/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
+++ b/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
@@ -31,8 +31,9 @@ public class DatabaseGlobalOpenHelper extends SQLiteOpenHelper {
      * V.4 - Add table for storing force close log entries that occur outside of an active session
      * V.5 - Add table for storing apps available for install
      * V.6 - Add table for storing (encrypted) passphrase for ConnectId DB
+     * V.7 - Add is_local column to ConnectKeyRecord table (to store both local and server passphrase)
      */
-    private static final int GLOBAL_DB_VERSION = 6;
+    private static final int GLOBAL_DB_VERSION = 7;
 
     private static final String GLOBAL_DB_LOCATOR = "database_global";
 

--- a/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
@@ -11,6 +11,7 @@ import org.commcare.android.database.global.models.AppAvailableToInstall;
 import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.android.database.global.models.ApplicationRecordV1;
 import org.commcare.android.database.global.models.ConnectKeyRecord;
+import org.commcare.android.database.global.models.ConnectKeyRecordV6;
 import org.commcare.android.logging.ForceCloseLogEntry;
 import org.commcare.models.database.ConcreteAndroidDbHelper;
 import org.commcare.models.database.DbUtil;
@@ -55,6 +56,12 @@ class GlobalDatabaseUpgrader {
         if (oldVersion == 5) {
             if (upgradeFiveSix(db)) {
                 oldVersion = 6;
+            }
+        }
+
+        if (oldVersion == 6) {
+            if (upgradeSixSeven(db)) {
+                oldVersion = 7;
             }
         }
     }
@@ -126,6 +133,43 @@ class GlobalDatabaseUpgrader {
 
     private boolean upgradeFiveSix(SQLiteDatabase db) {
         return addTableForNewModel(db, ConnectKeyRecord.STORAGE_KEY, new ConnectKeyRecord());
+    }
+
+    private boolean upgradeSixSeven(SQLiteDatabase db) {
+        db.beginTransaction();
+
+        //Migrate the old ConnectKeyRecord in storage to the new version including isLocal
+        try {
+            db.execSQL(DbUtil.addColumnToTable(
+                    ConnectKeyRecord.STORAGE_KEY,
+                    ConnectKeyRecord.IS_LOCAL,
+                    "TEXT"));
+
+            SqlStorage<Persistable> oldStorage = new SqlStorage<>(
+                    ConnectKeyRecordV6.STORAGE_KEY,
+                    ConnectKeyRecordV6.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            SqlStorage<Persistable> newStorage = new SqlStorage<>(
+                    ConnectKeyRecord.STORAGE_KEY,
+                    ConnectKeyRecord.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            for (Persistable r : oldStorage) {
+                ConnectKeyRecordV6 oldRecord = (ConnectKeyRecordV6)r;
+                ConnectKeyRecord newRecord = ConnectKeyRecord.fromV6(oldRecord);
+                //set this new record to have same ID as the old one
+                newRecord.setID(oldRecord.getID());
+                newStorage.write(newRecord);
+            }
+
+            db.setTransactionSuccessful();
+            return true;
+        } catch(Exception e) {
+            return false;
+        } finally {
+            db.endTransaction();
+        }
     }
 
     private static boolean addTableForNewModel(SQLiteDatabase db, String storageKey,


### PR DESCRIPTION
Several improvements to support having the database passphrase be issues by the ConnectID server, rather than generating a random passphrase locally.

Changes include:
-Not creating the DB until user registers/recovers account
-Deleting DB when forgetting user (and on corrupted DB)
-Retrieving the passphrase and rekeying the DB for existing users
-Supporting background network calls (with concurrent calls allowed)
