### PR TITLE
Quarantine forms due to malformed xml as unrecoverable

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1309,8 +1309,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                                 Localization.get("notification.formentry.save_error.title"),
                                 FormEntryConstants.EXIT);
                     }
-                    String reasonType = (saveStatus == SAVE_UNRECOVERABLE_ERROR) ? QuarantineReason_LOCAL_PROCESSING_ERROR
-                            : QuarantineReason_RECORD_ERROR ;
+                    String reasonType = (saveStatus == SAVE_UNRECOVERABLE_ERROR) ?
+                            QuarantineReason_LOCAL_PROCESSING_ERROR : QuarantineReason_RECORD_ERROR;
                     quarantineRecordOnError(errorMessage, reasonType);
                     return;
             }

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -108,7 +108,9 @@ import androidx.appcompat.app.ActionBar;
 import androidx.core.app.ActivityCompat;
 
 import static org.commcare.android.database.user.models.FormRecord.QuarantineReason_LOCAL_PROCESSING_ERROR;
+import static org.commcare.android.database.user.models.FormRecord.QuarantineReason_RECORD_ERROR;
 import static org.commcare.sync.FirebaseMessagingDataSyncer.PENGING_SYNC_ALERT_ACTION;
+import static org.commcare.tasks.SaveToDiskTask.SaveStatus.SAVE_UNRECOVERABLE_ERROR;
 
 /**
  * Displays questions, animates transitions between
@@ -1301,13 +1303,15 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                     uiController.refreshView();
                     saveAnswersForCurrentScreen(true);
                     return;
-                case SAVE_ERROR:
+                case SAVE_ERROR, SAVE_UNRECOVERABLE_ERROR:
                     if (!CommCareApplication.instance().isConsumerApp()) {
                         new UserfacingErrorHandling<>().createErrorDialog(this, errorMessage,
                                 Localization.get("notification.formentry.save_error.title"),
                                 FormEntryConstants.EXIT);
                     }
-                    quarantineRecordOnError(errorMessage);
+                    String reasonType = (saveStatus == SAVE_UNRECOVERABLE_ERROR) ? QuarantineReason_LOCAL_PROCESSING_ERROR
+                            : QuarantineReason_RECORD_ERROR ;
+                    quarantineRecordOnError(errorMessage, reasonType);
                     return;
             }
             if (!"".equals(toastMessage) && !CommCareApplication.instance().isConsumerApp()) {
@@ -1318,17 +1322,13 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     }
 
     // clean the form record in case it was saved
-    private void quarantineRecordOnError(String errorMessage) {
+    private void quarantineRecordOnError(String errorMessage, String reasonType) {
         AndroidSessionWrapper currentState = CommCareApplication.instance().getCurrentSessionWrapper();
         FormRecord toBeQuarantined = currentState.getFormRecord();
 
         // quarantine in case the form record was saved
         if (toBeQuarantined != null) {
-            new FormRecordProcessor(this).quarantineRecord(
-                    toBeQuarantined,
-                    QuarantineReason_LOCAL_PROCESSING_ERROR,
-                    errorMessage
-            );
+            new FormRecordProcessor(this).quarantineRecord(toBeQuarantined, reasonType, errorMessage);
         }
     }
 

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -396,8 +396,14 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
         if (FormRecord.STATUS_QUARANTINED.equals(value.getStatus())) {
             menu.add(Menu.NONE, VIEW_QUARANTINE_REASON, VIEW_QUARANTINE_REASON,
                     Localization.get("app.workflow.forms.view.quarantine.reason"));
-            menu.add(Menu.NONE, RESTORE_RECORD, RESTORE_RECORD,
-                    Localization.get("app.workflow.forms.restore"));
+
+            if (!FormRecord.QuarantineReason_LOCAL_PROCESSING_ERROR.equals(value.getQuarantineReasonType())) {
+                // Records that were quarantined due to a local processing error can't attempt
+                // re-submission, since doing so would send them straight to "Unsent" when they
+                // haven't even been processed
+                menu.add(Menu.NONE, RESTORE_RECORD, RESTORE_RECORD,
+                        Localization.get("app.workflow.forms.restore"));
+            }
         }
 
         menu.add(Menu.NONE, SCAN_RECORD, SCAN_RECORD, Localization.get("app.workflow.forms.scan"));

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -58,6 +58,7 @@ public class SaveToDiskTask extends
         SAVED_COMPLETE,
         SAVED_INCOMPLETE,
         SAVE_ERROR,
+        SAVE_UNRECOVERABLE_ERROR,
         INVALID_ANSWER,
         SAVED_AND_EXIT
     }
@@ -126,7 +127,7 @@ public class SaveToDiskTask extends
             // Likely a user level issue, so send error to HQ as a app build error
             XPathErrorLogger.INSTANCE.logErrorToCurrentApp(cleanedMessage);
 
-            return new ResultAndError<>(SaveStatus.SAVE_ERROR, cleanedMessage);
+            return new ResultAndError<>(SaveStatus.SAVE_UNRECOVERABLE_ERROR, cleanedMessage);
         }
 
         if (mMarkCompleted) {

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -101,7 +101,7 @@ public class SaveToDiskTask extends
         } catch (XPathException xpe) {
             String cleanedMessage = "An error in your form prevented it from saving: \n" +
                     xpe.getMessage();
-            return new ResultAndError<>(SaveStatus.SAVE_ERROR, cleanedMessage);
+            return new ResultAndError<>(SaveStatus.SAVE_UNRECOVERABLE_ERROR, cleanedMessage);
         }
 
         FormEntryActivity.mFormController.postProcessInstance();
@@ -110,15 +110,15 @@ public class SaveToDiskTask extends
             exportData(mMarkCompleted);
         } catch (FileNotFoundException e) {
             e.printStackTrace();
-            return new ResultAndError<>(SaveStatus.SAVE_ERROR,
+            return new ResultAndError<>(SaveStatus.SAVE_UNRECOVERABLE_ERROR,
                     "Something is blocking acesss to the submission file in " + mFormRecordPath);
         } catch (XFormSerializer.UnsupportedUnicodeSurrogatesException e) {
             Logger.log(LogTypes.TYPE_ERROR_CONFIG_STRUCTURE, "Form contains invalid data encoding\n\n" + ForceCloseLogger.getStackTrace(e));
-            return new ResultAndError<>(SaveStatus.SAVE_ERROR,
+            return new ResultAndError<>(SaveStatus.SAVE_UNRECOVERABLE_ERROR,
                     Localization.get("form.entry.save.invalid.unicode", e.getMessage()));
         } catch (IOException e) {
             Logger.log(LogTypes.TYPE_ERROR_STORAGE, "I/O Error when serializing form\n\n" + ForceCloseLogger.getStackTrace(e));
-            return new ResultAndError<>(SaveStatus.SAVE_ERROR,
+            return new ResultAndError<>(SaveStatus.SAVE_UNRECOVERABLE_ERROR,
                     "Unable to write xml to " + mFormRecordPath);
         } catch (FormInstanceTransactionException e) {
             e.printStackTrace();


### PR DESCRIPTION
## Summary
Errors that occur when saving the forms to disk are categorized under a single umbrella status [SAVE_ERROR](https://github.com/dimagi/commcare-android/blob/7b57114e32f2e5a878b73eebb47546179abbea3c/app/src/org/commcare/tasks/SaveToDiskTask.java#L60), which causes forms to be quarantined due to [LOCAL_PROCESSING_ERROR](https://github.com/dimagi/commcare-android/blob/7b57114e32f2e5a878b73eebb47546179abbea3c/app/src/org/commcare/android/database/user/models/FormRecord.java#L106) motive, which in turn prevents forms from being sent back to the queue for reprocessing. This PR adds a new `SaveStatus`, `SAVE_UNRECOVERABLE_ERROR`, to be used when quarantining forms due to malformed or corrupted form XML, leaving `SAVE_ERROR` to any other errors that are deemed recoverable. These forms are quarantine as `RECORD_ERROR` and can be added to the submissions queue to be reprocessed.

This PR was motivated by an NPE that occurred when [sending a data update broadcast](https://github.com/dimagi/commcare-android/blob/831747a00d29328ea0aaa886245e86588fc4af84/app/src/org/commcare/models/FormRecordProcessor.java#L93) during the Save to disk process, fixed in this [PR](https://github.com/dimagi/commcare-android/pull/2803), which caused the form to be quarantined in an unrecoverable manner. With this change, and while not applicable anymore due to the PR above, in case the same were to occur, the expectation is that the exception will bubble up as it did before, get caught by the [generic catch clause in CommCareTask.doInBackground()](https://github.com/dimagi/commcare-android/blob/831747a00d29328ea0aaa886245e86588fc4af84/app/src/org/commcare/tasks/templates/CommCareTask.java#L41), return `null` and subsequently [save the form with a SAVE_ERROR status](https://github.com/dimagi/commcare-android/blob/831747a00d29328ea0aaa886245e86588fc4af84/app/src/org/commcare/tasks/SaveToDiskTask.java#L275), the difference is that this status will now cause the form to be [quarantined as RECORD_ERROR](https://github.com/dimagi/commcare-android/blob/7b57114e32f2e5a878b73eebb47546179abbea3c/app/src/org/commcare/activities/FormEntryActivity.java#L1312).

cross-request: https://github.com/dimagi/commcare-core/pull/1437

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
Forms can be quarantined for various reasons and in order to test a few of the scenarios covered by this change, `IllegalStateException` and `RuntimeException` were purposely thrown at specific areas to simulate common real issues. Those quarantined due to `RuntimeException` were then sent back to the queue and submitted to HQ while the `IllegalStateException` ones didn't have the option to do so.
