### PR TITLE
Always launching learn/deliver app immediately after downloading

### DIFF
--- a/app/res/navigation/nav_graph_connect.xml
+++ b/app/res/navigation/nav_graph_connect.xml
@@ -99,9 +99,6 @@
         <argument
             android:name="learning"
             app:argType="boolean" />
-        <argument
-            android:name="goToApp"
-            app:argType="boolean" />
         <action
             android:id="@+id/action_connect_downloading_fragment_to_connect_job_learning_progress_fragment"
             app:destination="@id/connect_job_learning_progress_fragment"

--- a/app/src/org/commcare/adapters/ConnectJobAdapter.java
+++ b/app/src/org/commcare/adapters/ConnectJobAdapter.java
@@ -305,7 +305,7 @@ public class ConnectJobAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         else {
             int textId = isLearning ? R.string.connect_downloading_learn : R.string.connect_downloading_delivery;
             String title = parentContext.getString(textId);
-            Navigation.findNavController(view).navigate(ConnectJobsListsFragmentDirections.actionConnectJobsListFragmentToConnectDownloadingFragment(title, isLearning, true));
+            Navigation.findNavController(view).navigate(ConnectJobsListsFragmentDirections.actionConnectJobsListFragmentToConnectDownloadingFragment(title, isLearning));
         }
     }
 

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryDetailsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryDetailsFragment.java
@@ -158,7 +158,7 @@ public class ConnectDeliveryDetailsFragment extends Fragment {
         } else {
             String title = getString(R.string.connect_downloading_delivery);
             directions = ConnectDeliveryDetailsFragmentDirections
-                    .actionConnectJobDeliveryDetailsFragmentToConnectDownloadingFragment(title, false, false);
+                    .actionConnectJobDeliveryDetailsFragmentToConnectDownloadingFragment(title, false);
         }
 
         Navigation.findNavController(button).navigate(directions);

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressDeliveryFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressDeliveryFragment.java
@@ -88,7 +88,7 @@ public class ConnectDeliveryProgressDeliveryFragment extends Fragment {
             getActivity().finish();
         } else {
             String title = getString(R.string.connect_downloading_learn);
-            Navigation.findNavController(button).navigate(ConnectDeliveryProgressFragmentDirections.actionConnectJobDeliveryProgressFragmentToConnectDownloadingFragment(title, true, true));
+            Navigation.findNavController(button).navigate(ConnectDeliveryProgressFragmentDirections.actionConnectJobDeliveryProgressFragmentToConnectDownloadingFragment(title, true));
         }
     }
 
@@ -99,7 +99,7 @@ public class ConnectDeliveryProgressDeliveryFragment extends Fragment {
             getActivity().finish();
         } else {
             String title = getString(R.string.connect_downloading_delivery);
-            Navigation.findNavController(button).navigate(ConnectDeliveryProgressFragmentDirections.actionConnectJobDeliveryProgressFragmentToConnectDownloadingFragment(title, false, true));
+            Navigation.findNavController(button).navigate(ConnectDeliveryProgressFragmentDirections.actionConnectJobDeliveryProgressFragmentToConnectDownloadingFragment(title, false));
         }
     }
 

--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -33,7 +33,6 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
     private ProgressBar progressBar;
     private TextView statusText;
     private boolean getLearnApp;
-    private boolean goToApp;
 
     public ConnectDownloadingFragment() {
         // Required empty public constructor
@@ -48,7 +47,6 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
         super.onCreate(savedInstanceState);
         ConnectDownloadingFragmentArgs args = ConnectDownloadingFragmentArgs.fromBundle(getArguments());
         getLearnApp = args.getLearning();
-        goToApp = args.getGoToApp();
 
         //Disable back button during install (done by providing empty callback)
         setBackButtonEnabled(false);
@@ -114,26 +112,13 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
         setBackButtonEnabled(true);
         View view = getView();
         if (view != null) {
-            if(goToApp) {
-                Navigation.findNavController(view).popBackStack();
+            Navigation.findNavController(view).popBackStack();
 
-                //Launch the learn/deliver app
-                ConnectJobRecord job = ConnectManager.getActiveJob();
-                ConnectAppRecord appToLaunch = getLearnApp ? job.getLearnAppInfo() : job.getDeliveryAppInfo();
-                ConnectManager.launchApp(getContext(), getLearnApp, appToLaunch.getAppId());
-                getActivity().finish();
-            }
-            else {
-                //Go to learn/deliver progress
-                NavDirections directions;
-                if(getLearnApp) {
-                    directions = ConnectDownloadingFragmentDirections.actionConnectDownloadingFragmentToConnectJobLearningProgressFragment();
-                }
-                else {
-                    directions = ConnectDownloadingFragmentDirections.actionConnectDownloadingFragmentToConnectJobDeliveryProgressFragment();
-                }
-                Navigation.findNavController(statusText).navigate(directions);
-            }
+            //Launch the learn/deliver app
+            ConnectJobRecord job = ConnectManager.getActiveJob();
+            ConnectAppRecord appToLaunch = getLearnApp ? job.getLearnAppInfo() : job.getDeliveryAppInfo();
+            ConnectManager.launchApp(getContext(), getLearnApp, appToLaunch.getAppId());
+            getActivity().finish();
         }
     }
 

--- a/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
@@ -110,7 +110,7 @@ public class ConnectJobIntroFragment extends Fragment {
                             directions = ConnectJobIntroFragmentDirections.actionConnectJobIntroFragmentToConnectJobLearningProgressFragment();
                         } else {
                             String title = getString(R.string.connect_downloading_learn);
-                            directions = ConnectJobIntroFragmentDirections.actionConnectJobIntroFragmentToConnectDownloadingFragment(title, true, false);
+                            directions = ConnectJobIntroFragmentDirections.actionConnectJobIntroFragmentToConnectDownloadingFragment(title, true);
                         }
 
                         Navigation.findNavController(button).navigate(directions);

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
@@ -240,7 +240,7 @@ public class ConnectLearningProgressFragment extends Fragment {
                 getActivity().finish();
             } else {
                 String title = getString(R.string.connect_downloading_learn);
-                directions = ConnectLearningProgressFragmentDirections.actionConnectJobLearningProgressFragmentToConnectDownloadingFragment(title, true, true);
+                directions = ConnectLearningProgressFragmentDirections.actionConnectJobLearningProgressFragmentToConnectDownloadingFragment(title, true);
             }
 
             if(directions != null) {
@@ -260,7 +260,7 @@ public class ConnectLearningProgressFragment extends Fragment {
                 getActivity().finish();
             } else {
                 String title = getString(R.string.connect_downloading_learn);
-                directions = ConnectLearningProgressFragmentDirections.actionConnectJobLearningProgressFragmentToConnectDownloadingFragment(title, true, true);
+                directions = ConnectLearningProgressFragmentDirections.actionConnectJobLearningProgressFragmentToConnectDownloadingFragment(title, true);
             }
 
             if(directions != null) {


### PR DESCRIPTION
We no longer ever want to go to the learn/deliver progress page after downloading the corresponding learn/deliver app, and should always immediately launch and auto-login to the app. This PR removes the functionality that supported going to the progress pages.