### PR TITLE
Copy CCC Global database changes - Version 6

### DIFF
--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -1,0 +1,24 @@
+package org.commcare.android.database.global.models;
+
+import org.commcare.android.storage.framework.Persisted;
+import org.commcare.models.framework.Persisting;
+import org.commcare.modern.database.Table;
+
+@Table(ConnectKeyRecord.STORAGE_KEY)
+public class ConnectKeyRecord extends Persisted {
+    public static final String STORAGE_KEY = "connect_key";
+
+    @Persisting(1)
+    String userId;
+    @Persisting(2)
+    String encryptedPassphrase;
+
+    public ConnectKeyRecord() { }
+    public ConnectKeyRecord(String userId, String encryptedPassphrase) {
+        this.userId = userId;
+        this.encryptedPassphrase = encryptedPassphrase;
+    }
+
+    public String getUserID() { return userId; }
+    public String getEncryptedPassphrase() { return encryptedPassphrase; }
+}

--- a/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
+++ b/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
@@ -12,6 +12,7 @@ import net.sqlcipher.database.SQLiteOpenHelper;
 import org.commcare.android.database.global.models.AndroidSharedKeyRecord;
 import org.commcare.android.database.global.models.AppAvailableToInstall;
 import org.commcare.android.database.global.models.ApplicationRecord;
+import org.commcare.android.database.global.models.ConnectKeyRecord;
 import org.commcare.android.javarosa.AndroidLogEntry;
 import org.commcare.android.logging.ForceCloseLogEntry;
 import org.commcare.logging.DataChangeLog;
@@ -32,8 +33,9 @@ public class DatabaseGlobalOpenHelper extends SQLiteOpenHelper {
      * and InstanceProvider use per-app databases
      * V.4 - Add table for storing force close log entries that occur outside of an active session
      * V.5 - Add table for storing apps available for install
+     * V.6 - Add table for storing (encrypted) passphrase for ConnectId DB
      */
-    private static final int GLOBAL_DB_VERSION = 5;
+    private static final int GLOBAL_DB_VERSION = 6;
 
     private static final String GLOBAL_DB_LOCATOR = "database_global";
 
@@ -64,6 +66,10 @@ public class DatabaseGlobalOpenHelper extends SQLiteOpenHelper {
 
             builder = new TableBuilder(AppAvailableToInstall.STORAGE_KEY);
             builder.addData(new AppAvailableToInstall());
+            database.execSQL(builder.getTableCreateString());
+
+            builder = new TableBuilder(ConnectKeyRecord.STORAGE_KEY);
+            builder.addData(new ConnectKeyRecord());
             database.execSQL(builder.getTableCreateString());
 
             DbUtil.createNumbersTable(database);

--- a/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
@@ -6,6 +6,7 @@ import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.CommCareApplication;
 import org.commcare.android.database.global.models.AppAvailableToInstall;
+import org.commcare.android.database.global.models.ConnectKeyRecord;
 import org.commcare.android.logging.ForceCloseLogEntry;
 import org.commcare.modern.database.TableBuilder;
 import org.commcare.models.database.ConcreteAndroidDbHelper;
@@ -48,6 +49,11 @@ class GlobalDatabaseUpgrader {
         if (oldVersion == 4) {
             if (upgradeFourFive(db)) {
                 oldVersion = 5;
+            }
+        }
+        if (oldVersion == 5) {
+            if (upgradeFiveSix(db)) {
+                oldVersion = 6;
             }
         }
     }
@@ -115,6 +121,10 @@ class GlobalDatabaseUpgrader {
 
     private boolean upgradeFourFive(SQLiteDatabase db) {
         return addTableForNewModel(db, AppAvailableToInstall.STORAGE_KEY, new AppAvailableToInstall());
+    }
+
+    private boolean upgradeFiveSix(SQLiteDatabase db) {
+        return addTableForNewModel(db, ConnectKeyRecord.STORAGE_KEY, new ConnectKeyRecord());
     }
 
     private static boolean addTableForNewModel(SQLiteDatabase db, String storageKey,

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -355,6 +355,7 @@ public class FormStorageTest {
             , "org.commcare.suite.model.EndpointArgument"
             , "org.commcare.suite.model.EndpointAction"
             , "org.commcare.suite.model.QueryGroup"
+            , "org.commcare.android.database.global.models.ConnectKeyRecord"
     );
 
 


### PR DESCRIPTION
## Summary
This PR is to copy Global DB changes that were done as part of the CCC work. The goal with bringing these changes is to ensure a healthy update from that version to production. Changes included here are:
- Addition of table to global DB for storing ConnectKeyRecords (changed DB version to 6)

## Safety Assurance
- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
I believe this is safe as we are only adding a new table to the Global DB that is used by CCC. 

cross-request: https://github.com/dimagi/commcare-core/pull/1416
