### PR TITLE
Prevent read only forms form being auto saved

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -933,7 +933,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     private boolean shouldSaveFormOnStop() {
         // if feature enabled and the form has loaded and another widget workflow is not in progress and we
         // ourselves have not called exit as part of user workflow
-        return MainConfigurablePreferences.isAutoSaveFormOnPause() && formHasLoaded() && !triggeredExit;
+        return MainConfigurablePreferences.isAutoSaveFormOnPause() && formHasLoaded() && !triggeredExit
+                && !instanceIsReadOnly;
     }
 
     private void saveInlineVideoState() {


### PR DESCRIPTION
## Summary
This PR prevents read only forms from being auto saved as incomplete, which would allow them to be loaded and submitted again.

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
This only limits the scenarios where the auto-save feature is triggered.
