### PR TITLE
Update component exported attribute

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -93,22 +93,9 @@
     </permission>
 
     <permission
-        android:name="${applicationId}.permission.READ_NFC_DATA"
-        android:label="@string/permission_read_nfc_data_label"
-        android:permissionGroup="commcare.permission-group.INTERNAL_ACTION"
-        android:protectionLevel="signature">
-    </permission>
-
-    <permission
-        android:name="${applicationId}.permission.WRITE_NFC_DATA"
-        android:label="@string/permission_write_nfc_data_label"
-        android:permissionGroup="commcare.permission-group.INTERNAL_ACTION"
-        android:protectionLevel="signature">
-    </permission>
-
-    <permission
-        android:name="${applicationId}.permission.DRAW_BOUNDARY_AREA"
-        android:label="@string/permission_draw_boundary_area_label"
+        android:name="${applicationId}.permission.PROTECT_FALSELY_EXPOSED_COMPONENTS"
+        android:label="@string/permission_protect_falsely_exposed_components_label"
+        android:description="@string/permission_protect_falsely_exposed_components_description"
         android:permissionGroup="commcare.permission-group.INTERNAL_ACTION"
         android:protectionLevel="signature">
     </permission>
@@ -119,13 +106,6 @@
         android:description="@string/permission_update_to_latest_build_description"
         android:permissionGroup="commcare.permission-group.EXTERNAL_ACTION"
         android:protectionLevel="dangerous">
-    </permission>
-
-    <permission
-        android:name="${applicationId}.permission.PRINT"
-        android:label="@string/permission_print_label"
-        android:permissionGroup="commcare.permission-group.INTERNAL_ACTION"
-        android:protectionLevel="signature">
     </permission>
 
     <queries>
@@ -387,7 +367,7 @@
 
         <activity
             android:name="org.commcare.gis.DrawingBoundaryActivity"
-            android:permission="org.commcare.dalvik.permission.DRAW_BOUNDARY_AREA"
+            android:permission="org.commcare.dalvik.permission.PROTECT_FALSELY_EXPOSED_COMPONENTS"
             android:exported="true">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.action.DrawBoundary"/>
@@ -443,7 +423,7 @@
         <activity
             android:exported="true"
             android:name="org.commcare.android.nfc.NfcWriteActivity"
-            android:permission="org.commcare.dalvik.permission.WRITE_NFC_DATA">
+            android:permission="org.commcare.dalvik.permission.PROTECT_FALSELY_EXPOSED_COMPONENTS">
             <intent-filter>
                 <action android:name="org.commcare.nfc.WRITE"/>
 
@@ -453,7 +433,7 @@
         <activity
             android:exported="true"
             android:name="org.commcare.android.nfc.NfcReadActivity"
-            android:permission="org.commcare.dalvik.permission.READ_NFC_DATA">
+            android:permission="org.commcare.dalvik.permission.PROTECT_FALSELY_EXPOSED_COMPONENTS">
             <intent-filter>
                 <action android:name="org.commcare.nfc.READ"/>
 
@@ -548,7 +528,7 @@
         </activity>
         <activity
             android:name="org.commcare.print.TemplatePrinterActivity"
-            android:permission="org.commcare.dalvik.permission.PRINT"
+            android:permission="org.commcare.dalvik.permission.PROTECT_FALSELY_EXPOSED_COMPONENTS"
             android:exported="true">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.action.PRINT"/>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -100,14 +100,6 @@
         android:protectionLevel="signature">
     </permission>
 
-    <permission
-        android:name="${applicationId}.permission.UPDATE_TO_LATEST_BUILD"
-        android:label="@string/permission_update_to_latest_build_label"
-        android:description="@string/permission_update_to_latest_build_description"
-        android:permissionGroup="commcare.permission-group.EXTERNAL_ACTION"
-        android:protectionLevel="dangerous">
-    </permission>
-
     <queries>
         <intent>
             <action android:name="android.intent.action.TTS_SERVICE" />
@@ -462,8 +454,7 @@
 
         <receiver
             android:name="org.commcare.provider.RefreshToLatestBuildReceiver"
-            android:permission="org.commcare.dalvik.permission.UPDATE_TO_LATEST_BUILD"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.api.action.RefreshToLatestBuildAction"/>
 

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -71,6 +71,11 @@
         android:label="@string/permission_external_action_label"
         />
 
+    <permission-group
+        android:name="commcare.permission-group.INTERNAL_ACTION"
+        android:label="@string/permission_group_internal_action_label"
+        />
+
     <permission
         android:description="@string/permission_content_provider_description"
         android:label="@string/permission_content_provider_label"
@@ -85,6 +90,20 @@
         android:label="@string/permission_commcare_logout_label"
         android:permissionGroup="commcare.permission-group.EXTERNAL_ACTION"
         android:protectionLevel="dangerous">
+    </permission>
+
+    <permission
+        android:name="${applicationId}.permission.READ_NFC_DATA"
+        android:label="@string/permission_read_nfc_data_label"
+        android:permissionGroup="commcare.permission-group.INTERNAL_ACTION"
+        android:protectionLevel="signature">
+    </permission>
+
+    <permission
+        android:name="${applicationId}.permission.WRITE_NFC_DATA"
+        android:label="@string/permission_write_nfc_data_label"
+        android:permissionGroup="commcare.permission-group.INTERNAL_ACTION"
+        android:protectionLevel="signature">
     </permission>
 
     <queries>
@@ -400,7 +419,8 @@
         </activity>
         <activity
             android:exported="true"
-            android:name="org.commcare.android.nfc.NfcWriteActivity">
+            android:name="org.commcare.android.nfc.NfcWriteActivity"
+            android:permission="org.commcare.dalvik.permission.WRITE_NFC_DATA">
             <intent-filter>
                 <action android:name="org.commcare.nfc.WRITE"/>
 
@@ -409,7 +429,8 @@
         </activity>
         <activity
             android:exported="true"
-            android:name="org.commcare.android.nfc.NfcReadActivity">
+            android:name="org.commcare.android.nfc.NfcReadActivity"
+            android:permission="org.commcare.dalvik.permission.READ_NFC_DATA">
             <intent-filter>
                 <action android:name="org.commcare.nfc.READ"/>
 

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -346,7 +346,7 @@
 
         <activity
             android:name="org.commcare.gis.DrawingBoundaryActivity"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.action.DrawBoundary"/>
 
@@ -399,7 +399,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:exported="false"
+            android:exported="true"
             android:name="org.commcare.android.nfc.NfcWriteActivity">
             <intent-filter>
                 <action android:name="org.commcare.nfc.WRITE"/>
@@ -408,7 +408,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:exported="false"
+            android:exported="true"
             android:name="org.commcare.android.nfc.NfcReadActivity">
             <intent-filter>
                 <action android:name="org.commcare.nfc.READ"/>
@@ -438,7 +438,7 @@
 
         <receiver
             android:name="org.commcare.provider.RefreshToLatestBuildReceiver"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.api.action.RefreshToLatestBuildAction"/>
 
@@ -503,7 +503,7 @@
         </activity>
         <activity
             android:name="org.commcare.print.TemplatePrinterActivity"
-            android:exported="false"
+            android:exported="true"
             android:theme="@style/Theme.Dialog.NoTitle">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.action.PRINT"/>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -503,8 +503,7 @@
         </activity>
         <activity
             android:name="org.commcare.print.TemplatePrinterActivity"
-            android:exported="true"
-            android:theme="@style/Theme.Dialog.NoTitle">
+            android:exported="true">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.action.PRINT"/>
 

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -106,6 +106,13 @@
         android:protectionLevel="signature">
     </permission>
 
+    <permission
+        android:name="${applicationId}.permission.DRAW_BOUNDARY_AREA"
+        android:label="@string/permission_draw_boundary_area_label"
+        android:permissionGroup="commcare.permission-group.INTERNAL_ACTION"
+        android:protectionLevel="signature">
+    </permission>
+
     <queries>
         <intent>
             <action android:name="android.intent.action.TTS_SERVICE" />
@@ -365,6 +372,7 @@
 
         <activity
             android:name="org.commcare.gis.DrawingBoundaryActivity"
+            android:permission="org.commcare.dalvik.permission.DRAW_BOUNDARY_AREA"
             android:exported="true">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.action.DrawBoundary"/>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -121,6 +121,13 @@
         android:protectionLevel="dangerous">
     </permission>
 
+    <permission
+        android:name="${applicationId}.permission.PRINT"
+        android:label="@string/permission_print_label"
+        android:permissionGroup="commcare.permission-group.INTERNAL_ACTION"
+        android:protectionLevel="signature">
+    </permission>
+
     <queries>
         <intent>
             <action android:name="android.intent.action.TTS_SERVICE" />
@@ -541,6 +548,7 @@
         </activity>
         <activity
             android:name="org.commcare.print.TemplatePrinterActivity"
+            android:permission="org.commcare.dalvik.permission.PRINT"
             android:exported="true">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.action.PRINT"/>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -113,6 +113,14 @@
         android:protectionLevel="signature">
     </permission>
 
+    <permission
+        android:name="${applicationId}.permission.UPDATE_TO_LATEST_BUILD"
+        android:label="@string/permission_update_to_latest_build_label"
+        android:description="@string/permission_update_to_latest_build_description"
+        android:permissionGroup="commcare.permission-group.EXTERNAL_ACTION"
+        android:protectionLevel="dangerous">
+    </permission>
+
     <queries>
         <intent>
             <action android:name="android.intent.action.TTS_SERVICE" />
@@ -467,6 +475,7 @@
 
         <receiver
             android:name="org.commcare.provider.RefreshToLatestBuildReceiver"
+            android:permission="org.commcare.dalvik.permission.UPDATE_TO_LATEST_BUILD"
             android:exported="true">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.api.action.RefreshToLatestBuildAction"/>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -427,9 +427,9 @@
         </receiver>
 
         <receiver
-            android:exported="true"
             android:name="org.commcare.provider.CommCareLogoutReceiver"
-            android:permission="org.commcare.dalvik.permission.COMMCARE_LOGOUT">
+            android:permission="org.commcare.dalvik.permission.COMMCARE_LOGOUT"
+            android:exported="true">
             <intent-filter>
                 <action android:name="org.commcare.dalvik.api.action.CommCareLogoutAction"/>
                 <category android:name="android.intent.category.DEFAULT"/>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -157,8 +157,8 @@
     <string name="permission_write_nfc_data_label">Write NFC Data</string>
 
     <string name="permission_group_internal_action_label">Permission group for CommCare Internal Actions</string>
-
     <string name="permission_draw_boundary_area_label">Draw boundary area</string>
+    <string name="permission_print_label">Print documents</string>
     <string name="permission_update_to_latest_build_label">Allow App Update to the latest version</string>
     <string name="permission_update_to_latest_build_description">Makes it possible to update an app to the latest version even if it has not been released</string>
 

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -153,8 +153,8 @@
     <string name="permission_commcare_logout_label">Allow Auto CommCare Logout</string>
     <string name="permission_commcare_logout_description">Allows this app to logout a user from CommmCare App</string>
 
-    <string name="permission_protect_falsely_exposed_components_label">Protect falsely exposed components</string>
-    <string name="permission_protect_falsely_exposed_components_description">Due to implicit intent constrains, certain intent-aware components are now exposed, this permission is to prevent abusive use by external apps</string>
+    <string name="permission_protect_falsely_exposed_components_label">Protect internal components</string>
+    <string name="permission_protect_falsely_exposed_components_description">Restricts external apps from accessing internal components</string>
 
     <string name="permission_group_internal_action_label">Permission group for CommCare Internal Actions</string>
 

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -159,6 +159,8 @@
     <string name="permission_group_internal_action_label">Permission group for CommCare Internal Actions</string>
 
     <string name="permission_draw_boundary_area_label">Draw boundary area</string>
+    <string name="permission_update_to_latest_build_label">Allow App Update to the latest version</string>
+    <string name="permission_update_to_latest_build_description">Makes it possible to update an app to the latest version even if it has not been released</string>
 
     <string name="title_activity_report_problem">ReportProblemActivity</string>
     <string name="title_activity_comm_care_verification">CommCareVerificationActivity</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -157,8 +157,6 @@
     <string name="permission_protect_falsely_exposed_components_description">Due to implicit intent constrains, certain intent-aware components are now exposed, this permission is to prevent abusive use by external apps</string>
 
     <string name="permission_group_internal_action_label">Permission group for CommCare Internal Actions</string>
-    <string name="permission_update_to_latest_build_label">Allow App Update to the latest version</string>
-    <string name="permission_update_to_latest_build_description">Makes it possible to update an app to the latest version even if it has not been released</string>
 
     <string name="title_activity_report_problem">ReportProblemActivity</string>
     <string name="title_activity_comm_care_verification">CommCareVerificationActivity</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -158,6 +158,8 @@
 
     <string name="permission_group_internal_action_label">Permission group for CommCare Internal Actions</string>
 
+    <string name="permission_draw_boundary_area_label">Draw boundary area</string>
+
     <string name="title_activity_report_problem">ReportProblemActivity</string>
     <string name="title_activity_comm_care_verification">CommCareVerificationActivity</string>
     <string name="panes">one</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -153,6 +153,11 @@
     <string name="permission_commcare_logout_label">Allow Auto CommCare Logout</string>
     <string name="permission_commcare_logout_description">Allows this app to logout a user from CommmCare App</string>
 
+    <string name="permission_read_nfc_data_label">Read NFC Data</string>
+    <string name="permission_write_nfc_data_label">Write NFC Data</string>
+
+    <string name="permission_group_internal_action_label">Permission group for CommCare Internal Actions</string>
+
     <string name="title_activity_report_problem">ReportProblemActivity</string>
     <string name="title_activity_comm_care_verification">CommCareVerificationActivity</string>
     <string name="panes">one</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -153,12 +153,10 @@
     <string name="permission_commcare_logout_label">Allow Auto CommCare Logout</string>
     <string name="permission_commcare_logout_description">Allows this app to logout a user from CommmCare App</string>
 
-    <string name="permission_read_nfc_data_label">Read NFC Data</string>
-    <string name="permission_write_nfc_data_label">Write NFC Data</string>
+    <string name="permission_protect_falsely_exposed_components_label">Protect falsely exposed components</string>
+    <string name="permission_protect_falsely_exposed_components_description">Due to implicit intent constrains, certain intent-aware components are now exposed, this permission is to prevent abusive use by external apps</string>
 
     <string name="permission_group_internal_action_label">Permission group for CommCare Internal Actions</string>
-    <string name="permission_draw_boundary_area_label">Draw boundary area</string>
-    <string name="permission_print_label">Print documents</string>
     <string name="permission_update_to_latest_build_label">Allow App Update to the latest version</string>
     <string name="permission_update_to_latest_build_description">Makes it possible to update an app to the latest version even if it has not been released</string>
 


### PR DESCRIPTION
## Summary
[Android 14 brought new restrictions around implicit intents](https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents) and CC app callouts are based on implicit intents, this PR reviews the `exported` attribute of activities targeted by predefined app callout options.
Ticket: https://dimagi.atlassian.net/browse/QA-7356

## PR Checklist

- [X] If I think the PR is high risk, "High Risk" label is set
- [X] I have confidence that this PR will not introduce a regression for the reasons below
- [X] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, "Release Note" label is set and a "Release Note" is specified in PR description.
