### PR TITLE
Update test libs and work manager

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,32 +30,32 @@ configurations {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation('org.robolectric:robolectric:4.8.2') {
         exclude(group: 'org.bouncycastle', module: 'bcprov-jdk15on')
     }
-    testImplementation 'androidx.test:core:1.5.0'
-    testImplementation 'androidx.test:runner:1.5.2'
-    testImplementation 'androidx.test.ext:junit:1.1.3'
-    testImplementation 'androidx.work:work-testing:2.7.1'
-    testImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    testImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2'
+    testImplementation 'androidx.test:core:1.6.1'
+    testImplementation 'androidx.test:runner:1.6.2'
+    testImplementation 'androidx.test.ext:junit:1.2.1'
+    testImplementation 'androidx.work:work-testing:2.10.0'
+    testImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    testImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
     testImplementation 'io.mockk:mockk:1.12.7'
-    testImplementation 'org.json:json:20140107'
+    testImplementation 'org.json:json:20231013'
     testImplementation project(path: ':commcare-core', configuration: 'testsAsJar')
 
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.ext:truth:1.4.0'
-    androidTestImplementation 'androidx.test:rules:1.5.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
+    androidTestImplementation 'androidx.test:runner:1.6.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.ext:truth:1.6.0'
+    androidTestImplementation 'androidx.test:rules:1.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.6.1'
 
     // need uiautomator to rotate the device.
     // this only works with API >=18
-    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
 
     // release build type expects commcare jars to be in app/libs
     implementation(project(':commcare-core')) {
@@ -121,8 +121,8 @@ dependencies {
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-android-accounts'
         exclude group: 'io.realm'
     }
-    implementation 'androidx.work:work-runtime:2.7.1'
-    implementation 'androidx.work:work-runtime-ktx:2.7.1'
+    implementation 'androidx.work:work-runtime:2.10.0'
+    implementation 'androidx.work:work-runtime-ktx:2.10.0'
 
     implementation 'com.google.android.play:app-update:2.1.0'
     implementation 'android.arch.lifecycle:common-java8:1.1.1'
@@ -138,7 +138,7 @@ dependencies {
     implementation 'com.appmattus.certificatetransparency:certificatetransparency-android:2.5.4'
 
     // Dependency required for API desugaring
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_minimal:2.0.3'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_minimal:2.1.3'
 }
 
 ext {
@@ -222,7 +222,7 @@ static def getDate() {
 
 android {
     namespace 'org.commcare.dalvik'
-    compileSdk 34
+    compileSdk 35
 
     lintOptions {
         abortOnError false


### PR DESCRIPTION
## Summary

Updates work manager, test libs and desugaring lib


## PR Checklist

- [x] If I think the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
- [x] Does the PR introduce any major changes worth communicating ? If yes, "Release Note" label is set and a "Release Note" is specified in PR description.

### Automated test coverage

We have some unit test coverage for [Updates worker](https://github.com/dimagi/commcare-android/blob/master/app/unit-tests/src/org/commcare/update/UpdateWorkerTest.kt)

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 

Test and desugaring libs should not affect anything runtime
Work Manager update will get tested during auto updates test as part of Manual QA tests
