### PR TITLE
Don't recreate preference when blanking custom URL

### DIFF
--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -129,6 +129,7 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
                     SharedPreferences appPreferences = CommCareApplication.instance().getCurrentApp()
                             .getAppPreferences();
                     appPreferences.edit().remove(PREFS_LOG_POST_URL_KEY).apply();
+                    return false;
                 }
                 return true;
             });


### PR DESCRIPTION
## Summary
This PR corrects a minor issue when removing the custom log submission URL. After removing the preference, there shouldn't be any editing as it will add the preference again.

## Safety Assurance

- [X] If the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly

### Safety story
No need
