### PR TITLE
Disable menu items while downloading the applications

### DIFF
--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -41,7 +41,7 @@ import androidx.navigation.NavOptions;
 import androidx.navigation.fragment.NavHostFragment;
 
 public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
-    private boolean backButtonEnabled = true;
+    private boolean backButtonAndActionBarEnabled = true;
     private boolean waitDialogEnabled = true;
     String redirectionAction = "";
     String opportunityId = "";
@@ -160,6 +160,13 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
         return super.onCreateOptionsMenu(menu);
     }
 
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        menu.findItem(R.id.action_sync).setEnabled(backButtonAndActionBarEnabled);
+        menu.findItem(R.id.action_notification).setEnabled(backButtonAndActionBarEnabled);
+        return super.onPrepareOptionsMenu(menu);
+    }
+
     public void updateMessagingIcon() {
         if(messagingMenuItem != null) {
             int icon = R.drawable.ic_connect_menu_notification_none;
@@ -192,7 +199,7 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
 
     @Override
     public void onBackPressed() {
-        if (backButtonEnabled) {
+        if (backButtonAndActionBarEnabled) {
             super.onBackPressed();
         }
     }
@@ -221,8 +228,9 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
         return null;
     }
 
-    public void setBackButtonEnabled(boolean enabled) {
-        backButtonEnabled = enabled;
+    public void setBackButtonAndActionBarState(boolean enabled) {
+        backButtonAndActionBarEnabled = enabled;
+        invalidateOptionsMenu();
     }
 
     public void setWaitDialogEnabled(boolean enabled) {

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -162,8 +162,8 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
-        menu.findItem(R.id.action_sync).setEnabled(backButtonAndActionBarEnabled);
-        menu.findItem(R.id.action_notification).setEnabled(backButtonAndActionBarEnabled);
+        menu.findItem(R.id.action_sync).setVisible(backButtonAndActionBarEnabled);
+        menu.findItem(R.id.action_notification).setVisible(backButtonAndActionBarEnabled);
         return super.onPrepareOptionsMenu(menu);
     }
 

--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -49,7 +49,7 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
         getLearnApp = args.getLearning();
 
         //Disable back button during install (done by providing empty callback)
-        setBackButtonEnabled(false);
+        setBackButtonAndActionBarState(false);
 
         //Disable the default wait dialog during this fragment since it displays progress on its own
         setWaitDialogEnabled(false);
@@ -57,10 +57,10 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
         startAppDownload();
     }
 
-    private void setBackButtonEnabled(boolean enabled) {
+    private void setBackButtonAndActionBarState(boolean enabled) {
         Activity activity = getActivity();
         if(activity instanceof ConnectActivity connectActivity) {
-            connectActivity.setBackButtonEnabled(enabled);
+            connectActivity.setBackButtonAndActionBarState(enabled);
         }
     }
 
@@ -109,7 +109,7 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
     }
 
     public void onSuccessfulVerification() {
-        setBackButtonEnabled(true);
+        setBackButtonAndActionBarState(true);
         View view = getView();
         if (view != null) {
             Navigation.findNavController(view).popBackStack();
@@ -127,7 +127,7 @@ public class ConnectDownloadingFragment extends Fragment implements ResourceEngi
     }
 
     private void showInstallFailError(AppInstallStatus statusmissing) {
-        setBackButtonEnabled(true);
+        setBackButtonAndActionBarState(true);
         setWaitDialogEnabled(true);
         String installError = getString(R.string.connect_app_install_unknown_error);
         try {


### PR DESCRIPTION
## Product Description
Menu items of connect page are disabled while downloading the application

## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-721

## Feature Flag
For better user experience and fixing the bugs by pressing back/menu items while downloading the app

## Safety Assurance

### Safety story
This is small change and test on staging variant

### QA Plan
General QA
