### PR TITLE
Add support for a custom Map marker for the Case List

### DIFF
--- a/app/src/org/commcare/gis/EntityMapActivity.java
+++ b/app/src/org/commcare/gis/EntityMapActivity.java
@@ -101,37 +101,32 @@ public class EntityMapActivity extends CommCareActivity implements OnMapReadyCal
             final LatLngBounds bounds = builder.build();
 
             // Move camera to be include all markers
-            mMap.setOnMapLoadedCallback(() -> mMap.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, MAP_PADDING)));
+            mMap.setOnMapLoadedCallback(
+                    () -> mMap.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, MAP_PADDING)));
         }
 
         mMap.setOnInfoWindowClickListener(this);
-
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
-                || ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-            mMap.setMyLocationEnabled(true);
-        }
+        setMapLocationEnabled(true);
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-
-        if (mMap != null && (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
-                || ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED)) {
-            mMap.setMyLocationEnabled(true);
-        }
+        setMapLocationEnabled(true);
     }
 
     @Override
     protected void onPause() {
         super.onPause();
+        setMapLocationEnabled(false);
+    }
 
-        if (mMap != null) {
-            mMap.setOnMapLoadedCallback(null);  // Avoid memory leak in callback
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
-                    || ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-                mMap.setMyLocationEnabled(false);
-            }
+    private void setMapLocationEnabled(boolean enabled) {
+        if (mMap != null && ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED
+                || ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED) {
+            mMap.setMyLocationEnabled(enabled);
         }
     }
 

--- a/app/src/org/commcare/gis/EntityMapActivity.java
+++ b/app/src/org/commcare/gis/EntityMapActivity.java
@@ -25,6 +25,7 @@ import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.EntityDetailActivity;
 import org.commcare.cases.entity.Entity;
 import org.commcare.dalvik.R;
+import org.commcare.preferences.HiddenPreferences;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.DetailField;
 import org.commcare.suite.model.EntityDatum;
@@ -110,14 +111,18 @@ public class EntityMapActivity extends CommCareActivity implements OnMapReadyCal
         mMap = map;
 
         if (entityLocations.size() > 0) {
+            boolean showCustomMapMarker = HiddenPreferences.shouldShowCustomMapMarker();
             LatLngBounds.Builder builder = new LatLngBounds.Builder();
             // Add markers to map and find bounding region
             for (Pair<Entity<TreeReference>, LatLng> entityLocation : entityLocations) {
-                Marker marker = mMap.addMarker(new MarkerOptions()
+                MarkerOptions markerOptions = new MarkerOptions()
                         .position(entityLocation.second)
                         .title(entityLocation.first.getFieldString(0))
-                        .snippet(entityLocation.first.getFieldString(1))
-                        .icon(getEntityIcon(entityLocation.first)));
+                        .snippet(entityLocation.first.getFieldString(1));
+                if (showCustomMapMarker) {
+                    markerOptions.icon(getEntityIcon(entityLocation.first));
+                }
+                Marker marker = mMap.addMarker(markerOptions);
                 markerReferences.put(marker, entityLocation.first.getElement());
                 builder.include(entityLocation.second);
             }

--- a/app/src/org/commcare/gis/EntityMapActivity.java
+++ b/app/src/org/commcare/gis/EntityMapActivity.java
@@ -157,11 +157,14 @@ public class EntityMapActivity extends CommCareActivity implements OnMapReadyCal
     }
 
     private void setMapLocationEnabled(boolean enabled) {
-        if (mMap != null && ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
-                == PackageManager.PERMISSION_GRANTED
-                || ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION)
-                == PackageManager.PERMISSION_GRANTED) {
-            mMap.setMyLocationEnabled(enabled);
+        if (mMap != null) {
+            boolean fineLocationPermission = ContextCompat.checkSelfPermission(this,
+                    Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+            boolean coarseLocationPermission = ContextCompat.checkSelfPermission(this,
+                    Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+            if (fineLocationPermission || coarseLocationPermission) {
+                mMap.setMyLocationEnabled(enabled);
+            }
         }
     }
 

--- a/app/src/org/commcare/preferences/HiddenPreferences.java
+++ b/app/src/org/commcare/preferences/HiddenPreferences.java
@@ -110,6 +110,8 @@ public class HiddenPreferences {
     public final static String DONT_SHOW_PENDING_SYNC_DIALOG = "dont-show-pending-sync-dialog";
     private static final String ENABLE_BACKGROUND_SYNC = "cc-enable-background-sync";
 
+    private static final String ENABLE_CUSTOM_MAP_MARKER = "cc-enable-custom-map-marker";
+
     /**
      * The domain name in the application profile file comes in the <domain>.commcarehq.org form,
      * this is standard across the different HQ servers. This constant is to store that suffix and
@@ -433,6 +435,11 @@ public class HiddenPreferences {
     public static boolean shouldShowUnsentFormsWhenZero() {
         SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
         return properties.getString(SHOW_UNSENT_FORMS_WHEN_ZERO, PrefValues.NO).equals(PrefValues.YES);
+    }
+
+    public static boolean shouldShowCustomMapMarker() {
+        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        return properties.getString(ENABLE_CUSTOM_MAP_MARKER, PrefValues.NO).equals(PrefValues.YES);
     }
 
 


### PR DESCRIPTION
## Summary

Applies a custom map marker on the "Map" Case list view when a detail field with template `image` is defined for the case list when the property `cc-enable-custom-map-marker` is set to `yes` in app settings. 

## Product Description

Image with default icon:
<img width="309" height="500" alt="Screenshot 2025-01-13 at 4 01 41 PM" src="https://github.com/user-attachments/assets/39f97729-d3ef-4da2-a495-762548369410" />

Image with a custom icon applied:
<img width="310" height="500" alt="Screenshot 2025-01-13 at 4 04 14 PM" src="https://github.com/user-attachments/assets/ebcaccb7-7cbf-4bf9-918c-9f3fef56c79f" />


## PR Checklist

- [x] If I think the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below 
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
- [x] Does the PR introduce any major changes worth communicating ? If yes, "Release Note" label is set and a "Release Note" is specified in PR description.

### Automated test coverage

None

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

Tested locally for scenarios when an icon is defined for the case list and when it's not. 

**QA Note**: View on Map case list view now supports a custom map marker and an appropriate test case should be added to verify it. 

**Release Note**: Custom map marker support for Case list's "View on Map" feature. 

Best reviewed commit by commit. 