### PR TITLE
Remove media permissions

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -173,7 +173,15 @@
         <activity android:name="org.commcare.activities.StandardHomeActivity"/>
         <activity android:name="org.commcare.activities.RootMenuHomeActivity"/>
         <activity android:name="org.commcare.activities.MenuActivity"/>
-
+        <service android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data android:name="photopicker_activity:0:required" android:value="" />
+        </service>
         <provider
             android:name="org.commcare.provider.FormsProvider"
             android:exported="false"

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -27,8 +27,6 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation (name: 'realm-android-library-4.1.1', ext: 'aar')
     implementation (name: 'volley-1.1.0', ext: 'aar')
     implementation (name: 'storage-2.1.0', ext: 'aar')
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation (name: 'realm-android-library-4.1.1', ext: 'aar')
     implementation (name: 'volley-1.1.0', ext: 'aar')
     implementation (name: 'storage-2.1.0', ext: 'aar')
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation (name: 'realm-android-library-4.1.1', ext: 'aar')
     implementation (name: 'volley-1.1.0', ext: 'aar')
     implementation (name: 'storage-2.1.0', ext: 'aar')
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/app/instrumentation-tests/src/org/commcare/androidTests/BaseTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/BaseTest.kt
@@ -48,9 +48,7 @@ abstract class BaseTest {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             appPermissions.addAll(arrayOf(
-                    Manifest.permission.READ_MEDIA_IMAGES,
                     Manifest.permission.READ_MEDIA_AUDIO,
-                    Manifest.permission.READ_MEDIA_VIDEO,
                     Manifest.permission.POST_NOTIFICATIONS))
         } else {
             appPermissions.addAll(arrayOf(

--- a/app/src/org/commcare/utils/Permissions.java
+++ b/app/src/org/commcare/utils/Permissions.java
@@ -104,9 +104,7 @@ public class Permissions {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             appPermissions.addAll(Arrays.asList(new String[]{
-                    Manifest.permission.READ_MEDIA_IMAGES,
                     Manifest.permission.READ_MEDIA_AUDIO,
-                    Manifest.permission.READ_MEDIA_VIDEO,
                     Manifest.permission.POST_NOTIFICATIONS}));
         } else {
             appPermissions.addAll(Arrays.asList(new String[]{
@@ -122,9 +120,7 @@ public class Permissions {
     public static String[] getRequiredPerms() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             return new String[]{
-                    Manifest.permission.READ_MEDIA_IMAGES,
-                    Manifest.permission.READ_MEDIA_AUDIO,
-                    Manifest.permission.READ_MEDIA_VIDEO};
+                    Manifest.permission.READ_MEDIA_AUDIO};
         }
         return new String[]{
                 Manifest.permission.READ_EXTERNAL_STORAGE,

--- a/app/src/org/commcare/views/widgets/ImageWidget.java
+++ b/app/src/org/commcare/views/widgets/ImageWidget.java
@@ -136,11 +136,10 @@ public class ImageWidget extends QuestionWidget {
                 ImageCaptureProcessing.setCustomImagePath(null);
             } else {
                 mErrorTextView.setVisibility(View.GONE);
-                Intent i = new Intent(Intent.ACTION_GET_CONTENT);
-                i.setType("image/*");
 
                 try {
-                    ((AppCompatActivity)getContext()).startActivityForResult(i,
+                    ((AppCompatActivity)getContext()).startActivityForResult(
+                            WidgetUtils.createPickMediaIntent (getContext(), "image/*"),
                             FormEntryConstants.IMAGE_CHOOSER);
                     pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
                 } catch (ActivityNotFoundException e) {

--- a/app/src/org/commcare/views/widgets/ImageWidget.java
+++ b/app/src/org/commcare/views/widgets/ImageWidget.java
@@ -138,9 +138,9 @@ public class ImageWidget extends QuestionWidget {
                 mErrorTextView.setVisibility(View.GONE);
 
                 try {
-                    ((AppCompatActivity)getContext()).startActivityForResult(
-                            WidgetUtils.createPickMediaIntent (getContext(), "image/*"),
-                            FormEntryConstants.IMAGE_CHOOSER);
+                    ((AppCompatActivity)getContext())
+                            .startActivityForResult(WidgetUtils.createPickMediaIntent (getContext(), "image/*"),
+                                    FormEntryConstants.IMAGE_CHOOSER);
                     pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(getContext(),

--- a/app/src/org/commcare/views/widgets/VideoWidget.java
+++ b/app/src/org/commcare/views/widgets/VideoWidget.java
@@ -65,9 +65,9 @@ public class VideoWidget extends MediaWidget {
         // launch capture intent on click
         mChooseButton.setOnClickListener(v -> {
             try {
-                ((AppCompatActivity)getContext()).startActivityForResult(
-                        WidgetUtils.createPickMediaIntent (getContext(), "video/*"),
-                        FormEntryConstants.AUDIO_VIDEO_FETCH);
+                ((AppCompatActivity)getContext())
+                        .startActivityForResult(WidgetUtils.createPickMediaIntent (getContext(), "video/*"),
+                                FormEntryConstants.AUDIO_VIDEO_FETCH);
                 pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
             } catch (ActivityNotFoundException e) {
                 Toast.makeText(getContext(),

--- a/app/src/org/commcare/views/widgets/VideoWidget.java
+++ b/app/src/org/commcare/views/widgets/VideoWidget.java
@@ -64,10 +64,9 @@ public class VideoWidget extends MediaWidget {
 
         // launch capture intent on click
         mChooseButton.setOnClickListener(v -> {
-            Intent i = new Intent(Intent.ACTION_GET_CONTENT);
-            i.setType("video/*");
             try {
-                ((AppCompatActivity)getContext()).startActivityForResult(i,
+                ((AppCompatActivity)getContext()).startActivityForResult(
+                        WidgetUtils.createPickMediaIntent (getContext(), "video/*"),
                         FormEntryConstants.AUDIO_VIDEO_FETCH);
                 pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
             } catch (ActivityNotFoundException e) {

--- a/app/src/org/commcare/views/widgets/WidgetUtils.java
+++ b/app/src/org/commcare/views/widgets/WidgetUtils.java
@@ -1,7 +1,10 @@
 package org.commcare.views.widgets;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.provider.MediaStore;
 import android.text.Spannable;
 import android.text.TextUtils;
 import android.util.TypedValue;
@@ -74,5 +77,23 @@ public class WidgetUtils {
             intentIntegrator.setDesiredBarcodeFormats(formats);
         }
         return intentIntegrator.createScanIntent();
+    }
+
+    @SuppressLint("InlinedApi")
+    public static Intent createPickMediaIntent(Context context, String mimeType) {
+        Intent intent = new Intent();
+        if (isPhotoPickerSupported(context)) {
+            intent.setAction(MediaStore.ACTION_PICK_IMAGES);
+        } else {
+            intent.setAction(Intent.ACTION_GET_CONTENT);
+        }
+        return intent.setType(mimeType);
+    }
+
+    @SuppressLint("InlinedApi")
+    public static boolean isPhotoPickerSupported(Context context) {
+        Intent intent = new Intent(MediaStore.ACTION_PICK_IMAGES);
+        PackageManager packageManager = context.getPackageManager();
+        return intent.resolveActivity(packageManager) != null;
     }
 }


### PR DESCRIPTION
## Product Description
Google issued a new policy that states that [READ_MEDIA_IMAGES](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_IMAGES) and [READ_MEDIA_VIDEO](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_VIDEO) permissions can only be used by apps whose core functionality requires broad access to images and videos stored in the device. These permissions were introduced in Android 13 and as such, this policy mostly affects that version and later. For apps that don't require this level of access, the recommended approach is to use a system picker, like the [Android photo picker](https://developer.android.com/training/data-storage/shared/photopicker), which is available in Android 13 onward. Additionally, Google is committed to making the photo picker the default behaviour and is working to make it available to older versions too:
- Android 11 and 12 - through Google System updates
- Android 4.4 to 10 - via a backported version distributed through Google Play Services.

This PR implements the necessary changes to comply with this policy considering that CommCare doesn't need broad access to media files. 
**Note to reviewers:** this work also involved assessing whether to adopt the _ActivityResult API_, since _startActivityForResult_ is now deprecated. However, these two approaches can't be mixed, meaning that migrating would require the definition of ActivitResult contracts for every option in the `FormEntryActivity.onAtivityResult` method.

## Safety Assurance

### Safety story
This changes the current approach when selecting media files to upload in CommCare, it sets preference to system photo and video pickers that can handle the [ACTION_PICK_IMAGE](https://developer.android.com/reference/android/provider/MediaStore#ACTION_PICK_IMAGES) action, falling back to `ACTION_GET_CONTENT` when an appropriate component is not available, so is not supposed to break anything. Moreover, these change were tested on Android 5, 6, 8, 9, 10, 11, 12 and 13

### QA Plan
A QA label has been  added to ensure that this gets tested on both  the minimum (Android 5) and maximum (Android 14) supported versions.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change

cross-request: https://github.com/dimagi/commcare-core/pull/1462