### PR TITLE
Show button to "Add Record Back to Unsent Queue" for forms quarantined even due to local processing errors

### DIFF
--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -396,14 +396,8 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         if (FormRecord.STATUS_QUARANTINED.equals(value.getStatus())) {
             menu.add(Menu.NONE, VIEW_QUARANTINE_REASON, VIEW_QUARANTINE_REASON,
                     Localization.get("app.workflow.forms.view.quarantine.reason"));
-
-            if (!FormRecord.QuarantineReason_LOCAL_PROCESSING_ERROR.equals(value.getQuarantineReasonType())) {
-                // Records that were quarantined due to a local processing error can't attempt
-                // re-submission, since doing so would send them straight to "Unsent" when they
-                // haven't even been processed
-                menu.add(Menu.NONE, RESTORE_RECORD, RESTORE_RECORD,
-                        Localization.get("app.workflow.forms.restore"));
-            }
+            menu.add(Menu.NONE, RESTORE_RECORD, RESTORE_RECORD,
+                    Localization.get("app.workflow.forms.restore"));
         }
 
         menu.add(Menu.NONE, SCAN_RECORD, SCAN_RECORD, Localization.get("app.workflow.forms.scan"));


### PR DESCRIPTION
## Product Description

There are some edge cases when local processing errors while form processing are not necessarily due to bad form xml and can be recoverable. As such, this PR makes a change to show the button to "Add Record Back to Unsent Queue" for all quarantined forms. 

Think long term we can potentially categorize the error modes here better (bad form payload vs all others) and hide this button only for errors related to bad form payload. 


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
Very small surface area for the change, tested locally. 
