### PR TITLE
Removed adding Go to connect jobs in dropdown in login screen

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -737,12 +737,6 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
         appIdDropdownList.clear();
 
-        boolean includeConnect = ConnectManager.isConnectIdConfigured();
-        if (includeConnect) {
-            appNames.add(Localization.get("login.app.connect"));
-            appIdDropdownList.add("");
-        }
-
         for (ApplicationRecord r : readyApps) {
             appNames.add(r.getDisplayName());
             appIdDropdownList.add(r.getUniqueId());


### PR DESCRIPTION


## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-712

## Feature Flag
This is bug fix


### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
User should login with CommCare account and then move to sign up for connect sign up. After this, move to login page, where duplication of Go to Connect Jobs should not be visible in dropdown.

## Labels and Review
Not applicable for this PR.
