### PR TITLE
Remove Multidex usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ git clone https://github.com/dimagi/commcare-core.git
 - Click "OK" to use the Gradle wrapper
 - Wait while Android Studio spins its wheels
 - Download any build dependencies that the SDK Manager tells you you need.
-- Disable _Instant Run_ found in Settings > Build, Execution, Deployment > Instant Run. (It does not play well with multidexing, which we have enabled, or with some of the processes we have set up for Google Services)
 
 ## Building
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     testImplementation('org.robolectric:robolectric:4.8.2') {
         exclude(group: 'org.bouncycastle', module: 'bcprov-jdk15on')
     }
-    testImplementation 'org.robolectric:shadows-multidex:4.8.2'
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'androidx.test:runner:1.5.2'
     testImplementation 'androidx.test.ext:junit:1.1.3'
@@ -75,7 +74,6 @@ dependencies {
     implementation (name: 'volley-1.1.0', ext: 'aar')
     implementation (name: 'storage-2.1.0', ext: 'aar')
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
@@ -251,7 +249,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 33
-        multiDexEnabled true
         applicationId 'org.commcare.dalvik'
         testNamespace 'org.commcare.dalvik.test'
 
@@ -462,7 +459,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
             testProguardFiles 'test-proguard.cfg'
 
-            multiDexKeepProguard file('proguard-multidex.pro')
             // enable crashlytics
             buildConfigField 'boolean', 'USE_CRASHLYTICS', 'true'
             ext.enableCrashlytics = true

--- a/app/proguard-multidex.pro
+++ b/app/proguard-multidex.pro
@@ -1,2 +1,0 @@
-#Need to make sure these classes are available in primary dex file
--keep class org.commcare.** { *; }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -2,6 +2,7 @@ package org.commcare;
 
 import android.annotation.SuppressLint;
 import android.app.ActivityManager;
+import android.app.Application;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -17,7 +18,6 @@ import android.text.format.DateUtils;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import androidx.multidex.MultiDexApplication;
 import androidx.preference.PreferenceManager;
 import androidx.work.BackoffPolicy;
 import androidx.work.Constraints;
@@ -143,7 +143,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 
-public class CommCareApplication extends MultiDexApplication {
+public class CommCareApplication extends Application {
 
     private static final String TAG = CommCareApplication.class.getSimpleName();
 


### PR DESCRIPTION
## Summary

Since the min SDK is 21, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l

## Safety Assurance

- [ ] If the PR is high risk, "High Risk" label is set
- [ ] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 