### PR TITLE
Added support for translations to fetch from server for repeat group …

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -896,8 +896,8 @@ repeat.dialog.go.back=Go Back
 repeat.dialog.leave=Do Not Add
 repeat.dialog.exit=Do Not Add. I'm Finished.
 repeat.dialog.add=Add Group
-repeat.dialog.add.another=Add another "${0}" group?
-repeat.dialog.add.new=Add a new "${0}" group?
+repeat.dialog.add.another=Add another ${0}?
+repeat.dialog.add.new=Add a new ${0}?
 lookup.table.missing.error=Unable to find lookup table "${0}". Make sure it exists and this user has access to it.
 
 ethiopian_months=Mäskäräm,T’ïk’ïmt,Hïdar,Tahsas,T’ïr,Yäkatit,Mägabit,Miyaziya,Gïnbot,Säne,Hämle,Nähäse,P’agume

--- a/app/instrumentation-tests/src/org/commcare/androidTests/DialogTests.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/DialogTests.kt
@@ -2,6 +2,7 @@ package org.commcare.androidTests
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -44,15 +45,16 @@ class DialogTests: BaseTest() {
         onView(withId(R.id.nav_btn_next))
                 .perform(click())
 
-        withText("Add a new \"Error on add\" group?").isDisplayed()
+        onView(withId(R.id.choice_dialog_panel_2)).check(matches(withText("Add a new Error on add?")))
 
         InstrumentationUtility.rotateLeft()
         //TODO Expect dialog to not persist due to a activity lifecycle bug in our dialog framework.
-        withText("Add a new \"Error on add\" group?").doesNotExist()
+        withText(R.id.choice_dialog_panel_2).doesNotExist()
+
         InstrumentationUtility.rotatePortrait()
         onView(withId(R.id.nav_btn_next))
                 .perform(click())
-        onView(withText("ADD GROUP"))
+        onView(withId(R.id.choice_dialog_panel_2))
                 .perform(click())
 
         checkDialogExistence_withRotation("Error Occurred")

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -498,8 +498,14 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
 
         // Assign title and text strings based on the current state
         String backText = Localization.get("repeat.dialog.go.back");
-        String addAnotherText = repeatCaptionPrompt.getRepeatText(FormEntryActivity.mFormController.getLastRepeatCount() > 0 ? "add" : "add-empty");
+
+        // Checking the repetitions here
+        boolean hasRepetitions = FormEntryActivity.mFormController.getLastRepeatCount() > 0;
+        // Setting the text based on repetitions
+        String addAnotherText = repeatCaptionPrompt.getRepeatText(hasRepetitions ? "add" : "add-empty");
+
         String title, skipText;
+
         if (!nextExitsForm) {
             skipText = Localization.get("repeat.dialog.leave");
         } else {

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -49,6 +49,7 @@ import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.InvalidData;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
+import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.xpath.XPathException;
@@ -493,20 +494,19 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         final boolean backExitsForm = !details.relevantBeforeCurrentScreen;
         final boolean nextExitsForm = details.relevantAfterCurrentScreen == 0;
 
+        final FormEntryCaption repeatCaptionPrompt = FormEntryActivity.mFormController.getCaptionPrompt();
+
         // Assign title and text strings based on the current state
         String backText = Localization.get("repeat.dialog.go.back");
-        String addAnotherText = Localization.get("repeat.dialog.add");
+        String addAnotherText = repeatCaptionPrompt.getRepeatText(FormEntryActivity.mFormController.getLastRepeatCount() > 0 ? "add" : "add-empty");
         String title, skipText;
         if (!nextExitsForm) {
             skipText = Localization.get("repeat.dialog.leave");
         } else {
             skipText = Localization.get("repeat.dialog.exit");
         }
-        if (FormEntryActivity.mFormController.getLastRepeatCount() > 0) {
-            title = Localization.get("repeat.dialog.add.another", FormEntryActivity.mFormController.getLastGroupText());
-        } else {
-            title = Localization.get("repeat.dialog.add.new", FormEntryActivity.mFormController.getLastGroupText());
-        }
+
+        title = addAnotherText;
 
         // Create the choice dialog
         ContextThemeWrapper wrapper = new ContextThemeWrapper(activity, R.style.DialogBaseTheme);

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -499,9 +499,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         // Assign title and text strings based on the current state
         String backText = Localization.get("repeat.dialog.go.back");
 
-        // Checking the repetitions here
         boolean hasRepetitions = FormEntryActivity.mFormController.getLastRepeatCount() > 0;
-        // Setting the text based on repetitions
         String addAnotherText = repeatCaptionPrompt.getRepeatText(hasRepetitions ? "add" : "add-empty");
 
         String title, skipText;

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -500,9 +500,9 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         String backText = Localization.get("repeat.dialog.go.back");
 
         boolean hasRepetitions = FormEntryActivity.mFormController.getLastRepeatCount() > 0;
-        String addAnotherText = repeatCaptionPrompt.getRepeatText(hasRepetitions ? "add" : "add-empty");
+        final String addAnotherText = repeatCaptionPrompt.getRepeatText(hasRepetitions ? "add" : "add-empty");
 
-        String title, skipText;
+        String skipText;
 
         if (!nextExitsForm) {
             skipText = Localization.get("repeat.dialog.leave");
@@ -510,11 +510,9 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
             skipText = Localization.get("repeat.dialog.exit");
         }
 
-        title = addAnotherText;
-
         // Create the choice dialog
         ContextThemeWrapper wrapper = new ContextThemeWrapper(activity, R.style.DialogBaseTheme);
-        final PaneledChoiceDialog dialog = new HorizontalPaneledChoiceDialog(wrapper, title);
+        final PaneledChoiceDialog dialog = new HorizontalPaneledChoiceDialog(wrapper, addAnotherText);
 
         // Panel 1: Back option
         View.OnClickListener backListener = v -> {


### PR DESCRIPTION
## Summary
This PR addresses the changes required for issue: [2795](https://github.com/dimagi/commcare-android/issues/2795)

## Product Description
We are now fetching the custom translations from the server for the elements of repeat groups.

## Safety Assurance

- [ ] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

SS from commcarehq:
<img width="917" alt="Screenshot 2024-09-11 at 4 25 36 PM" src="https://github.com/user-attachments/assets/1f8a6f5c-d1d5-462b-80b7-ef90fe90bbce">

App SS:
![Screenshot_20240911_162358](https://github.com/user-attachments/assets/4f592336-2c68-477b-87bc-def1ef7e32be)
![Screenshot_20240911_162419](https://github.com/user-attachments/assets/4f0cbb88-c349-434a-98ca-48fe71c1d3e9)

**Release Note**: Adds support for custom translations for "Add" button in repeat group