### PR TITLE
Safeguard sendBroadcast calls to not crash

### DIFF
--- a/app/src/org/commcare/CommCareNoficationManager.java
+++ b/app/src/org/commcare/CommCareNoficationManager.java
@@ -27,6 +27,8 @@ import java.util.Vector;
 
 import static android.content.Context.NOTIFICATION_SERVICE;
 
+import static org.commcare.sync.ExternalDataUpdateHelper.sendBroadcastFailSafe;
+
 /**
  * Handles displaying and clearing pinned notifications for CommCare
  */
@@ -112,7 +114,7 @@ public class CommCareNoficationManager {
 
     public ArrayList<NotificationMessage> purgeNotifications() {
         synchronized (pendingMessages) {
-            context.sendBroadcast(new Intent(ACTION_PURGE_NOTIFICATIONS));
+            sendBroadcastFailSafe(context, new Intent(ACTION_PURGE_NOTIFICATIONS), null);
             ArrayList<NotificationMessage> cloned = (ArrayList<NotificationMessage>)pendingMessages.clone();
             clearNotifications(null);
             return cloned;

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -1,5 +1,7 @@
 package org.commcare.services;
 
+import static org.commcare.sync.ExternalDataUpdateHelper.sendBroadcastFailSafe;
+
 import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationManager;
@@ -29,6 +31,7 @@ import org.commcare.models.database.user.DatabaseUserOpenHelper;
 import org.commcare.models.database.user.UserSandboxUtils;
 import org.commcare.models.encryption.CipherPool;
 import org.commcare.preferences.HiddenPreferences;
+import org.commcare.sync.ExternalDataUpdateHelper;
 import org.commcare.sync.FormSubmissionHelper;
 import org.commcare.tasks.DataSubmissionListener;
 import org.commcare.util.LogTypes;
@@ -309,7 +312,7 @@ public class CommCareSessionService extends Service {
 
                 //Let anyone who is listening know!
                 Intent i = new Intent("org.commcare.dalvik.api.action.session.login");
-                this.sendBroadcast(i);
+                sendBroadcastFailSafe(this, i, null);
             }
 
             this.user = user;
@@ -462,7 +465,7 @@ public class CommCareSessionService extends Service {
 
             // Let anyone who is listening know!
             Intent i = new Intent("org.commcare.dalvik.api.action.session.logout");
-            this.sendBroadcast(i);
+            sendBroadcastFailSafe(this, i, null);
 
             Logger.log(LogTypes.TYPE_MAINTENANCE, "Logging out service login");
 

--- a/app/src/org/commcare/sync/ExternalDataUpdateHelper.java
+++ b/app/src/org/commcare/sync/ExternalDataUpdateHelper.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 
 import org.commcare.CommCareApplication;
+import org.javarosa.core.services.Logger;
 
 import java.util.ArrayList;
 
@@ -32,12 +33,12 @@ public class ExternalDataUpdateHelper {
         if (CommCareApplication.instance().getSession().isActive()) {
             i.putExtra("cc-logged-in-user-id", CommCareApplication.instance().getCurrentUserId());
         }
-        c.sendBroadcast(i, COMMCARE_CASE_READ_PERMISSION);
+        sendBroadcastFailSafe(c, i, COMMCARE_CASE_READ_PERMISSION);
 
         // send explicit broadcast to CommCare Reminders App
         i.setComponent(new ComponentName("org.commcare.dalvik.reminders",
                 "org.commcare.dalvik.reminders.CommCareReceiver"));
-        c.sendBroadcast(i);
+        sendBroadcastFailSafe(c, i, null);
 
         // Broadcast to CommCare, there is the option to handle the permission required by the
         // broadcast above
@@ -48,6 +49,14 @@ public class ExternalDataUpdateHelper {
     private static void broadcastDataUpdateToCommCare(Context c){
         Intent i = new Intent(COMMCARE_DATA_UPDATE_ACTION);
         i.setPackage(c.getPackageName());
-        c.sendBroadcast(i);
+        sendBroadcastFailSafe(c, i, null);
+    }
+
+    public static void sendBroadcastFailSafe(Context context, Intent intent, @Nullable String receiverPermission) {
+        try {
+            context.sendBroadcast(intent, receiverPermission);
+        } catch (Exception e) {
+            Logger.exception("Exception when sending a broadcast with intent " + intent, e);
+        }
     }
 }

--- a/app/src/org/commcare/sync/FirebaseMessagingDataSyncer.java
+++ b/app/src/org/commcare/sync/FirebaseMessagingDataSyncer.java
@@ -194,8 +194,7 @@ public class FirebaseMessagingDataSyncer implements CommCareTaskConnector {
         Bundle b = new Bundle();
         b.putSerializable(FCM_MESSAGE_DATA, FirebaseMessagingUtil.serializeFCMMessageData(fcmMessageData));
         intent.putExtra(FCM_MESSAGE_DATA_KEY, b);
-
-        context.sendBroadcast(intent);
+        ExternalDataUpdateHelper.sendBroadcastFailSafe(context, intent, null);
     }
 
     @Override


### PR DESCRIPTION
## Summary

[Fix for Crash](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/fafe874f6870be2706f26d75856dd3ce)

````
Attempt to read from field 'java.lang.String com.transsion.griffin.lib.app.AppInfo.processName' on a null object reference in method 'boolean b.c.b(java.lang.String)'
       at android.os.Parcel.createExceptionOrNull(Parcel.java:2432)
       at android.os.Parcel.createException(Parcel.java:2410)
       at android.os.Parcel.readException(Parcel.java:2393)
       at android.os.Parcel.readException(Parcel.java:2335)
       at android.app.IActivityManager$Stub$Proxy.broadcastIntentWithFeature(IActivityManager.java:6273)
       at android.app.ContextImpl.sendBroadcast(ContextImpl.java:1198)
       at android.content.ContextWrapper.sendBroadcast(ContextWrapper.java:479)
       at org.commcare.sync.ExternalDataUpdateHelper.broadcastDataUpdate(ExternalDataUpdateHelper.java:40)
 ````
 
 This seems quite unusual to me and seems like a device abnormality specially since the [call before](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/sync/ExternalDataUpdateHelper.java#L35) doesn't crash. I think it's therefore preferrable to call all `.sendBroadcast` calls in a fail-safe manner.  

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

NA
