### PR TITLE
Enable Firebase Performance Monitoring perf monitoring

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
 apply from: 'jacoco.gradle'
+apply plugin: 'com.google.firebase.firebase-perf'
 
 repositories {
     // for local aar inclusion

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics:17.5.0'
     implementation 'com.google.firebase:firebase-messaging:21.1.0'
     implementation 'com.google.firebase:firebase-crashlytics:17.2.1'
+    implementation 'com.google.firebase:firebase-perf:21.0.1'
     implementation 'androidx.legacy:legacy-support-core-ui:1.0.0'
     implementation (name: 'rtl-viewpager-2.0.0', ext: 'aar')
     implementation('com.github.bumptech.glide:glide:4.9.0') {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.jacoco:org.jacoco.core:0.8.10'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
+        classpath 'com.google.firebase:perf-plugin:1.4.2'
     }
 }
 


### PR DESCRIPTION
## Summary
This PR enables [Firebase Performance Monitoring](https://firebase.google.com/docs/perf-mon) for CommCare. This service automatically captures metrics related to the performance of Android apps, such as screen rendering times, network latency, component lifecycle events, and offers the possibility to include custom traces targeting specific app behaviours.

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
Considering that this adds a new SDK to the app and runs on its own service, it's important to ensure that it doesn't impact App size and there are no major performance implications.
