### PR TITLE
Move autosave preference from developer options to user settings

### DIFF
--- a/app/res/xml/main_preferences.xml
+++ b/app/res/xml/main_preferences.xml
@@ -54,6 +54,13 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-enable-tts"
         android:title="Enable Text To Speech"/>
+    <androidx.preference.ListPreference
+        android:defaultValue="no"
+        android:enabled="true"
+        android:entries="@array/pref_enabled_labels"
+        android:entryValues="@array/pref_enabled_vals"
+        android:key="cc-auto-form-save-on-pause"
+        android:title="Auto Save Form on Pause"/>
     <Preference
         android:key="disable-analytics-button"/>
     <Preference

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -173,11 +173,4 @@
         android:entryValues="@array/pref_enabled_vals"
         android:key="cc-enable-certificate-transparency"
         android:title="Certificate Transparency"/>
-    <androidx.preference.ListPreference
-        android:defaultValue="no"
-        android:enabled="true"
-        android:entries="@array/pref_enabled_labels"
-        android:entryValues="@array/pref_enabled_vals"
-        android:key="cc-auto-form-save-on-pause"
-        android:title="Auto Save Form on Pause"/>
 </PreferenceScreen>

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -61,6 +61,7 @@ import org.commcare.models.database.InterruptedFormState;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.preferences.HiddenPreferences;
+import org.commcare.preferences.MainConfigurablePreferences;
 import org.commcare.services.FCMMessageData;
 import org.commcare.services.PendingSyncAlertBroadcastReceiver;
 import org.commcare.tasks.FormLoaderTask;
@@ -935,7 +936,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     private boolean shouldSaveFormOnStop() {
         // if feature enabled and the form has loaded and another widget workflow is not in progress and we
         // ourselves have not called exit as part of user workflow
-        return DeveloperPreferences.isAutoSaveFormOnPause() && formHasLoaded() && !triggeredExit;
+        return MainConfigurablePreferences.isAutoSaveFormOnPause() && formHasLoaded() && !triggeredExit;
     }
 
     private void saveInlineVideoState() {

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -77,8 +77,6 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     public final static String ALTERNATE_QUESTION_LAYOUT_ENABLED = "cc-alternate-question-text-format";
     public final static String OFFER_PIN_FOR_LOGIN = "cc-offer-pin-for-login";
 
-    public final static String AUTO_SAVE_FORM_ON_PAUSE = "cc-auto-form-save-on-pause";
-
     private static final Set<String> WHITELISTED_DEVELOPER_PREF_KEYS = new HashSet<>();
 
     static {
@@ -87,7 +85,6 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
         WHITELISTED_DEVELOPER_PREF_KEYS.add(AUTO_PURGE_ENABLED);
         WHITELISTED_DEVELOPER_PREF_KEYS.add(ALTERNATE_QUESTION_LAYOUT_ENABLED);
         WHITELISTED_DEVELOPER_PREF_KEYS.add(ENABLE_CERTIFICATE_TRANSPARENCY);
-        WHITELISTED_DEVELOPER_PREF_KEYS.add(AUTO_SAVE_FORM_ON_PAUSE);
     }
 
     /**
@@ -429,10 +426,6 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
 
     public static boolean useExpressionCachingInForms() {
         return doesPropertyMatch(USE_EXPRESSION_CACHING_IN_FORMS, PrefValues.NO, PrefValues.YES);
-    }
-
-    public static boolean isAutoSaveFormOnPause() {
-        return doesPropertyMatch(AUTO_SAVE_FORM_ON_PAUSE, PrefValues.NO, PrefValues.YES);
     }
 
     private void  hideOrShowDangerousSettings() {

--- a/app/src/org/commcare/preferences/MainConfigurablePreferences.java
+++ b/app/src/org/commcare/preferences/MainConfigurablePreferences.java
@@ -35,6 +35,7 @@ public class MainConfigurablePreferences
     public final static String ANALYTICS_ENABLED = "cc-analytics-enabled";
     public final static String INTENT_CALLOUT_FOR_SCANNER = "cc-intent-callout-for-scanner";
     public final static String ENABLE_TEXT_TO_SPEECH = "cc-enable-tts";
+    public final static String AUTO_SAVE_FORM_ON_PAUSE = "cc-auto-form-save-on-pause";
 
     // Fake settings that really act as buttons to open a new activity or choice dialog
     private final static String DEVELOPER_SETTINGS = "developer-settings-button";
@@ -180,6 +181,14 @@ public class MainConfigurablePreferences
             return false;
         }
         return app.getAppPreferences().getString(INTENT_CALLOUT_FOR_SCANNER, PrefValues.NO).equals(PrefValues.YES);
+    }
+
+    public static boolean isAutoSaveFormOnPause() {
+        CommCareApp app = CommCareApplication.instance().getCurrentApp();
+        if (app == null) {
+            return false;
+        }
+        return app.getAppPreferences().getString(AUTO_SAVE_FORM_ON_PAUSE, PrefValues.NO).equals(PrefValues.YES);
     }
 
     public static boolean isTTSEnabled() {


### PR DESCRIPTION
## Summary
Allow all users to manually configure form autosaving.

## Product Description
Shift the location of autosave from a developer preference into a user facing preference, to allow all users to access.

This both will make it easier to access, and allow configuration of this setting by any end user until this feature is the default. This is more appropriate for this feature because unlike other developer settings, which are only relevant in tandem with the program or administrator, this setting could positively impact a user based on their specific device or usage profile.

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
This is a pre-release feature, I have tested this change locally, and this code area has minimal surface area. 