### PR TITLE
Improve logging around audio recording events

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -444,7 +444,7 @@ custom.restore.file.not.set=Custom restore file path is not set in preferences
 custom.restore.error=Error loading custom sync
 
 start.recording=Start Recording
-start.recording.failed=Unable to start recording while another application is recording!
+start.recording.failed=Unable to start recording while another application is using the microphone!
 stop.recording=Stop Recording
 recording.header=Record a sound
 before.recording=Tap to start recording

--- a/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
+++ b/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
@@ -18,8 +18,10 @@ import android.widget.Toast;
 import org.commcare.activities.components.FormEntryConstants;
 import org.commcare.dalvik.R;
 import org.commcare.logic.PendingCalloutInterface;
+import org.commcare.util.LogTypes;
 import org.commcare.utils.StringUtils;
 import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.services.Logger;
 import org.javarosa.form.api.FormEntryPrompt;
 
 import java.io.File;
@@ -132,6 +134,7 @@ public class CommCareAudioWidget extends AudioWidget
 
     @Override
     public void onRecordingCompletion(String audioFile) {
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Saving recording: " + audioFile);
         if (new File(audioFile).exists()) {
             setBinaryData(audioFile);
             togglePlayButton(true);

--- a/app/src/org/commcare/views/widgets/MediaWidget.java
+++ b/app/src/org/commcare/views/widgets/MediaWidget.java
@@ -309,12 +309,16 @@ public abstract class MediaWidget extends QuestionWidget {
         String extension = FileUtil.getExtension(binaryPath);
         destMediaPath = mInstanceFolder + System.currentTimeMillis() +
                 customFileTag + "." + extension;
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Setting recording destination folder: " + destMediaPath
+                + "|" + HiddenPreferences.isMediaCaptureEncryptionEnabled());
         try {
             if (HiddenPreferences.isMediaCaptureEncryptionEnabled()) {
                 destMediaPath = destMediaPath + AES_EXTENSION;
                 EncryptionIO.encryptFile(binaryPath, destMediaPath, getSecretKey());
+                Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Media successfully encrypted and saved: " + destMediaPath);
             } else {
                 FileUtil.copyFile(binaryPath, destMediaPath);
+                Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Media successfully saved: " + destMediaPath);
             }
         } catch (IOException e) {
             showToast("form.attachment.copy.fail");

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -225,12 +225,12 @@ public class RecordingFragment extends DialogFragment {
         }
         recorder.setAudioSamplingRate(isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE);
         recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
-        recorder.setOutputFile(fileName);
         if (isHeAacSupported) {
             recorder.setAudioEncoder(MediaRecorder.AudioEncoder.HE_AAC);
         } else {
             recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
         }
+        recorder.setOutputFile(fileName);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             registerAudioRecordingConfigurationChangeCallback();
         }

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -182,6 +182,7 @@ public class RecordingFragment extends DialogFragment {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             if (MediaUtil.isRecordingActive(getContext())) {
                 Toast.makeText(getContext(), Localization.get("start.recording.failed"), Toast.LENGTH_SHORT).show();
+                Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording cancelled due to an ongoing recording");
                 return;
             }
         }

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -192,7 +192,7 @@ public class RecordingFragment extends DialogFragment {
         recorder.start();
         recordingDuration.setBase(SystemClock.elapsedRealtime());
         recordingInProgress();
-        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording starting");
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording started");
     }
 
     private void recordingInProgress() {
@@ -239,9 +239,9 @@ public class RecordingFragment extends DialogFragment {
         }
         try {
             recorder.prepare();
-            Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Prepare recording: " + fileName
-                    + "|" + (isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE)
-                    + "|" + (isHeAacSupported ? MediaRecorder.AudioEncoder.HE_AAC : MediaRecorder.AudioEncoder.AMR_NB));
+            Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Preparing recording: " + fileName
+                    + " | " + (isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE)
+                    + " | " + (isHeAacSupported ? MediaRecorder.AudioEncoder.HE_AAC : MediaRecorder.AudioEncoder.AMR_NB));
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -37,8 +37,10 @@ import org.commcare.CommCareApplication;
 import org.commcare.CommCareNoficationManager;
 import org.commcare.activities.DispatchActivity;
 import org.commcare.dalvik.R;
+import org.commcare.util.LogTypes;
 import org.commcare.utils.MediaUtil;
 import org.commcare.utils.NotificationUtil;
+import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 
 import java.io.File;
@@ -190,6 +192,7 @@ public class RecordingFragment extends DialogFragment {
         recorder.start();
         recordingDuration.setBase(SystemClock.elapsedRealtime());
         recordingInProgress();
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording starting");
     }
 
     private void recordingInProgress() {
@@ -236,6 +239,10 @@ public class RecordingFragment extends DialogFragment {
         }
         try {
             recorder.prepare();
+            Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Prepare recording: " + fileName
+                    + "|" + (isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE)
+                    + "|" + (isHeAacSupported ? MediaRecorder.AudioEncoder.HE_AAC : MediaRecorder.AudioEncoder.AMR_NB));
+
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -272,6 +279,7 @@ public class RecordingFragment extends DialogFragment {
 
     @SuppressLint("NewApi")
     private void stopRecording() {
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording stopping");
         recordingDuration.stop();
         recordingProgress.setVisibility(View.INVISIBLE);
 
@@ -285,10 +293,12 @@ public class RecordingFragment extends DialogFragment {
         toggleRecording.setOnClickListener(v -> playAudio());
         instruction.setText(Localization.get("after.recording"));
         enableSave();
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording stopped");
     }
 
     @SuppressLint("NewApi")
     private void pauseRecording(boolean pausedByUser) {
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording pausing");
         inPausedState = true;
         recordingDuration.stop();
         chronoPause();
@@ -299,6 +309,7 @@ public class RecordingFragment extends DialogFragment {
         toggleRecording.setOnClickListener(v -> resumeRecording());
         instruction.setText(Localization.get(pausedByUser ? "pause.recording"
                 : "pause.recording.because.no.sound.captured"));
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording paused");
     }
 
     private void enableSave() {
@@ -310,10 +321,12 @@ public class RecordingFragment extends DialogFragment {
 
     @SuppressLint("NewApi")
     private void resumeRecording() {
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording resuming");
         inPausedState = false;
         chronoResume();
         recorder.resume();
         recordingInProgress();
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording resumed");
     }
 
     private boolean isPauseSupported() {


### PR DESCRIPTION
## Summary
Some users reported crashes during long audio recordings, more concretely when starting or stopping a recording. From the crash reports, we could see that these are related with what seems to be OS runtime errors, probably related to the allocation of the microphone or its state, here are some examples:
```
Fatal Exception: java.lang.IllegalStateException:
       at android.media.MediaRecorder.native_start(MediaRecorder.java)
       at android.media.MediaRecorder.start(MediaRecorder.java:1409)
       at org.commcare.views.widgets.RecordingFragment.startRecording(RecordingFragment.java:171)
       at org.commcare.views.widgets.RecordingFragment.lambda$prepareButtons$3(RecordingFragment.java:138)
       at org.commcare.views.widgets.RecordingFragment.$r8$lambda$_f4gpgcFmBpYAjMTw-zPR52rFnE(RecordingFragment.java)
       at org.commcare.views.widgets.RecordingFragment$$InternalSyntheticLambda$0$cc1961f5746e23f7491a3d6e1f5a06d308627bd6d301c3274e25a58d59953a04$1.onClick(RecordingFragment.java:2)
       at android.view.View.performClick(View.java:6329)
       at android.view.View$PerformClick.run(View.java:25002)
       at android.os.Handler.handleCallback(Handler.java:809)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:166)
       at android.app.ActivityThread.main(ActivityThread.java:7555)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:469)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:963)
```

```
Fatal Exception: java.lang.RuntimeException: stop failed.
       at android.media.MediaRecorder._stop(MediaRecorder.java)
       at android.media.MediaRecorder.stop(MediaRecorder.java:1702)
       at org.commcare.views.widgets.RecordingFragment.stopRecording(RecordingFragment.java:254)
       at org.commcare.views.widgets.RecordingFragment.lambda$recordingInProgress$6(RecordingFragment.java:183)
       at org.commcare.views.widgets.RecordingFragment.$r8$lambda$beGLzrFE2bYi61lNMyXMhSdypSk(RecordingFragment.java)
       at org.commcare.views.widgets.RecordingFragment$$InternalSyntheticLambda$0$98b14779c8186ae0e19413b331847be0c5e0c253de5d93aa79fc455e6d89f01d$1.onClick(RecordingFragment.java:2)
       at android.view.View.performClick(View.java:7912)
       at android.view.View.performClickInternal(View.java:7889)
       at android.view.View.-$$Nest$mperformClickInternal()
       at android.view.View$PerformClick.run(View.java:31082)
       at android.os.Handler.handleCallback(Handler.java:942)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8810)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```
```
          Fatal Exception: java.lang.IllegalStateException:
       at android.media.MediaRecorder.pause(MediaRecorder.java)
       at org.commcare.views.widgets.RecordingFragment.pauseRecording(RecordingFragment.java:295)
       at org.commcare.views.widgets.RecordingFragment$1.onRecordingConfigChanged(RecordingFragment.java:441)
       at android.media.AudioManager$ServiceEventHandlerDelegate$1.handleMessage(AudioManager.java:2228)
       at android.os.Handler.dispatchMessage(Handler.java:110)
       at android.os.Looper.loop(Looper.java:203)
       at android.app.ActivityThread.main(ActivityThread.java:6442)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1063)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:924)
```
Considering that these type of errors are usually outside of the apps' control, the approach is to improve logging around these events, gather more information to then decide how to address them. It can be that there isn't much to do besides wrapping these call with `try..catch` to prevent CommCare from crashing.

cross-request: https://github.com/dimagi/commcare-core/pull/1416

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below
