### PR TITLE
Fix an issue when unregistering Pending Sync Alerts receiver

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -907,11 +907,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         if (broadcastReceiver != null) {
             try {
                 unregisterReceiver(broadcastReceiver);
-            } catch (IllegalArgumentException e) {
-                // Thrown when given receiver isn't registered.
-                Logger.log(LogTypes.TYPE_ERROR_ASSERTION,
-                        "Tried to unregister a BroadcastReceiver that wasn't registered: " + e.getMessage());
-            }
+            } catch (IllegalArgumentException e) {}
         }
     }
 

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -900,7 +900,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
         TextToSpeechConverter.INSTANCE.stop();
 
-        unregisterReceiver(pendingSyncAlertBroadcastReceiver);
+        attemptToUnregisterBroadcastReceiver(pendingSyncAlertBroadcastReceiver);
     }
 
     private void attemptToUnregisterBroadcastReceiver(BroadcastReceiver broadcastReceiver){

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -891,16 +891,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             saveAnswersForCurrentScreen(false);
         }
 
-        if (mLocationServiceIssueReceiver != null) {
-            try {
-                unregisterReceiver(mLocationServiceIssueReceiver);
-            } catch (IllegalArgumentException e) {
-                // Thrown when given receiver isn't registered.
-                // This shouldn't ever happen, but seems to come up in production
-                Logger.log(LogTypes.TYPE_ERROR_ASSERTION,
-                        "Tried to unregister a BroadcastReceiver that wasn't registered: " + e.getMessage());
-            }
-        }
+        attemptToUnregisterBroadcastReceiver(mLocationServiceIssueReceiver);
 
         saveInlineVideoState();
 
@@ -910,6 +901,18 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         TextToSpeechConverter.INSTANCE.stop();
 
         unregisterReceiver(pendingSyncAlertBroadcastReceiver);
+    }
+
+    private void attemptToUnregisterBroadcastReceiver(BroadcastReceiver broadcastReceiver){
+        if (broadcastReceiver != null) {
+            try {
+                unregisterReceiver(broadcastReceiver);
+            } catch (IllegalArgumentException e) {
+                // Thrown when given receiver isn't registered.
+                Logger.log(LogTypes.TYPE_ERROR_ASSERTION,
+                        "Tried to unregister a BroadcastReceiver that wasn't registered: " + e.getMessage());
+            }
+        }
     }
 
     private void saveInlineVideoState() {


### PR DESCRIPTION
## Summary
This PR fixes an issue when unregistering the Pending Sync alerts receiver, it seems that for some reason the registration of the receiver failed. Here's the stacktrace:
```
Fatal Exception: java.lang.RuntimeException: Unable to pause activity {org.commcare.dalvik/org.commcare.activities.FormEntryActivity}: java.lang.IllegalArgumentException: Receiver not registered: org.commcare.services.PendingSyncAlertBroadcastReceiver@3592b8b
       at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:5266)
       at android.app.ActivityThread.performPauseActivity(ActivityThread.java:5217)
       at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:5168)
       at android.app.servertransaction.PauseActivityItem.execute(PauseActivityItem.java:46)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2336)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:246)
       at android.app.ActivityThread.main(ActivityThread.java:8653)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```
Link to the in Crashlytics: [31900d304ee55c06bdbebdc58d102951](https://console.firebase.google.com/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/31900d304ee55c06bdbebdc58d102951)

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## Safety Assurance

- [X I have confidence that this PR will not introduce a regression for the reasons below
