### PR TITLE
Extend user session

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -18,6 +18,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.commcare.CommCareApplication;
 import org.commcare.activities.components.FormEntryConstants;
 import org.commcare.activities.components.FormLayoutHelpers;
 import org.commcare.activities.components.FormNavigationController;
@@ -246,6 +247,10 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
 
         setupGroupLabel();
         checkForOrientationRequirements();
+
+        if (questionsView.hasNonRecoverableWidgets()) {
+            CommCareApplication.instance().getSession().extendUserSessionIfNeeded();
+        }
     }
 
     private void checkForOrientationRequirements() {

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -82,6 +82,11 @@ public class CommCareSessionService extends Service {
      */
     public static final ReentrantLock sessionAliveLock = new ReentrantLock();
 
+    /**
+     * 2h time in Milliseconds to extend the session if needed
+     */
+    private static final long SESSION_EXTENSION_TIME = 2 * 60 * 60 * 1000;
+
     private Timer maintenanceTimer;
     private CipherPool pool;
 
@@ -673,6 +678,17 @@ public class CommCareSessionService extends Service {
 
     public boolean shouldShowInAppUpdate() {
         return this.showInAppUpdate;
+    }
+
+    public void extendUserSessionIfNeeded(){
+        long currentTime = new Date().getTime();
+
+        if (sessionExpireDate.getTime() < currentTime + SESSION_EXTENSION_TIME) {
+            sessionExpireDate.setTime(sessionExpireDate.getTime() + SESSION_EXTENSION_TIME);
+            sessionLength += SESSION_EXTENSION_TIME;
+
+            mNM.notify(NOTIFICATION, createSessionNotification());
+        }
     }
 
     private Notification createSessionNotification(){

--- a/app/src/org/commcare/services/CommCareSessionService.java
+++ b/app/src/org/commcare/services/CommCareSessionService.java
@@ -202,44 +202,9 @@ public class CommCareSessionService extends Service {
      */
     @SuppressLint("UnspecifiedImmutableFlag")
     public void showLoggedInNotification(@Nullable User user) {
-        //We always want this click to simply bring the live stack back to the top
-        Intent callable = new Intent(this, DispatchActivity.class);
-        callable.setAction("android.intent.action.MAIN");
-        callable.addCategory("android.intent.category.LAUNCHER");
-
-        // The PendingIntent to launch our activity if the user selects this notification
-        PendingIntent contentIntent;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            contentIntent = PendingIntent.getActivity(this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
-        else
-            contentIntent = PendingIntent.getActivity(this, 0, callable, 0);
-
-        String notificationText;
-        if (AppUtils.getInstalledAppRecords().size() > 1) {
-            try {
-                notificationText = Localization.get("notification.logged.in",
-                        new String[]{Localization.get("app.display.name")});
-            } catch (NoLocalizedTextException e) {
-                notificationText = getString(NOTIFICATION);
-            }
-        } else {
-            notificationText = getString(NOTIFICATION);
-        }
-
-        // Set the icon, scrolling text and timestamp
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_ERRORS_ID)
-                .setContentTitle(notificationText)
-                .setSmallIcon(R.drawable.notification)
-                .setContentIntent(contentIntent);
-
-        if (user != null) {
-            String contentText = "Session Expires: " + DateFormat.format("MMM dd h:mmaa", sessionExpireDate);
-            notificationBuilder.setContentText(contentText);
-        }
-
         // Send the notification. This will cause error messages if CommCare doesn't have
         // permission to post notifications
-        this.startForeground(NOTIFICATION, notificationBuilder.build());
+        this.startForeground(NOTIFICATION, createSessionNotification());
     }
 
     /**
@@ -708,5 +673,43 @@ public class CommCareSessionService extends Service {
 
     public boolean shouldShowInAppUpdate() {
         return this.showInAppUpdate;
+    }
+
+    private Notification createSessionNotification(){
+        //We always want this click to simply bring the live stack back to the top
+        Intent callable = new Intent(this, DispatchActivity.class);
+        callable.setAction("android.intent.action.MAIN");
+        callable.addCategory("android.intent.category.LAUNCHER");
+
+        // The PendingIntent to launch our activity if the user selects this notification
+        PendingIntent contentIntent;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            contentIntent = PendingIntent.getActivity(this, 0, callable, PendingIntent.FLAG_IMMUTABLE);
+        else
+            contentIntent = PendingIntent.getActivity(this, 0, callable, 0);
+
+        String notificationText;
+        if (AppUtils.getInstalledAppRecords().size() > 1) {
+            try {
+                notificationText = Localization.get("notification.logged.in",
+                        new String[]{Localization.get("app.display.name")});
+            } catch (NoLocalizedTextException e) {
+                notificationText = getString(NOTIFICATION);
+            }
+        } else {
+            notificationText = getString(NOTIFICATION);
+        }
+
+        // Set the icon, scrolling text and timestamp
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_ERRORS_ID)
+                .setContentTitle(notificationText)
+                .setSmallIcon(R.drawable.notification)
+                .setContentIntent(contentIntent);
+
+        if (user != null) {
+            String contentText = "Session Expires: " + DateFormat.format("MMM dd h:mmaa", sessionExpireDate);
+            notificationBuilder.setContentText(contentText);
+        }
+        return notificationBuilder.build();
     }
 }

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -71,6 +71,8 @@ public class QuestionsView extends ScrollView
      */
     private static final boolean SEPERATORS_ENABLED = false;
 
+    private boolean mContainsNonRecoverableWidgets = false;
+
     public QuestionsView(Context context, BlockingActionsManager blockingActionsManager) {
         super(context);
         mQuestionFontsize = FormEntryPreferences.getQuestionFontSize();

--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -71,7 +71,7 @@ public class QuestionsView extends ScrollView
      */
     private static final boolean SEPERATORS_ENABLED = false;
 
-    private boolean mContainsNonRecoverableWidgets = false;
+    private boolean containsNonRecoverableWidgets = false;
 
     public QuestionsView(Context context, BlockingActionsManager blockingActionsManager) {
         super(context);
@@ -139,6 +139,7 @@ public class QuestionsView extends ScrollView
             mView.addView(qw, mLayout);
 
             qw.setChangedListeners(this, blockingActionsManager);
+            containsNonRecoverableWidgets = containsNonRecoverableWidgets || qw.isNonRecoverable();
         }
 
         markLastStringWidget();
@@ -497,5 +498,9 @@ public class QuestionsView extends ScrollView
             return null;
         }
         return compoundedCallout;
+    }
+
+    public boolean hasNonRecoverableWidgets(){
+        return containsNonRecoverableWidgets;
     }
 }

--- a/app/src/org/commcare/views/widgets/MediaWidget.java
+++ b/app/src/org/commcare/views/widgets/MediaWidget.java
@@ -69,7 +69,7 @@ public abstract class MediaWidget extends QuestionWidget {
 
     public MediaWidget(Context context, FormEntryPrompt prompt,
                        PendingCalloutInterface pendingCalloutInterface) {
-        super(context, prompt);
+        super(context, prompt, true);
 
         this.pendingCalloutInterface = pendingCalloutInterface;
 
@@ -79,7 +79,6 @@ public abstract class MediaWidget extends QuestionWidget {
         initializeButtons();
         setupLayout();
     }
-
 
     @Override
     protected void onVisibilityChanged(@NonNull View changedView, int visibility) {

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -91,6 +91,9 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
     private ShrinkingTextView mHintText;
     private View warningView;
 
+    // This signals that the widget can't be recovered after a session expiration
+    protected boolean mNonRecoverable;
+
     //Whether this question widget needs to request focus on
     //its next draw, due to a new element having been added (which couldn't have
     //requested focus yet due to having not been layed out)
@@ -103,13 +106,18 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
     private LinearLayout compactLayout;
 
     public QuestionWidget(Context context, FormEntryPrompt p) {
-        this(context, p, false);
+        this(context, p, false, false);
     }
 
-    public QuestionWidget(Context context, FormEntryPrompt p, boolean inCompactGroup) {
+    public QuestionWidget(Context context, FormEntryPrompt p, boolean nonRecoverable) {
+        this(context, p, false, nonRecoverable);
+    }
+
+    public QuestionWidget(Context context, FormEntryPrompt p, boolean inCompactGroup, boolean nonRecoverable) {
         super(context);
         mPrompt = p;
         mCompact = inCompactGroup;
+        mNonRecoverable = nonRecoverable;
 
         //this is pretty sketch but is the only way to make the required background to work trivially for now
         this.setClipToPadding(false);
@@ -133,6 +141,10 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
             addHelpPlaceholder();
             addHintText();
         }
+    }
+
+    public boolean isNonRecoverable(){
+        return mNonRecoverable;
     }
 
     protected void acceptFocus() {


### PR DESCRIPTION
## Summary
This PR adds the option for CommCare to extend the session of the user when they are navigating a widget that can't be recovered in case of session expiration. In another words, it extends the session to prevent the auto logout from being triggered and the user to lose any data captured using the widget. The widget in question is the [CommCareAudioWidget](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/views/widgets/CommCareAudioWidget.java).
This issue came up recently for a project that makes use of this widget to audio record long session in which users were being logout in the middle of the recording due to the session expiration. More information on [this](https://dimagi.atlassian.net/browse/SAAS-15417) ticket.

## Safety Assurance

- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
This only adds more time to the current session. Local tests were successfully. 
