### PR TITLE
Remove test credentials from release build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -556,7 +556,7 @@ tasks.whenTaskAdded { task ->
             && "true" == isConsumerApp && "true" == runDownloadScripts) {
         task.dependsOn downloadRestoreFile
     }
-    if ((task.name != null) && (task.name.startsWith('assemble') && task.name.endsWith('AndroidTest'))) {
+    if (task.name == 'assembleCommcareReleaseAndroidTest') {
         android.defaultConfig.buildConfigField "String", "HQ_API_USERNAME", "\"${project.ext.HQ_API_USERNAME}\""
         android.defaultConfig.buildConfigField "String", "HQ_API_PASSWORD", "\"${project.ext.HQ_API_PASSWORD}\""
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -276,8 +276,6 @@ android {
         buildConfigField 'String', 'ANALYTICS_TRACKING_ID_DEV', "\"${project.ext.ANALYTICS_TRACKING_ID_DEV}\""
         buildConfigField 'String', 'MAPBOX_SDK_API_KEY', "\"${project.ext.MAPBOX_SDK_API_KEY}\""
 
-        buildConfigField "String", "HQ_API_USERNAME", "\"${project.ext.HQ_API_USERNAME}\""
-        buildConfigField "String", "HQ_API_PASSWORD", "\"${project.ext.HQ_API_PASSWORD}\""
         buildConfigField "String", "FIREBASE_DATABASE_URL", "\"${project.ext.FIREBASE_DATABASE_URL}\""
 
         buildConfigField 'String', 'CCC_HOST', "\"connect.dimagi.com\""
@@ -557,6 +555,10 @@ tasks.whenTaskAdded { task ->
             task.name == 'processStandaloneReleaseResources')
             && "true" == isConsumerApp && "true" == runDownloadScripts) {
         task.dependsOn downloadRestoreFile
+    }
+    if ((task.name != null) && (task.name.startsWith('assemble') && task.name.endsWith('AndroidTest'))) {
+        android.defaultConfig.buildConfigField "String", "HQ_API_USERNAME", "\"${project.ext.HQ_API_USERNAME}\""
+        android.defaultConfig.buildConfigField "String", "HQ_API_PASSWORD", "\"${project.ext.HQ_API_PASSWORD}\""
     }
 }
 

--- a/app/instrumentation-tests/src/org/commcare/androidTests/InstallFromListTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/InstallFromListTest.kt
@@ -17,8 +17,8 @@ import org.commcare.CommCareInstrumentationTestApplication
 import org.commcare.activities.InstallFromListActivity
 import org.commcare.android.database.global.models.AppAvailableToInstall
 import org.commcare.annotations.BrowserstackTests
-import org.commcare.dalvik.BuildConfig
 import org.commcare.dalvik.R
+import org.commcare.dalvik.test.BuildConfig
 import org.commcare.utils.CustomMatchers
 import org.commcare.utils.InstrumentationUtility
 import org.commcare.utils.isPresent

--- a/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
+++ b/app/instrumentation-tests/src/org/commcare/utils/HQApi.java
@@ -9,7 +9,7 @@ import com.google.common.collect.ImmutableMultimap;
 import org.commcare.core.network.AuthInfo;
 import org.commcare.core.network.CommCareNetworkService;
 import org.commcare.core.network.CommCareNetworkServiceGenerator;
-import org.commcare.dalvik.BuildConfig;
+import org.commcare.dalvik.test.BuildConfig;
 import org.commcare.modern.util.Pair;
 import org.commcare.network.HttpUtils;
 import org.joda.time.DateTime;


### PR DESCRIPTION
## Summary
Our release `BuildConfig` class contains test credentials that are used by instrumentation tests. This PR makes these credentials only available to the Instrumentation tests `BuildConfig` class. 

After this change, here are the fields available in the release `BuildConfig` class
```
# static fields
.field public static final ANALYTICS_TRACKING_ID_DEV:Ljava/lang/String; = ""
.field public static final ANALYTICS_TRACKING_ID_LIVE:Ljava/lang/String; = ""
.field public static final APPLICATION_ID:Ljava/lang/String; = "org.commcare.dalvik"
.field public static final BUILD_DATE:Ljava/lang/String; = "2024-08-13"
.field public static final BUILD_NUMBER:Ljava/lang/String; = "..."
.field public static final BUILD_TYPE:Ljava/lang/String; = "release"
.field public static final CCC_HOST:Ljava/lang/String; = "connect.dimagi.com"
.field public static final CC_AUTHORITY:Ljava/lang/String; = "org.commcare.dalvik"
.field public static final CONSUMER_APP_PASSWORD:Ljava/lang/String; = ""
.field public static final CONSUMER_APP_USERNAME:Ljava/lang/String; = ""
.field public static final DEBUG:Z = false
.field public static final FIREBASE_DATABASE_URL:Ljava/lang/String; = "..."
.field public static final FLAVOR:Ljava/lang/String; = "commcare"
.field public static final IS_CONSUMER_APP:Z = false
.field public static final IS_SINGLE_APP_BUILD:Z = false
.field public static final MAPBOX_SDK_API_KEY:Ljava/lang/String; = "..."
.field public static final ODK_AUTHORITY:Ljava/lang/String; = "org.commcare.android.provider.odk"
.field public static final TRUSTED_SOURCE_PUBLIC_KEY:Ljava/lang/String; = "xxx"
.field public static final USE_CRASHLYTICS:Z = true
.field public static final VERSION_CODE:I = 0x72102
.field public static final VERSION_NAME:Ljava/lang/String; = "2.54"
```

## Safety Assurance
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
This is only relevant to the build process.
