### PR TITLE
Clear state on user exiting/saving the form

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1380,6 +1380,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
      *                    activity
      */
     private void finishReturnInstance(boolean reportSaved) {
+        HiddenPreferences.clearInterruptedFormState();
+        HiddenPreferences.clearInterruptedSSD();
+
         String action = getIntent().getAction();
         if (Intent.ACTION_PICK.equals(action) || Intent.ACTION_EDIT.equals(action)) {
             Intent formReturnIntent = new Intent();


### PR DESCRIPTION
## Summary

https://dimagi.atlassian.net/browse/QA-6984

Bug Fix: If user switches app while working on a form and then come back, exits the form (By clicking on either "Exit without Saving" or "Save Incomplete") and logout. On logging in again, user is redirected again to the form they were working on.

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 

Using method calls already used in other places to clear the state, small changes. Locally tested that the feature doesn't break due to this. 


