### PR TITLE
Add logging when session recovery is identified

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1036,6 +1036,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                     // only retrieve a potentially stored form index when loading an existing form record
                     AndroidSessionWrapper asw = CommCareApplication.instance().getCurrentSessionWrapper();
                     lastFormIndex = retrieveAndValidateFormIndex(asw.getSessionDescriptorId());
+                    if (lastFormIndex != null) {
+                        Logger.log(LogTypes.TYPE_FORM_ENTRY, "Recovering form entry session");
+                    }
                 } else if (intent.hasExtra(KEY_FORM_DEF_ID)) {
                     formId = intent.getIntExtra(KEY_FORM_DEF_ID, -1);
                     instanceState.setFormDefPath(FormFileSystemHelpers.getFormDefPath(formDefStorage, formId));

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -359,6 +359,7 @@ public class CommCareSessionService extends Service {
                 return;
             }
             try {
+                Logger.log(LogTypes.TYPE_USER, "Expiring user session forcefully due to session timeout");
                 CommCareApplication.instance().expireUserSession();
             } finally {
                 CommCareSessionService.sessionAliveLock.unlock();
@@ -378,6 +379,7 @@ public class CommCareSessionService extends Service {
             }
 
             try {
+                Logger.log(LogTypes.TYPE_USER, "Expiring user session due to session timeout");
                 saveFormAndCloseSession();
             } finally {
                 CommCareSessionService.sessionAliveLock.unlock();


### PR DESCRIPTION
## Summary
Adds logging when a form session recovery was triggered. 

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
Logging only change, tested locally and confirmed appropriate conditions are logged / not logged