### PR TITLE
Minor cleanup after adding InterruptedFormState model

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1107,6 +1107,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     }
 
     private void handleFormLoadCompletion(AndroidFormController fc) {
+        HiddenPreferences.clearInterruptedFormState();
+
         if (PollSensorAction.XPATH_ERROR_ACTION.equals(locationRecieverErrorAction)) {
             handleXpathErrorBroadcast();
         }
@@ -1144,8 +1146,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             Toast.makeText(this,
                     Localization.get("form.entry.restart.after.expiration"), Toast.LENGTH_LONG).show();
         }
-
-        HiddenPreferences.clearInterruptedFormState();
     }
 
     private void handleXpathErrorBroadcast() {

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -14,7 +14,6 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.speech.tts.TextToSpeech;
-import android.util.Base64;
 import android.util.Log;
 import android.util.Pair;
 import android.view.ContextMenu;
@@ -59,7 +58,6 @@ import org.commcare.models.AndroidSessionWrapper;
 import org.commcare.models.FormRecordProcessor;
 import org.commcare.models.database.InterruptedFormState;
 import org.commcare.models.database.SqlStorage;
-import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.preferences.MainConfigurablePreferences;
 import org.commcare.services.FCMMessageData;
@@ -73,7 +71,6 @@ import org.commcare.utils.Base64Wrapper;
 import org.commcare.utils.CompoundIntentList;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.GeoUtils;
-import org.commcare.utils.SerializationUtil;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.utils.StringUtils;
 import org.commcare.views.QuestionsView;
@@ -1106,18 +1103,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
         // data format is invalid, so better to clear the data
         HiddenPreferences.clearInterruptedFormState();
-        return null;
-    }
-
-    private FormIndex deserializeFormIndex(String serializedFormIndex) {
-        if (serializedFormIndex != null) {
-            try{
-                byte[] decodedFormIndex = Base64.decode(serializedFormIndex, Base64.DEFAULT);
-                return SerializationUtil.deserialize(decodedFormIndex, FormIndex.class);
-            } catch(Exception e) {
-                Logger.exception("Deserialization of last form index failed ", e);
-            }
-        }
         return null;
     }
 

--- a/app/src/org/commcare/logic/AndroidFormController.java
+++ b/app/src/org/commcare/logic/AndroidFormController.java
@@ -1,15 +1,12 @@
 package org.commcare.logic;
 
-import android.util.Base64;
 
 import androidx.annotation.NonNull;
 
 import org.commcare.google.services.analytics.FormAnalyticsHelper;
-import org.commcare.utils.SerializationUtil;
 import org.commcare.views.widgets.WidgetFactory;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
-import org.javarosa.core.services.Logger;
 import org.javarosa.form.api.FormController;
 import org.javarosa.form.api.FormEntryController;
 
@@ -88,16 +85,5 @@ public class AndroidFormController extends FormController implements PendingCall
 
     public FormDef getFormDef() {
         return mFormEntryController.getModel().getForm();
-    }
-
-    // TODO: we should cache this
-    public String getSerializedFormIndex() {
-        try{
-            byte[] serializedFormIndex = SerializationUtil.serialize(getFormIndex());
-            return Base64.encodeToString(serializedFormIndex, Base64.DEFAULT);
-        } catch (Exception e){
-            Logger.exception("Serialization of last form index failed ", e);
-            return null;
-        }
     }
 }

--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -645,7 +645,6 @@ public class HiddenPreferences {
         }
     }
 
-    // This was changed to Double due to the way Gson handles numeric values
     public static InterruptedFormState getInterruptedFormState() {
         try {
             String currentUserId = CommCareApplication.instance().getCurrentUserId();


### PR DESCRIPTION
## Summary
This is to remove some unused methods and outdated comments. In addition to that, a small change to when the stored form index is cleared, this is now at the top of the [handledFormLoadCompletion(...)](https://github.com/dimagi/commcare-android/blob/755913bfaf583c2960c36bf5d5de1d457c2d7c71/app/src/org/commcare/activities/FormEntryActivity.java#L1124) method for visibility.

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
