### PR TITLE
Adds New Analytics event

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -596,7 +596,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                 startActivityForResult(pref, FormEntryConstants.FORM_PREFERENCES_KEY);
                 return true;
             case android.R.id.home:
-                FirebaseAnalyticsUtil.reportFormQuitAttempt(AnalyticsParamValue.NAV_BUTTON_PRESS);
+                FirebaseAnalyticsUtil.reportFormQuitAttempt(AnalyticsParamValue.NAV_BUTTON_PRESS, getCurrentFormXmlnsFailSafe());
                 triggerUserQuitInput();
                 return true;
 
@@ -1131,12 +1131,12 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
     private void handleFormLoadCompletion(AndroidFormController fc) {
         HiddenPreferences.clearInterruptedFormState();
-
         if (PollSensorAction.XPATH_ERROR_ACTION.equals(locationRecieverErrorAction)) {
             handleXpathErrorBroadcast();
         }
 
         mFormController = fc;
+        FirebaseAnalyticsUtil.reportFormEntry(getCurrentFormXmlnsFailSafe());
 
         // Newer menus may have already built the menu, before all data was ready
         invalidateOptionsMenu();
@@ -1217,7 +1217,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         switch (keyCode) {
             case KeyEvent.KEYCODE_BACK:
-                FirebaseAnalyticsUtil.reportFormQuitAttempt(AnalyticsParamValue.BACK_BUTTON_PRESS);
+                FirebaseAnalyticsUtil.reportFormQuitAttempt(AnalyticsParamValue.BACK_BUTTON_PRESS, getCurrentFormXmlnsFailSafe());
                 triggerUserQuitInput();
                 return true;
             case KeyEvent.KEYCODE_DPAD_RIGHT:
@@ -1432,7 +1432,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     protected boolean onBackwardSwipe() {
         FirebaseAnalyticsUtil.reportFormNav(
                 AnalyticsParamValue.DIRECTION_BACKWARD,
-                AnalyticsParamValue.SWIPE);
+                AnalyticsParamValue.SWIPE, getCurrentFormXmlnsFailSafe());
 
         uiController.showPreviousView(true);
         return true;
@@ -1442,7 +1442,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     protected boolean onForwardSwipe() {
         FirebaseAnalyticsUtil.reportFormNav(
                 AnalyticsParamValue.DIRECTION_FORWARD,
-                AnalyticsParamValue.SWIPE);
+                AnalyticsParamValue.SWIPE, getCurrentFormXmlnsFailSafe());
 
         if (canNavigateForward()) {
             uiController.next();
@@ -1680,6 +1680,15 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
     private int getCurrentFormID() {
         return mFormController.getFormID();
+    }
+
+    public String getCurrentFormXmlnsFailSafe() {
+        try {
+            return mFormController.getFormEntryController().getModel().getForm().getMainInstance().schema;
+        } catch (Exception e) {
+            Logger.exception("Error trying to get form schema", e);
+        }
+        return null;
     }
 
     /**

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1296,6 +1296,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             }
         } else if (saveStatus != null) {
             String toastMessage = "";
+            FirebaseAnalyticsUtil.reportFormSubmission(saveStatus.toString(), getCurrentFormXmlnsFailSafe(), userTriggered);
             switch (saveStatus) {
                 case SAVED_COMPLETE:
                     toastMessage = Localization.get("form.entry.complete.save.success");

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -107,8 +107,6 @@ import javax.crypto.spec.SecretKeySpec;
 import androidx.appcompat.app.ActionBar;
 import androidx.core.app.ActivityCompat;
 
-import static org.commcare.activities.components.FormEntryConstants.DO_NOT_EXIT;
-import static org.commcare.activities.components.FormEntryConstants.EXIT;
 import static org.commcare.android.database.user.models.FormRecord.QuarantineReason_LOCAL_PROCESSING_ERROR;
 import static org.commcare.android.database.user.models.FormRecord.QuarantineReason_RECORD_ERROR;
 import static org.commcare.sync.FirebaseMessagingDataSyncer.PENGING_SYNC_ALERT_ACTION;
@@ -1296,7 +1294,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             }
         } else if (saveStatus != null) {
             String toastMessage = "";
-            FirebaseAnalyticsUtil.reportFormSubmission(saveStatus.toString(), getCurrentFormXmlnsFailSafe(), userTriggered);
+            FirebaseAnalyticsUtil.reportFormFinishAttempt(saveStatus.toString(), getCurrentFormXmlnsFailSafe(), userTriggered);
             switch (saveStatus) {
                 case SAVED_COMPLETE:
                     toastMessage = Localization.get("form.entry.complete.save.success");

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -111,7 +111,8 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         nextButton.setOnClickListener(v -> {
             FirebaseAnalyticsUtil.reportFormNav(
                     AnalyticsParamValue.DIRECTION_FORWARD,
-                    AnalyticsParamValue.NAV_BUTTON_PRESS);
+                    AnalyticsParamValue.NAV_BUTTON_PRESS,
+                    activity.getCurrentFormXmlnsFailSafe());
             showNextView();
             TextToSpeechConverter.INSTANCE.stop();
         });
@@ -120,10 +121,12 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
             if (!FormEntryConstants.NAV_STATE_QUIT.equals(v.getTag())) {
                 FirebaseAnalyticsUtil.reportFormNav(
                         AnalyticsParamValue.DIRECTION_BACKWARD,
-                        AnalyticsParamValue.NAV_BUTTON_PRESS);
+                        AnalyticsParamValue.NAV_BUTTON_PRESS,
+                        activity.getCurrentFormXmlnsFailSafe());
                 showPreviousView(true);
             } else {
-                FirebaseAnalyticsUtil.reportFormQuitAttempt(AnalyticsParamValue.NAV_BUTTON_PRESS);
+                FirebaseAnalyticsUtil.reportFormQuitAttempt(AnalyticsParamValue.NAV_BUTTON_PRESS,
+                        activity.getCurrentFormXmlnsFailSafe());
                 activity.triggerUserQuitInput();
             }
             TextToSpeechConverter.INSTANCE.stop();
@@ -132,7 +135,8 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         finishButton.setOnClickListener(v -> {
             FirebaseAnalyticsUtil.reportFormNav(
                     AnalyticsParamValue.DIRECTION_FORWARD,
-                    AnalyticsParamValue.NAV_BUTTON_PRESS);
+                    AnalyticsParamValue.NAV_BUTTON_PRESS,
+                    activity.getCurrentFormXmlnsFailSafe());
             activity.triggerUserFormComplete();
         });
 

--- a/app/src/org/commcare/activities/HomeButtons.java
+++ b/app/src/org/commcare/activities/HomeButtons.java
@@ -145,7 +145,10 @@ public class HomeButtons {
     }
 
     private static View.OnClickListener getStartButtonListener(final StandardHomeActivity activity) {
-        return v -> activity.enterRootModule();
+        return v ->  {
+            reportButtonClick(AnalyticsParamValue.START_BUTTON);
+            activity.enterRootModule();
+        };
     }
 
     private static View.OnClickListener getTrainingButtonListener(final StandardHomeActivity activity) {
@@ -185,7 +188,10 @@ public class HomeButtons {
     }
 
     private static View.OnClickListener getLogoutButtonListener(final StandardHomeActivity activity) {
-        return v -> activity.userTriggeredLogout();
+        return v -> {
+            reportButtonClick(AnalyticsParamValue.LOGOUT_BUTTON);
+            activity.userTriggeredLogout();
+        };
     }
 
     private static TextSetter getLogoutButtonTextSetter(final StandardHomeActivity activity) {

--- a/app/src/org/commcare/activities/components/MenuList.java
+++ b/app/src/org/commcare/activities/components/MenuList.java
@@ -16,6 +16,7 @@ import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.HomeScreenBaseActivity;
 import org.commcare.adapters.MenuAdapter;
 import org.commcare.dalvik.R;
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.Entry;
 import org.commcare.suite.model.Menu;
@@ -90,7 +91,7 @@ public class MenuList implements AdapterView.OnItemClickListener {
         } else {
             commandId = ((Menu)value).getId();
         }
-
+        FirebaseAnalyticsUtil.reportMenuItemClick(commandId);
         Intent i = new Intent(activity.getIntent());
         i.putExtra(SessionFrame.STATE_COMMAND_ID, commandId);
         if (beingUsedInHomeScreen) {

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -86,6 +86,8 @@ public class AnalyticsParamValue {
     public static final String SAVED_FORMS_BUTTON = "saved_forms";
     public static final String INCOMPLETE_FORMS_BUTTON = "incomplete_forms";
     public static final String SYNC_BUTTON = "sync";
+    public static final String START_BUTTON = "start";
+    public static final String LOGOUT_BUTTON = "logout";
     public static final String SYNC_SUBTEXT = "sync_subtext";
     public static final String REPORT_BUTTON = "report_an_issue";
 

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -141,4 +141,10 @@ public class AnalyticsParamValue {
 
     public static final String IN_APP_UPDATE_SUCCESS = "success";
 
+    // Param values for Form Submission Event
+
+    public static final String USER_TRIGGERED = "user_triggered";
+    public static final String SYSTEM_TRIGGERED = "system_triggered";
+
+
 }

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -26,6 +26,7 @@ public class CCAnalyticsEvent {
     static final String VIEW_QUESTION_MEDIA = "view_question_media";
     static final String COMMON_COMMCARE_EVENT = "common_commcare_event";
     static final String FORM_QUARANTINE_EVENT = "form_quarantine_event";
+    static final String MENU_SCREEN_ITEM_CLICK = "menu_screen_item_click";
     static final String IN_APP_UPDATE_EVENT = "in_app_update_event";
 
 }

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -16,6 +16,7 @@ public class CCAnalyticsEvent {
     static final String FORM_ENTRY_ATTEMPT = "form_entry_attempt";
     static final String FORM_EXIT_ATTEMPT = "form_exit_attempt";
     static final String FORM_SUBMISSION_ATTEMPT = "form_submission_attempt";
+    static final String FORM_UPLOAD_ATTEMPT = "form_upload_attempt";
     static final String FORM_NAVIGATION = "form_navigation";
     static final String GRAPH_ACTION = "graphing_action";
     static final String HOME_BUTTON_CLICK = "home_button_click";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -15,7 +15,7 @@ public class CCAnalyticsEvent {
     static final String FEATURE_USAGE = "feature_usage";
     static final String FORM_ENTRY_ATTEMPT = "form_entry_attempt";
     static final String FORM_EXIT_ATTEMPT = "form_exit_attempt";
-    static final String FORM_SUBMISSION_ATTEMPT = "form_submission_attempt";
+    static final String FORM_FINISH_ATTEMPT = "form_finish_attempt";
     static final String FORM_UPLOAD_ATTEMPT = "form_upload_attempt";
     static final String FORM_NAVIGATION = "form_navigation";
     static final String GRAPH_ACTION = "graphing_action";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -13,6 +13,7 @@ public class CCAnalyticsEvent {
     static final String ENABLE_PRIVILEGE = "enable_privilege";
     static final String ENTITY_DETAIL_NAVIGATION = "entity_detail_navigation";
     static final String FEATURE_USAGE = "feature_usage";
+    static final String FORM_ENTRY_ATTEMPT = "form_entry_attempt";
     static final String FORM_EXIT_ATTEMPT = "form_exit_attempt";
     static final String FORM_NAVIGATION = "form_navigation";
     static final String GRAPH_ACTION = "graphing_action";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -15,6 +15,7 @@ public class CCAnalyticsEvent {
     static final String FEATURE_USAGE = "feature_usage";
     static final String FORM_ENTRY_ATTEMPT = "form_entry_attempt";
     static final String FORM_EXIT_ATTEMPT = "form_exit_attempt";
+    static final String FORM_SUBMISSION_ATTEMPT = "form_submission_attempt";
     static final String FORM_NAVIGATION = "form_navigation";
     static final String GRAPH_ACTION = "graphing_action";
     static final String HOME_BUTTON_CLICK = "home_button_click";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
@@ -18,6 +18,7 @@ public class CCAnalyticsParam {
     static final String TIME_IN_MINUTES = "time_in_minutes";
     static final String MODE = "mode";
     static final String REASON = "reason";
+    static final String RESULT = "result";
     static final String UI_STATE = "uite_state";
     static final String USERNAME = "username";
     static final String FORM_ID = "form_id";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
@@ -20,6 +20,7 @@ public class CCAnalyticsParam {
     static final String REASON = "reason";
     static final String UI_STATE = "uite_state";
     static final String USERNAME = "username";
+    static final String FORM_ID = "form_id";
 
     static final String USER_RETURNED = "user_returned";
 

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -194,6 +194,14 @@ public class FirebaseAnalyticsUtil {
                 new String[]{method, formId});
     }
 
+    public static void reportFormSubmission(String saveResult, String formId, boolean userTriggered) {
+        String method = userTriggered ? AnalyticsParamValue.USER_TRIGGERED : AnalyticsParamValue.SYSTEM_TRIGGERED;
+        reportEvent(CCAnalyticsEvent.FORM_SUBMISSION_ATTEMPT,
+                new String[]{CCAnalyticsParam.FORM_ID, FirebaseAnalytics.Param.VALUE,
+                        FirebaseAnalytics.Param.METHOD},
+                new String[]{formId, saveResult, method});
+    }
+
     /**
      * Report a user event of navigating backward out of the entity detail screen
      */

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -1,6 +1,5 @@
 package org.commcare.google.services.analytics;
 
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.text.TextUtils;
@@ -15,8 +14,6 @@ import org.commcare.suite.model.OfflineUserRestore;
 import org.commcare.utils.EncryptionUtils;
 import org.commcare.utils.FormUploadResult;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Date;
 
 import static org.commcare.google.services.analytics.AnalyticsParamValue.CORRUPT_APP_STATE;
@@ -195,10 +192,10 @@ public class FirebaseAnalyticsUtil {
                 new String[]{method, formId});
     }
 
-    public static void reportFormSubmission(String saveResult, String formId, boolean userTriggered) {
+    public static void reportFormFinishAttempt(String saveResult, String formId, boolean userTriggered) {
         String method = userTriggered ? AnalyticsParamValue.USER_TRIGGERED : AnalyticsParamValue.SYSTEM_TRIGGERED;
-        reportEvent(CCAnalyticsEvent.FORM_SUBMISSION_ATTEMPT,
-                new String[]{CCAnalyticsParam.FORM_ID, FirebaseAnalytics.Param.VALUE,
+        reportEvent(CCAnalyticsEvent.FORM_FINISH_ATTEMPT,
+                new String[]{CCAnalyticsParam.FORM_ID, CCAnalyticsParam.RESULT,
                         FirebaseAnalytics.Param.METHOD},
                 new String[]{formId, saveResult, method});
     }

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -13,6 +13,7 @@ import org.commcare.android.logging.ReportingUtils;
 import org.commcare.preferences.MainConfigurablePreferences;
 import org.commcare.suite.model.OfflineUserRestore;
 import org.commcare.utils.EncryptionUtils;
+import org.commcare.utils.FormUploadResult;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -362,5 +363,11 @@ public class FirebaseAnalyticsUtil {
         reportEvent(CCAnalyticsEvent.MENU_SCREEN_ITEM_CLICK,
                 new String[]{FirebaseAnalytics.Param.ITEM_ID},
                 new String[]{commandId});
+    }
+
+    public static void reportFormUploadAttempt(FormUploadResult first, Integer second) {
+        reportEvent(CCAnalyticsEvent.FORM_UPLOAD_ATTEMPT,
+                new String[]{CCAnalyticsParam.RESULT, FirebaseAnalytics.Param.VALUE},
+                new String[]{String.valueOf(first), String.valueOf(second)});
     }
 }

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -349,4 +349,10 @@ public class FirebaseAnalyticsUtil {
                 new String[]{FirebaseAnalytics.Param.ITEM_ID},
                 new String[]{quarantineReasonType});
     }
+
+    public static void reportMenuItemClick(String commandId) {
+        reportEvent(CCAnalyticsEvent.MENU_SCREEN_ITEM_CLICK,
+                new String[]{FirebaseAnalytics.Param.ITEM_ID},
+                new String[]{commandId});
+    }
 }

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -174,16 +174,24 @@ public class FirebaseAnalyticsUtil {
                 CCAnalyticsParam.ACTION_TYPE, actionType);
     }
 
-    public static void reportFormNav(String direction, String method) {
+    public static void reportFormEntry(String formId) {
+        reportEvent(CCAnalyticsEvent.FORM_ENTRY_ATTEMPT,
+                new String[]{CCAnalyticsParam.FORM_ID},
+                new String[]{formId});
+    }
+
+    public static void reportFormNav(String direction, String method, String formId) {
         if (rateLimitReporting(.1)) {
             reportEvent(CCAnalyticsEvent.FORM_NAVIGATION,
-                    new String[]{CCAnalyticsParam.DIRECTION, FirebaseAnalytics.Param.METHOD},
-                    new String[]{direction, method});
+                    new String[]{CCAnalyticsParam.DIRECTION, FirebaseAnalytics.Param.METHOD, CCAnalyticsParam.FORM_ID},
+                    new String[]{direction, method, formId});
         }
     }
 
-    public static void reportFormQuitAttempt(String method) {
-        reportEvent(CCAnalyticsEvent.FORM_EXIT_ATTEMPT, FirebaseAnalytics.Param.METHOD, method);
+    public static void reportFormQuitAttempt(String method, String formId) {
+        reportEvent(CCAnalyticsEvent.FORM_EXIT_ATTEMPT,
+                new String[]{FirebaseAnalytics.Param.METHOD, CCAnalyticsParam.FORM_ID},
+                new String[]{method, formId});
     }
 
     /**

--- a/app/src/org/commcare/sync/FormSubmissionHelper.java
+++ b/app/src/org/commcare/sync/FormSubmissionHelper.java
@@ -12,6 +12,7 @@ import org.commcare.cases.util.InvalidCaseGraphException;
 import org.commcare.dalvik.R;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.models.FormRecordProcessor;
+import org.commcare.modern.util.Pair;
 import org.commcare.preferences.ServerUrls;
 import org.commcare.suite.model.Profile;
 import org.commcare.tasks.DataSubmissionListener;
@@ -159,10 +160,12 @@ public class FormSubmissionHelper implements DataSubmissionListener {
         } catch (SessionUnavailableException sue) {
             return FormUploadResult.PROGRESS_LOGGED_OUT;
         } finally {
-            boolean success =
-                    FormUploadResult.FULL_SUCCESS.equals(FormUploadResult.getWorstResult(mResults));
+            Pair<FormUploadResult, Integer> resultWithSuccessCount =
+                    FormUploadResult.getWorstResultWithSuccessCount(mResults);
+            boolean success = FormUploadResult.FULL_SUCCESS.equals(resultWithSuccessCount.first);
             endSubmissionProcess(success);
-
+            FirebaseAnalyticsUtil.reportFormUploadAttempt(resultWithSuccessCount.first,
+                    resultWithSuccessCount.second);
             synchronized (processTasks) {
                 processTasks.remove(this);
             }

--- a/app/src/org/commcare/utils/FormUploadResult.java
+++ b/app/src/org/commcare/utils/FormUploadResult.java
@@ -1,5 +1,6 @@
 package org.commcare.utils;
 
+import org.commcare.modern.util.Pair;
 import org.commcare.views.notifications.MessageTag;
 
 /**
@@ -115,12 +116,20 @@ public enum FormUploadResult implements MessageTag {
     }
 
     public static FormUploadResult getWorstResult(FormUploadResult[] results) {
+        return getWorstResultWithSuccessCount(results).first;
+    }
+
+    public static Pair<FormUploadResult, Integer> getWorstResultWithSuccessCount(FormUploadResult[] results) {
+        int successCount = 0;
         FormUploadResult worstResult = FULL_SUCCESS;
         for (FormUploadResult result : results) {
+            if (result == FULL_SUCCESS) {
+                successCount++;
+            }
             if (result.orderVal > worstResult.orderVal) {
                 worstResult = result;
             }
         }
-        return worstResult;
+        return new Pair<>(worstResult, successCount);
     }
 }


### PR DESCRIPTION
## Summary
Makes following changes to Analytics - 

-  Send Start and Logut button clicks as part of `home_button_click` event
- Adds form xmlns to form related analytics events (same ashttps://github.com/dimagi/commcare-android/pull/2951 but for `master`)
- Adds following new events 
  1. `form_finish_attempt`: Logs a form save attempt with the save `result` and `method` (user_triggered save vs system_triggered) event params
  2. `menu_screen_item_click`:  Whenever a menu/form is selected from the menu screen with menu id as `item_id` event param
  3. `form_upload_attempt` : Whenever we do a form upload process to the server with `result` and `value` as 2 event params representing the result of the form upload process and # of forms uploaded as part of the form upload attempt. 
  

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. Would be good to add screenshots/videos for any major user facing changes -->

## PR Checklist

- [x] If I think the PR is high risk, "High Risk" label is set
- [x] I have confidence that this PR will not introduce a regression for the reasons below
- [x] Do we need to enhance manual QA test coverage ? If yes, "QA Note" label is set correctly
- [x] Does the PR introduce any major changes worth communicating ? If yes, "Release Note" label is set and a "Release Note" is specified in PR description.

### Automated test coverage

N/A

### Safety story

Analytics only, instrumentation tests should catch any errors given all events are in instrumented workflows
