### PR TITLE
Fix NPE when logging app process memory info 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,6 +105,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-process:$lifecycle_version"
 
     // Markdown
     implementation "io.noties.markwon:core:$markwon_version"

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -260,6 +260,8 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
         customiseOkHttp();
 
         setRxJavaGlobalHandler();
+
+        ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
     }
 
     protected void loadSqliteLibs() {

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -17,6 +17,10 @@ import android.text.format.DateUtils;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ProcessLifecycleOwner;
 import androidx.multidex.MultiDexApplication;
 import androidx.preference.PreferenceManager;
 import androidx.work.BackoffPolicy;
@@ -143,7 +147,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 
-public class CommCareApplication extends MultiDexApplication {
+public class CommCareApplication extends MultiDexApplication implements LifecycleEventObserver {
 
     private static final String TAG = CommCareApplication.class.getSimpleName();
 
@@ -1223,5 +1227,18 @@ public class CommCareApplication extends MultiDexApplication {
 
             Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), throwable);
         });
+    }
+
+    @Override
+    public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event) {
+        Logger.log("commcare-state-changed", "Lifecycle.Event : " + event.name());
+        switch (event.name()) {
+            case "ON_START":
+            case "ON_RESUME":
+            case "ON_STOP":
+                break;
+            case "ON_PAUSE":
+                break;
+        }
     }
 }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -1244,11 +1244,15 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
                 break;
             case "ON_PAUSE":
                 Logger.log("commcare-state-changed", "User leaving CommCare. App lifecycle changed: " + event.name());
-                logMemoryInfo();
-                logBatteryInfo();
+                logMemoryAndBatteryInfo("commcare-state-changed");
                 break;
         }
     }
+
+    private void logMemoryAndBatteryInfo(String logType) {
+        logMemoryInfo();
+        logBatteryInfo();
+   }
 
     @Override
     public void onTrimMemory(int level) {
@@ -1262,8 +1266,7 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
             case TRIM_MEMORY_MODERATE:
             case TRIM_MEMORY_COMPLETE:
                 Logger.log("memory-trim-request", "Memory level: "+ getMemoryLevelName(level));
-                logMemoryInfo();
-                logBatteryInfo();
+                logMemoryAndBatteryInfo("memory-trim-request");
                 break;
         }
     }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -1261,7 +1261,12 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
     @Override
     public void onTrimMemory(int level) {
         super.onTrimMemory(level);
-        switch (level){
+        Logger.log("memory-trim-request", "Memory level: " + getMemoryLevelName(level));
+        switch (level) {
+            case android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
+                    android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE,
+                    android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW:
+                break;
             case TRIM_MEMORY_UI_HIDDEN:
                 // this could be an option to write the logs when the app goes to the background but
                 // LifecycleEventObserver seems more reliable
@@ -1269,7 +1274,6 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
             case TRIM_MEMORY_BACKGROUND:
             case TRIM_MEMORY_MODERATE:
             case TRIM_MEMORY_COMPLETE:
-                Logger.log("memory-trim-request", "Memory level: "+ getMemoryLevelName(level));
                 logMemoryAndBatteryInfo("memory-trim-request");
                 break;
         }
@@ -1286,7 +1290,7 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
             case TRIM_MEMORY_COMPLETE:
                 return "TRIM_MEMORY_COMPLETE";
             default:
-                return "OTHER";
+                return "Level: " + level;
         }
     }
 

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -1240,7 +1240,26 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
             case "ON_STOP":
                 break;
             case "ON_PAUSE":
+                logMemoryInfo();
+                logBatteryInfo();
                 break;
         }
+    }
+
+    @Override
+    public void onTrimMemory(int level) {
+        super.onTrimMemory(level);
+        Logger.log("memory-trim-request", this.getClass()+" - "+ level);
+        switch (level){
+            case TRIM_MEMORY_UI_HIDDEN:
+                // this could be an option to write the logs when the app goes to the background but
+                // LifecycleEventObserver seems more reliable
+                break;
+            case TRIM_MEMORY_BACKGROUND:
+            case TRIM_MEMORY_MODERATE:
+            case TRIM_MEMORY_COMPLETE:
+                break;
+        }
+
     }
 }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -1302,6 +1302,10 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
                 "LowMemory: " + memoryInfo.lowMemory);
 
         List<ActivityManager.RunningAppProcessInfo> runningAppProcesses = activityManager.getRunningAppProcesses();
+        if (runningAppProcesses == null) {
+            // if there are no running processes no need to report on memory usage
+            return;
+        }
         Map<Integer, String> pidMap = new TreeMap<Integer, String>();
         for (ActivityManager.RunningAppProcessInfo runningAppProcessInfo : runningAppProcesses) {
             pidMap.put(runningAppProcessInfo.pid, runningAppProcessInfo.processName);

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -8,7 +8,9 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.os.BatteryManager;
 import android.os.Build;
+import android.os.Debug;
 import android.os.Environment;
 import android.os.IBinder;
 import android.os.Looper;
@@ -130,10 +132,13 @@ import org.javarosa.core.util.PropertyUtils;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -1233,13 +1238,12 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
 
     @Override
     public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event) {
-        Logger.log("commcare-state-changed", "Lifecycle.Event : " + event.name());
         switch (event.name()) {
-            case "ON_START":
             case "ON_RESUME":
-            case "ON_STOP":
+                Logger.log("commcare-state-changed", "User returning to CommCare. App lifecycle changed: " + event.name());
                 break;
             case "ON_PAUSE":
+                Logger.log("commcare-state-changed", "User leaving CommCare. App lifecycle changed: " + event.name());
                 logMemoryInfo();
                 logBatteryInfo();
                 break;
@@ -1249,7 +1253,6 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
     @Override
     public void onTrimMemory(int level) {
         super.onTrimMemory(level);
-        Logger.log("memory-trim-request", this.getClass()+" - "+ level);
         switch (level){
             case TRIM_MEMORY_UI_HIDDEN:
                 // this could be an option to write the logs when the app goes to the background but
@@ -1258,8 +1261,63 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
             case TRIM_MEMORY_BACKGROUND:
             case TRIM_MEMORY_MODERATE:
             case TRIM_MEMORY_COMPLETE:
+                Logger.log("memory-trim-request", "Memory level: "+ getMemoryLevelName(level));
+                logMemoryInfo();
+                logBatteryInfo();
                 break;
         }
+    }
 
+    private String getMemoryLevelName(int level) {
+        switch (level) {
+            case TRIM_MEMORY_UI_HIDDEN:
+                return "TRIM_MEMORY_UI_HIDDEN";
+            case TRIM_MEMORY_BACKGROUND:
+                return "TRIM_MEMORY_BACKGROUND";
+            case TRIM_MEMORY_MODERATE:
+                return "TRIM_MEMORY_MODERATE";
+            case TRIM_MEMORY_COMPLETE:
+                return "TRIM_MEMORY_COMPLETE";
+            default:
+                return "OTHER";
+        }
+    }
+
+    private void logMemoryInfo(){
+        ActivityManager activityManager = (ActivityManager) getSystemService(ACTIVITY_SERVICE);
+        ActivityManager.MemoryInfo memoryInfo = new ActivityManager.MemoryInfo();
+        activityManager.getMemoryInfo(memoryInfo);
+
+        Logger.log(LogTypes.TYPE_MEMINFO, "Device memory info - " +
+                "AvailMemory: " + (memoryInfo.availMem / 1048576) + "MB / " +
+                "Threshold: " + (memoryInfo.threshold / 1048576) + "MB / " +
+                "TotalMemory: " + (memoryInfo.totalMem / 1048576) + "MB / " +
+                "LowMemory: " + memoryInfo.lowMemory);
+
+        List<ActivityManager.RunningAppProcessInfo> runningAppProcesses = activityManager.getRunningAppProcesses();
+        Map<Integer, String> pidMap = new TreeMap<Integer, String>();
+        for (ActivityManager.RunningAppProcessInfo runningAppProcessInfo : runningAppProcesses) {
+            pidMap.put(runningAppProcessInfo.pid, runningAppProcessInfo.processName);
+        }
+
+        Collection<Integer> keys = pidMap.keySet();
+        for(int key : keys) {
+            Debug.MemoryInfo[] memoryInfoArray = activityManager.getProcessMemoryInfo(new int[]{key});
+            for(Debug.MemoryInfo pidMemoryInfo: memoryInfoArray) {
+                Logger.log(LogTypes.TYPE_MEMINFO, "PID Memory Info - " +
+                        "TotalPrivateDirty: " + (pidMemoryInfo.getTotalPrivateDirty()/1024) + "MB / " +
+                        "TotalPss: " + (pidMemoryInfo.getTotalPss()/1024) + "MB / " +
+                        "TotalSharedDirty: " + (pidMemoryInfo.getTotalSharedDirty()/1024) + "MB");
+            }
+        }
+    }
+
+    private void logBatteryInfo() {
+        int batteryLevel = -1;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+            BatteryManager bM = (BatteryManager) getSystemService(BATTERY_SERVICE);
+            batteryLevel = bM.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
+        }
+        Logger.log("battery-status", "Battery status: " + batteryLevel + "%");
     }
 }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -1250,9 +1250,13 @@ public class CommCareApplication extends MultiDexApplication implements Lifecycl
     }
 
     private void logMemoryAndBatteryInfo(String logType) {
-        logMemoryInfo();
-        logBatteryInfo();
-   }
+        try {
+            logMemoryInfo();
+            logBatteryInfo();
+        } catch (Exception e){
+            Logger.log(logType, "Exception while logging memory and battery info: "+ e.getMessage());
+        }
+    }
 
     @Override
     public void onTrimMemory(int level) {


### PR DESCRIPTION
## Summary
Fix NPE when logging memory when there are no app processes running. Here's the stacktrace:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke interface method 'java.util.Iterator java.util.List.iterator()' on a null object reference
       at org.commcare.CommCareApplication.logMemoryInfo(CommCareApplication.java:1299)
       at org.commcare.CommCareApplication.onStateChanged(CommCareApplication.java:1247)
       at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.java:360)
       at androidx.lifecycle.LifecycleRegistry.backwardPass(LifecycleRegistry.java:290)
       at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.java:308)
       at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.java:151)
       at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.java:134)
       at androidx.lifecycle.ProcessLifecycleOwner.dispatchPauseIfNeeded(ProcessLifecycleOwner.java:145)
       at androidx.lifecycle.ProcessLifecycleOwner$1.run(ProcessLifecycleOwner.java:71)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:7870)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1009)
```

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
This is just to safeguard the logging from errors
