### PR TITLE
Fix the number of Nav drawer items 

### DIFF
--- a/app/src/org/commcare/activities/HomeNavDrawerController.java
+++ b/app/src/org/commcare/activities/HomeNavDrawerController.java
@@ -105,11 +105,12 @@ public class HomeNavDrawerController {
     private void determineDrawerItemsToInclude() {
         boolean hideSavedFormsItem = !HiddenPreferences.isSavedFormsEnabled();
         boolean hideChangeLanguageItem = ChangeLocaleUtil.getLocaleNames().length <= 1;
+        boolean hideTrainingItem = !CommCareApplication.instance().getCurrentApp().hasVisibleTrainingContent();
         int numItemsToInclude = allDrawerItems.size()
                 - (hideChangeLanguageItem ? 1 : 0)
                 - (hideSavedFormsItem ? 1 : 0)
+                - (hideTrainingItem ? 1 : 0)
                 - (activity.showCommCareUpdateMenu ? 0 : 1);
-        boolean hideTrainingItem = !CommCareApplication.instance().getCurrentApp().hasVisibleTrainingContent();
 
         drawerItemsShowing = new NavDrawerItem[numItemsToInclude];
         int index = 0;


### PR DESCRIPTION
## Summary
The current logic doesn't consider the `Training` menu item causing the creation of an extra item, which is `null` and when pressed causes CommCare to crash.

## Feature Flag
Custom property `cc-use-root-menu-as-home-screen`

## Safety Assurance
- [X] I have confidence that this PR will not introduce a regression for the reasons below
