### PR TITLE
QA-6911 || User Redirection Issue

### DIFF
--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -95,13 +95,28 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
                     .build();
             navController.navigate(fragmentId, bundle, options);
         } else if (redirectionAction != null) {
-            ConnectManager.init(this);
-            ConnectManager.unlockConnect(this, success -> {
-                if (success) {
-                    getJobDetails();
-                }
-            });
+            initializeAndUnlockConnection();
         }
+    }
+
+    /**
+     * Initializes the ConnectManager and attempts to unlock the connection.
+     * <p>
+     * This method performs the following steps:
+     * <ul>
+     *     <li>Initializes the ConnectManager with the current context.</li>
+     *     <li>Attempts to unlock the connection using the ConnectManager.</li>
+     *     <li>If the unlock operation is successful, retrieves job details by calling {@link #getJobDetails()}.</li>
+     * </ul>
+     * </p>
+     */
+    private void initializeAndUnlockConnection() {
+        ConnectManager.init(this);
+        ConnectManager.unlockConnect(this, success -> {
+            if (success) {
+                getJobDetails();
+            }
+        });
     }
 
     /**
@@ -287,5 +302,15 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
                 ConnectNetworkHelper.showOutdatedApiError(ConnectActivity.this);
             }
         });
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        redirectionAction = intent.getStringExtra("action");
+        opportunityId = intent.getStringExtra("opportunity_id");
+        if(redirectionAction != null){
+            initializeAndUnlockConnection();
+        }
     }
 }


### PR DESCRIPTION
Solved notification redirection issue for inactive learn/delivery notification

## Summary
https://dimagi.atlassian.net/browse/QA-6911
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [ ] If the PR is high risk, "High Risk" label is set
- [ ] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
