### PR TITLE
Fixes form navigation error due to multiple search callout extras 

### DIFF
--- a/app/src/org/commcare/adapters/EntityListAdapter.java
+++ b/app/src/org/commcare/adapters/EntityListAdapter.java
@@ -16,6 +16,7 @@ import org.commcare.cases.entity.Entity;
 import org.commcare.cases.entity.NodeEntityFactory;
 import org.commcare.dalvik.R;
 import org.commcare.interfaces.AndroidSortableEntityAdapter;
+import org.commcare.modern.session.SessionWrapper;
 import org.commcare.preferences.MainConfigurablePreferences;
 import org.commcare.session.SessionInstanceBuilder;
 import org.commcare.suite.model.Action;
@@ -429,7 +430,10 @@ public class EntityListAdapter extends AndroidSortableEntityAdapter implements L
 
     public void saveCalloutDataToSession() {
         if (isFilteringByCalloutResult) {
-            CommCareApplication.instance().getCurrentSession().addExtraToCurrentFrameStep(SessionInstanceBuilder.KEY_ENTITY_LIST_EXTRA_DATA, calloutResponseData);
+            SessionWrapper session = CommCareApplication.instance().getCurrentSession();
+            session.removeExtraFromCurrentFrameStep(SessionInstanceBuilder.KEY_ENTITY_LIST_EXTRA_DATA);
+            session.addExtraToCurrentFrameStep(SessionInstanceBuilder.KEY_ENTITY_LIST_EXTRA_DATA,
+                    calloutResponseData);
         }
     }
 


### PR DESCRIPTION
## Summary

https://dimagi.atlassian.net/browse/SUPPORT-22243

## Product Description

Bug fix: Fixes form navigation error due to multiple search callout extras 

Repro:

1. Use case search list callout to search and filter the case list
2. Make a case selection to enter into a form
3. Exit the form without saving and go back to the case list
4. Select the case again from filtered case list and go into the form again
5. Form errors with an error -"_Multiple Extras found with key entity-list-data_"

## Technical Summary

On making a case selection from the case list filtered with a callout, we [add an extra](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/adapters/EntityListAdapter.java#L432) called `entity-list-data` to the top frame step. On re-selecting the case from case list, this extra ends up getting added again to the frame step which eventually errors when user opens the form with exception thrown from [here](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/suite/model/StackFrameStep.java#L178).

## Safety Assurance

- [x] If the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
None. 

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
Small change to remove the extra before adding. Locally tested. 