### PR TITLE
Fix location capture in Airplane mode

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -992,3 +992,5 @@ background.sync.fail=Background sync failed. Please try to trigger a normal Sync
 android.package.name.org.commcare.dalvik.reminders=CommCare Reminders
 android.package.name.callout.commcare.org.sendussd=Commcare USSD
 android.package.name.org.commcare.dalvik.abha=CommCare ABHA
+
+location.capture.cancelled=Location capture cancelled

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -349,6 +349,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             } else if (requestCode == FormEntryConstants.INTENT_CALLOUT) {
                 processIntentResponse(intent, true);
                 Toast.makeText(this, Localization.get("intent.callout.cancelled"), Toast.LENGTH_SHORT).show();
+            } else if (requestCode == FormEntryConstants.LOCATION_CAPTURE){
+                Toast.makeText(this, Localization.get("location.capture.cancelled"), Toast.LENGTH_SHORT).show();
             }
         } else {
             switch (requestCode) {

--- a/app/src/org/commcare/location/CommCareLocationControllerFactory.kt
+++ b/app/src/org/commcare/location/CommCareLocationControllerFactory.kt
@@ -1,6 +1,7 @@
 package org.commcare.location
 
 import android.content.Context
+import android.provider.Settings
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 
@@ -14,7 +15,7 @@ class CommCareLocationControllerFactory {
         fun getLocationController(context: Context, mListener: CommCareLocationListener): CommCareLocationController {
             // We only wanna use FusedLocationClient when play services are available.
             // Otherwise, we'll fallback to using LocationManager, rather than asking user to update playservices.
-            return when (isPlayServiceAvailable(context)) {
+            return when (isPlayServiceAvailable(context) && !isAirplaneModeOn(context)) {
                 true -> CommCareFusedLocationController(context, mListener)
                 false -> CommCareProviderLocationController(context, mListener)
             }
@@ -23,6 +24,9 @@ class CommCareLocationControllerFactory {
         private fun isPlayServiceAvailable(context: Context): Boolean {
             return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
         }
-    }
 
+        private fun isAirplaneModeOn(context: Context): Boolean {
+            return Settings.Global.getInt(context.contentResolver, Settings.Global.AIRPLANE_MODE_ON) != 0;
+        }
+    }
 }


### PR DESCRIPTION
## Product Description
This PR addresses an issue with the GPS widget when the device is in Airplane Mode. Upon pressing the `Record Location` button, the screen flashes and the user returns to the previous screen. 

<video src="https://github.com/user-attachments/assets/2f3579c9-73ea-43c1-958f-b5c01028b05b" width="200px"></video>

There is an exception being thrown and here's the stack trace:
```
com.google.android.gms.common.api.ApiException: 8502: SETTINGS_CHANGE_UNAVAILABLE
13:43:05.638  W  	at com.google.android.gms.common.internal.ApiExceptionUtil.fromStatus(com.google.android.gms:play-services-base@@18.4.0:3)
13:43:05.638  W  	at com.google.android.gms.common.internal.zap.onComplete(com.google.android.gms:play-services-base@@18.4.0:4)
13:43:05.638  W  	at com.google.android.gms.common.api.internal.BasePendingResult.zab(com.google.android.gms:play-services-base@@18.4.0:7)
13:43:05.638  W  	at com.google.android.gms.common.api.internal.BasePendingResult.setResult(com.google.android.gms:play-services-base@@18.4.0:6)
13:43:05.638  W  	at com.google.android.gms.common.api.internal.BaseImplementation$ApiMethodImpl.setResult(com.google.android.gms:play-services-base@@18.4.0:1)
13:43:05.638  W  	at com.google.android.gms.internal.location.zzbc.zza(Unknown Source:2)
13:43:05.638  W  	at com.google.android.gms.internal.location.zzar.dispatchTransaction(Unknown Source:11)
13:43:05.638  W  	at com.google.android.gms.internal.location.zzb.onTransact(Unknown Source:22)
13:43:05.638  W  	at android.os.Binder.execTransactInternal(Binder.java:1380)
13:43:05.638  W  	at android.os.Binder.execTransact(Binder.java:1311)
```
According to the [documentation](https://developers.google.com/android/reference/com/google/android/gms/location/LocationSettingsStatusCodes#SETTINGS_CHANGE_UNAVAILABLE), this error occurs when `Location settings can't be changed to meet the requirements`.

Ticket: https://dimagi.atlassian.net/browse/SAAS-15924

## Technical Summary
The approach here was to change the `CommCareLocationControllerFactory` to use `LocationManager` when the device is in Airplane mode instead of `FuseLocationProvider`. 

## Safety Assurance

### Safety story
This was tested locally and it was successful. 

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
