### PR TITLE
Expires entity cache for related cases

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
     testImplementation 'io.mockk:mockk:1.12.7'
+    testImplementation 'org.mockito:mockito-core:5.5.0'
     testImplementation 'org.json:json:20231013'
     testImplementation project(path: ':commcare-core', configuration: 'testsAsJar')
 

--- a/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
+++ b/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java
@@ -203,6 +203,26 @@ public class AndroidCaseIndexTable implements CaseIndexTable {
     }
 
     /**
+     * Get a list of Case Record id's for cases which index a provided target value.
+     *
+     * @param targetValue The case targeted by the index
+     * @return An integer array of indexed case record ids
+     */
+    @Override
+    public LinkedHashSet<Integer> getCasesWithTarget(String targetValue) {
+        String[] args = new String[]{targetValue};
+        if (SqlStorage.STORAGE_OUTPUT_DEBUG) {
+            String query = String.format("SELECT %s FROM %s WHERE %s = ?", COL_CASE_RECORD_ID, TABLE_NAME, COL_INDEX_TARGET);
+            DbUtil.explainSql(db, query, args);
+        }
+        Cursor c = db.query(TABLE_NAME, new String[]{COL_CASE_RECORD_ID}, COL_INDEX_TARGET + " =  ?", args, null,
+                null, null);
+        LinkedHashSet<Integer> ret = new LinkedHashSet<>();
+        SqlStorage.fillIdWindow(c, COL_CASE_RECORD_ID, ret);
+        return ret;
+    }
+
+    /**
      * Get a list of Case Record id's for cases which index any of a set of provided values
      *
      * @param indexName      The name of the index

--- a/app/unit-tests/resources/commcare-apps/case_list_lookup/restore.xml
+++ b/app/unit-tests/resources/commcare-apps/case_list_lookup/restore.xml
@@ -14,6 +14,9 @@
             <sample_choice_question>choice3</sample_choice_question>
             <sample_number_question>145</sample_number_question>
         </update>
+        <index>
+            <parent case_type="case">c44c7ade-0cec-4401-b422-4c475f0043ae</parent>
+        </index>
     </case>
     <case case_id="8e011880-602f-4017-b9d6-ed9dcbba7516"
           date_modified="2016-03-10T11:16:45.182000Z" user_id="441bdbb17001bade54aa23dcb7313950"
@@ -27,6 +30,9 @@
             <sample_choice_question>choice1</sample_choice_question>
             <sample_number_question>147</sample_number_question>
         </update>
+        <index>
+            <parent case_type="case">b319e951-03f1-4172-b662-4fb3964a0be7</parent>
+        </index>
     </case>
     <case case_id="c44c7ade-0cec-4401-b422-4c475f0043ae"
           date_modified="2016-03-10T11:19:50.826000Z" user_id="441bdbb17001bade54aa23dcb7313950"

--- a/app/unit-tests/resources/commcare-apps/index_and_cache_test/incremental_restore.xml
+++ b/app/unit-tests/resources/commcare-apps/index_and_cache_test/incremental_restore.xml
@@ -1,0 +1,18 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <fixture id="user-groups" user_id="441bdbb17001bade54aa23dcb7313950">
+        <groups/>
+    </fixture>
+    <case case_id="b319e951-03f1-4172-b662-4fb3964a0be7"
+        date_modified="2016-03-10T11:16:54.774000Z" user_id="441bdbb17001bade54aa23dcb7313950"
+        xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>case</case_type>
+            <case_name>stan</case_name>
+            <owner_id>441bdbb17001bade54aa23dcb7313950</owner_id>
+        </create>
+        <update>
+            <sample_choice_question>choice2</sample_choice_question>
+            <sample_number_question>145</sample_number_question>
+        </update>
+    </case>
+</OpenRosaResponse>

--- a/app/unit-tests/src/org/commcare/android/tests/caselist/EntityListCacheIndexTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/caselist/EntityListCacheIndexTest.java
@@ -1,5 +1,11 @@
 package org.commcare.android.tests.caselist;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mockStatic;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
 import org.commcare.CommCareTestApplication;
 import org.commcare.activities.EntitySelectActivity;
 import org.commcare.adapters.EntityListAdapter;
@@ -7,14 +13,17 @@ import org.commcare.android.util.ActivityLaunchUtils;
 import org.commcare.android.util.CaseLoadUtils;
 import org.commcare.android.util.TestAppInstaller;
 import org.commcare.android.util.TestUtils;
+import org.commcare.models.database.user.models.CommCareEntityStorageCache;
+import org.commcare.preferences.DeveloperPreferences;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.MockedStatic;
 import org.robolectric.annotation.Config;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * Test the cache and index sort property
@@ -26,19 +35,52 @@ import static org.junit.Assert.assertEquals;
 public class EntityListCacheIndexTest {
     private EntitySelectActivity entitySelectActivity;
     private EntityListAdapter adapter;
+
+
+    @Parameterized.Parameter
+    public boolean useBulkProcessing;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {true},
+                {false}
+        });
+    }
+
     @Before
     public void setup() {
         String appProfileResource =
                 "jr://resource/commcare-apps/index_and_cache_test/profile.ccpr";
         TestAppInstaller.installAppAndLogin(appProfileResource, "test", "123");
-        TestUtils.processResourceTransactionIntoAppDb("/commcare-apps/case_list_lookup/restore.xml");
     }
 
     @Test
-    public void testCacheAndIndex() {
-        entitySelectActivity = ActivityLaunchUtils.launchEntitySelectActivity("m1-f0");
-        adapter = CaseLoadUtils.loadList(entitySelectActivity);
-        assertEquals(8, adapter.getCount());
-        // Because the crash happens off the main thread, wait for backgrounds threads to terminate
+    public void testCaseCacheExpiration() {
+        try (MockedStatic<DeveloperPreferences> mockedStatic = mockStatic(DeveloperPreferences.class)) {
+            mockedStatic.when(DeveloperPreferences::isBulkPerformanceEnabled).thenReturn(useBulkProcessing);
+
+            // Restore
+            TestUtils.processResourceTransactionIntoAppDb("/commcare-apps/case_list_lookup/restore.xml");
+
+            // Load Case List
+            entitySelectActivity = ActivityLaunchUtils.launchEntitySelectActivity("m1-f0");
+            adapter = CaseLoadUtils.loadList(entitySelectActivity);
+            assertEquals(8, adapter.getCount());
+
+            // verify cases have been cached
+            CommCareEntityStorageCache entityStorageCache = new CommCareEntityStorageCache("case");
+            String cacheKey = entityStorageCache.getCacheKey("m1_case_short", "0");
+            assertEquals("stan", entityStorageCache.retrieveCacheValue("1", cacheKey));
+            assertEquals("ellen", entityStorageCache.retrieveCacheValue("2", cacheKey));
+            assertEquals("pat", entityStorageCache.retrieveCacheValue("3", cacheKey));
+
+            // verify changing a case expires the related cases in cache
+            TestUtils.processResourceTransactionIntoAppDb(
+                    "/commcare-apps/index_and_cache_test/incremental_restore.xml");
+            assertNull(entityStorageCache.retrieveCacheValue("1", cacheKey));
+            assertNull(entityStorageCache.retrieveCacheValue("2", cacheKey));
+            assertNull(entityStorageCache.retrieveCacheValue("3", cacheKey));
+        }
     }
 }


### PR DESCRIPTION
## Summary

[Spec](https://docs.google.com/document/d/1VE6yjo-yOfhnwpHMRZWavgJmbmbRhsoVvWS3Kq3yh2g/edit?tab=t.0#heading=h.ivv3e8sh6t45)

Expires cache for all related cases in order to support caching xpath calculation results for related cases like `instance('casedb')/casedb/case[@case_type='mother'][@case_id=current()/index/parent]/case_name`. Without expiring related cases from cache, these kind of expressions may result in obsolete data to the user. 


## Feature Flag

CACHE_AND_INDEX


## PR Checklist

- [x] If I think the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
- [x] Does the PR introduce any major changes worth communicating ? If yes, "Release Note" label is set and a "Release Note" is specified in PR description.

### Automated test coverage

PR adds a test to demonstrate desired cache expiration. 

### Safety story

To remove the cache for related cases, we are doing a [lookup in the case index table](https://github.com/dimagi/commcare-android/blob/dddccd8acd7c6d98a8dfe75b85367b0d18f59f5e/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java#L212), every time a case gets changed which may have a performance impact. We currently only [index the case index table](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/models/database/user/models/AndroidCaseIndexTable.java#L63) on case_id and index_name columns but not on target case and I am wondering whether we should add an index on target case to make these lookups much faster ?

cross-request: https://github.com/dimagi/commcare-core/pull/1456