### PR TITLE
Fixes Crash on App Resume after Session Expiration + Logs

### DIFF
--- a/app/src/org/commcare/activities/HomeButtons.java
+++ b/app/src/org/commcare/activities/HomeButtons.java
@@ -130,7 +130,14 @@ public class HomeButtons {
 
     private static TextSetter getSyncButtonTextSetter(final StandardHomeActivity activity) {
         return (cardDisplayData, squareButtonViewHolder, context, notificationText) -> {
-            SyncDetailCalculations.updateSubText(activity, squareButtonViewHolder, cardDisplayData, notificationText);
+            try {
+                SyncDetailCalculations.updateSubText(activity, squareButtonViewHolder, cardDisplayData,
+                        notificationText);
+            } catch (SessionUnavailableException e) {
+                // stop button setup, since redirection to login is imminent
+                return;
+            }
+
             squareButtonViewHolder.subTextView.setBackgroundColor(activity.getResources().getColor(cardDisplayData.subTextBgColor));
             squareButtonViewHolder.textView.setTextColor(context.getResources().getColor(cardDisplayData.textColor));
             squareButtonViewHolder.textView.setText(cardDisplayData.text);

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -350,9 +350,14 @@ public class CommCareSessionService extends Service {
         // timeout then wrap-up the process.
         if (logoutStartedAt != -1 &&
                 currentTime > (logoutStartedAt + LOGOUT_TIMEOUT)) {
+            Logger.log(LogTypes.TYPE_USER,
+                    "Crossed threshold to save form session state during scheduled session expiration. Passed " + (
+                            currentTime - logoutStartedAt) + "ms");
             // Try and grab the logout lock, aborting if synchronization is in
             // progress.
             if (!CommCareSessionService.sessionAliveLock.tryLock()) {
+                Logger.log(LogTypes.TYPE_USER,
+                        "Unabled to get session lock during scheduled session expiration");
                 return;
             }
             try {
@@ -371,6 +376,8 @@ public class CommCareSessionService extends Service {
             // Try and grab the logout lock, aborting if synchronization is in
             // progress.
             if (!CommCareSessionService.sessionAliveLock.tryLock()) {
+                Logger.log(LogTypes.TYPE_USER,
+                        "Unabled to get session lock during scheduled session expiration");
                 return;
             }
 


### PR DESCRIPTION
## Summary

- Handles SessionExpiration in the home button view setup, this escapes the default session expiration and causes the app to crash when resuming after a session expiration event.  Other buttons already have this safety implemented and sync was the only one remaining. 

- Adds some helpful logs around session expiration

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

