### PR TITLE
Potential fix for incorrect session recovery

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -839,6 +839,11 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             return;
         }
 
+        if (complete) {
+            HiddenPreferences.clearInterruptedFormState();
+            HiddenPreferences.clearInterruptedSSD();
+        }
+
         mSaveToDiskTask = new SaveToDiskTask(getIntent().getIntExtra(KEY_FORM_RECORD_ID, -1),
                 getIntent().getIntExtra(KEY_FORM_DEF_ID, -1),
                 FormEntryInstanceState.mFormRecordPath,

--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -8,6 +8,7 @@ import org.commcare.activities.GeoPointActivity;
 import org.commcare.android.logging.ReportingUtils;
 import org.commcare.models.database.InterruptedFormState;
 import org.commcare.services.FCMMessageData;
+import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidCommCarePlatform;
 import org.commcare.utils.FirebaseMessagingUtil;
 import org.commcare.utils.GeoUtils;
@@ -296,6 +297,7 @@ public class HiddenPreferences {
     }
 
     public static void setInterruptedSSD(int ssdId) {
+        Logger.log(LogTypes.TYPE_MAINTENANCE, "Saving interrupted state");
         String currentUserId = CommCareApplication.instance().getCurrentUserId();
         CommCareApplication.instance().getCurrentApp().getAppPreferences().edit()
                 .putInt(ID_OF_INTERRUPTED_SSD + currentUserId, ssdId).apply();
@@ -308,6 +310,7 @@ public class HiddenPreferences {
     }
 
     public static void clearInterruptedSSD() {
+        Logger.log(LogTypes.TYPE_MAINTENANCE, "Clearing interrupted state");
         String currentUserId = CommCareApplication.instance().getCurrentUserId();
         CommCareApplication.instance().getCurrentApp().getAppPreferences().edit()
                 .putInt(ID_OF_INTERRUPTED_SSD + currentUserId, -1).apply();


### PR DESCRIPTION
## Summary

This is a potential fix for some of the issues we are seeing where user gets restored to a saved session state even after saving the form as complete. Today [we clear this state after the Form Saved ](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/activities/FormEntryActivity.java#L1237) async task has been finished successfully but that may cause issues in scenarios when the activity get deattached from the async task itself.

I have not been able to reproduce these issues but the change is harmless and would love to see if that fixes the issue for users.  If not, also added some helpful logs to get more info on if we are managing the interrupted state correctly. 


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
Small code change with all code pathways already in usage