### PR TITLE
Apk dependencies additions

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -104,6 +104,10 @@
         <package android:name="callout.commcare.org.sendussd" />
         <package android:name="org.commcare.dalvik.abha" />
         <package android:name="com.dimagi.biometric" />
+        <package android:name="org.rdtoolkit" />
+        <package android:name="richard.chard.lu.android.areamapper" />
+        <package android:name="org.commcare.respiratory" />
+        <package android:name="com.simprints.id" />
     </queries>
 
     <application


### PR DESCRIPTION
## Summary

Adds common Android apps packages CC may depend on for [App depndency](https://dimagi.atlassian.net/wiki/spaces/GS/pages/2374238277/Set+Android+app+dependencies+that+must+be+installed+before+using+a+CommCare+app).

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

NA

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
No business logic change. A build pass should confirm the safety here. 
