### PR TITLE
Fixes AS make project Function

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -556,7 +556,7 @@ tasks.whenTaskAdded { task ->
             && "true" == isConsumerApp && "true" == runDownloadScripts) {
         task.dependsOn downloadRestoreFile
     }
-    if (task.name == 'assembleCommcareReleaseAndroidTest') {
+    if (task.name == 'assembleCommcareReleaseAndroidTest' || task.name == 'assembleCommcareDebugAndroidTest') {
         android.defaultConfig.buildConfigField "String", "HQ_API_USERNAME", "\"${project.ext.HQ_API_USERNAME}\""
         android.defaultConfig.buildConfigField "String", "HQ_API_PASSWORD", "\"${project.ext.HQ_API_PASSWORD}\""
     }


### PR DESCRIPTION
## Summary
Makes test credentials available for debug builds to fix "Build->Make Project" which otherwise fails with no field found for `HQ_API_USERNAME` and `HQ_API_PASSWORD`


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly


### Safety story
Build Only change
