### PR TITLE
Delete SSO token storage when token auth fails

### DIFF
--- a/app/src/org/commcare/android/database/connect/models/ConnectJobAssessmentRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobAssessmentRecord.java
@@ -1,7 +1,6 @@
 package org.commcare.android.database.connect.models;
 
 import org.commcare.android.storage.framework.Persisted;
-import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
 import org.commcare.modern.models.MetaField;

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobDeliveryRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobDeliveryRecord.java
@@ -1,7 +1,6 @@
 package org.commcare.android.database.connect.models;
 
 import org.commcare.android.storage.framework.Persisted;
-import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
 import org.commcare.modern.models.MetaField;

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobLearningRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobLearningRecord.java
@@ -1,7 +1,6 @@
 package org.commcare.android.database.connect.models;
 
 import org.commcare.android.storage.framework.Persisted;
-import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
 import org.commcare.modern.models.MetaField;

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobPaymentRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobPaymentRecord.java
@@ -1,7 +1,6 @@
 package org.commcare.android.database.connect.models;
 
 import org.commcare.android.storage.framework.Persisted;
-import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
 import org.commcare.modern.models.MetaField;

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobPaymentRecordV3.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobPaymentRecordV3.java
@@ -1,18 +1,12 @@
 package org.commcare.android.database.connect.models;
 
 import org.commcare.android.storage.framework.Persisted;
-import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
 import org.commcare.modern.models.MetaField;
-import org.javarosa.core.model.utils.DateUtils;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.io.Serializable;
-import java.text.ParseException;
 import java.util.Date;
-import java.util.Locale;
 
 @Table(ConnectJobPaymentRecordV3.STORAGE_KEY)
 public class ConnectJobPaymentRecordV3 extends Persisted implements Serializable {

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -1,23 +1,17 @@
 package org.commcare.android.database.connect.models;
 
-import android.view.View;
-
 import org.commcare.android.storage.framework.Persisted;
-import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
 import org.commcare.modern.models.MetaField;
 import org.commcare.utils.CrashUtil;
 import org.javarosa.core.model.utils.DateUtils;
-import org.javarosa.core.services.Logger;
-import org.joda.time.LocalDate;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.Serializable;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;

--- a/app/src/org/commcare/android/database/connect/models/ConnectLinkedAppRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectLinkedAppRecord.java
@@ -117,6 +117,11 @@ public class ConnectLinkedAppRecord extends Persisted {
         hqTokenExpiration = token.expiration;
     }
 
+    public void clearHqToken() {
+        hqToken = null;
+        hqTokenExpiration = new Date();
+    }
+
     public boolean getConnectIdLinked() { return connectIdLinked; }
     public void setConnectIdLinked(boolean linked) { connectIdLinked = linked; }
 

--- a/app/src/org/commcare/android/database/connect/models/ConnectUserRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectUserRecord.java
@@ -194,6 +194,11 @@ public class ConnectUserRecord extends Persisted {
         connectTokenExpiration = expirationDate;
     }
 
+    public void clearConnectToken() {
+        connectToken = null;
+        connectTokenExpiration = new Date();
+    }
+
     public String getConnectToken() {
         return connectToken;
     }

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -1,10 +1,7 @@
 package org.commcare.connect;
 
-import static org.commcare.android.database.connect.models.ConnectJobRecord.STATUS_AVAILABLE;
 import static org.commcare.android.database.connect.models.ConnectJobRecord.STATUS_DELIVERING;
-import static org.commcare.android.database.connect.models.ConnectJobRecord.STATUS_LEARNING;
 import static org.commcare.connect.ConnectConstants.CONNECTID_REQUEST_CODE;
-import static org.commcare.connect.ConnectConstants.DELIVERY_APP;
 
 import android.app.Activity;
 import android.content.Context;
@@ -17,7 +14,6 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
-import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.work.BackoffPolicy;
 import androidx.work.Constraints;
 import androidx.work.ExistingPeriodicWorkPolicy;
@@ -28,7 +24,6 @@ import androidx.work.WorkManager;
 import org.commcare.AppUtils;
 import org.commcare.CommCareApplication;
 import org.commcare.activities.CommCareActivity;
-import org.commcare.activities.StandardHomeActivity;
 import org.commcare.activities.connect.ConnectActivity;
 import org.commcare.activities.connect.ConnectIdActivity;
 import org.commcare.activities.connect.ConnectMessagingActivity;

--- a/app/src/org/commcare/connect/network/ApiConnectId.java
+++ b/app/src/org/commcare/connect/network/ApiConnectId.java
@@ -98,7 +98,7 @@ public class ApiConnectId {
         ConnectNetworkHelper.PostResult postResult = ConnectNetworkHelper.postSync(context, url,
                 API_VERSION_NONE, new AuthInfo.NoAuth(), params, true, false);
         Logger.log(LogTypes.TYPE_MAINTENANCE, "OAuth Token Post Result " + postResult.responseCode);
-        if (postResult.responseCode == 200) {
+        if (postResult.responseCode == 200 || postResult.responseCode == 201) {
             try {
                 String responseAsString = new String(StreamsUtil.inputStreamToByteArray(
                         postResult.responseStream));
@@ -122,6 +122,9 @@ public class ApiConnectId {
             } catch (IOException | JSONException e) {
                 Logger.exception("Parsing return from HQ OIDC call", e);
             }
+        } else if (postResult.responseCode == 401) {
+            Logger.exception("Invalid ConnectID SSO token", new Exception("Invalid ConnectID token when trying to retrieve HQ token"));
+            ConnectSsoHelper.discardTokens(context, hqUsername);
         }
 
         return null;

--- a/app/src/org/commcare/connect/network/ConnectNetworkHelper.java
+++ b/app/src/org/commcare/connect/network/ConnectNetworkHelper.java
@@ -198,7 +198,8 @@ public class ConnectNetworkHelper {
                         requestBody,
                         HTTPMethod.POST,
                         authInfo);
-        postTask.connect(getResponseProcessor(context, url, background, handler));
+        postTask.connect(getResponseProcessor(context, url, authInfo instanceof AuthInfo.TokenAuth,
+                background, handler));
 
         postTask.executeParallel();
 
@@ -324,14 +325,15 @@ public class ConnectNetworkHelper {
                         ArrayListMultimap.create(),
                         headers,
                         authInfo);
-        getTask.connect(getResponseProcessor(context, url, background, handler));
+        getTask.connect(getResponseProcessor(context, url, authInfo instanceof AuthInfo.TokenAuth,
+                background, handler));
         getTask.executeParallel();
 
         return true;
     }
 
     private ConnectorWithHttpResponseProcessor<HttpResponseProcessor> getResponseProcessor(
-            Context context, String url, boolean background, IApiCallback handler) {
+            Context context, String url, boolean usingTokenAuth, boolean background, IApiCallback handler) {
         return new ConnectorWithHttpResponseProcessor<>() {
             @Override
             public void processSuccess(int responseCode, InputStream responseData, String apiVersion) {
@@ -351,6 +353,11 @@ public class ConnectNetworkHelper {
                     handler.processOldApiError();
                 } else {
                     //400 error
+                    if (responseCode == 401 && usingTokenAuth) {
+                        Logger.exception("Invalid token", new Exception("Invalid token during API call"));
+                        ConnectSsoHelper.discardTokens(context, null);
+                    }
+
                     handler.processFailure(responseCode, null);
                 }
             }

--- a/app/src/org/commcare/connect/network/ConnectSsoHelper.java
+++ b/app/src/org/commcare/connect/network/ConnectSsoHelper.java
@@ -4,10 +4,13 @@ import android.content.Context;
 import android.os.AsyncTask;
 
 import org.commcare.CommCareApplication;
+import org.commcare.android.database.connect.models.ConnectUserRecord;
 import org.commcare.connect.ConnectDatabaseHelper;
 import org.commcare.connect.ConnectManager;
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
 import org.commcare.core.network.AuthInfo;
+import org.commcare.util.LogTypes;
+import org.javarosa.core.services.Logger;
 
 import java.lang.ref.WeakReference;
 
@@ -94,5 +97,25 @@ public class ConnectSsoHelper {
         TokenTask task = new TokenTask(context, null, false, callback);
 
         task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    public static void discardTokens(Context context, String username) {
+        String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
+
+        Logger.log(LogTypes.TYPE_MAINTENANCE, "Clearing SSO tokens");
+
+        if(username != null) {
+            ConnectLinkedAppRecord appRecord = ConnectDatabaseHelper.getAppData(context, seatedAppId, username);
+            if (appRecord != null) {
+                appRecord.clearHqToken();
+                ConnectDatabaseHelper.storeApp(context, appRecord);
+            }
+        }
+
+        ConnectUserRecord user = ConnectDatabaseHelper.getUser(context);
+        if(user != null) {
+            user.clearConnectToken();
+            ConnectDatabaseHelper.storeUser(context, user);
+        }
     }
 }

--- a/app/src/org/commcare/fragments/connectId/ConnectIDSignupFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIDSignupFragment.java
@@ -28,7 +28,6 @@ import org.commcare.connect.ConnectConstants;
 import org.commcare.connect.ConnectDatabaseHelper;
 import org.commcare.connect.ConnectManager;
 import org.commcare.connect.network.ApiConnectId;
-import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.connect.network.IApiCallback;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.FragmentSignupBinding;
@@ -42,7 +41,6 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.ParseException;
 import java.util.Locale;
 import java.util.Random;
 


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-666

When an API call fails due to a 401 error while using TokenAuth, we should delete the token from local storage.
This is most likely to occur due to a clock error (drift or time zone mismatch) on the device.
For whatever reason the token failed, it should be discarded so a new token is retrieved the next time an API call is made.

This code addresses token failures for both HQ and ConnectID tokens in several places:
- [Checking response for HQ calls](https://github.com/dimagi/commcare-android/blob/5113bd1950004148398a740c04add1016ceb242c/app/src/org/commcare/network/CommcareRequestGenerator.java#L215)
- [ResponseProcessor for Connect calls using ConnectID token](https://github.com/dimagi/commcare-android/blob/5113bd1950004148398a740c04add1016ceb242c/app/src/org/commcare/connect/network/ConnectNetworkHelper.java#L356)
- [Failure getting new HQ token using ConnectID token](https://github.com/dimagi/commcare-android/blob/5113bd1950004148398a740c04add1016ceb242c/app/src/org/commcare/connect/network/ApiConnectId.java#L126)

## Feature Flag
ConnectID

## Safety Assurance

### Safety story
Tested by performing a successful HQ API call with an app managed by ConnectID, to get valid ConnectID and HQ tokens.
Then waited for the tokens to expire
Manually set date on the device to the day before so it thought the tokens were still valid
Tried to make a Connect API, observed the 401 call and discarded token, observed retry on the call succeeding (including new token retrieval).
Repeated the test from the beginning (new tokens, then expired), then attempted a managed HQ API call and observed the same results as previous test.

The main idea here is that tokens are pretty cheap, so if a token isn't good when we thought it would be we should just go get a new one and expect things to work at that point.

In normal usage where tokens are managed correctly (no clock errors resulting in using expired tokens), there will be no effect from this new change.

### Automated test coverage
No automated tests for ConnectID yet.

### QA Plan
QA should attempt similar steps for testing to the ones described above, i.e. manually altering the clock to trick the device into attempting an API call with one or both bad tokens.

## Labels and Review

- [ x ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
