### PR TITLE
Do not save read only forms

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -167,6 +167,7 @@ form.entry.incomplete.save.success=Form saved as incomplete
 form.entry.save.error=Sorry, form save failed. Please contact CommCare Support to look into the issue.
 form.entry.save.invalid.unicode=Could not save '${0}' text in form.
 form.entry.finish.button=FINISH
+form.entry.exit.button=EXIT
 form.entry.restart.after.expiration=You were logged out due to session expiration. The form you were in the middle of has been saved and resumed.
 
 login.attempt.badcred=Username or password are incorrect. Please try again.

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -820,6 +820,10 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             return;
         }
 
+        if (mFormController.isFormReadOnly()) {
+            return;
+        }
+
         // save current answer; if headless, don't evaluate the constraints
         // before doing so.
         boolean wasScreenSaved =

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -82,6 +82,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
     private boolean formRelevanciesUpdateInProgress = false;
 
     private static final String KEY_LAST_CHANGED_WIDGET = "index-of-last-changed-widget";
+    private TextView finishText;
 
     enum AnimationType {
         LEFT, RIGHT, FADE
@@ -103,7 +104,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
 
         View finishButton = activity.findViewById(R.id.nav_btn_finish);
 
-        TextView finishText = finishButton.findViewById(R.id.nav_btn_finish_text);
+        finishText = finishButton.findViewById(R.id.nav_btn_finish_text);
         finishText.setText(Localization.get("form.entry.finish.button").toUpperCase());
 
         nextButton.setOnClickListener(v -> {
@@ -198,6 +199,10 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         } else {
             QuestionsView current = createView();
             showView(current, AnimationType.FADE, animateLastView);
+        }
+
+        if (finishText != null && FormEntryActivity.mFormController.isFormReadOnly()) {
+            finishText.setText(Localization.get("form.entry.exit.button").toUpperCase());
         }
     }
 


### PR DESCRIPTION
## Summary
Makes 2 changes in context of completed/read only forms -

1. Do not allow re-saving completed forms 
2. Reword Form's "FINISH" button to say "EXIT" for completed forms

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly


### Safety story

Tested locally and verified that we are able to save non-completed forms as usual. 
