### PR TITLE
Handling CID unlock in ConnectActivity

### DIFF
--- a/app/res/layout/fragment_connect_unlock.xml
+++ b/app/res/layout/fragment_connect_unlock.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/res/navigation/nav_graph_connect.xml
+++ b/app/res/navigation/nav_graph_connect.xml
@@ -6,6 +6,13 @@
     app:startDestination="@id/connect_jobs_list_fragment">
 
     <fragment
+        android:id="@+id/connect_unlock_fragment"
+        android:name="org.commcare.fragments.connect.ConnectUnlockFragment"
+        android:label="fragment_connect_unlock"
+        tools:layout="@layout/fragment_connect_unlock">
+    </fragment>
+
+    <fragment
         android:id="@+id/connect_jobs_list_fragment"
         android:name="org.commcare.fragments.connect.ConnectJobsListsFragment"
         android:label="fragment_connect_jobs_list"

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -649,7 +649,9 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     private void updateConnectButton() {
         installFragment.updateConnectButton(!fromManager && !fromExternal && ConnectManager.isConnectIdConfigured(), v -> {
             ConnectManager.unlockConnect(this, success -> {
-                ConnectManager.goToConnectJobsList(this);
+                if(success) {
+                    ConnectManager.goToConnectJobsList(this);
+                }
             });
         });
     }

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -1,54 +1,31 @@
 package org.commcare.activities.connect;
 
 import android.app.Activity;
-import android.app.SearchManager;
-import android.content.Context;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 import android.view.Window;
-import android.widget.EditText;
-import android.widget.Toast;
+
+import com.google.common.base.Strings;
 
 import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.CommCareVerificationActivity;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
-import org.commcare.connect.ConnectDatabaseHelper;
 import org.commcare.connect.ConnectManager;
-import org.commcare.connect.network.ApiConnect;
-import org.commcare.connect.network.ConnectNetworkHelper;
-import org.commcare.connect.network.IApiCallback;
 import org.commcare.dalvik.R;
 import org.commcare.fragments.connect.ConnectDownloadingFragment;
-import org.commcare.fragments.connectId.ConnectIdBiometricConfigFragment;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.tasks.ResourceEngineListener;
 import org.commcare.views.dialogs.CustomProgressDialog;
-import org.javarosa.core.io.StreamsUtil;
-import org.javarosa.core.services.Logger;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
 
 import javax.annotation.Nullable;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.SearchView;
-import androidx.core.content.ContextCompat;
-import androidx.core.view.MenuItemCompat;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
 import androidx.navigation.NavOptions;
@@ -60,10 +37,6 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
     String redirectionAction = "";
     String opportunityId = "";
     NavController navController;
-    private static final String CCC_OPPORTUNITY_SUMMARY_PAGE = "ccc_opportunity_summary_page";
-    private static final String CCC_LEARN_PROGRESS = "ccc_learn_progress";
-    private static final String CCC_DELIVERY_PROGRESS = "ccc_delivery_progress";
-    public static final String CCC_PAYMENTS = "ccc_payment";
 
     NavController.OnDestinationChangedListener destinationListener = null;
 
@@ -83,7 +56,13 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.screen_connect);
         setTitle(getString(R.string.connect_title));
-        getIntentData();
+
+        redirectionAction = getIntent().getStringExtra("action");
+        opportunityId = getIntent().getStringExtra("opportunity_id");
+        if(opportunityId == null) {
+            opportunityId = "";
+        }
+
         updateBackButton();
         Window window = getWindow();
         window.setStatusBarColor(getResources().getColor(R.color.connect_status_bar_color));
@@ -111,13 +90,19 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
                     .setPopUpTo(navController.getGraph().getStartDestinationId(), true)
                     .build();
             navController.navigate(fragmentId, bundle, options);
-        } else if (redirectionAction != null) {
+        } else if (!Strings.isNullOrEmpty(redirectionAction)) {
+            //Entering from a notification, so we may need to initialize
             ConnectManager.init(this);
-            ConnectManager.unlockConnect(this, success -> {
-                if (success) {
-                    getJobDetails();
-                }
-            });
+
+            //Navigate to the unlock fragment first, then it will navigate on as desired
+            NavOptions options = new NavOptions.Builder()
+                    .setPopUpTo(navController.getGraph().getStartDestinationId(), true)
+                    .build();
+            Bundle bundle = new Bundle();
+            bundle.putString("action", redirectionAction);
+            bundle.putString("opportunity_id", opportunityId);
+            bundle.putBoolean("buttons", getIntent().getBooleanExtra("buttons", true));
+            navController.navigate(R.id.connect_unlock_fragment, bundle, options);
         }
     }
 
@@ -126,6 +111,13 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
         super.setTitle(title);
         getSupportActionBar().setTitle(title);
     }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @androidx.annotation.Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        ConnectManager.handleFinishedActivity(this, requestCode, resultCode, data);
+    }
+
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_connect, menu);
@@ -146,58 +138,6 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
         Fragment currentFragment =
                 navHostFragment.getChildFragmentManager().getPrimaryNavigationFragment();
        return  currentFragment;
-    }
-    /**
-     * Returns the fragment ID based on the redirection action.
-     * <p>
-     * This method determines which fragment should be displayed based on the value of the redirectionAction.
-     * It maps specific actions to their corresponding fragment IDs.
-     *
-     * @return The ID of the fragment to be displayed.
-     */
-    private int getFragmentId() {
-        int fragmentId;
-        if (redirectionAction.equals(CCC_OPPORTUNITY_SUMMARY_PAGE)) {
-            fragmentId = R.id.connect_job_intro_fragment;
-        } else if (redirectionAction.equals(CCC_LEARN_PROGRESS)) {
-            fragmentId = R.id.connect_job_learning_progress_fragment;
-        } else {
-            fragmentId = R.id.connect_job_delivery_progress_fragment;
-        }
-        return fragmentId;
-    }
-
-    private void getIntentData() {
-        redirectionAction = getIntent().getStringExtra("action");
-        opportunityId = getIntent().getStringExtra("opportunity_id");
-    }
-
-    /**
-     * Sets the fragment redirection based on the redirection action.
-     * <p>
-     * This method determines the fragment to be displayed using the getFragmentId() method,
-     * prepares a bundle with additional data, and navigates to the appropriate fragment.
-     */
-    private void setFragmentRedirection(boolean ApiSuccess) {
-        if (ApiSuccess) {
-            int fragmentId = getFragmentId();
-
-            boolean buttons = getIntent().getBooleanExtra("buttons", true);
-            Bundle bundle = new Bundle();
-            bundle.putBoolean("showLaunch", buttons);
-
-            // Set the tab position in the bundle based on the redirection action
-            if (redirectionAction.equals(CCC_DELIVERY_PROGRESS)) {
-                bundle.putString("tabPosition", "0");
-            } else if (redirectionAction.equals(CCC_PAYMENTS)) {
-                bundle.putString("tabPosition", "1");
-            }
-
-            NavOptions options = new NavOptions.Builder()
-                    .setPopUpTo(navController.getGraph().getStartDestinationId(), true)
-                    .build();
-            navController.navigate(fragmentId, bundle, options);
-        }
     }
 
     @Override
@@ -273,56 +213,5 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
         Intent i = new Intent(this, CommCareVerificationActivity.class);
         i.putExtra(CommCareVerificationActivity.KEY_LAUNCH_FROM_SETTINGS, true);
         verificationLauncher.launch(i);
-    }
-
-    public void getJobDetails() {
-        ApiConnect.getConnectOpportunities(ConnectActivity.this, new IApiCallback() {
-            @Override
-            public void processSuccess(int responseCode, InputStream responseData) {
-                try {
-                    String responseAsString = new String(StreamsUtil.inputStreamToByteArray(responseData));
-                    if (responseAsString.length() > 0) {
-                        //Parse the JSON
-                        JSONArray json = new JSONArray(responseAsString);
-                        List<ConnectJobRecord> jobs = new ArrayList<>(json.length());
-                        for (int i = 0; i < json.length(); i++) {
-                            JSONObject obj = (JSONObject) json.get(i);
-                            ConnectJobRecord job = ConnectJobRecord.fromJson(obj);
-                            jobs.add(job);
-                            if (job.getJobId() == Integer.parseInt(opportunityId)) {
-                                ConnectManager.setActiveJob(job);
-                            }
-                        }
-                        ConnectDatabaseHelper.storeJobs(ConnectActivity.this, jobs, true);
-                        setFragmentRedirection(true);
-                    }
-                } catch (IOException | JSONException | ParseException e) {
-                    setFragmentRedirection(false);
-                    Toast.makeText(ConnectActivity.this, R.string.connect_job_list_api_failure, Toast.LENGTH_SHORT).show();
-                    Logger.exception("Parsing return from Opportunities request", e);
-                }
-            }
-
-            @Override
-            public void processFailure(int responseCode, IOException e) {
-                setFragmentRedirection(false);
-                Toast.makeText(ConnectActivity.this, R.string.connect_job_list_api_failure, Toast.LENGTH_SHORT).show();
-                Logger.log("ERROR", String.format(Locale.getDefault(), "Opportunities call failed: %d", responseCode));
-            }
-
-            @Override
-            public void processNetworkFailure() {
-                setFragmentRedirection(false);
-                Toast.makeText(ConnectActivity.this, R.string.recovery_network_unavailable, Toast.LENGTH_SHORT).show();
-                Logger.log("ERROR", "Failed (network)");
-            }
-
-            @Override
-            public void processOldApiError() {
-                setFragmentRedirection(false);
-                Toast.makeText(ConnectActivity.this, R.string.connect_job_list_api_failure, Toast.LENGTH_SHORT).show();
-                ConnectNetworkHelper.showOutdatedApiError(ConnectActivity.this);
-            }
-        });
     }
 }

--- a/app/src/org/commcare/connect/ConnectConstants.java
+++ b/app/src/org/commcare/connect/ConnectConstants.java
@@ -35,6 +35,10 @@ public class ConnectConstants {
     public static final String NEW_APP = "new-app";
     public static final String LEARN_APP = "learn-app";
     public static final String DELIVERY_APP = "delivery-app";
+    public static final String CCC_DEST_OPPORTUNITY_SUMMARY_PAGE = "ccc_opportunity_summary_page";
+    public static final String CCC_DEST_LEARN_PROGRESS = "ccc_learn_progress";
+    public static final String CCC_DEST_DELIVERY_PROGRESS = "ccc_delivery_progress";
+    public static final String CCC_DEST_PAYMENTS = "ccc_payment";
 
     public final static int CONNECT_NO_ACTIVITY = ConnectConstants.ConnectIdTaskIdOffset;
     public final static int CONNECT_REGISTRATION_PRIMARY_PHONE = ConnectConstants.ConnectIdTaskIdOffset + 2;

--- a/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
@@ -1,0 +1,165 @@
+package org.commcare.fragments.connect;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import com.google.common.base.Strings;
+
+import org.commcare.activities.CommCareActivity;
+import org.commcare.android.database.connect.models.ConnectJobRecord;
+import org.commcare.connect.ConnectConstants;
+import org.commcare.connect.ConnectDatabaseHelper;
+import org.commcare.connect.ConnectManager;
+import org.commcare.connect.network.ApiConnect;
+import org.commcare.connect.network.ConnectNetworkHelper;
+import org.commcare.connect.network.IApiCallback;
+import org.commcare.dalvik.R;
+import org.javarosa.core.io.StreamsUtil;
+import org.javarosa.core.services.Logger;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import javax.annotation.Nullable;
+
+import androidx.fragment.app.Fragment;
+import androidx.navigation.NavController;
+import androidx.navigation.NavOptions;
+import androidx.navigation.Navigation;
+
+public class ConnectUnlockFragment extends Fragment {
+    View view;
+    String redirectionAction = "";
+    String opportunityId = "";
+
+    public ConnectUnlockFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        getActivity().setTitle(R.string.connect_title);
+
+        redirectionAction = getArguments().getString("action");
+        opportunityId = getArguments().getString("opportunity_id");
+
+        view = inflater.inflate(R.layout.blank_activity, container, false);
+
+        ConnectManager.unlockConnect((CommCareActivity<?>)requireActivity(), success -> {
+            if (success) {
+                retrieveOpportunities();
+            }
+        });
+
+        return view;
+    }
+
+    public void retrieveOpportunities() {
+        ApiConnect.getConnectOpportunities(requireContext(), new IApiCallback() {
+            @Override
+            public void processSuccess(int responseCode, InputStream responseData) {
+                try {
+                    String responseAsString = new String(StreamsUtil.inputStreamToByteArray(responseData));
+                    if (responseAsString.length() > 0) {
+                        //Parse the JSON
+                        JSONArray json = new JSONArray(responseAsString);
+                        List<ConnectJobRecord> jobs = new ArrayList<>(json.length());
+                        for (int i = 0; i < json.length(); i++) {
+                            JSONObject obj = (JSONObject) json.get(i);
+                            ConnectJobRecord job = ConnectJobRecord.fromJson(obj);
+                            jobs.add(job);
+                        }
+                        ConnectDatabaseHelper.storeJobs(requireContext(), jobs, true);
+                    }
+                } catch (IOException | JSONException | ParseException e) {
+                    Toast.makeText(requireContext(), R.string.connect_job_list_api_failure, Toast.LENGTH_SHORT).show();
+                    Logger.exception("Parsing return from Opportunities request", e);
+                }
+
+                setFragmentRedirection();
+            }
+
+            @Override
+            public void processFailure(int responseCode, IOException e) {
+                setFragmentRedirection();
+                Toast.makeText(requireContext(), R.string.connect_job_list_api_failure, Toast.LENGTH_SHORT).show();
+                Logger.log("ERROR", String.format(Locale.getDefault(), "Opportunities call failed: %d", responseCode));
+            }
+
+            @Override
+            public void processNetworkFailure() {
+                setFragmentRedirection();
+                Toast.makeText(requireContext(), R.string.recovery_network_unavailable, Toast.LENGTH_SHORT).show();
+                Logger.log("ERROR", "Failed (network)");
+            }
+
+            @Override
+            public void processOldApiError() {
+                setFragmentRedirection();
+                Toast.makeText(requireContext(), R.string.connect_job_list_api_failure, Toast.LENGTH_SHORT).show();
+                ConnectNetworkHelper.showOutdatedApiError(requireContext());
+            }
+        });
+    }
+
+    /**
+     * Sets the fragment redirection based on the redirection action.
+     * <p>
+     * This method determines the fragment to be displayed using the getFragmentId() method,
+     * prepares a bundle with additional data, and navigates to the appropriate fragment.
+     */
+    private void setFragmentRedirection() {
+        boolean buttons = getArguments().getBoolean("buttons", true);
+        Bundle bundle = new Bundle();
+        bundle.putBoolean("showLaunch", buttons);
+
+        if(!Strings.isNullOrEmpty(opportunityId)) {
+            int jobId = Integer.parseInt(opportunityId);
+            ConnectJobRecord job = ConnectDatabaseHelper.getJob(requireContext(), jobId);
+            if(job != null) {
+                ConnectManager.setActiveJob(job);
+            }
+        }
+
+        int fragmentId;
+        if (redirectionAction.equals(ConnectConstants.CCC_DEST_OPPORTUNITY_SUMMARY_PAGE)) {
+            fragmentId = R.id.connect_job_intro_fragment;
+        } else if (redirectionAction.equals(ConnectConstants.CCC_DEST_LEARN_PROGRESS)) {
+            fragmentId = R.id.connect_job_learning_progress_fragment;
+        } else if (redirectionAction.equals(ConnectConstants.CCC_DEST_DELIVERY_PROGRESS)) {
+            fragmentId = R.id.connect_job_delivery_progress_fragment;
+            // Set the tab position in the bundle based on the redirection action
+            bundle.putString("tabPosition", "0");
+        } else if (redirectionAction.equals(ConnectConstants.CCC_DEST_PAYMENTS)) {
+            fragmentId = R.id.connect_job_delivery_progress_fragment;
+            // Set the tab position in the bundle based on the redirection action
+            bundle.putString("tabPosition", "1");
+        } else {
+            //Default case
+            fragmentId = R.id.connect_jobs_list_fragment;
+        }
+
+        NavController navController = Navigation.findNavController(view);
+        navController.popBackStack();
+        NavOptions options = new NavOptions.Builder()
+                .setPopUpTo(navController.getGraph().getStartDestinationId(), true, true)
+                .build();
+        navController.navigate(fragmentId, bundle, options);
+    }
+}

--- a/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
@@ -64,6 +64,8 @@ public class ConnectUnlockFragment extends Fragment {
         ConnectManager.unlockConnect((CommCareActivity<?>)requireActivity(), success -> {
             if (success) {
                 retrieveOpportunities();
+            } else {
+                requireActivity().finish();
             }
         });
 

--- a/app/src/org/commcare/services/CommCareFirebaseMessagingService.java
+++ b/app/src/org/commcare/services/CommCareFirebaseMessagingService.java
@@ -17,6 +17,7 @@ import org.commcare.activities.connect.ConnectActivity;
 import org.commcare.activities.connect.ConnectMessagingActivity;
 import org.commcare.android.database.connect.models.ConnectMessagingChannelRecord;
 import org.commcare.android.database.connect.models.ConnectMessagingMessageRecord;
+import org.commcare.connect.ConnectConstants;
 import org.commcare.connect.ConnectDatabaseHelper;
 import org.commcare.connect.MessageManager;
 import org.commcare.dalvik.R;
@@ -176,7 +177,7 @@ public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
                 .setWhen(System.currentTimeMillis());
 
         // Check if the payload action is CCC_PAYMENTS
-        if (action.equals(ConnectActivity.CCC_PAYMENTS)) {
+        if (action.equals(ConnectConstants.CCC_DEST_PAYMENTS)) {
             // Yes button intent with payment_id from payload
             Intent yesIntent = new Intent(this, PaymentAcknowledgeReceiver.class);
             yesIntent.putExtra(OPPORTUNITY_ID,payloadData.get(OPPORTUNITY_ID));


### PR DESCRIPTION
## Summary
This addresses an issue where the user would be directed to the Connect activity on clicking a push notification, and while unlocking ConnectID the opportunity list fragment would already appear in the background and begin updating. Now instead, a blank fragment is shown when the user enters the app this way while the user is prompted to unlock ConnectID. This also addresses a bug where the wait dialog (shown while updating the opportunity list from the API) would sometimes fail to dismiss when the call completed.

cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Product Description
Users will not see the opportunity list behind the Connect biometric unlock popup. Instead, the screen behind will be blank during this time.

## PR Checklist

- [ ] If I think the PR is high risk, "High Risk" label is set
- [ ] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, "Release Note" label is set and a "Release Note" is specified in PR description.

### Automated test coverage
No automated tests for Connect code yet...

### Safety story
This increases safety slightly by not showing any information about current or available opportunities until the user has successfully unlocked ConnectID via their biometric.
