### PR TITLE
Handle failed logins due to insufficient permission

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -531,7 +531,7 @@ login.attempt.fail.changed.action=If you had unsent data or incomplete forms on 
 
 login.attempt.insufficient.role.permission.title=User doesn't have permission to access the CommCare application
 login.attempt.insufficient.role.permission.detail=The role assigned to your user doesn't have permission to access CommCare mobile application
-login.attempt.insufficient.role.permission.action=Contact your CommCare Administrator or CommCare Support for assistance with this matter
+login.attempt.insufficient.role.permission.action=Contact Support for assistance with this matter
 
 notification.credential.mismatch.title=Mismatching Login Credentials
 notification.credential.mismatch.detail=The server recognized your password, but the password it sent to the device does not match 

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -529,6 +529,10 @@ login.attempt.fail.changed.title=Password Changed since Last Login
 login.attempt.fail.changed.detail=You've logged in with a new password since you're last login. You may need to log in with your old credentials to ensure you have no unsent data.
 login.attempt.fail.changed.action=If you had unsent data or incomplete forms on the phone before you logged in with your new password you should log out, and log in with your old password. Make sure all your unsent forms are sent and incomplete forms are submitted, then log in again with your new password and sync. 
 
+login.attempt.insufficient.role.permission.title=User doesn't have permission to access the CommCare application
+login.attempt.insufficient.role.permission.detail=The role assigned to your user doesn't have permission to access CommCare mobile application
+login.attempt.insufficient.role.permission.action=Contact your CommCare Administrator or CommCare Support for assistance with this matter
+
 notification.credential.mismatch.title=Mismatching Login Credentials
 notification.credential.mismatch.detail=The server recognized your password, but the password it sent to the device does not match 
 notification.credential.mismatch.action=Contact CommCare Support for assistance with your account

--- a/app/src/org/commcare/network/HttpCalloutTask.java
+++ b/app/src/org/commcare/network/HttpCalloutTask.java
@@ -43,6 +43,7 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, Ht
         NetworkFailureBadPassword,
         IncorrectPin,
         AuthOverHttp,
+        InsufficientRolePermission,
         CaptivePortal
     }
 
@@ -81,6 +82,8 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, Ht
                     outcome = doResponseSuccess(response);
                 } else if (responseCode == 401) {
                     outcome = doResponseAuthFailed(response);
+                } else if (responseCode == 403) {
+                    outcome = doResponseInsufficientRolePermission(response);
                 } else {
                     outcome = doResponseOther(response);
                 }
@@ -119,6 +122,10 @@ public abstract class HttpCalloutTask<R> extends CommCareTask<Object, String, Ht
         // So either we didn't need our our HTTP callout or we succeeded. Either way, move on
         // to the next step
         return doPostCalloutTask(calloutFailed);
+    }
+
+    private HttpCalloutOutcomes doResponseInsufficientRolePermission(Response response) {
+        return HttpCalloutOutcomes.InsufficientRolePermission;
     }
 
     protected boolean processSuccessfulRequest() {

--- a/app/src/org/commcare/tasks/ManageKeyRecordTask.java
+++ b/app/src/org/commcare/tasks/ManageKeyRecordTask.java
@@ -207,6 +207,10 @@ public abstract class ManageKeyRecordTask<R extends DataPullController> extends 
                 Logger.log(LogTypes.TYPE_USER, "ManageKeyRecordTask error|captive portal detected");
                 receiver.raiseLoginMessage(StockMessages.Sync_CaptivePortal, true);
                 break;
+            case InsufficientRolePermission:
+                Logger.log(LogTypes.TYPE_USER, "ManageKeyRecordTask error|insufficient role permission");
+                receiver.raiseLoginMessage(StockMessages.Auth_InsufficientRolePermission, true);
+                break;
             default:
                 break;
         }

--- a/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
+++ b/app/src/org/commcare/views/notifications/NotificationMessageFactory.java
@@ -60,6 +60,10 @@ public class NotificationMessageFactory {
          * No PIN was entered
          */
         Auth_EmptyPin("login.attempt.fail.empty.pin"),
+        /**
+         * User's role doesn't have the right to access CommCare mobile app
+         */
+        Auth_InsufficientRolePermission("login.attempt.insufficient.role.permission"),
 
         /**
          * Server 500 when retrieving data.


### PR DESCRIPTION
## Product Description
This PR improves the user message for login failures because the user's role doesn't have the `Mobile App Access` right. Right now, whenever such user tries to log in, they receive a generic a `Bad Server Response` message, which provides no guidance on how to address the issue.

## Technical Summary
This properly handle a `403` HTTP response and shows to the user a more appropriate message.
<table><tr>
<td>
<img src="https://github.com/user-attachments/assets/9458ac2f-54b3-4a2f-95d1-a11aa2b1e904"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/165bdd5b-ddff-48fd-9614-5afd56d323c7"/>
</td>
</tr>
</table>

Ticket: https://dimagi.atlassian.net/browse/SAAS-16077

## Safety Assurance

### Safety story
Tested this locally as per the results in the images above.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
