### PR TITLE
Update messaging pages when active instead of showing push notification

### DIFF
--- a/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
+++ b/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
@@ -1,6 +1,9 @@
 package org.commcare.fragments.connectMessaging;
 
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.os.Handler;
 import android.text.Editable;
@@ -8,10 +11,10 @@ import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.commcare.adapters.ConnectMessageAdapter;
@@ -20,6 +23,7 @@ import org.commcare.android.database.connect.models.ConnectMessagingMessageRecor
 import org.commcare.connect.ConnectDatabaseHelper;
 import org.commcare.connect.MessageManager;
 import org.commcare.dalvik.databinding.FragmentConnectMessageBinding;
+import org.commcare.services.CommCareFirebaseMessagingService;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -27,7 +31,7 @@ import java.util.List;
 import java.util.UUID;
 
 public class ConnectMessageFragment extends Fragment {
-
+    public static String activeChannel;
     private String channelId;
     private FragmentConnectMessageBinding binding;
     private ConnectMessageAdapter adapter;
@@ -63,6 +67,11 @@ public class ConnectMessageFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
+        activeChannel = channelId;
+
+        LocalBroadcastManager.getInstance(requireContext()).registerReceiver(updateReceiver,
+                new IntentFilter(CommCareFirebaseMessagingService.MESSAGING_UPDATE_BROADCAST));
+
         // Start periodic API calls
         handler.post(apiCallRunnable);
     }
@@ -70,9 +79,20 @@ public class ConnectMessageFragment extends Fragment {
     @Override
     public void onPause() {
         super.onPause();
+        activeChannel = null;
+
+        LocalBroadcastManager.getInstance(requireContext()).unregisterReceiver(updateReceiver);
+
         // Stop the periodic API calls when the screen is not active
         handler.removeCallbacks(apiCallRunnable);
     }
+
+    private final BroadcastReceiver updateReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            refreshUi();
+        }
+    };
 
     private void makeApiCall() {
         MessageManager.retrieveMessages(requireActivity(), success -> {

--- a/app/src/org/commcare/services/CommCareFirebaseMessagingService.java
+++ b/app/src/org/commcare/services/CommCareFirebaseMessagingService.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.os.Build;
 
 import androidx.core.app.NotificationCompat;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
@@ -20,6 +21,8 @@ import org.commcare.android.database.connect.models.ConnectMessagingMessageRecor
 import org.commcare.connect.ConnectDatabaseHelper;
 import org.commcare.connect.MessageManager;
 import org.commcare.dalvik.R;
+import org.commcare.fragments.connectMessaging.ConnectMessageChannelListFragment;
+import org.commcare.fragments.connectMessaging.ConnectMessageFragment;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.sync.FirebaseMessagingDataSyncer;
 import org.commcare.util.LogTypes;
@@ -36,6 +39,7 @@ import java.util.Map;
 public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
 
     private final static int FCM_NOTIFICATION = R.string.fcm_notification;
+    public static final String MESSAGING_UPDATE_BROADCAST = "com.dimagi.messaging.update";
     public static final String OPPORTUNITY_ID = "opportunity_id";
     public static final String PAYMENT_ID = "payment_id";
     public static final String PAYMENT_STATUS = "payment_status";
@@ -61,7 +65,8 @@ public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
      */
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
-        Logger.log(LogTypes.TYPE_FCM, "CommCareFirebaseMessagingService Message received: " + remoteMessage.getData());
+        Logger.log(LogTypes.TYPE_FCM, "CommCareFirebaseMessagingService Message received: " +
+                remoteMessage.getData());
         Map<String, String> payloadData = remoteMessage.getData();
 
         // Check if the message contains a data object, there is no further action if not
@@ -95,9 +100,8 @@ public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
     private void showNotification(Map<String, String> payloadData) {
         String notificationTitle = payloadData.get("title");
         String notificationText = payloadData.get("body");
-        NotificationManager mNM = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 
-        Intent intent;
+        Intent intent = null;
         String action = payloadData.get("action");
 
         if (hasCccAction(action)) {
@@ -111,14 +115,12 @@ public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
                 //On channels page (just update the page)
                 //On message page for the active channel
 
-                intent = new Intent(getApplicationContext(), ConnectMessagingActivity.class);
-                intent.putExtra("action", action);
-
                 int notificationTitleId;
                 String notificationMessage;
                 String channelId;
                 if(isMessage) {
-                    ConnectMessagingMessageRecord message = MessageManager.handleReceivedMessage(this, payloadData);
+                    ConnectMessagingMessageRecord message = MessageManager.handleReceivedMessage(this,
+                            payloadData);
 
                     if(message == null) {
                         Logger.log(LogTypes.TYPE_FCM, "Ignoring message without known consented channel: " +
@@ -127,26 +129,40 @@ public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
                         return;
                     }
 
-                    ConnectMessagingChannelRecord channel = ConnectDatabaseHelper.getMessagingChannel(this, message.getChannelId());
+                    ConnectMessagingChannelRecord channel = ConnectDatabaseHelper.getMessagingChannel(this,
+                            message.getChannelId());
 
                     notificationTitleId = R.string.connect_messaging_message_notification_title;
-                    notificationMessage = getString(R.string.connect_messaging_message_notification_message, channel.getChannelName());
+                    notificationMessage = getString(R.string.connect_messaging_message_notification_message,
+                            channel.getChannelName());
 
                     channelId = message.getChannelId();
                 } else {
                     //Channel
-                    ConnectMessagingChannelRecord channel = MessageManager.handleReceivedChannel(this, payloadData);
+                    ConnectMessagingChannelRecord channel = MessageManager.handleReceivedChannel(this,
+                            payloadData);
 
                     notificationTitleId = R.string.connect_messaging_channel_notification_title;
-                    notificationMessage = getString(R.string.connect_messaging_channel_notification_message, channel.getChannelName());
+                    notificationMessage = getString(R.string.connect_messaging_channel_notification_message,
+                            channel.getChannelName());
 
                     channelId = channel.getChannelId();
                 }
 
-                notificationTitle = getString(notificationTitleId);
-                notificationText = notificationMessage;
+                if(ConnectMessageChannelListFragment.isActive ||
+                        channelId.equals(ConnectMessageFragment.activeChannel)) {
+                    //Notify active page to update instead of showing notification
+                    Intent broadcastIntent = new Intent(MESSAGING_UPDATE_BROADCAST);
+                    LocalBroadcastManager.getInstance(this).sendBroadcast(broadcastIntent);
+                } else {
+                    //Show push notification
+                    notificationTitle = getString(notificationTitleId);
+                    notificationText = notificationMessage;
 
-                intent.putExtra(ConnectMessagingMessageRecord.META_MESSAGE_CHANNEL_ID, channelId);
+                    intent = new Intent(getApplicationContext(), ConnectMessagingActivity.class);
+                    intent.putExtra("action", action);
+                    intent.putExtra(ConnectMessagingMessageRecord.META_MESSAGE_CHANNEL_ID, channelId);
+                }
             } else {
                 //Intent for ConnectActivity
                 intent = new Intent(getApplicationContext(), ConnectActivity.class);
@@ -157,46 +173,53 @@ public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
             intent.setAction(Intent.ACTION_MAIN);
             intent.addCategory(Intent.CATEGORY_LAUNCHER);
         }
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
 
-        int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-                ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
-                : PendingIntent.FLAG_UPDATE_CURRENT;
+        if(intent != null) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP |
+                    Intent.FLAG_ACTIVITY_NEW_TASK);
 
-        PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, flags);
+            int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                    ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+                    : PendingIntent.FLAG_UPDATE_CURRENT;
 
-        NotificationCompat.Builder fcmNotification = new NotificationCompat.Builder(this,
-                CommCareNoficationManager.NOTIFICATION_CHANNEL_PUSH_NOTIFICATIONS_ID)
-                .setContentTitle(notificationTitle)
-                .setContentText(notificationText)
-                .setContentIntent(contentIntent)
-                .setAutoCancel(true)
-                .setSmallIcon(R.drawable.commcare_actionbar_logo)
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .setWhen(System.currentTimeMillis());
+            PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, flags);
 
-        // Check if the payload action is CCC_PAYMENTS
-        if (action.equals(ConnectActivity.CCC_PAYMENTS)) {
-            // Yes button intent with payment_id from payload
-            Intent yesIntent = new Intent(this, PaymentAcknowledgeReceiver.class);
-            yesIntent.putExtra(OPPORTUNITY_ID,payloadData.get(OPPORTUNITY_ID));
-            yesIntent.putExtra(PAYMENT_ID,payloadData.get(PAYMENT_ID));
-            yesIntent.putExtra(PAYMENT_STATUS,true);
-            PendingIntent yesPendingIntent = PendingIntent.getBroadcast(this, 1, yesIntent, flags);
+            NotificationCompat.Builder fcmNotification = new NotificationCompat.Builder(this,
+                    CommCareNoficationManager.NOTIFICATION_CHANNEL_PUSH_NOTIFICATIONS_ID)
+                    .setContentTitle(notificationTitle)
+                    .setContentText(notificationText)
+                    .setContentIntent(contentIntent)
+                    .setAutoCancel(true)
+                    .setSmallIcon(R.drawable.commcare_actionbar_logo)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setWhen(System.currentTimeMillis());
 
-            // No button intent with payment_id from payload
-            Intent noIntent = new Intent(this, PaymentAcknowledgeReceiver.class);
-            noIntent.putExtra(OPPORTUNITY_ID,payloadData.get(OPPORTUNITY_ID));
-            noIntent.putExtra(PAYMENT_ID,payloadData.get(PAYMENT_ID));
-            noIntent.putExtra(PAYMENT_STATUS,false);
-            PendingIntent noPendingIntent = PendingIntent.getBroadcast(this, 2, noIntent, flags);
+            // Check if the payload action is CCC_PAYMENTS
+            if (action.equals(ConnectActivity.CCC_PAYMENTS)) {
+                // Yes button intent with payment_id from payload
+                Intent yesIntent = new Intent(this, PaymentAcknowledgeReceiver.class);
+                yesIntent.putExtra(OPPORTUNITY_ID, payloadData.get(OPPORTUNITY_ID));
+                yesIntent.putExtra(PAYMENT_ID, payloadData.get(PAYMENT_ID));
+                yesIntent.putExtra(PAYMENT_STATUS, true);
+                PendingIntent yesPendingIntent = PendingIntent.getBroadcast(this, 1,
+                        yesIntent, flags);
 
-            // Add Yes & No action button to the notification
-            fcmNotification.addAction(0, getString(R.string.connect_payment_acknowledge_notification_yes), yesPendingIntent);
-            fcmNotification.addAction(0, getString(R.string.connect_payment_acknowledge_notification_no), noPendingIntent);
+                // No button intent with payment_id from payload
+                Intent noIntent = new Intent(this, PaymentAcknowledgeReceiver.class);
+                noIntent.putExtra(OPPORTUNITY_ID, payloadData.get(OPPORTUNITY_ID));
+                noIntent.putExtra(PAYMENT_ID, payloadData.get(PAYMENT_ID));
+                noIntent.putExtra(PAYMENT_STATUS, false);
+                PendingIntent noPendingIntent = PendingIntent.getBroadcast(this, 2,
+                        noIntent, flags);
+
+                // Add Yes & No action button to the notification
+                fcmNotification.addAction(0, getString(R.string.connect_payment_acknowledge_notification_yes), yesPendingIntent);
+                fcmNotification.addAction(0, getString(R.string.connect_payment_acknowledge_notification_no), noPendingIntent);
+            }
+
+            NotificationManager mNM = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+            mNM.notify(FCM_NOTIFICATION, fcmNotification.build());
         }
-
-        mNM.notify(FCM_NOTIFICATION, fcmNotification.build());
     }
 
     private boolean hasCccAction(String action) {
@@ -204,7 +227,8 @@ public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
     }
 
     public static void clearNotification(Context context){
-        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(
+                Context.NOTIFICATION_SERVICE);
         if (notificationManager != null) {
             notificationManager.cancel(R.string.fcm_notification);
         }


### PR DESCRIPTION
## Summary
This change allows the CommCareFirebaseMessagingService to send a broadcast instead of issuing a push notification when the received FCM message is related to messaging and one of the messaging pages is active either the channel list or the message page with the corresponding channel).
[Jira ticket](https://dimagi.atlassian.net/browse/CCCT-649)

The two related fragments use static variables to indicate their active state easily to the service, and register/unregister for the broadcasts when the fragment resumes/pauses.

cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Feature Flag
ConnectID Messaging

## Product Description
When the user is on the channel list page or messaging page (for the channel indicated in the FCM message), they will no longer see a push notification for the received message. Instead, they will see the page update immediately with the new channel or message.

## PR Checklist

- [ ] If I think the PR is high risk, "High Risk" label is set
- [ ] I have confidence that this PR will not introduce a regression for the reasons below
- [ ] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, "Release Note" label is set and a "Release Note" is specified in PR description.

### Automated test coverage
No automated tests for Connect code yet.


### Safety story
This change is only implemented in the special case of FCM messages where the action is "ccc_message", so push notifications will never be skipped for other FCM messages.
