### PR TITLE
Add extra logging during form entry start

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -415,6 +415,12 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
         if (existing != null) {
             AndroidSessionWrapper state = CommCareApplication.instance().getCurrentSessionWrapper();
             state.loadFromStateDescription(existing);
+
+            FormRecord formRecord = state.getFormRecord();
+            //TODO: Temporary for GD, to remove
+            Logger.log(LogTypes.TYPE_FORM_ENTRY, "Restoring form from expired Session |" +
+                    (formRecord.getInstanceID() == null ? "" : formRecord.getInstanceID() + "|") +
+                    formRecord.getFormNamespace());
             formEntry(CommCareApplication.instance().getCommCarePlatform()
                             .getFormDefId(state.getSession().getForm()), state.getFormRecord(),
                     null, true);
@@ -632,6 +638,11 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
                         AndroidCommCarePlatform platform =
                                 CommCareApplication.instance().getCommCarePlatform();
+
+                        //TODO: Temporary for GD, to remove
+                        Logger.log(LogTypes.TYPE_FORM_ENTRY, "Loading an incomplete form |" +
+                                (r.getInstanceID() == null ? "" : r.getInstanceID() + "|") +
+                                r.getFormNamespace());
                         formEntry(platform.getFormDefId(r.getFormNamespace()), r);
                         return;
                     }


### PR DESCRIPTION
## Summary
This PR adds temporary logging around the Form Entry initiation, this is to help troubleshooting an issue with re-submitting a previously saved session state by the auto-save feature.

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below


