### PR TITLE
Badge size to correctly display Overflow of characters

### DIFF
--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -35,7 +35,7 @@
     <dimen name="list_icon_bounding_dimen">60dp</dimen>
     <dimen name="list_grid_bounding_dimension">180dp</dimen>
 
-    <dimen name="numeric_badge_width_for_list">20dp</dimen>
+    <dimen name="numeric_badge_width_for_list">28dp</dimen>
     <dimen name="numeric_badge_font_size_list">10dp</dimen>
 
     <dimen name="menu_grid_icon_size">120dp</dimen>

--- a/app/src/org/commcare/adapters/MenuAdapter.java
+++ b/app/src/org/commcare/adapters/MenuAdapter.java
@@ -250,7 +250,13 @@ public class MenuAdapter extends BaseAdapter {
         if (badgeText != null && !"".equals(badgeText) && !"0".equals(badgeText)) {
             if (badgeText.length() > 3) {
                 // A badge can only fit up to 3 characters
-                badgeText = badgeText.substring(0, 3);
+                try {
+                    Integer.parseInt(badgeText);
+                    badgeText = "999+";
+                } catch (NumberFormatException e) {
+                    // if not a integer then just show an overflow string
+                    badgeText = badgeText.substring(0, 3) + "..";
+                }
             }
             TextView badgeTextView = badgeView.findViewById(R.id.badge_text);
             badgeTextView.setText(badgeText);


### PR DESCRIPTION
## Summary

https://dimagi.atlassian.net/browse/SC-3315

## Feature Flag

Custom Icon Badges for modules and forms 

## Product Description

Correctly display an overflow of text for Badge View. 

<img src="https://github.com/user-attachments/assets/3912f9eb-79b6-47f0-956e-490aa6d5f494" width="400" height="600">

<img src="https://github.com/user-attachments/assets/77576d2c-d294-4099-9de9-cbf9a38e0071" width="400" height="600">

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

Feature has coverage around normal use case in MenuBadgeTests without testing for overflow of characters. I can add it but feels like an overdo for a small thing. Happy to reconsider. 

### Safety story

tested locally. 
