### PR TITLE
Remove misleading comment reg. 1 MB Sql Limitation

### DIFF
--- a/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
+++ b/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
@@ -254,9 +254,6 @@ public class CommCareEntityStorageCache implements EntityStorageCache {
 
     private static void populateEntitySet(SQLiteDatabase db, String sqlStatement, String[] args,
             Hashtable<String, AsyncEntity> entitySet) {
-        //TODO: This will _only_ query up to about a meg of data, which is an un-great limitation.
-        //Should probably split this up SQL LIMIT based looped
-        //For reference the current limitation is about 10k rows with 1 field each.
         Cursor walker = db.rawQuery(sqlStatement, args);
         while (walker.moveToNext()) {
             String entityId = walker.getString(walker.getColumnIndex("entity_key"));


### PR DESCRIPTION
There is no 1 MB limitaion on data we can can query in sql queries, the only limitaion is that a single sql row can't be more than 1 mb


## PR Checklist

- [x] If I think the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
- [x] Does the PR introduce any major changes worth communicating ? If yes, "Release Note" label is set and a "Release Note" is specified in PR description.

### Automated test coverage

NA

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
No code changes