### PR TITLE
Expires entity cache for related cases

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
     testImplementation 'io.mockk:mockk:1.12.7'
     testImplementation 'org.json:json:20231013'
+    testImplementation 'org.mockito:mockito-core:5.5.0'
+    testImplementation 'org.json:json:20140107'
     testImplementation project(path: ':commcare-core', configuration: 'testsAsJar')
 
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -1258,12 +1258,19 @@ public class CommCareApplication extends Application implements LifecycleEventOb
     }
 
     public void scheduleEntityCacheInvalidation() {
-        OneTimeWorkRequest entityCacheInvalidationRequest = new OneTimeWorkRequest.Builder(
-                EntityCacheInvalidationWorker.class)
-                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
-                .build();
-        WorkManager wm = WorkManager.getInstance(CommCareApplication.instance());
-        wm.enqueueUniqueWork(ENTITY_CACHE_INVALIDATION_REQUEST, ExistingWorkPolicy.KEEP,
-                entityCacheInvalidationRequest);
+        try {
+            User u = CommCareApplication.instance().getSession().getLoggedInUser();
+            if (!User.TYPE_DEMO.equals(u.getUserType())) {
+                OneTimeWorkRequest entityCacheInvalidationRequest = new OneTimeWorkRequest.Builder(
+                        EntityCacheInvalidationWorker.class)
+                        .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                        .build();
+                WorkManager wm = WorkManager.getInstance(CommCareApplication.instance());
+                wm.enqueueUniqueWork(ENTITY_CACHE_INVALIDATION_REQUEST, ExistingWorkPolicy.KEEP,
+                        entityCacheInvalidationRequest);
+            }
+        } catch (SessionUnavailableException e) {
+            // ignore
+        }
     }
 }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -1258,19 +1258,15 @@ public class CommCareApplication extends Application implements LifecycleEventOb
     }
 
     public void scheduleEntityCacheInvalidation() {
-        try {
-            User u = CommCareApplication.instance().getSession().getLoggedInUser();
-            if (!User.TYPE_DEMO.equals(u.getUserType())) {
-                OneTimeWorkRequest entityCacheInvalidationRequest = new OneTimeWorkRequest.Builder(
-                        EntityCacheInvalidationWorker.class)
-                        .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
-                        .build();
-                WorkManager wm = WorkManager.getInstance(CommCareApplication.instance());
-                wm.enqueueUniqueWork(ENTITY_CACHE_INVALIDATION_REQUEST, ExistingWorkPolicy.KEEP,
-                        entityCacheInvalidationRequest);
-            }
-        } catch (SessionUnavailableException e) {
-            // ignore
+        CommCareEntityStorageCache entityStorageCache = new CommCareEntityStorageCache("case");
+        if (!entityStorageCache.isEmpty()) {
+            OneTimeWorkRequest entityCacheInvalidationRequest = new OneTimeWorkRequest.Builder(
+                    EntityCacheInvalidationWorker.class)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .build();
+            WorkManager wm = WorkManager.getInstance(CommCareApplication.instance());
+            wm.enqueueUniqueWork(ENTITY_CACHE_INVALIDATION_REQUEST, ExistingWorkPolicy.KEEP,
+                    entityCacheInvalidationRequest);
         }
     }
 }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -1265,7 +1265,7 @@ public class CommCareApplication extends Application implements LifecycleEventOb
                     .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                     .build();
             WorkManager wm = WorkManager.getInstance(CommCareApplication.instance());
-            wm.enqueueUniqueWork(ENTITY_CACHE_INVALIDATION_REQUEST, ExistingWorkPolicy.KEEP,
+            wm.enqueueUniqueWork(ENTITY_CACHE_INVALIDATION_REQUEST, ExistingWorkPolicy.REPLACE,
                     entityCacheInvalidationRequest);
         }
     }

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -101,7 +101,6 @@ import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.DeleteLogs;
 import org.commcare.tasks.EntityCacheInvalidationWorker;
 import org.commcare.tasks.LogSubmissionTask;
-import org.commcare.tasks.PrimeEntityCache;
 import org.commcare.tasks.PrimeEntityCacheHelper;
 import org.commcare.tasks.PurgeStaleArchivedFormsTask;
 import org.commcare.tasks.templates.ManagedAsyncTask;
@@ -1258,7 +1257,7 @@ public class CommCareApplication extends Application implements LifecycleEventOb
         }
     }
 
-    public void propogateEntityCacheInvalidation() {
+    public void scheduleEntityCacheInvalidation() {
         OneTimeWorkRequest entityCacheInvalidationRequest = new OneTimeWorkRequest.Builder(
                 EntityCacheInvalidationWorker.class)
                 .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -31,6 +31,7 @@ import androidx.work.ExistingPeriodicWorkPolicy;
 import androidx.work.ExistingWorkPolicy;
 import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
+import androidx.work.OutOfQuotaPolicy;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 
@@ -98,6 +99,7 @@ import org.commcare.sync.FormSubmissionWorker;
 import org.commcare.tasks.AsyncRestoreHelper;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.DeleteLogs;
+import org.commcare.tasks.EntityCacheInvalidationWorker;
 import org.commcare.tasks.LogSubmissionTask;
 import org.commcare.tasks.PrimeEntityCache;
 import org.commcare.tasks.PrimeEntityCacheHelper;
@@ -167,6 +169,7 @@ public class CommCareApplication extends Application implements LifecycleEventOb
     private static final long BACKOFF_DELAY_FOR_UPDATE_RETRY = 5 * 60 * 1000L; // 5 mins
     private static final long BACKOFF_DELAY_FOR_FORM_SUBMISSION_RETRY = 5 * 60 * 1000L; // 5 mins
     private static final long PERIODICITY_FOR_FORM_SUBMISSION_IN_HOURS = 1;
+    private static final String ENTITY_CACHE_INVALIDATION_REQUEST = "entity-cache-invalidation-request";
     private static Markwon markwon;
 
 
@@ -1253,5 +1256,15 @@ public class CommCareApplication extends Application implements LifecycleEventOb
                 Logger.log(LogTypes.TYPE_MAINTENANCE, "CommCare has been closed");
                 break;
         }
+    }
+
+    public void propogateEntityCacheInvalidation() {
+        OneTimeWorkRequest entityCacheInvalidationRequest = new OneTimeWorkRequest.Builder(
+                EntityCacheInvalidationWorker.class)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .build();
+        WorkManager wm = WorkManager.getInstance(CommCareApplication.instance());
+        wm.enqueueUniqueWork(ENTITY_CACHE_INVALIDATION_REQUEST, ExistingWorkPolicy.KEEP,
+                entityCacheInvalidationRequest);
     }
 }

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -24,10 +24,6 @@ import android.widget.Toast;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
-import androidx.work.ExistingWorkPolicy;
-import androidx.work.OneTimeWorkRequest;
-import androidx.work.OutOfQuotaPolicy;
-import androidx.work.WorkManager;
 
 import com.google.android.play.core.install.model.InstallErrorCode;
 
@@ -74,9 +70,7 @@ import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackFrameStep;
 import org.commcare.suite.model.Text;
 import org.commcare.sync.FirebaseMessagingDataSyncer;
-import org.commcare.sync.FormSubmissionWorker;
 import org.commcare.tasks.DataPullTask;
-import org.commcare.tasks.EntityCacheInvalidationWorker;
 import org.commcare.tasks.FormLoaderTask;
 import org.commcare.tasks.FormRecordCleanupTask;
 import org.commcare.tasks.ResultAndError;
@@ -923,7 +917,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             // The form is either ready for processing, or not, depending on how it was saved
             if (complete) {
                 startUnsentFormsTask(false, false);
-                CommCareApplication.instance().propogateEntityCacheInvalidation();
+                CommCareApplication.instance().scheduleEntityCacheInvalidation();
                 refreshUI();
 
                 if (exitFromExternalLaunch()) {

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -24,6 +24,10 @@ import android.widget.Toast;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.OutOfQuotaPolicy;
+import androidx.work.WorkManager;
 
 import com.google.android.play.core.install.model.InstallErrorCode;
 
@@ -70,7 +74,9 @@ import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackFrameStep;
 import org.commcare.suite.model.Text;
 import org.commcare.sync.FirebaseMessagingDataSyncer;
+import org.commcare.sync.FormSubmissionWorker;
 import org.commcare.tasks.DataPullTask;
+import org.commcare.tasks.EntityCacheInvalidationWorker;
 import org.commcare.tasks.FormLoaderTask;
 import org.commcare.tasks.FormRecordCleanupTask;
 import org.commcare.tasks.ResultAndError;
@@ -917,6 +923,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             // The form is either ready for processing, or not, depending on how it was saved
             if (complete) {
                 startUnsentFormsTask(false, false);
+                CommCareApplication.instance().propogateEntityCacheInvalidation();
                 refreshUI();
 
                 if (exitFromExternalLaunch()) {

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -917,7 +917,6 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             // The form is either ready for processing, or not, depending on how it was saved
             if (complete) {
                 startUnsentFormsTask(false, false);
-                CommCareApplication.instance().scheduleEntityCacheInvalidation();
                 refreshUI();
 
                 if (exitFromExternalLaunch()) {

--- a/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
+++ b/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
@@ -261,6 +261,7 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
                 updateUiForFormUploadResult(Localization.get(result.getLocaleKeyBase()), false);
                 break;
         }
+        CommCareApplication.instance().scheduleEntityCacheInvalidation();
     }
 
     public void updateUiForFormUploadResult(String message, boolean success) {

--- a/app/src/org/commcare/engine/cases/CaseUtils.java
+++ b/app/src/org/commcare/engine/cases/CaseUtils.java
@@ -181,6 +181,9 @@ public class CaseUtils {
 
     private static String getRecordIdFromCaseId(SqlStorage<ACase> storage, String caseId) {
         Vector<Integer> result = storage.getIDsForValue(INDEX_CASE_ID, caseId);
+        if (result == null || result.isEmpty()) {
+            throw new IllegalStateException("No record found for case ID: " + caseId);
+        }
         return String.valueOf(result.get(0));
     }
 

--- a/app/src/org/commcare/engine/cases/CaseUtils.java
+++ b/app/src/org/commcare/engine/cases/CaseUtils.java
@@ -3,7 +3,6 @@ package org.commcare.engine.cases;
 import static org.commcare.cases.model.Case.INDEX_CASE_ID;
 import static org.commcare.cases.util.CaseDBUtils.xordata;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import net.sqlcipher.database.SQLiteDatabase;
@@ -164,9 +163,9 @@ public class CaseUtils {
      * @param recordIds databse ids for the cases we want to find related cases
      * @return database ids for all related cases for the given set of cases
      */
-    public static Set<Integer> getRelatedCases(Set<String> recordIds) {
+    public static Vector<Integer> getRelatedCases(Set<String> recordIds) {
         if (recordIds.isEmpty()) {
-            return ImmutableSet.of();
+            return new Vector<>();
         }
 
         SqlStorage<ACase> storage = CommCareApplication.instance().getUserStorage(ACase.STORAGE_KEY, ACase.class);
@@ -174,20 +173,7 @@ public class CaseUtils {
                 new Vector<>());
         Set<String> caseIds = getCaseIdsFromRecordsIds(storage, recordIds);
         Set<String> relatedCaseIds = fullCaseGraph.getRelatedRecords(caseIds);
-        Set<Integer> relatedRecordIds = new HashSet<>();
-        for (String relatedCaseId : relatedCaseIds) {
-            Integer relatedRecordId = getRecordIdFromCaseId(storage, relatedCaseId);
-            relatedRecordIds.add(relatedRecordId);
-        }
-        return relatedRecordIds;
-    }
-
-    private static Integer getRecordIdFromCaseId(SqlStorage<ACase> storage, String caseId) {
-        Vector<Integer> result = storage.getIDsForValue(INDEX_CASE_ID, caseId);
-        if (result == null || result.isEmpty()) {
-            throw new IllegalStateException("No record found for case ID: " + caseId);
-        }
-        return result.get(0);
+        return storage.getIDsForValues(new String[]{INDEX_CASE_ID}, relatedCaseIds.toArray());
     }
 
     private static Set<String> getCaseIdsFromRecordsIds(SqlStorage<ACase> storage, Set<String> recordIds) {

--- a/app/src/org/commcare/engine/cases/CaseUtils.java
+++ b/app/src/org/commcare/engine/cases/CaseUtils.java
@@ -84,8 +84,8 @@ public class CaseUtils {
         SQLiteDatabase db = CommCareApplication.instance().getUserDbHandle();
         int removedCaseCount;
         int removedLedgers;
+        db.beginTransaction();
         try {
-            db.beginTransaction();
             SqlStorage<ACase> storage = CommCareApplication.instance().getUserStorage(ACase.STORAGE_KEY, ACase.class);
             DAG<String, int[], String> fullCaseGraph = getFullCaseGraph(storage, new AndroidCaseIndexTable(), owners);
 

--- a/app/src/org/commcare/engine/cases/CaseUtils.java
+++ b/app/src/org/commcare/engine/cases/CaseUtils.java
@@ -3,8 +3,6 @@ package org.commcare.engine.cases;
 import static org.commcare.cases.model.Case.INDEX_CASE_ID;
 import static org.commcare.cases.util.CaseDBUtils.xordata;
 
-import com.google.common.collect.ImmutableSet;
-
 import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.CommCareApplication;
@@ -172,7 +170,7 @@ public class CaseUtils {
         DAG<String, int[], String> fullCaseGraph = getFullCaseGraph(storage, new AndroidCaseIndexTable(),
                 new Vector<>());
         Set<String> caseIds = getCaseIdsFromRecordsIds(storage, recordIds);
-        Set<String> relatedCaseIds = fullCaseGraph.getRelatedRecords(caseIds);
+        Set<String> relatedCaseIds = fullCaseGraph.findConnectedRecords(caseIds);
         return storage.getIDsForValues(new String[]{INDEX_CASE_ID}, relatedCaseIds.toArray());
     }
 

--- a/app/src/org/commcare/engine/cases/CaseUtils.java
+++ b/app/src/org/commcare/engine/cases/CaseUtils.java
@@ -3,6 +3,9 @@ package org.commcare.engine.cases;
 import static org.commcare.cases.model.Case.INDEX_CASE_ID;
 import static org.commcare.cases.util.CaseDBUtils.xordata;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
 import net.sqlcipher.database.SQLiteDatabase;
 
 import org.commcare.CommCareApplication;
@@ -161,9 +164,9 @@ public class CaseUtils {
      * @param recordIds databse ids for the cases we want to find related cases
      * @return database ids for all related cases for the given set of cases
      */
-    public static Set<String> getRelatedCases(Set<String> recordIds) {
+    public static Set<Integer> getRelatedCases(Set<String> recordIds) {
         if (recordIds.isEmpty()) {
-            return recordIds;
+            return ImmutableSet.of();
         }
 
         SqlStorage<ACase> storage = CommCareApplication.instance().getUserStorage(ACase.STORAGE_KEY, ACase.class);
@@ -171,20 +174,20 @@ public class CaseUtils {
                 new Vector<>());
         Set<String> caseIds = getCaseIdsFromRecordsIds(storage, recordIds);
         Set<String> relatedCaseIds = fullCaseGraph.getRelatedRecords(caseIds);
-        Set<String> relatedRecordIds = new HashSet<>();
+        Set<Integer> relatedRecordIds = new HashSet<>();
         for (String relatedCaseId : relatedCaseIds) {
-            String relatedRecordId = getRecordIdFromCaseId(storage, relatedCaseId);
+            Integer relatedRecordId = getRecordIdFromCaseId(storage, relatedCaseId);
             relatedRecordIds.add(relatedRecordId);
         }
         return relatedRecordIds;
     }
 
-    private static String getRecordIdFromCaseId(SqlStorage<ACase> storage, String caseId) {
+    private static Integer getRecordIdFromCaseId(SqlStorage<ACase> storage, String caseId) {
         Vector<Integer> result = storage.getIDsForValue(INDEX_CASE_ID, caseId);
         if (result == null || result.isEmpty()) {
             throw new IllegalStateException("No record found for case ID: " + caseId);
         }
-        return String.valueOf(result.get(0));
+        return result.get(0);
     }
 
     private static Set<String> getCaseIdsFromRecordsIds(SqlStorage<ACase> storage, Set<String> recordIds) {

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -66,9 +66,10 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
      * v.26 - Adds a column for 'last_sync' in IndexedFixtureIndex
      * v.27 - Adds a column `descriptor` in FormRecord.
      * v.28 - Adds and indexes columns for Case state and category
+     * v.29 - Add columns for is_dirty and is_shallow in entity_cache table
      */
 
-    private static final int USER_DB_VERSION = 28;
+    private static final int USER_DB_VERSION = 29;
 
     private static final String USER_DB_LOCATOR = "database_sandbox_";
 

--- a/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/user/UserDatabaseUpgrader.java
@@ -230,6 +230,12 @@ class UserDatabaseUpgrader {
                 oldVersion = 28;
             }
         }
+
+        if (oldVersion == 28) {
+            if (updateTwentyEightTwentyNine(db)) {
+                oldVersion = 29;
+            }
+        }
     }
 
     private boolean upgradeOneTwo(final SQLiteDatabase db) {
@@ -784,6 +790,19 @@ class UserDatabaseUpgrader {
                     "case_category_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_CATEGORY)));
             db.execSQL(DatabaseIndexingUtils.indexOnTableCommand(
                     "case_state_index", "AndroidCase", TableBuilder.scrubName(Case.INDEX_STATE)));
+            db.setTransactionSuccessful();
+            return true;
+        } finally {
+            db.endTransaction();
+        }
+    }
+
+    private boolean updateTwentyEightTwentyNine(SQLiteDatabase db) {
+        //drop the existing table and recreate using current definition
+        db.beginTransaction();
+        try {
+            db.execSQL("DROP TABLE IF EXISTS " + CommCareEntityStorageCache.TABLE_NAME);
+            db.execSQL(CommCareEntityStorageCache.getTableDefinition());
             db.setTransactionSuccessful();
             return true;
         } finally {

--- a/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
+++ b/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
@@ -149,8 +149,8 @@ public class CommCareEntityStorageCache implements EntityStorageCache {
         if (isEmpty()) {
             return;
         }
+        db.beginTransaction();
         try {
-            db.beginTransaction();
             markRecordsAsShallow(recordIds);
             db.setTransactionSuccessful();
         } finally {

--- a/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
+++ b/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
@@ -234,6 +234,9 @@ public class CommCareEntityStorageCache implements EntityStorageCache {
     public void primeCache(Hashtable<String, AsyncEntity> entitySet, String[][] cachePrimeKeys,
             Detail detail) {
         if (detail.isCacheEnabled()) {
+            // first make sure to process shallow records in case they are present
+            processShallowRecords();
+
             Vector<String> cacheKeys = new Vector<>();
             String validKeys = buildValidKeys(cacheKeys, detail);
             if (validKeys.isEmpty()) {

--- a/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
+++ b/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
@@ -162,7 +162,7 @@ public class CommCareEntityStorageCache implements EntityStorageCache {
     /**
      * Removes cache records associated with the provided IDs
      */
-    public void deleteRecords(Set<Integer> recordIds) {
+    private void deleteRecords(Set<Integer> recordIds) {
         List<Pair<String, String[]>> whereParamList = TableBuilder.sqlList(recordIds);
         int removed = 0;
         for (Pair<String, String[]> querySet : whereParamList) {
@@ -174,7 +174,7 @@ public class CommCareEntityStorageCache implements EntityStorageCache {
         }
     }
 
-    public Set<String> getShallowRecords() {
+    private Set<String> getShallowRecords() {
         String whereClause = String.format("%s = ? AND %s = ?", COL_CACHE_NAME, COL_IS_SHALLOW);
         Cursor c = db.query(TABLE_NAME, new String[]{COL_ENTITY_KEY}, whereClause,
                 new String[]{mCacheName, "1"}, null, null, null);
@@ -191,8 +191,8 @@ public class CommCareEntityStorageCache implements EntityStorageCache {
 
 
     public int getFieldIdFromCacheKey(String detailId, String cacheKey) {
-        cacheKey = cacheKey.replace(String.valueOf(TYPE_SORT_FIELD) + "_", "");
-        cacheKey = cacheKey.replace(String.valueOf(TYPE_NORMAL_FIELD) + "_", "");
+        cacheKey = cacheKey.replace(TYPE_SORT_FIELD + "_", "");
+        cacheKey = cacheKey.replace(TYPE_NORMAL_FIELD + "_", "");
         String intId = cacheKey.substring(detailId.length() + 1);
         try {
             return Integer.parseInt(intId);

--- a/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
+++ b/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
@@ -162,7 +162,7 @@ public class CommCareEntityStorageCache implements EntityStorageCache {
     /**
      * Removes cache records associated with the provided IDs
      */
-    public void deleteRecords(Set<String> recordIds) {
+    public void deleteRecords(Set<Integer> recordIds) {
         List<Pair<String, String[]>> whereParamList = TableBuilder.sqlList(recordIds);
         int removed = 0;
         for (Pair<String, String[]> querySet : whereParamList) {
@@ -281,7 +281,7 @@ public class CommCareEntityStorageCache implements EntityStorageCache {
     public void processShallowRecords() {
         try (Closeable ignored = lockCache()) {
             Set<String> shallowRecordIds = getShallowRecords();
-            Set<String> relatedRecordIds = CaseUtils.getRelatedCases(shallowRecordIds);
+            Set<Integer> relatedRecordIds = CaseUtils.getRelatedCases(shallowRecordIds);
             deleteRecords(relatedRecordIds);
         } catch (IOException e) {
             Logger.exception("Error while processing shallow records", e);

--- a/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
+++ b/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java
@@ -162,7 +162,7 @@ public class CommCareEntityStorageCache implements EntityStorageCache {
     /**
      * Removes cache records associated with the provided IDs
      */
-    private void deleteRecords(Set<Integer> recordIds) {
+    private void deleteRecords(Vector<Integer> recordIds) {
         List<Pair<String, String[]>> whereParamList = TableBuilder.sqlList(recordIds);
         int removed = 0;
         for (Pair<String, String[]> querySet : whereParamList) {
@@ -281,7 +281,7 @@ public class CommCareEntityStorageCache implements EntityStorageCache {
     public void processShallowRecords() {
         try (Closeable ignored = lockCache()) {
             Set<String> shallowRecordIds = getShallowRecords();
-            Set<Integer> relatedRecordIds = CaseUtils.getRelatedCases(shallowRecordIds);
+            Vector<Integer> relatedRecordIds = CaseUtils.getRelatedCases(shallowRecordIds);
             deleteRecords(relatedRecordIds);
         } catch (IOException e) {
             Logger.exception("Error while processing shallow records", e);

--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -451,6 +451,7 @@ public abstract class DataPullTask<R>
         recordSuccessfulSyncTime(username);
 
         ExternalDataUpdateHelper.broadcastDataUpdate(context, null);
+        CommCareApplication.instance().scheduleEntityCacheInvalidation();
 
         if (loginNeeded) {
             CommCareApplication.instance().getAppStorage(UserKeyRecord.class).write(ukrForLogin);

--- a/app/src/org/commcare/tasks/EntityCacheInvalidationWorker.kt
+++ b/app/src/org/commcare/tasks/EntityCacheInvalidationWorker.kt
@@ -1,0 +1,23 @@
+package org.commcare.tasks
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import org.commcare.engine.cases.CaseUtils
+import org.commcare.models.database.user.models.CommCareEntityStorageCache
+import org.javarosa.core.services.Logger
+
+class EntityCacheInvalidationWorker(context: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(context, workerParams) {
+
+    override suspend fun doWork(): Result {
+        try {
+            val entityStorageCache: CommCareEntityStorageCache = CommCareEntityStorageCache("case")
+            entityStorageCache.processShallowRecords()
+        } catch (e: Exception) {
+            Logger.exception("Error encountered while invalidating entity cache", e)
+            return Result.failure()
+        }
+        return Result.success()
+    }
+}

--- a/app/src/org/commcare/xml/AndroidBulkCaseXmlParser.java
+++ b/app/src/org/commcare/xml/AndroidBulkCaseXmlParser.java
@@ -83,7 +83,7 @@ public class AndroidBulkCaseXmlParser extends BulkProcessingCaseXmlParser {
                 recordIdsToWipe.add(c.getID());
             }
             if (mEntityCache != null) {
-                mEntityCache.invalidateCaches(recordIdsToWipe);
+                mEntityCache.invalidateRecords(recordIdsToWipe);
             }
             mCaseIndexTable.clearCaseIndices(recordIdsToWipe);
 

--- a/app/src/org/commcare/xml/AndroidCaseXmlParser.java
+++ b/app/src/org/commcare/xml/AndroidCaseXmlParser.java
@@ -97,7 +97,7 @@ public class AndroidCaseXmlParser extends CaseXmlParser {
         try {
             super.commit(parsed);
             if (mEntityCache != null) {
-                mEntityCache.invalidateCache(String.valueOf(parsed.getID()));
+                mEntityCache.invalidateRecord(String.valueOf(parsed.getID()));
             }
             mCaseIndexTable.clearCaseIndices(parsed);
             mCaseIndexTable.indexCase(parsed);

--- a/app/unit-tests/resources/commcare-apps/case_list_lookup/restore.xml
+++ b/app/unit-tests/resources/commcare-apps/case_list_lookup/restore.xml
@@ -14,6 +14,9 @@
             <sample_choice_question>choice3</sample_choice_question>
             <sample_number_question>145</sample_number_question>
         </update>
+        <index>
+            <parent case_type="case">c44c7ade-0cec-4401-b422-4c475f0043ae</parent>
+        </index>
     </case>
     <case case_id="8e011880-602f-4017-b9d6-ed9dcbba7516"
           date_modified="2016-03-10T11:16:45.182000Z" user_id="441bdbb17001bade54aa23dcb7313950"
@@ -27,6 +30,9 @@
             <sample_choice_question>choice1</sample_choice_question>
             <sample_number_question>147</sample_number_question>
         </update>
+        <index>
+            <parent case_type="case">b319e951-03f1-4172-b662-4fb3964a0be7</parent>
+        </index>
     </case>
     <case case_id="c44c7ade-0cec-4401-b422-4c475f0043ae"
           date_modified="2016-03-10T11:19:50.826000Z" user_id="441bdbb17001bade54aa23dcb7313950"

--- a/app/unit-tests/resources/commcare-apps/index_and_cache_test/incremental_restore.xml
+++ b/app/unit-tests/resources/commcare-apps/index_and_cache_test/incremental_restore.xml
@@ -1,0 +1,18 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <fixture id="user-groups" user_id="441bdbb17001bade54aa23dcb7313950">
+        <groups/>
+    </fixture>
+    <case case_id="b319e951-03f1-4172-b662-4fb3964a0be7"
+        date_modified="2016-03-10T11:16:54.774000Z" user_id="441bdbb17001bade54aa23dcb7313950"
+        xmlns="http://commcarehq.org/case/transaction/v2">
+        <create>
+            <case_type>case</case_type>
+            <case_name>stan</case_name>
+            <owner_id>441bdbb17001bade54aa23dcb7313950</owner_id>
+        </create>
+        <update>
+            <sample_choice_question>choice2</sample_choice_question>
+            <sample_number_question>145</sample_number_question>
+        </update>
+    </case>
+</OpenRosaResponse>

--- a/app/unit-tests/resources/commcare-apps/index_and_cache_test/suite.xml
+++ b/app/unit-tests/resources/commcare-apps/index_and_cache_test/suite.xml
@@ -73,13 +73,13 @@
       </template>
     </field>
   </detail>
-  <detail id="m1_case_short">
+  <detail id="m1_case_short" cache_enabled="true">
     <title>
       <text>
         <locale id="m1.case_short.title"/>
       </text>
     </title>
-    <field>
+    <field cache_enabled="true">
       <header>
         <text>
           <locale id="m1.case_short.case_name_1.header"/>
@@ -90,7 +90,7 @@
           <xpath function="case_name"/>
         </text>
       </template>
-      <sort type="string" order="-2" direction="ascending">
+      <sort type="string" direction="ascending">
         <text>
           <xpath function="case_name"/>
         </text>

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -66,7 +66,6 @@ public class CommCareTestApplication extends CommCareApplication implements Test
     private static final String TAG = CommCareTestApplication.class.getSimpleName();
     private static PrototypeFactory testPrototypeFactory;
     private static final ArrayList<String> factoryClassNames = new ArrayList<>();
-
     private String cachedUserPassword;
 
     private final ArrayList<Throwable> asyncExceptions = new ArrayList<>();
@@ -75,6 +74,7 @@ public class CommCareTestApplication extends CommCareApplication implements Test
     public void onCreate() {
         // set if before calling super to initialte the dataChangeLogger correctly
         setExternalStorageState(Environment.MEDIA_MOUNTED);
+        initWorkManager();
 
         super.onCreate();
 
@@ -104,10 +104,15 @@ public class CommCareTestApplication extends CommCareApplication implements Test
 
     public static void initWorkManager() {
         Context context = ApplicationProvider.getApplicationContext();
-        Configuration config = new Configuration.Builder()
-                .setMinimumLoggingLevel(Log.DEBUG)
-                .build();
-        WorkManager.initialize(context, config);
+        try {
+            // first try to get instance to see if it's already initialised
+            WorkManager.getInstance(context);
+        } catch (IllegalStateException e) {
+            Configuration config = new Configuration.Builder()
+                    .setMinimumLoggingLevel(Log.DEBUG)
+                    .build();
+            WorkManager.initialize(context, config);
+        }
     }
 
     @Override

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -69,12 +69,12 @@ public class CommCareTestApplication extends CommCareApplication implements Test
     private String cachedUserPassword;
 
     private final ArrayList<Throwable> asyncExceptions = new ArrayList<>();
+    private boolean skipWorkManager = false;
 
     @Override
     public void onCreate() {
         // set if before calling super to initialte the dataChangeLogger correctly
         setExternalStorageState(Environment.MEDIA_MOUNTED);
-        initWorkManager();
 
         super.onCreate();
 
@@ -82,7 +82,6 @@ public class CommCareTestApplication extends CommCareApplication implements Test
 
         // allow "jr://resource" references
         ReferenceManager.instance().addReferenceFactory(new ResourceReferenceFactory());
-
         Thread.setDefaultUncaughtExceptionHandler((thread, ex) -> {
             asyncExceptions.add(ex);
             Assert.fail(ex.getMessage());
@@ -102,7 +101,7 @@ public class CommCareTestApplication extends CommCareApplication implements Test
     }
 
 
-    public static void initWorkManager() {
+    public void initWorkManager() {
         Context context = ApplicationProvider.getApplicationContext();
         try {
             // first try to get instance to see if it's already initialised
@@ -320,5 +319,9 @@ public class CommCareTestApplication extends CommCareApplication implements Test
     @Override
     public boolean isNsdServicesEnabled() {
         return false;
+    }
+
+    public void setSkipWorkManager() {
+        skipWorkManager = true;
     }
 }

--- a/app/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
@@ -14,6 +14,7 @@ import org.commcare.network.LocalReferencePullResponseFactory;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.ResultAndError;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -98,7 +99,6 @@ public class DataPullTaskTest {
 
     @Test
     public void dataPullRecoverWithRetryTest() {
-        initWorkManager();
         installLoginAndUseLocalKeys();
         runDataPull(new Integer[]{412, 202, 200}, new String[]{GOOD_RESTORE, RETRY_RESPONSE, GOOD_RESTORE});
         Assert.assertEquals(DataPullTask.PullTaskResult.DOWNLOAD_SUCCESS, dataPullResult.data);

--- a/app/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/DataPullTaskTest.java
@@ -1,9 +1,8 @@
 package org.commcare.android.tests;
 
-import static org.commcare.CommCareTestApplication.initWorkManager;
 
-import android.content.Context;
-import android.util.Log;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
@@ -20,11 +19,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
-
-import androidx.test.core.app.ApplicationProvider;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.work.Configuration;
-import androidx.work.WorkManager;
 
 /**
  * Coverage for different DataPullTask codepaths.
@@ -47,6 +41,11 @@ public class DataPullTaskTest {
      */
     private static ResultAndError<DataPullTask.PullTaskResult> dataPullResult;
     private static DataPullTask pullTask;
+
+    @Before
+    public void setUp() {
+        ((CommCareTestApplication)CommCareTestApplication.instance()).initWorkManager();
+    }
 
     @Test
     public void dataPullWithMissingRemoteKeyRecordTest() {

--- a/app/unit-tests/src/org/commcare/android/tests/DemoUserRestoreTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/DemoUserRestoreTest.java
@@ -51,6 +51,11 @@ public class DemoUserRestoreTest {
     private final static String REF_BASE_DIR =
             "jr://resource/commcare-apps/demo_user_restore/";
 
+    @Before
+    public void setUp() throws Exception {
+        ((CommCareTestApplication)CommCareTestApplication.instance()).setSkipWorkManager();
+    }
+
     private static void loginAsDemoUser() {
         Intent loginActivityIntent =
                 new Intent(ApplicationProvider.getApplicationContext(), LoginActivity.class);

--- a/app/unit-tests/src/org/commcare/android/tests/activities/PostRequestActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/PostRequestActivityTest.java
@@ -61,11 +61,13 @@ import java.util.HashMap;
 @Config(application = CommCareTestApplication.class)
 @RunWith(AndroidJUnit4.class)
 public class PostRequestActivityTest {
+
     @Before
     public void setup() {
         TestAppInstaller.installAppAndLogin(
                 "jr://resource/commcare-apps/case_search_and_claim/profile.ccpr",
                 "test", "123");
+        ((CommCareTestApplication)CommCareTestApplication.instance()).initWorkManager();
     }
 
     @Test

--- a/app/unit-tests/src/org/commcare/android/tests/activities/UpdateActivityTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/activities/UpdateActivityTest.java
@@ -47,6 +47,7 @@ public class UpdateActivityTest {
         TestAppInstaller.installAppAndLogin(
                 "jr://resource/commcare-apps/update_tests/base_app/profile.ccpr",
                 "test", "123");
+        ((CommCareTestApplication)CommCareTestApplication.instance()).initWorkManager();
     }
 
     /**

--- a/app/unit-tests/src/org/commcare/android/tests/caselist/EntityListCacheIndexTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/caselist/EntityListCacheIndexTest.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.MockedStatic;
 import org.robolectric.annotation.Config;
+import org.commcare.cases.entity.EntityStorageCache.ValueType;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -70,7 +71,7 @@ public class EntityListCacheIndexTest {
 
             // verify cases have been cached
             CommCareEntityStorageCache entityStorageCache = new CommCareEntityStorageCache("case");
-            String cacheKey = entityStorageCache.getCacheKey("m1_case_short", "0");
+            String cacheKey = entityStorageCache.getCacheKey("m1_case_short", "0", ValueType.TYPE_NORMAL_FIELD);
             assertEquals("stan", entityStorageCache.retrieveCacheValue("1", cacheKey));
             assertEquals("ellen", entityStorageCache.retrieveCacheValue("2", cacheKey));
             assertEquals("pat", entityStorageCache.retrieveCacheValue("3", cacheKey));
@@ -78,6 +79,7 @@ public class EntityListCacheIndexTest {
             // verify changing a case expires the related cases in cache
             TestUtils.processResourceTransactionIntoAppDb(
                     "/commcare-apps/index_and_cache_test/incremental_restore.xml");
+            entityStorageCache.processShallowRecords();
             assertNull(entityStorageCache.retrieveCacheValue("1", cacheKey));
             assertNull(entityStorageCache.retrieveCacheValue("2", cacheKey));
             assertNull(entityStorageCache.retrieveCacheValue("3", cacheKey));

--- a/app/unit-tests/src/org/commcare/android/tests/caselist/EntityListCacheIndexTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/caselist/EntityListCacheIndexTest.java
@@ -1,5 +1,11 @@
 package org.commcare.android.tests.caselist;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mockStatic;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
 import org.commcare.CommCareTestApplication;
 import org.commcare.activities.EntitySelectActivity;
 import org.commcare.adapters.EntityListAdapter;
@@ -7,14 +13,17 @@ import org.commcare.android.util.ActivityLaunchUtils;
 import org.commcare.android.util.CaseLoadUtils;
 import org.commcare.android.util.TestAppInstaller;
 import org.commcare.android.util.TestUtils;
+import org.commcare.models.database.user.models.CommCareEntityStorageCache;
+import org.commcare.preferences.DeveloperPreferences;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.MockedStatic;
 import org.robolectric.annotation.Config;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * Test the cache and index sort property
@@ -26,19 +35,52 @@ import static org.junit.Assert.assertEquals;
 public class EntityListCacheIndexTest {
     private EntitySelectActivity entitySelectActivity;
     private EntityListAdapter adapter;
+
+
+    @Parameterized.Parameter
+    public boolean useBulkProcessing;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {true},
+                {false}
+        });
+    }
+
     @Before
     public void setup() {
         String appProfileResource =
                 "jr://resource/commcare-apps/index_and_cache_test/profile.ccpr";
         TestAppInstaller.installAppAndLogin(appProfileResource, "test", "123");
-        TestUtils.processResourceTransactionIntoAppDb("/commcare-apps/case_list_lookup/restore.xml");
     }
 
     @Test
-    public void testCacheAndIndex() {
-        entitySelectActivity = ActivityLaunchUtils.launchEntitySelectActivity("m1-f0");
-        adapter = CaseLoadUtils.loadList(entitySelectActivity);
-        assertEquals(8, adapter.getCount());
-        // Because the crash happens off the main thread, wait for backgrounds threads to terminate
+    public void testCaseCacheExpiration() {
+        try (MockedStatic<DeveloperPreferences> mockedStatic = mockStatic(DeveloperPreferences.class)) {
+            mockedStatic.when(DeveloperPreferences::isBulkPerformanceEnabled).thenReturn(useBulkProcessing);
+
+            // Restore
+            TestUtils.processResourceTransactionIntoAppDb("/commcare-apps/case_list_lookup/restore.xml");
+
+            // Load Case List
+            entitySelectActivity = ActivityLaunchUtils.launchEntitySelectActivity("m1-f0");
+            adapter = CaseLoadUtils.loadList(entitySelectActivity);
+            assertEquals(8, adapter.getCount());
+
+            // verify cases have been cached
+            CommCareEntityStorageCache entityStorageCache = new CommCareEntityStorageCache("case");
+            String cacheKey = entityStorageCache.getCacheKey("m1_case_short", "0");
+            assertEquals("stan", entityStorageCache.retrieveCacheValue("1", cacheKey));
+            assertEquals("ellen", entityStorageCache.retrieveCacheValue("2", cacheKey));
+            assertEquals("pat", entityStorageCache.retrieveCacheValue("3", cacheKey));
+
+            // verify changing a case expires the related cases in cache
+            TestUtils.processResourceTransactionIntoAppDb(
+                    "/commcare-apps/index_and_cache_test/incremental_restore.xml");
+            assertNull(entityStorageCache.retrieveCacheValue("1", cacheKey));
+            assertNull(entityStorageCache.retrieveCacheValue("2", cacheKey));
+            assertNull(entityStorageCache.retrieveCacheValue("3", cacheKey));
+        }
     }
 }

--- a/app/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formnav/EndOfFormTest.java
@@ -42,6 +42,7 @@ public class EndOfFormTest {
         TestAppInstaller.installAppAndLogin(
                 "jr://resource/commcare-apps/form_nav_tests/profile.ccpr",
                 "test", "123");
+        ((CommCareTestApplication)CommCareTestApplication.instance()).initWorkManager();
     }
 
     /**


### PR DESCRIPTION
## Product Description
[Spec](https://docs.google.com/document/d/1VE6yjo-yOfhnwpHMRZWavgJmbmbRhsoVvWS3Kq3yh2g/edit?tab=t.0#heading=h.ivv3e8sh6t45)

https://dimagi.atlassian.net/browse/SC-4279

Expires cache for all related cases in order to support caching xpath calculation results for related cases like instance('casedb')/casedb/case[@case_type='mother'][@case_id=current()/index/parent]/case_name. Without expiring related cases from cache, these kind of expressions may result in obsolete data to the user.

## Technical Summary

Alternate approach to https://github.com/dimagi/commcare-android/pull/2944

Adds a new field `is_shallow` in the entity cache to signify any cases that have changed from the last time the cache was primed. These shallow records are then further processed by a background worker after form submission and restores to delete any cache records related to these cases or their related cases. 

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
CACHE_AND_LAZY_LOAD

## Safety Assurance

### Safety story

should only affect projects implementing caching for case list. 

### Automated test coverage
Adds a test to verify the cache expiration behavior

### QA Plan
This whole feature will be QA'ed as part of mobile release cycle.

## Labels and Review

- [x] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [x] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

cross-request: https://github.com/dimagi/commcare-core/pull/1460