### PR TITLE
Fixes a bug causing Updates to get stale

### DIFF
--- a/app/src/org/commcare/heartbeat/HeartbeatWorker.kt
+++ b/app/src/org/commcare/heartbeat/HeartbeatWorker.kt
@@ -29,9 +29,10 @@ class HeartbeatWorker(context: Context, workerParams: WorkerParameters):
                     Result.retry()
                 }
                 else -> {
-                    Logger.log(LogTypes.TYPE_ERROR_SERVER_COMMS,
-                            "Encountered unexpected exception during heartbeat communications: "
-                                    + e.message + ". Stopping the heartbeat thread.")
+                    Logger.exception(
+                        "Encountered unexpected exception during heartbeat communications, stopping the heartbeat thread.",
+                        e
+                    )
                     Result.failure()
                 }
             }

--- a/app/src/org/commcare/update/UpdateHelper.java
+++ b/app/src/org/commcare/update/UpdateHelper.java
@@ -18,7 +18,6 @@ import org.commcare.preferences.PrefValues;
 import org.commcare.resources.ResourceInstallContext;
 import org.commcare.resources.model.InstallCancelled;
 import org.commcare.resources.model.InstallCancelledException;
-import org.commcare.resources.model.InstallRequestSource;
 import org.commcare.resources.model.InvalidResourceException;
 import org.commcare.resources.model.Resource;
 import org.commcare.resources.model.ResourceTable;
@@ -84,7 +83,7 @@ public class UpdateHelper implements TableStateListener {
 
     // Main UpdateHelper function for staging updates
     public ResultAndError<AppInstallStatus> update(String profileRef, ResourceInstallContext resourceInstallContext) {
-        setupUpdate(profileRef);
+        setupUpdate(profileRef, resourceInstallContext);
 
         try {
             return new ResultAndError<>(stageUpdate(profileRef, resourceInstallContext));
@@ -123,10 +122,10 @@ public class UpdateHelper implements TableStateListener {
         }
     }
 
-    private void setupUpdate(String profileRef) {
+    private void setupUpdate(String profileRef, ResourceInstallContext resourceInstallContext) {
         ResourceInstallUtils.recordUpdateAttemptTime(mApp);
         Logger.log(LogTypes.TYPE_RESOURCES,
-                "Beginning install attempt for profile " + profileRef);
+                "Beginning install attempt as " + resourceInstallContext.getInstallRequestSource() + " for profile " + profileRef);
 
         if (isAutoUpdate) {
             ResourceInstallUtils.recordAutoUpdateStart(mApp);
@@ -150,7 +149,7 @@ public class UpdateHelper implements TableStateListener {
 
         AppInstallStatus result = mResourceManager.checkAndPrepareUpgradeResources(profileRefWithParams, mAuthority, resourceInstallContext);
 
-        if (result == AppInstallStatus.UpdateStaged) {
+        if (result == AppInstallStatus.UpdateStaged || result == AppInstallStatus.UpToDate) {
             RequestStats.markSuccess(resourceInstallContext.getInstallRequestSource());
         }
 

--- a/app/src/org/commcare/update/UpdateWorker.kt
+++ b/app/src/org/commcare/update/UpdateWorker.kt
@@ -55,17 +55,20 @@ class UpdateWorker(appContext: Context, workerParams: WorkerParameters)
     }
 
     private fun doUpdateWork(): Result {
-        val updateResult: ResultAndError<AppInstallStatus>
-
-        // skip if - An update task is already running | no app is seated
-        if (UpdateTask.getRunningInstance() == null &&
-                CommCareApplication.instance().currentApp != null) {
-            updateHelper.startPinnedNotification(CommCareApplication.instance())
-            updateResult = updateHelper.update(ResourceInstallUtils.getDefaultProfileRef(),
-                    ResourceInstallContext(InstallRequestSource.BACKGROUND_UPDATE))
-        } else {
+        if (UpdateTask.getRunningInstance() != null) {
+            // there is already an update running, lets just skip this run
             return Result.success()
         }
+
+        if (CommCareApplication.instance().currentApp == null) {
+            // we need a seated app to update
+            return Result.failure()
+        }
+
+        updateHelper.startPinnedNotification(CommCareApplication.instance())
+        val updateResult: ResultAndError<AppInstallStatus> = updateHelper.update(
+            ResourceInstallUtils.getDefaultProfileRef(),
+            ResourceInstallContext(InstallRequestSource.BACKGROUND_UPDATE))
         return handleUpdateResult(updateResult)
     }
 

--- a/app/src/org/commcare/update/UpdateWorker.kt
+++ b/app/src/org/commcare/update/UpdateWorker.kt
@@ -44,8 +44,8 @@ class UpdateWorker(appContext: Context, workerParams: WorkerParameters)
                 when {
                     exception is CancellationException -> handleUpdateResult(ResultAndError(AppInstallStatus.Cancelled))
                     exception != null -> {
-                        Logger.exception("Unknown error while app update", exception);
-                        handleUpdateResult(ResultAndError(AppInstallStatus.UnknownFailure))
+                        Logger.exception("Unknown error while app update", exception)
+                        Result.failure()
                     }
                 }
             }
@@ -61,7 +61,6 @@ class UpdateWorker(appContext: Context, workerParams: WorkerParameters)
         if (UpdateTask.getRunningInstance() == null &&
                 CommCareApplication.instance().currentApp != null &&
                 CommCareApplication.instance().session.isActive) {
-
             updateHelper.startPinnedNotification(CommCareApplication.instance())
             updateResult = updateHelper.update(ResourceInstallUtils.getDefaultProfileRef(),
                     ResourceInstallContext(InstallRequestSource.BACKGROUND_UPDATE))

--- a/app/src/org/commcare/update/UpdateWorker.kt
+++ b/app/src/org/commcare/update/UpdateWorker.kt
@@ -57,10 +57,9 @@ class UpdateWorker(appContext: Context, workerParams: WorkerParameters)
     private fun doUpdateWork(): Result {
         val updateResult: ResultAndError<AppInstallStatus>
 
-        // skip if - An update task is already running | no app is seated | user session is not active
+        // skip if - An update task is already running | no app is seated
         if (UpdateTask.getRunningInstance() == null &&
-                CommCareApplication.instance().currentApp != null &&
-                CommCareApplication.instance().session.isActive) {
+                CommCareApplication.instance().currentApp != null) {
             updateHelper.startPinnedNotification(CommCareApplication.instance())
             updateResult = updateHelper.update(ResourceInstallUtils.getDefaultProfileRef(),
                     ResourceInstallContext(InstallRequestSource.BACKGROUND_UPDATE))

--- a/app/src/org/commcare/update/UpdateWorker.kt
+++ b/app/src/org/commcare/update/UpdateWorker.kt
@@ -52,7 +52,6 @@ class UpdateWorker(appContext: Context, workerParams: WorkerParameters)
 
             job.await()
         }
-
     }
 
     private fun doUpdateWork(): Result {
@@ -82,6 +81,7 @@ class UpdateWorker(appContext: Context, workerParams: WorkerParameters)
 
         return when {
             updateResult.data == AppInstallStatus.UpdateStaged -> Result.success()
+            updateResult.data == AppInstallStatus.UpToDate -> Result.success()
             updateResult.data.shouldRetryUpdate() -> Result.retry()
             else -> Result.failure()
         }

--- a/app/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.kt
+++ b/app/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.kt
@@ -82,7 +82,7 @@ class AppUpdateTest {
         UpdateUtils.installUpdate(profileRef,
                 AppInstallStatus.UpToDate,
                 AppInstallStatus.UnknownFailure)
-        checkUpdateComplete(6, true, false)
+        checkUpdateComplete(6, true, true)
     }
 
     @Test

--- a/app/unit-tests/src/org/commcare/update/UpdateWorkerTest.kt
+++ b/app/unit-tests/src/org/commcare/update/UpdateWorkerTest.kt
@@ -41,9 +41,8 @@ class UpdateWorkerTest {
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
-        TestAppInstaller.installAppAndLogin(
-                UpdateUtils.buildResourceRef(REF_BASE_DIR, "base_app", "profile.ccpr"),
-                "test", "123")
+        TestAppInstaller.installApp(
+                UpdateUtils.buildResourceRef(REF_BASE_DIR, "base_app", "profile.ccpr"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

https://dimagi.atlassian.net/browse/SC-3923

Bug Fix for App updates. 

Background updates were failing due to SessionNotAvailable exception due to us unneccesarily checking for user session being active in the Update Worker. This PR makes 2 important changes to eliminate this - 

1. Remove the check for user session from UpdateWrapper, we already perform user updates outside user sessions. 
2. If the error is caused by the wrapper code in UpdateWorker, we can simply result a task failure instead of handling it as an update code error and resetting the update downloads. 


## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

Covered in [UpdateWorkerTests](https://github.com/dimagi/commcare-android/blob/master/app/unit-tests/src/org/commcare/update/UpdateWorkerTest.kt)

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Mostly relying on tests coverage here plus the change not affecting any functional update code. 
