### PR TITLE
Override RxJava Global Error Handler

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -137,6 +137,7 @@ import javax.crypto.SecretKey;
 import io.noties.markwon.Markwon;
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin;
 import io.noties.markwon.ext.tables.TablePlugin;
+import io.reactivex.exceptions.UndeliverableException;
 import io.reactivex.plugins.RxJavaPlugins;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
@@ -1211,7 +1212,11 @@ public class CommCareApplication extends MultiDexApplication {
 
     private void setRxJavaGlobalHandler() {
         RxJavaPlugins.setErrorHandler(throwable -> {
-            // Not sure the type of exceptions we should handle here
+            // Swallow UndeliverableException
+            if (throwable instanceof UndeliverableException) {
+                return;
+            }
+            Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), throwable);
         });
     }
 }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -137,6 +137,7 @@ import javax.crypto.SecretKey;
 import io.noties.markwon.Markwon;
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin;
 import io.noties.markwon.ext.tables.TablePlugin;
+import io.reactivex.plugins.RxJavaPlugins;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 
@@ -251,8 +252,9 @@ public class CommCareApplication extends MultiDexApplication {
         FirebaseMessagingUtil.verifyToken();
 
         customiseOkHttp();
-    }
 
+        setRxJavaGlobalHandler();
+    }
 
     protected void loadSqliteLibs() {
         SQLiteDatabase.loadLibs(this);
@@ -1205,5 +1207,11 @@ public class CommCareApplication extends MultiDexApplication {
 
     public void customiseOkHttp() {
         CommCareNetworkServiceGenerator.customizeRetrofitSetup(new OkHttpBuilderCustomConfig());
+    }
+
+    private void setRxJavaGlobalHandler() {
+        RxJavaPlugins.setErrorHandler(throwable -> {
+            // Not sure the type of exceptions we should handle here
+        });
     }
 }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -116,6 +116,7 @@ import org.commcare.utils.SessionStateUninitException;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.views.widgets.CleanRawMedia;
 import org.javarosa.core.model.User;
+import org.javarosa.core.model.condition.RequestAbandonedException;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.RootTranslator;
 import org.javarosa.core.services.Logger;
@@ -1212,10 +1213,14 @@ public class CommCareApplication extends MultiDexApplication {
 
     private void setRxJavaGlobalHandler() {
         RxJavaPlugins.setErrorHandler(throwable -> {
-            // Swallow UndeliverableException
             if (throwable instanceof UndeliverableException) {
+                throwable = throwable.getCause();
+            }
+            // Swallow RequestAbandonedException
+            if (throwable instanceof RequestAbandonedException) {
                 return;
             }
+
             Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), throwable);
         });
     }


### PR DESCRIPTION
## Summary
RxJava 2.x brought changes to the way Throwable errors are handled, causing them to not be swallowed. This means that when any exception that is not being handled occurs, RxJava now bubbles it up through the current thread's uncaught exception handler, which causes CommCare to crash. This PR overrides RxJava Global error handler to offer a more controlled behaviour.  

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
This is only to swallow RxJava RequestAbandonedException exceptions, other exceptions should continue being handled the same way.
