### PR TITLE
Remove microphone status check for Android 9 and lower

### DIFF
--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -499,9 +499,7 @@ public class RecordingFragment extends DialogFragment {
                     .findAny();
             return currentAudioConfig.isPresent() ? currentAudioConfig.get().isClientSilenced() : false;
         } else {
-            if (recorder.getMaxAmplitude() == 0) {
-                return true;
-            }
+            // TODO: Add logic to check if the recording has gone silent for Android 9 and prior
             return false;
         }
     }


### PR DESCRIPTION
## Summary
This PR removes logic used to assess the status of the microphone after a recording configuration change on Android 9 and earlier versions. While this logic passed previous rounds of QA, there are instances in which it unexpectedly pauses the recording at the beginning  of the beginning.
Ticket: https://dimagi.atlassian.net/browse/SAAS-15417?focusedCommentId=341302

Note: I park this an issue for future investigation.

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->


### Safety story
No need.
