### PR TITLE
Change progress dialog cancel button visibility state

### DIFF
--- a/app/res/layout/progress_dialog_cancel_button.xml
+++ b/app/res/layout/progress_dialog_cancel_button.xml
@@ -14,5 +14,5 @@
     android:layout_marginBottom="@dimen/standard_spacer"
     android:padding="@dimen/standard_spacer"
     android:text="STOP"
-    android:visibility="visible"
+    android:visibility="gone"
     tools:viewBindingIgnore="true" />


### PR DESCRIPTION
## Summary
This PR reverts a change that appears to have been made by mistake during the UI revamping work, which caused a `Stop` button to be visible during app installations.
Ticket: https://dimagi.atlassian.net/browse/QA-7351

## PR Checklist

- [X] If I think the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, "Release Note" label is set and a "Release Note" is specified in PR description.
