### PR TITLE
UKRs managed by server for Connect apps

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -637,7 +637,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     }
 
     private void updateConnectButton() {
-        installFragment.updateConnectButton(!fromManager && !fromExternal && ConnectManager.isConnectIdIntroduced(), v -> {
+        installFragment.updateConnectButton(!fromManager && !fromExternal && ConnectManager.isConnectIdConfigured(), v -> {
             ConnectManager.unlockConnect(this, success -> {
                 if(success) {
                     ConnectManager.goToConnectJobsList();

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -388,7 +388,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
     private String getUniformUsername() {
         String username = uiController.getEnteredUsername();
-        if (ConnectManager.isUnlocked() && appLaunchedFromConnect) {
+        if (ConnectManager.isConnectIdConfigured() && appLaunchedFromConnect) {
             username = ConnectManager.getUser(this).getUserId();
         }
         return username.toLowerCase().trim();
@@ -479,7 +479,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     }
 
     public boolean handleConnectSignIn() {
-        if(ConnectManager.isConnectIdIntroduced()) {
+        if(ConnectManager.isConnectIdConfigured()) {
             String appId = CommCareApplication.instance().getCurrentApp().getUniqueId();
             ConnectJobRecord job = ConnectManager.setConnectJobForApp(this, appId);
             if(job != null) {
@@ -523,7 +523,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
     private void checkForSavedCredentials() {
         boolean loginWithConnectIDVisible = false;
-        if (ConnectManager.isConnectIdIntroduced()) {
+        if (ConnectManager.isConnectIdConfigured()) {
             if (appLaunchedFromConnect && !connectLaunchPerformed) {
                 loginWithConnectIDVisible = true;
                 uiController.setConnectButtonVisible(false);
@@ -711,7 +711,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
         appIdDropdownList.clear();
 
-        boolean includeConnect = ConnectManager.isConnectIdIntroduced();
+        boolean includeConnect = ConnectManager.isConnectIdConfigured();
         if (includeConnect) {
             appNames.add(Localization.get("login.app.connect"));
             appIdDropdownList.add("");
@@ -735,7 +735,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     }
 
     private boolean isConnectJobsSelected() {
-        return ConnectManager.isConnectIdIntroduced() && uiController.getSelectedAppIndex() == 0;
+        return ConnectManager.isConnectIdConfigured() && uiController.getSelectedAppIndex() == 0;
     }
 
     @Override

--- a/app/src/org/commcare/activities/LoginActivityUiController.java
+++ b/app/src/org/commcare/activities/LoginActivityUiController.java
@@ -225,7 +225,7 @@ public class LoginActivityUiController implements CommCareActivityUIController {
         ApplicationRecord presetAppRecord = getPresetAppRecord(readyApps);
         boolean noApps = readyApps.isEmpty();
         setLoginInputsVisibility(!noApps);
-        if (!ConnectManager.isConnectIdIntroduced() && (readyApps.size() == 1 || presetAppRecord != null)) {
+        if (!ConnectManager.isConnectIdConfigured() && (readyApps.size() == 1 || presetAppRecord != null)) {
             setLoginInputsVisibility(true);
 
             // Set this app as the last selected app, for use in choosing what app to initialize
@@ -270,7 +270,7 @@ public class LoginActivityUiController implements CommCareActivityUIController {
     public void updateConnectLoginState() {
         setConnectButtonVisible(ConnectManager.shouldShowConnectButton());
 
-        if (ConnectManager.isConnectIdIntroduced()) {
+        if (ConnectManager.isConnectIdConfigured()) {
             String welcomeText = activity.getString(R.string.login_welcome_connect_signed_in,
                     ConnectDatabaseHelper.getUser(activity).getName());
 

--- a/app/src/org/commcare/android/database/connect/models/ConnectLinkedAppRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectLinkedAppRecord.java
@@ -100,9 +100,9 @@ public class ConnectLinkedAppRecord extends Persisted {
         newRecord.hqTokenExpiration = oldRecord.getHqTokenExpiration();
         newRecord.connectIdLinked = oldRecord.getConnectIdLinked();
         newRecord.linkOffered1 = oldRecord.getLinkOfferDate1() != null;
-        newRecord.linkOfferDate1 = oldRecord.getLinkOfferDate1();
+        newRecord.linkOfferDate1 = newRecord.linkOffered1 ? oldRecord.getLinkOfferDate1() : new Date();
         newRecord.linkOffered2 = oldRecord.getLinkOfferDate2() != null;
-        newRecord.linkOfferDate2 = oldRecord.getLinkOfferDate2();
+        newRecord.linkOfferDate2 = newRecord.linkOffered2 ? oldRecord.getLinkOfferDate2() : new Date();
 
         newRecord.usingLocalPassphrase = true;
 

--- a/app/src/org/commcare/android/database/connect/models/ConnectLinkedAppRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectLinkedAppRecord.java
@@ -26,6 +26,7 @@ public class ConnectLinkedAppRecord extends Persisted {
     public static final String META_OFFERED_1_DATE = "link_offered_1_date";
     public static final String META_OFFERED_2 = "link_offered_2";
     public static final String META_OFFERED_2_DATE = "link_offered_2_date";
+    public static final String META_LOCAL_PASSPHRASE = "using_local_passphrase";
 
     @Persisting(1)
     @MetaField(META_APP_ID)
@@ -57,6 +58,10 @@ public class ConnectLinkedAppRecord extends Persisted {
     @MetaField(META_OFFERED_2_DATE)
     private Date linkOfferDate2;
 
+    @Persisting(12)
+    @MetaField(META_LOCAL_PASSPHRASE)
+    private boolean usingLocalPassphrase;
+
     public ConnectLinkedAppRecord() {
         hqTokenExpiration = new Date();
         linkOfferDate1 = new Date();
@@ -78,6 +83,28 @@ public class ConnectLinkedAppRecord extends Persisted {
         newRecord.linkOfferDate1 = new Date();
         newRecord.linkOffered2 = false;
         newRecord.linkOfferDate2 = new Date();
+
+        newRecord.usingLocalPassphrase = true;
+
+        return newRecord;
+    }
+
+    public static ConnectLinkedAppRecord fromV8(ConnectLinkedAppRecordV8 oldRecord) {
+        ConnectLinkedAppRecord newRecord = new ConnectLinkedAppRecord();
+
+        newRecord.appId = oldRecord.getAppId();
+        newRecord.userId = oldRecord.getUserId();
+        newRecord.password = oldRecord.getPassword();
+        newRecord.workerLinked = oldRecord.getWorkerLinked();
+        newRecord.hqToken = oldRecord.getHqToken();
+        newRecord.hqTokenExpiration = oldRecord.getHqTokenExpiration();
+        newRecord.connectIdLinked = oldRecord.getConnectIdLinked();
+        newRecord.linkOffered1 = oldRecord.getLinkOfferDate1() != null;
+        newRecord.linkOfferDate1 = oldRecord.getLinkOfferDate1();
+        newRecord.linkOffered2 = oldRecord.getLinkOfferDate2() != null;
+        newRecord.linkOfferDate2 = oldRecord.getLinkOfferDate2();
+
+        newRecord.usingLocalPassphrase = true;
 
         return newRecord;
     }
@@ -154,4 +181,7 @@ public class ConnectLinkedAppRecord extends Persisted {
         linkOffered2 = true;
         linkOfferDate2 = date;
     }
+
+    public boolean isUsingLocalPassphrase() { return usingLocalPassphrase; }
+    public void setIsUsingLocalPassphrase(boolean using) { usingLocalPassphrase = using; }
 }

--- a/app/src/org/commcare/android/database/connect/models/ConnectLinkedAppRecordV8.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectLinkedAppRecordV8.java
@@ -1,0 +1,95 @@
+package org.commcare.android.database.connect.models;
+
+import org.commcare.android.storage.framework.Persisted;
+import org.commcare.models.framework.Persisting;
+import org.commcare.modern.database.Table;
+import org.commcare.modern.models.MetaField;
+
+import java.util.Date;
+
+/**
+ * DB model holding info for an HQ app linked to ConnectID
+ *
+ * @author dviggiano
+ */
+@Table(ConnectLinkedAppRecord.STORAGE_KEY)
+public class ConnectLinkedAppRecordV8 extends Persisted {
+    /**
+     * Name of database that stores Connect user records
+     */
+    public static final String STORAGE_KEY = "app_info";
+
+    public static final String META_APP_ID = "app_id";
+    public static final String META_USER_ID = "user_id";
+    public static final String META_CONNECTID_LINKED = "connectid_linked";
+    public static final String META_OFFERED_1 = "link_offered_1";
+    public static final String META_OFFERED_1_DATE = "link_offered_1_date";
+    public static final String META_OFFERED_2 = "link_offered_2";
+    public static final String META_OFFERED_2_DATE = "link_offered_2_date";
+
+    @Persisting(1)
+    @MetaField(META_APP_ID)
+    private String appId;
+    @Persisting(2)
+    @MetaField(META_USER_ID)
+    private String userId;
+    @Persisting(3)
+    private String password;
+    @Persisting(4)
+    private boolean workerLinked;
+    @Persisting(value = 5, nullable = true)
+    private String hqToken;
+    @Persisting(6)
+    private Date hqTokenExpiration;
+    @Persisting(7)
+    @MetaField(META_CONNECTID_LINKED)
+    private boolean connectIdLinked;
+    @Persisting(8)
+    @MetaField(META_OFFERED_1)
+    private boolean linkOffered1;
+    @Persisting(9)
+    @MetaField(META_OFFERED_1_DATE)
+    private Date linkOfferDate1;
+    @Persisting(10)
+    @MetaField(META_OFFERED_2)
+    private boolean linkOffered2;
+    @Persisting(11)
+    @MetaField(META_OFFERED_2_DATE)
+    private Date linkOfferDate2;
+
+    public String getAppId(){ return appId; }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public boolean getWorkerLinked() {
+        return workerLinked;
+    }
+
+    public String getHqToken() {
+        return hqToken;
+    }
+
+    public Date getHqTokenExpiration() {
+        return hqTokenExpiration;
+    }
+
+    public boolean getConnectIdLinked() { return connectIdLinked; }
+
+    public Date getLinkOfferDate1() {
+        return linkOffered1 ? linkOfferDate1 : null;
+    }
+
+    public Date getLinkOfferDate2() {
+        return linkOffered2 ? linkOfferDate2 : null;
+    }
+}

--- a/app/src/org/commcare/connect/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/ConnectDatabaseHelper.java
@@ -224,7 +224,7 @@ public class ConnectDatabaseHelper {
         storage.remove(record);
     }
 
-    public static ConnectLinkedAppRecord storeApp(Context context, String appId, String userId, boolean connectIdLinked, String passwordOrPin, boolean workerLinked) {
+    public static ConnectLinkedAppRecord storeApp(Context context, String appId, String userId, boolean connectIdLinked, String passwordOrPin, boolean workerLinked, boolean localPassphrase) {
         ConnectLinkedAppRecord record = getAppData(context, appId, userId);
         if (record == null) {
             record = new ConnectLinkedAppRecord(appId, userId, connectIdLinked, passwordOrPin);
@@ -233,6 +233,7 @@ public class ConnectDatabaseHelper {
         }
 
         record.setConnectIdLinked(connectIdLinked);
+        record.setIsUsingLocalPassphrase(localPassphrase);
 
         if(workerLinked) {
             //If passed in false, we'll leave the setting unchanged

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -172,12 +172,7 @@ public class ConnectManager {
         getInstance().parentActivity = parent;
     }
 
-    public static boolean isConnectIdIntroduced() {
-        return AppManagerDeveloperPreferences.isConnectIdEnabled()
-                && getInstance().connectStatus == ConnectIdStatus.LoggedIn;
-    }
-
-    public static boolean isUnlocked() {
+    public static boolean isConnectIdConfigured() {
         return AppManagerDeveloperPreferences.isConnectIdEnabled()
                 && getInstance().connectStatus == ConnectIdStatus.LoggedIn;
     }
@@ -194,7 +189,7 @@ public class ConnectManager {
     public static boolean shouldShowSecondaryPhoneConfirmationTile(Context context) {
         boolean show = false;
 
-        if(isConnectIdIntroduced()) {
+        if(isConnectIdConfigured()) {
             ConnectUserRecord user = getUser(context);
             show = !user.getSecondaryPhoneVerified();
         }
@@ -515,7 +510,7 @@ public class ConnectManager {
     }
 
     public static AuthInfo.TokenAuth getConnectToken() {
-        if (isUnlocked()) {
+        if (isConnectIdConfigured()) {
             ConnectUserRecord user = ConnectDatabaseHelper.getUser(manager.parentActivity);
             if (user != null && (new Date()).compareTo(user.getConnectTokenExpiration()) < 0) {
                 return new AuthInfo.TokenAuth(user.getConnectToken());
@@ -526,7 +521,7 @@ public class ConnectManager {
     }
 
     public static AuthInfo.TokenAuth getTokenCredentialsForApp(String appId, String userId) {
-        if (isUnlocked()) {
+        if (isConnectIdConfigured()) {
             ConnectLinkedAppRecord record = ConnectDatabaseHelper.getAppData(manager.parentActivity, appId,
                     userId);
             if (record != null && (new Date()).compareTo(record.getHqTokenExpiration()) < 0) {
@@ -621,7 +616,7 @@ public class ConnectManager {
 
     public static String checkAutoLoginAndOverridePassword(Context context, String appId, String username,
                                                     String passwordOrPin, boolean appLaunchedFromConnect, boolean uiInAutoLogin) {
-        if (isUnlocked()) {
+        if (isConnectIdConfigured()) {
             if(appLaunchedFromConnect) {
                 //Configure some things if we haven't already
                 ConnectLinkedAppRecord record = ConnectDatabaseHelper.getAppData(context,

--- a/app/src/org/commcare/connect/network/ConnectSsoHelper.java
+++ b/app/src/org/commcare/connect/network/ConnectSsoHelper.java
@@ -58,7 +58,7 @@ public class ConnectSsoHelper {
     }
 
     public static AuthInfo.TokenAuth retrieveHqSsoTokenSync(Context context, String hqUsername, boolean performLink) {
-        if (!ConnectManager.isUnlocked()) {
+        if (!ConnectManager.isConnectIdConfigured()) {
             return null;
         }
 

--- a/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
+++ b/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
@@ -13,7 +13,7 @@ class ConnectHeartbeatWorker(context: Context, workerParams: WorkerParameters) :
 
     override suspend fun doWork(): Result {
         return withContext(Dispatchers.IO) {
-            if (!ConnectManager.isUnlocked()) {
+            if (!ConnectManager.isConnectIdConfigured()) {
                 return@withContext Result.failure()
             }
 

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -163,7 +163,7 @@ public class ConnectDeliveryProgressFragment extends Fragment {
     public void onResume() {
         super.onResume();
 
-        if (ConnectManager.isUnlocked()) {
+        if (ConnectManager.isConnectIdConfigured()) {
             refreshData();
         }
     }

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
@@ -91,7 +91,7 @@ public class ConnectLearningProgressFragment extends Fragment {
     public void onResume() {
         super.onResume();
 
-        if(ConnectManager.isUnlocked()) {
+        if(ConnectManager.isConnectIdConfigured()) {
             refreshData();
         }
     }

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -39,6 +39,7 @@ public class CCAnalyticsEvent {
     static final String CCC_LAUNCH_APP = "ccc_launch_app";
     static final String PARAM_CCC_LAUNCH_APP_TYPE = "ccc_launch_app_type";
     static final String CCC_AUTO_LOGIN_FAILED = "ccc_auto_login_failed";
+    static final String CCC_AUTO_LOGIN_LOCAL_PASSPHRASE = "ccc_auto_login_local_passphrase";
     static final String PARAM_CCC_APP_NAME = "ccc_app_name";
     static final String CCC_API_JOBS = "ccc_api_jobs";
     static final String PARAM_API_SUCCESS = "ccc_api_success";

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -371,6 +371,12 @@ public class FirebaseAnalyticsUtil {
                 new String[]{type, appId});
     }
 
+    public static void reportCccAppAutoLoginWithLocalPassphrase(String app) {
+        reportEvent(CCAnalyticsEvent.CCC_AUTO_LOGIN_LOCAL_PASSPHRASE,
+                new String[]{CCAnalyticsEvent.PARAM_CCC_APP_NAME},
+                new String[]{app});
+    }
+
     public static void reportCccAppFailedAutoLogin(String app) {
         reportEvent(CCAnalyticsEvent.CCC_AUTO_LOGIN_FAILED,
                 new String[]{CCAnalyticsEvent.PARAM_CCC_APP_NAME},

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -96,7 +96,7 @@ public class FirebaseAnalyticsUtil {
         }
 
         analyticsInstance.setUserProperty(CCAnalyticsParam.CCC_ENABLED,
-                String.valueOf(ConnectManager.isConnectIdIntroduced()));
+                String.valueOf(ConnectManager.isConnectIdConfigured()));
     }
 
     private static String getFreeDiskBucket() {

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -41,8 +41,10 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
      * V.5 - Added projectStartDate and isActive to ConnectJobRecord
      * V.6 - Added pin,secondaryPhoneVerified, and registrationDate fields to ConnectUserRecord
      * V.7 - Added ConnectPaymentUnitRecord table
+     * V.8 - Added is_user_suspended to ConnectJobRecord
+     * V.9 - Added using_local_passphrase to ConnectLinkedAppRecord
      */
-    private static final int CONNECT_DB_VERSION = 8;
+    private static final int CONNECT_DB_VERSION = 9;
 
     private static final String CONNECT_DB_LOCATOR = "database_connect";
 

--- a/app/src/org/commcare/utils/CrashUtil.java
+++ b/app/src/org/commcare/utils/CrashUtil.java
@@ -51,7 +51,7 @@ public class CrashUtil {
     }
 
     public static void registerConnectUser() {
-        if (crashlyticsEnabled && ConnectManager.isUnlocked()) {
+        if (crashlyticsEnabled && ConnectManager.isConnectIdConfigured()) {
             FirebaseCrashlytics.getInstance().setCustomKey(CCC_USER, ConnectManager.getUser(CommCareApplication.instance()).getUserId());
         }
     }

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -357,6 +357,7 @@ public class FormStorageTest {
             , "org.commcare.suite.model.EndpointAction"
             , "org.commcare.suite.model.QueryGroup"
             , "org.commcare.android.database.connect.models.ConnectLinkedAppRecordV3"
+            , "org.commcare.android.database.connect.models.ConnectLinkedAppRecordV8"
             , "org.commcare.android.database.connect.models.ConnectLinkedAppRecord"
             , "org.commcare.android.database.connect.models.ConnectUserRecordV5"
             , "org.commcare.android.database.connect.models.ConnectUserRecord"


### PR DESCRIPTION
Changed code so when logging into a Connect app for the first time, a random DB passphrase is no longer generated locally. Instead, the standard HQ login call is made (using token auth instead of password), and the returned server-managed DB passphrase is used for encrypting the app database.

Note that a random local password is still generated to encrypt the DB passphrase so it can be stored in the unencrypted global database.