### PR TITLE
Google map SDK version upgrade from 17.0.0 to 19.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation 'org.bouncycastle:bcprov-jdk15to18:1.72'
-    implementation 'com.google.android.gms:play-services-maps:17.0.0'
+    implementation 'com.google.android.gms:play-services-maps:19.0.0'
     implementation 'joda-time:joda-time:2.9.4'
     implementation 'net.zetetic:android-database-sqlcipher:4.5.3@aar'
     implementation 'androidx.sqlite:sqlite:2.2.0'


### PR DESCRIPTION
## Summary
Upgrading the Google maps SDK from version 17.0.0 to 19.0.0

## Product Description
https://github.com/dimagi/commcare-android/issues/2821

## Safety Assurance
- PR may introduce a regression for the reasons below.
- The map should work fine and similar to what it was working before this version upgrade.
- Testing should cover each areas like Registration form, Followup form, etc.
- Attaching an SS of testing of map in follow up form testing from my end:
![Screenshot_20240906_132528](https://github.com/user-attachments/assets/bbd82d64-2e26-4646-8ad7-6ae94e22556a)


**QA Note**: Test maps related functionality
