### PR TITLE
Removes some logs which are killing our sumo usage

### DIFF
--- a/app/src/org/commcare/activities/CommCareGraphActivity.java
+++ b/app/src/org/commcare/activities/CommCareGraphActivity.java
@@ -31,9 +31,5 @@ public class CommCareGraphActivity extends CommCareActivity {
     protected void onDestroy() {
         super.onDestroy();
         FirebaseAnalyticsUtil.reportGraphViewFullScreenClosed();
-
-        String title = getTitle() == null || getTitle().length() == 0 ? "(no title)" : getTitle().toString();
-        Logger.log(LogTypes.TYPE_GRAPHING,
-                String.format("End viewing full screen graph for %s", title));
     }
 }

--- a/app/src/org/commcare/android/javarosa/IntentCallout.java
+++ b/app/src/org/commcare/android/javarosa/IntentCallout.java
@@ -165,7 +165,6 @@ public class IntentCallout implements Externalizable {
                 }
             }
         }
-        Logger.log(LogTypes.TYPE_FORM_ENTRY, "Generated intent for callout: " + i.toString());
         return i;
     }
 

--- a/app/src/org/commcare/appupdate/CommcareFlexibleAppUpdateManager.java
+++ b/app/src/org/commcare/appupdate/CommcareFlexibleAppUpdateManager.java
@@ -161,8 +161,6 @@ public class CommcareFlexibleAppUpdateManager implements FlexibleAppUpdateContro
         if (mAppUpdateState == newState) {
             return;
         }
-        Logger.log(LogTypes.TYPE_CC_UPDATE, "Publishing status update to : " + newState.name() + ", from : "
-                + (mAppUpdateState != null ? mAppUpdateState.name() : "null"));
         mAppUpdateState = newState;
         mCallback.run();
     }

--- a/app/src/org/commcare/graph/view/GraphView.java
+++ b/app/src/org/commcare/graph/view/GraphView.java
@@ -83,20 +83,12 @@ public class GraphView {
         protected void onAttachedToWindow() {
             super.onAttachedToWindow();
             FirebaseAnalyticsUtil.reportGraphViewAttached();
-
-            String displayTitle = mTitle == null || "".equals(mTitle) ? "(no title)" : mTitle;
-            Logger.log(LogTypes.TYPE_GRAPHING,
-                    String.format("Start viewing graph in list for %s", displayTitle));
         }
 
         @Override
         protected void onDetachedFromWindow() {
             super.onDetachedFromWindow();
             FirebaseAnalyticsUtil.reportGraphViewDetached();
-
-            String displayTitle = mTitle == null || "".equals(mTitle) ? "(no title)" : mTitle;
-            Logger.log(LogTypes.TYPE_GRAPHING,
-                    String.format("End viewing graph in list for %s", displayTitle));
         }
     }
 

--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -310,7 +310,6 @@ public class HiddenPreferences {
     }
 
     public static void clearInterruptedSSD() {
-        Logger.log(LogTypes.TYPE_MAINTENANCE, "Clearing interrupted state");
         String currentUserId = CommCareApplication.instance().getCurrentUserId();
         CommCareApplication.instance().getCurrentApp().getAppPreferences().edit()
                 .putInt(ID_OF_INTERRUPTED_SSD + currentUserId, -1).apply();

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -152,7 +152,6 @@ public abstract class DataPullTask<R>
 
         publishProgress(PROGRESS_STARTED);
         HiddenPreferences.setPostUpdateSyncNeeded(false);
-        Logger.log(LogTypes.TYPE_USER, "Starting Sync");
         determineIfLoginNeeded();
 
         AndroidTransactionParserFactory factory = getTransactionParserFactory();

--- a/app/src/org/commcare/tasks/LogSubmissionTask.java
+++ b/app/src/org/commcare/tasks/LogSubmissionTask.java
@@ -355,7 +355,6 @@ public class LogSubmissionTask extends AsyncTask<Void, Long, LogSubmitOutcomes> 
         if (submittedSuccesfully.size() == numberOfLogsToSubmit) {
             return LogSubmitOutcomes.SUBMITTED;
         } else {
-            Logger.log(LogTypes.TYPE_MAINTENANCE, numberOfLogsToSubmit - submittedSuccesfully.size() + " logs remain on phone.");
             //Some remain unsent
             return LogSubmitOutcomes.SERIALIZED;
         }

--- a/app/src/org/commcare/utils/FormUploadUtil.java
+++ b/app/src/org/commcare/utils/FormUploadUtil.java
@@ -361,10 +361,14 @@ public class FormUploadUtil {
                 }
             }
         }
-        Logger.log(LogTypes.TYPE_FORM_SUBMISSION, "Attempted to add "
-                + numAttachmentsInInstanceFolder + " attachments to submission entity");
-        Logger.log(LogTypes.TYPE_FORM_SUBMISSION, "Successfully added "
-                + numAttachmentsSuccessfullyAdded + " attachments to submission entity");
+        if (numAttachmentsInInstanceFolder > 0) {
+            Logger.log(LogTypes.TYPE_FORM_SUBMISSION, "Attempted to add "
+                    + numAttachmentsInInstanceFolder + " attachments to submission entity");
+        }
+        if (numAttachmentsSuccessfullyAdded > 0) {
+            Logger.log(LogTypes.TYPE_FORM_SUBMISSION, "Successfully added "
+                    + numAttachmentsSuccessfullyAdded + " attachments to submission entity");
+        }
         return true;
     }
 


### PR DESCRIPTION
## Summary

Cleaning some not so useful logs which makes up for almost half of the log entries in sumologic in hopes to reduce our sumo usage by a good factor. 

<img width="490" alt="Screenshot 2024-12-05 at 10 40 35 PM" src="https://github.com/user-attachments/assets/5bbb196e-8ce2-4dfe-83f9-9279a8159dfd">


## PR Checklist

- [x] If I think the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
- [x] Does the PR introduce any major changes worth communicating ? If yes, "Release Note" label is set and a "Release Note" is specified in PR description.

### Automated test coverage

NA

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--> 
Logs only
