### PR TITLE
Remove pay-per-visit text from job summary cards

### DIFF
--- a/app/res/layout/view_job_card.xml
+++ b/app/res/layout/view_job_card.xml
@@ -35,32 +35,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/tv_job_title" />
 
-        <LinearLayout
-            android:id="@+id/linearLayout6"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:orientation="horizontal"
-            app:layout_constraintStart_toStartOf="@+id/tv_job_discrepation"
-            app:layout_constraintTop_toBottomOf="@+id/tv_job_discrepation">
-
-            <org.commcare.views.connect.connecttextview.ConnectMediumTextView
-                android:id="@+id/connect_job_pay"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="100"
-                android:textColor="@color/connect_blue_color"
-                android:textSize="14sp" />
-
-            <org.commcare.views.connect.connecttextview.ConnectRegularTextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:text="@string/connect_job_info_per_visit"
-                android:textColor="@color/connect_subtext_color"
-                android:textSize="14sp" />
-        </LinearLayout>
-
         <org.commcare.views.connect.connecttextview.ConnectMediumTextView
             android:id="@+id/tv_view_more"
             android:layout_width="0dp"
@@ -70,7 +44,7 @@
             android:textColor="@color/connect_dark_blue_color"
             android:textSize="14sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/linearLayout6" />
+            app:layout_constraintTop_toBottomOf="@+id/tv_job_discrepation" />
 
 
         <org.commcare.views.connect.connecttextview.ConnectBoldTextView
@@ -81,7 +55,7 @@
             android:textColor="@color/connect_grey"
             android:textSize="12sp"
             android:visibility="visible"
-            app:layout_constraintBottom_toTopOf="@+id/tv_job_time"
+            app:layout_constraintTop_toBottomOf="@+id/tv_job_discrepation"
             app:layout_constraintEnd_toEndOf="parent"
             tools:visibility="visible" />
 
@@ -89,12 +63,11 @@
             android:id="@+id/tv_job_time"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
             android:text="8:00 AM - 5:00 PM"
             android:textColor="@color/connect_dark_blue_color"
             android:textSize="16sp"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="@+id/tv_view_more" />
+            app:layout_constraintTop_toBottomOf="@+id/tvDailyVisitTitle" />
 
 
         <org.commcare.views.connect.connecttextview.ConnectRegularTextView

--- a/app/res/layout/view_progress_job_card.xml
+++ b/app/res/layout/view_progress_job_card.xml
@@ -35,32 +35,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/tv_job_title" />
 
-        <LinearLayout
-            android:id="@+id/linearLayout6"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:orientation="horizontal"
-            app:layout_constraintStart_toStartOf="@+id/tv_job_discrepation"
-            app:layout_constraintTop_toBottomOf="@+id/tv_job_discrepation">
-
-            <org.commcare.views.connect.connecttextview.ConnectMediumTextView
-                android:id="@+id/connect_job_pay"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="100"
-                android:textColor="@color/connect_blue_color"
-                android:textSize="14sp" />
-
-            <org.commcare.views.connect.connecttextview.ConnectRegularTextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:text="@string/connect_job_info_per_visit"
-                android:textColor="@color/connect_subtext_color"
-                android:textSize="14sp" />
-        </LinearLayout>
-
         <org.commcare.views.connect.connecttextview.ConnectMediumTextView
             android:id="@+id/tv_view_more"
             android:layout_width="0dp"
@@ -71,7 +45,7 @@
             android:textColor="@color/connect_dark_blue_color"
             android:textSize="14sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/linearLayout6" />
+            app:layout_constraintTop_toBottomOf="@+id/tv_job_discrepation" />
 
         <org.commcare.views.connect.connecttextview.ConnectBoldTextView
             android:id="@+id/tvDailyVisitTitle"
@@ -81,9 +55,8 @@
             android:textColor="@color/connect_grey"
             android:textSize="12sp"
             android:visibility="visible"
-            app:layout_constraintBottom_toBottomOf="@+id/linearLayout6"
+            app:layout_constraintTop_toBottomOf="@+id/tv_job_discrepation"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/linearLayout6"
             tools:visibility="visible" />
 
         <org.commcare.views.connect.connecttextview.ConnectBoldTextView

--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -85,13 +85,11 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
             ConnectMediumTextView tvJobDiscrepation = viewJobCard.findViewById(R.id.tv_job_discrepation);
             ConnectBoldTextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
             ConnectBoldTextView tv_job_time = viewJobCard.findViewById(R.id.tv_job_time);
-            ConnectMediumTextView connectJobPay = viewJobCard.findViewById(R.id.connect_job_pay);
             ConnectRegularTextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
 
             tvJobTitle.setText(job.getTitle());
             tvViewMore.setVisibility(View.GONE);
             tvJobDiscrepation.setText(job.getDescription());
-            connectJobPay.setText(job.getMoneyString(job.getBudgetPerVisit()));
             connectJobEndDate.setText(activity.getString(R.string.connect_learn_complete_by, ConnectManager.formatDate(job.getProjectEndDate())));
 
             String workingHours = job.getWorkingHours();

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryDetailsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryDetailsFragment.java
@@ -24,8 +24,6 @@ import org.commcare.connect.network.IApiCallback;
 import org.commcare.dalvik.R;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.utils.MultipleAppsUtil;
-import org.commcare.views.connect.connecttextview.ConnectBoldTextView;
-import org.commcare.views.connect.connecttextview.ConnectMediumTextView;
 import org.commcare.views.connect.connecttextview.ConnectRegularTextView;
 
 import java.io.IOException;
@@ -89,14 +87,6 @@ public class ConnectDeliveryDetailsFragment extends Fragment {
 
         textView.setText(paymentText);
 
-//        boolean expired = daysRemaining < 0;
-//        textView = view.findViewById(R.id.connect_delivery_action_title);
-//        textView.setText(expired ? R.string.connect_delivery_expired : R.string.connect_delivery_ready_to_claim);
-
-//        textView = view.findViewById(R.id.connect_delivery_action_details);
-//        textView.setText(expired ? R.string.connect_delivery_expired_detailed :
-//                R.string.connect_delivery_ready_to_claim_detailed);
-
         boolean jobClaimed = job.getStatus() == ConnectJobRecord.STATUS_DELIVERING;
         boolean installed = false;
         for (ApplicationRecord app : MultipleAppsUtil.appRecordArray()) {
@@ -114,7 +104,6 @@ public class ConnectDeliveryDetailsFragment extends Fragment {
 
         Button button = view.findViewById(R.id.connect_delivery_button);
         button.setText(buttonTextId);
-//        button.setEnabled(!expired);
         button.setOnClickListener(v -> {
             if (jobClaimed) {
                 proceedAfterJobClaimed(button, job, appInstalled);
@@ -148,36 +137,7 @@ public class ConnectDeliveryDetailsFragment extends Fragment {
             }
         });
 
-//        jobCardDataHandle(view, job);
         return view;
-    }
-
-    private void jobCardDataHandle(View view, ConnectJobRecord job) {
-        View viewJobCard = view.findViewById(R.id.viewJobCard);
-        ConnectMediumTextView viewMore = viewJobCard.findViewById(R.id.tv_view_more);
-        ConnectBoldTextView tvJobTitle = viewJobCard.findViewById(R.id.tv_job_title);
-        ConnectBoldTextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
-        ConnectBoldTextView tv_job_time = viewJobCard.findViewById(R.id.tv_job_time);
-        ConnectMediumTextView tvJobDiscrepation = viewJobCard.findViewById(R.id.tv_job_discrepation);
-        ConnectMediumTextView connect_job_pay = viewJobCard.findViewById(R.id.connect_job_pay);
-        ConnectRegularTextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
-
-        viewMore.setOnClickListener(view1 -> {
-            Navigation.findNavController(viewMore).navigate(ConnectDeliveryProgressFragmentDirections.actionConnectJobDeliveryProgressFragmentToConnectJobDetailBottomSheetDialogFragment());
-        });
-
-        tvJobTitle.setText(job.getTitle());
-        tvJobDiscrepation.setText(job.getDescription());
-        connect_job_pay.setText(job.getMoneyString(job.getBudgetPerVisit()));
-        connectJobEndDate.setText(getString(R.string.connect_learn_complete_by, ConnectManager.formatDate(job.getProjectEndDate())));
-
-        String workingHours = job.getWorkingHours();
-        boolean showHours = workingHours != null;
-        tv_job_time.setVisibility(showHours ? View.VISIBLE : View.GONE);
-        hoursTitle.setVisibility(showHours ? View.VISIBLE : View.GONE);
-        if(showHours) {
-            tv_job_time.setText(workingHours);
-        }
     }
 
     private void reportApiCall(boolean success) {

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -172,7 +172,6 @@ public class ConnectDeliveryProgressFragment extends Fragment {
         ConnectBoldTextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
         ConnectBoldTextView tv_job_time = viewJobCard.findViewById(R.id.tv_job_time);
         ConnectMediumTextView tvJobDiscrepation = viewJobCard.findViewById(R.id.tv_job_discrepation);
-        ConnectMediumTextView connect_job_pay = viewJobCard.findViewById(R.id.connect_job_pay);
         ConnectRegularTextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
 
         viewMore.setOnClickListener(view1 -> {
@@ -181,7 +180,6 @@ public class ConnectDeliveryProgressFragment extends Fragment {
 
         tvJobTitle.setText(job.getTitle());
         tvJobDiscrepation.setText(job.getDescription());
-        connect_job_pay.setText(job.getMoneyString(job.getBudgetPerVisit()));
         connectJobEndDate.setText(getString(R.string.connect_learn_complete_by, ConnectManager.formatDate(job.getProjectEndDate())));
 
         String workingHours = job.getWorkingHours();

--- a/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
@@ -137,7 +137,6 @@ public class ConnectJobIntroFragment extends Fragment {
         ConnectBoldTextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
         ConnectBoldTextView tv_job_time = viewJobCard.findViewById(R.id.tv_job_time);
         ConnectMediumTextView tvJobDiscrepation = viewJobCard.findViewById(R.id.tv_job_discrepation);
-        ConnectMediumTextView connect_job_pay = viewJobCard.findViewById(R.id.connect_job_pay);
         ConnectRegularTextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
 
         viewMore.setOnClickListener(view1 -> {
@@ -146,7 +145,6 @@ public class ConnectJobIntroFragment extends Fragment {
 
         tvJobTitle.setText(job.getTitle());
         tvJobDiscrepation.setText(job.getDescription());
-        connect_job_pay.setText(job.getMoneyString(job.getBudgetPerVisit()));
         connectJobEndDate.setText(getString(R.string.connect_learn_complete_by, ConnectManager.formatDate(job.getProjectEndDate())));
 
         String workingHours = job.getWorkingHours();

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
@@ -279,14 +279,12 @@ public class ConnectLearningProgressFragment extends Fragment {
         ConnectBoldTextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
         ConnectBoldTextView tv_job_time = viewJobCard.findViewById(R.id.tv_job_time);
         ConnectMediumTextView tvJobDiscrepation = viewJobCard.findViewById(R.id.tv_job_discrepation);
-        ConnectMediumTextView connect_job_pay = viewJobCard.findViewById(R.id.connect_job_pay);
         ConnectRegularTextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
 
         viewMore.setVisibility(View.GONE);
 
         tvJobTitle.setText(job.getTitle());
         tvJobDiscrepation.setText(job.getDescription());
-        connect_job_pay.setText(job.getMoneyString(job.getBudgetPerVisit()));
         connectJobEndDate.setText(getString(R.string.connect_learn_complete_by, ConnectManager.formatDate(job.getProjectEndDate())));
 
         String workingHours = job.getWorkingHours();


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-606

cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Product Description
Removes the pay-per-visit text from the job summary card that is shown on several Connect pages.
The concept increasingly does not make sense since opportunities often involve several visits with different pay amounts.
So if a user gets $10 for an initial visit and $5 for a follow-up visit, an overall "pay per visit" isn't meaningful.
View on most pages:
<img src="https://github.com/user-attachments/assets/cf163a27-ebb4-4e6c-866f-2f5374745455" width="300">

View on app home (with daily progress):
<img src="https://github.com/user-attachments/assets/abbbeb38-1898-4049-b47b-9e2c4245af75" width="300">

## Technical Summary
Removes the pay-per-visit UI fields from the two related cards, and code on related pages that updated the value of the pay-per-visit text.

## Feature Flag
Connect

## Safety Assurance

### Safety story
Relatively simple change, just removing some UI fields and the code that updates them. I also viewed the tiles on each of the related pages to verify that their layout still looks correct, and had to change the layout for the "working hours" to still line up properly.

### Automated test coverage
No automated tests for Connect yet.

### QA Plan
View the job summary card on any of the pages listed below and verify that there is no info shown related to "pay per visit":
- Job intro
- Learning progress
- App home
- Delivery progress

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
