### PR TITLE
Copy connect v7 global database upgrades

### DIFF
--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -4,17 +4,23 @@ import org.commcare.android.storage.framework.Persisted;
 import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
 
+/**
+ * @author dviggiano
+ */
 @Table(ConnectKeyRecord.STORAGE_KEY)
 public class ConnectKeyRecord extends Persisted {
     public static final String STORAGE_KEY = "connect_key";
     @Persisting(1)
     String encryptedPassphrase;
 
-    public ConnectKeyRecord() { }
+    public ConnectKeyRecord() {
+    }
 
     public ConnectKeyRecord(String encryptedPassphrase) {
         this.encryptedPassphrase = encryptedPassphrase;
     }
 
-    public String getEncryptedPassphrase() { return encryptedPassphrase; }
+    public String getEncryptedPassphrase() {
+        return encryptedPassphrase;
+    }
 }

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -5,8 +5,9 @@ import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
 
 /**
- * @author dviggiano
  * DB model for storing the encrypted/encoded Connect DB passphrase
+ *
+ * @author dviggiano
  */
 @Table(ConnectKeyRecord.STORAGE_KEY)
 public class ConnectKeyRecord extends Persisted {

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -6,6 +6,7 @@ import org.commcare.modern.database.Table;
 
 /**
  * @author dviggiano
+ * DB model for storing the encrypted/encoded Connect DB passphrase
  */
 @Table(ConnectKeyRecord.STORAGE_KEY)
 public class ConnectKeyRecord extends Persisted {

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -7,7 +7,7 @@ import org.commcare.modern.database.Table;
 @Table(ConnectKeyRecord.STORAGE_KEY)
 public class ConnectKeyRecord extends Persisted {
     public static final String STORAGE_KEY = "connect_key";
-    @Persisting(2)
+    @Persisting(1)
     String encryptedPassphrase;
 
     public ConnectKeyRecord() { }

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -7,18 +7,14 @@ import org.commcare.modern.database.Table;
 @Table(ConnectKeyRecord.STORAGE_KEY)
 public class ConnectKeyRecord extends Persisted {
     public static final String STORAGE_KEY = "connect_key";
-
-    @Persisting(1)
-    String userId;
     @Persisting(2)
     String encryptedPassphrase;
 
     public ConnectKeyRecord() { }
-    public ConnectKeyRecord(String userId, String encryptedPassphrase) {
-        this.userId = userId;
+
+    public ConnectKeyRecord(String encryptedPassphrase) {
         this.encryptedPassphrase = encryptedPassphrase;
     }
 
-    public String getUserID() { return userId; }
     public String getEncryptedPassphrase() { return encryptedPassphrase; }
 }

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -3,6 +3,9 @@ package org.commcare.android.database.global.models;
 import org.commcare.android.storage.framework.Persisted;
 import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
+import org.commcare.modern.models.MetaField;
+
+import kotlin.Metadata;
 
 /**
  * DB model for storing the encrypted/encoded Connect DB passphrase
@@ -12,17 +15,30 @@ import org.commcare.modern.database.Table;
 @Table(ConnectKeyRecord.STORAGE_KEY)
 public class ConnectKeyRecord extends Persisted {
     public static final String STORAGE_KEY = "connect_key";
+    public static final String IS_LOCAL = "is_local";
     @Persisting(1)
     String encryptedPassphrase;
+
+    @Persisting(2)
+    @MetaField(IS_LOCAL)
+    boolean isLocal;
 
     public ConnectKeyRecord() {
     }
 
-    public ConnectKeyRecord(String encryptedPassphrase) {
+    public ConnectKeyRecord(String encryptedPassphrase, boolean isLocal) {
         this.encryptedPassphrase = encryptedPassphrase;
+        this.isLocal = isLocal;
     }
 
     public String getEncryptedPassphrase() {
         return encryptedPassphrase;
+    }
+    public boolean getIsLocal() {
+        return isLocal;
+    }
+
+    public static ConnectKeyRecord fromV6(ConnectKeyRecordV6 oldVersion) {
+        return new ConnectKeyRecord(oldVersion.getEncryptedPassphrase(), true);
     }
 }

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -34,6 +34,9 @@ public class ConnectKeyRecord extends Persisted {
     public String getEncryptedPassphrase() {
         return encryptedPassphrase;
     }
+    public void setEncryptedPassphrase(String passphrase) {
+        encryptedPassphrase = passphrase;
+    }
     public boolean getIsLocal() {
         return isLocal;
     }

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecordV6.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecordV6.java
@@ -1,0 +1,29 @@
+package org.commcare.android.database.global.models;
+
+import org.commcare.android.storage.framework.Persisted;
+import org.commcare.models.framework.Persisting;
+import org.commcare.modern.database.Table;
+
+/**
+ * DB model for storing the encrypted/encoded Connect DB passphrase
+ * Used up to global DB V6
+ *
+ * @author dviggiano
+ */
+@Table(ConnectKeyRecordV6.STORAGE_KEY)
+public class ConnectKeyRecordV6 extends Persisted {
+    public static final String STORAGE_KEY = "connect_key";
+    @Persisting(1)
+    String encryptedPassphrase;
+
+    public ConnectKeyRecordV6() {
+    }
+
+    public ConnectKeyRecordV6(String encryptedPassphrase) {
+        this.encryptedPassphrase = encryptedPassphrase;
+    }
+
+    public String getEncryptedPassphrase() {
+        return encryptedPassphrase;
+    }
+}

--- a/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
+++ b/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.commcare.models.database.global;
 
 import android.content.Context;

--- a/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
+++ b/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
@@ -31,8 +31,9 @@ public class DatabaseGlobalOpenHelper extends SQLiteOpenHelper {
      * V.4 - Add table for storing force close log entries that occur outside of an active session
      * V.5 - Add table for storing apps available for install
      * V.6 - Add table for storing (encrypted) passphrase for ConnectId DB
+     * V.7 - Add is_local column to ConnectKeyRecord table (to store both local and server passphrase)
      */
-    private static final int GLOBAL_DB_VERSION = 6;
+    private static final int GLOBAL_DB_VERSION = 7;
 
     private static final String GLOBAL_DB_LOCATOR = "database_global";
 

--- a/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
@@ -132,7 +132,7 @@ class GlobalDatabaseUpgrader {
     }
 
     private boolean upgradeFiveSix(SQLiteDatabase db) {
-        return addTableForNewModel(db, ConnectKeyRecord.STORAGE_KEY, new ConnectKeyRecord());
+        return addTableForNewModel(db, ConnectKeyRecord.STORAGE_KEY, new ConnectKeyRecordV6());
     }
 
     private boolean upgradeSixSeven(SQLiteDatabase db) {

--- a/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
@@ -2,23 +2,24 @@ package org.commcare.models.database.global;
 
 import android.content.Context;
 
+import java.io.File;
+
 import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.CommCareApplication;
 import org.commcare.android.database.global.models.AppAvailableToInstall;
+import org.commcare.android.database.global.models.ApplicationRecord;
+import org.commcare.android.database.global.models.ApplicationRecordV1;
 import org.commcare.android.database.global.models.ConnectKeyRecord;
 import org.commcare.android.logging.ForceCloseLogEntry;
-import org.commcare.modern.database.TableBuilder;
 import org.commcare.models.database.ConcreteAndroidDbHelper;
 import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.MigrationException;
 import org.commcare.models.database.SqlStorage;
-import org.commcare.android.database.global.models.ApplicationRecord;
-import org.commcare.android.database.global.models.ApplicationRecordV1;
+import org.commcare.modern.database.TableBuilder;
 import org.commcare.provider.ProviderUtils;
-import org.javarosa.core.services.storage.Persistable;
 
-import java.io.File;
+import org.javarosa.core.services.storage.Persistable;
 
 /**
  * @author ctsims

--- a/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
@@ -165,8 +165,6 @@ class GlobalDatabaseUpgrader {
 
             db.setTransactionSuccessful();
             return true;
-        } catch(Exception e) {
-            return false;
         } finally {
             db.endTransaction();
         }
@@ -182,8 +180,6 @@ class GlobalDatabaseUpgrader {
 
             db.setTransactionSuccessful();
             return true;
-        } catch (Exception e) {
-            return false;
         } finally {
             db.endTransaction();
         }

--- a/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/global/GlobalDatabaseUpgrader.java
@@ -11,6 +11,7 @@ import org.commcare.android.database.global.models.AppAvailableToInstall;
 import org.commcare.android.database.global.models.ApplicationRecord;
 import org.commcare.android.database.global.models.ApplicationRecordV1;
 import org.commcare.android.database.global.models.ConnectKeyRecord;
+import org.commcare.android.database.global.models.ConnectKeyRecordV6;
 import org.commcare.android.logging.ForceCloseLogEntry;
 import org.commcare.models.database.ConcreteAndroidDbHelper;
 import org.commcare.models.database.DbUtil;
@@ -55,6 +56,12 @@ class GlobalDatabaseUpgrader {
         if (oldVersion == 5) {
             if (upgradeFiveSix(db)) {
                 oldVersion = 6;
+            }
+        }
+
+        if (oldVersion == 6) {
+            if (upgradeSixSeven(db)) {
+                oldVersion = 7;
             }
         }
     }
@@ -126,6 +133,43 @@ class GlobalDatabaseUpgrader {
 
     private boolean upgradeFiveSix(SQLiteDatabase db) {
         return addTableForNewModel(db, ConnectKeyRecord.STORAGE_KEY, new ConnectKeyRecord());
+    }
+
+    private boolean upgradeSixSeven(SQLiteDatabase db) {
+        db.beginTransaction();
+
+        //Migrate the old ConnectKeyRecord in storage to the new version including isLocal
+        try {
+            db.execSQL(DbUtil.addColumnToTable(
+                    ConnectKeyRecord.STORAGE_KEY,
+                    ConnectKeyRecord.IS_LOCAL,
+                    "TEXT"));
+
+            SqlStorage<Persistable> oldStorage = new SqlStorage<>(
+                    ConnectKeyRecordV6.STORAGE_KEY,
+                    ConnectKeyRecordV6.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            SqlStorage<Persistable> newStorage = new SqlStorage<>(
+                    ConnectKeyRecord.STORAGE_KEY,
+                    ConnectKeyRecord.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            for (Persistable r : oldStorage) {
+                ConnectKeyRecordV6 oldRecord = (ConnectKeyRecordV6)r;
+                ConnectKeyRecord newRecord = ConnectKeyRecord.fromV6(oldRecord);
+                //set this new record to have same ID as the old one
+                newRecord.setID(oldRecord.getID());
+                newStorage.write(newRecord);
+            }
+
+            db.setTransactionSuccessful();
+            return true;
+        } catch(Exception e) {
+            return false;
+        } finally {
+            db.endTransaction();
+        }
     }
 
     private static boolean addTableForNewModel(SQLiteDatabase db, String storageKey,

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -356,6 +356,7 @@ public class FormStorageTest {
             , "org.commcare.suite.model.EndpointAction"
             , "org.commcare.suite.model.QueryGroup"
             , "org.commcare.android.database.global.models.ConnectKeyRecord"
+            , "org.commcare.android.database.global.models.ConnectKeyRecordV6"
     );
 
 


### PR DESCRIPTION
## Summary
This PR is to copy Global DB changes that were done as part of the CCC work. The goal with bringing these changes is to ensure a healthy update from that version to production. Changes included here are:
- Added is_local column to ConnectKeyRecord table in global DB

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
These changes have already been released in the beta stream, the risk is in the update itself and there are plans to test that update before releasing this to production users.
