### PR TITLE
Fix Case detail tab title

### DIFF
--- a/app/src/org/commcare/adapters/EntityDetailPagerAdapter.java
+++ b/app/src/org/commcare/adapters/EntityDetailPagerAdapter.java
@@ -59,6 +59,11 @@ public class EntityDetailPagerAdapter extends FragmentStateAdapter {
         return fragment;
     }
 
+    public CharSequence getPageTitle(int position) {
+        Detail detailShowing = detail.isCompound() ? displayableChildDetails[position] : detail;
+        return detailShowing.getTitle().getText().evaluate();
+    }
+
     @Override
     public int getItemCount() {
         return detail.isCompound() ? displayableChildDetails.length : 1;

--- a/app/src/org/commcare/adapters/EntityDetailPagerAdapter.java
+++ b/app/src/org/commcare/adapters/EntityDetailPagerAdapter.java
@@ -21,7 +21,7 @@ import org.javarosa.core.model.instance.TreeReference;
  *
  * @author jschweers
  */
-public class EntityDetailPagerAdapter extends FragmentStateAdapter{
+public class EntityDetailPagerAdapter extends FragmentStateAdapter {
 
     private final ListItemViewModifier modifier;
     private final Detail detail;

--- a/app/src/org/commcare/views/TabbedDetailView.java
+++ b/app/src/org/commcare/views/TabbedDetailView.java
@@ -86,7 +86,7 @@ public class TabbedDetailView extends RelativeLayout {
 
         if (detail.isCompound()) {
             new TabLayoutMediator(mTabLayout, mViewPager,
-                    (tab, position) -> tab.setText(detail.getDetails()[position].getTitle().getText().evaluate()))
+                    (tab, position) -> tab.setText(entityDetailPagerAdapter.getPageTitle(position)))
                     .attach();
         } else {
             mTabLayout.setVisibility(GONE);


### PR DESCRIPTION
## Product Description
This PR fixes an issue in the Case details which causes a mismatch between tab items and their respective content when a display condition is set. The fix is basically to restore a method that was removed during the migration to ViewPager2 that retrieves the title of the page from the visible tabs.

Ticket: https://dimagi.atlassian.net/browse/SAAS-16528

## Safety Assurance

### Safety story
This was tested locally and with different configurations, all seems fine. 

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
