### PR TITLE
Include original exception in wrapper InvalidStateException

### DIFF
--- a/app/src/org/commcare/android/database/user/models/FormRecord.java
+++ b/app/src/org/commcare/android/database/user/models/FormRecord.java
@@ -430,18 +430,18 @@ public class FormRecord extends Persisted implements EncryptedModel {
                     this, CommCareApplication.instance().getUserStorage(FormRecord.class));
         } catch (InvalidStructureException e1) {
             e1.printStackTrace();
-            throw new InvalidStateException("Invalid data structure found while parsing form. There's something wrong with the application structure, please contact your supervisor.");
+            throw new InvalidStateException("Invalid data structure found while parsing form. There's something wrong with the application structure, please contact your supervisor", e1);
         } catch (XmlPullParserException | IOException e) {
             e.printStackTrace();
-            throw new InvalidStateException("There was a problem with the local storage and the form could not be read.");
+            throw new InvalidStateException("There was a problem with the local storage and the form could not be read.", e);
         } catch (UnfullfilledRequirementsException e) {
             throw new RuntimeException(e);
         }
     }
 
     private static class InvalidStateException extends Exception {
-        public InvalidStateException(String message) {
-            super(message);
+        public InvalidStateException(String message, Throwable e) {
+            super(message, e);
         }
     }
 


### PR DESCRIPTION
## Summary
`InvalidStateException` is thrown when reparsing a saved form and there are errors/inconsistencies with the form XML. This PR makes the original exception to bubble up and with it the original stack-trace, this is to improve future troubleshooting efforts.

Ticket: https://dimagi.atlassian.net/browse/SAAS-15947?focusedCommentId=346141

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
No need.
