### PR TITLE
Muting DateWidgetTest due to failures

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/androidTests/DateWidgetsTests.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/DateWidgetsTests.kt
@@ -29,7 +29,6 @@ import kotlin.math.absoluteValue
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
-@BrowserstackTests
 class DateWidgetsTests : BaseTest() {
     companion object {
         const val CCZ_NAME = "date_widgets_tests.ccz"


### PR DESCRIPTION
## Summary
Temporary removing `DateWidgetTest` due to consistent timezone related to failures.
