### PR TITLE
Pass query params to HTTP requests that don't require authentication

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -1178,7 +1178,7 @@ public class CommCareApplication extends MultiDexApplication {
 
         CommCareNetworkService networkService;
         if (authInfo instanceof AuthInfo.NoAuth) {
-            networkService = CommCareNetworkServiceGenerator.createNoAuthCommCareNetworkService();
+            networkService = CommCareNetworkServiceGenerator.createNoAuthCommCareNetworkService(params);
         } else {
             networkService = CommCareNetworkServiceGenerator.createCommCareNetworkService(
                     HttpUtils.getCredential(authInfo),


### PR DESCRIPTION
## Summary
This PR fixes an issue that is causing the `app_id` in the response body of the Recovery Measures GET request to be `null`. 
```
{
    "latest_apk_version": "2.53.1",
    "latest_ccz_version": 127,
    "app_id": null,
    "recovery_measures": [
        {
            "sequence_number": 9,
            "type": "app_reinstall_and_update",
            "app_version_min": 128,
            "app_version_max": 131
        }
    ]
}
```
In CommCareHQ, the `app_id` is added to the [response body from the GET request itself](https://github.com/dimagi/commcare-hq/blob/33fc0df006a54e57bfe23a204155dd5a8d5ea33a/corehq/apps/ota/views.py#L485), from a query param, and because the existing logic that builds HTTP requests for requests that don't need authentication is ignoring any params that have been passed, the `app_id` is not part of the request, causing it to be `null` in the response body. With the `app_id` logic not present the Recovery Measures are not being triggered when they should.

cross-request: https://github.com/dimagi/commcare-core/pull/1422
Ticket: https://dimagi.atlassian.net/browse/QA-6606

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
This only passes query params for HTTP requests without auth


