### PR TITLE
Preview of message in messages channel changed

### DIFF
--- a/app/src/org/commcare/android/database/connect/models/ConnectMessagingChannelRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectMessagingChannelRecord.java
@@ -1,5 +1,7 @@
 package org.commcare.android.database.connect.models;
 
+import android.text.SpannableString;
+
 import org.commcare.android.storage.framework.Persisted;
 import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
@@ -62,7 +64,7 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
     @MetaField(META_KEY)
     private String key;
 
-    private String preview;
+    private SpannableString preview;
 
     private List<ConnectMessagingMessageRecord> messages = new ArrayList<>();
 
@@ -153,11 +155,11 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
     }
     public List<ConnectMessagingMessageRecord> getMessages() { return messages; }
 
-    public void setPreview(String preview) {
+    public void setPreview(SpannableString preview) {
         this.preview = preview;
     }
 
-    public String getPreview() {
+    public SpannableString getPreview() {
         return preview;
     }
 }

--- a/app/src/org/commcare/connect/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/ConnectDatabaseHelper.java
@@ -1,8 +1,17 @@
 package org.commcare.connect;
 
+import static android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE;
+
+import static org.commcare.utils.StringUtils.convertDpToPixel;
+
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.text.SpannableString;
+import android.text.style.ImageSpan;
 import android.widget.Toast;
+
+import androidx.core.content.ContextCompat;
 
 import net.sqlcipher.database.SQLiteDatabase;
 
@@ -852,22 +861,25 @@ public class ConnectDatabaseHelper {
             List<ConnectMessagingMessageRecord> messages = channel.getMessages();
             ConnectMessagingMessageRecord lastMessage = messages.size() > 0 ?
                     messages.get(messages.size() - 1) : null;
-            String preview = "";
+            SpannableString preview;
             if(!channel.getConsented()) {
-                preview = context.getString(R.string.connect_messaging_channel_list_unconsented);
+                preview = new SpannableString(context.getString(R.string.connect_messaging_channel_list_unconsented));
             } else if(lastMessage != null) {
-                int senderId = lastMessage.getIsOutgoing() ?
-                        R.string.connect_messaging_channel_preview_you :
-                        R.string.connect_messaging_channel_preview_them;
-                String sender = context.getString(senderId);
 
                 String trimmed = lastMessage.getMessage().split("\n")[0];
                 int maxLength = 25;
                 if(trimmed.length() > maxLength) {
                     trimmed = trimmed.substring(0, maxLength - 3) + "...";
                 }
-
-                preview = String.format("%s: %s", sender, trimmed);
+                preview = new SpannableString(lastMessage.getIsOutgoing()? "  "+trimmed:trimmed);
+                if(lastMessage.getIsOutgoing()){
+                    Drawable drawable = lastMessage.getConfirmed() ? ContextCompat.getDrawable(context, R.drawable.ic_connect_message_read) : ContextCompat.getDrawable(context, R.drawable.ic_connect_message_unread);
+                    float lineHeight = convertDpToPixel(14);
+                    drawable.setBounds(0,0,(int) lineHeight, (int) lineHeight);
+                    preview.setSpan(new ImageSpan(drawable), 0, 1, SPAN_EXCLUSIVE_EXCLUSIVE);
+                }
+            } else {
+                preview = new SpannableString("");
             }
 
             channel.setPreview(preview);

--- a/app/src/org/commcare/connect/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/ConnectDatabaseHelper.java
@@ -2,8 +2,6 @@ package org.commcare.connect;
 
 import static android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE;
 
-import static org.commcare.utils.StringUtils.convertDpToPixel;
-
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -38,6 +36,7 @@ import org.commcare.models.database.connect.DatabaseConnectOpenHelper;
 import org.commcare.models.database.user.UserSandboxUtils;
 import org.commcare.modern.database.Table;
 import org.commcare.util.Base64;
+import org.commcare.utils.DimensionUtils;
 import org.commcare.utils.EncryptionUtils;
 import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.storage.Persistable;
@@ -874,7 +873,7 @@ public class ConnectDatabaseHelper {
                 preview = new SpannableString(lastMessage.getIsOutgoing()? "  "+trimmed:trimmed);
                 if(lastMessage.getIsOutgoing()){
                     Drawable drawable = lastMessage.getConfirmed() ? ContextCompat.getDrawable(context, R.drawable.ic_connect_message_read) : ContextCompat.getDrawable(context, R.drawable.ic_connect_message_unread);
-                    float lineHeight = convertDpToPixel(14);
+                    float lineHeight = DimensionUtils.INSTANCE.convertDpToPixel(14);
                     drawable.setBounds(0,0,(int) lineHeight, (int) lineHeight);
                     preview.setSpan(new ImageSpan(drawable), 0, 1, SPAN_EXCLUSIVE_EXCLUSIVE);
                 }

--- a/app/src/org/commcare/utils/DimensionUtils.kt
+++ b/app/src/org/commcare/utils/DimensionUtils.kt
@@ -1,0 +1,12 @@
+package org.commcare.utils
+
+import android.content.res.Resources
+
+object DimensionUtils {
+
+    fun convertDpToPixel(dp: Float): Float {
+        val metrics = Resources.getSystem().displayMetrics
+        val px = dp * (metrics.densityDpi / 160f)
+        return Math.round(px).toFloat()
+    }
+}

--- a/app/src/org/commcare/utils/StringUtils.java
+++ b/app/src/org/commcare/utils/StringUtils.java
@@ -1,9 +1,7 @@
 package org.commcare.utils;
 
 import android.content.Context;
-import android.content.res.Resources;
 import android.text.Spannable;
-import android.util.DisplayMetrics;
 
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;

--- a/app/src/org/commcare/utils/StringUtils.java
+++ b/app/src/org/commcare/utils/StringUtils.java
@@ -1,7 +1,9 @@
 package org.commcare.utils;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.text.Spannable;
+import android.util.DisplayMetrics;
 
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
@@ -48,5 +50,11 @@ public class StringUtils {
             ret = c.getString(resId, args);
         }
         return MarkupUtil.styleSpannable(c, ret);
+    }
+
+    public static float convertDpToPixel(float dp){
+        DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
+        float px = dp * (metrics.densityDpi / 160f);
+        return Math.round(px);
     }
 }

--- a/app/src/org/commcare/utils/StringUtils.java
+++ b/app/src/org/commcare/utils/StringUtils.java
@@ -51,10 +51,4 @@ public class StringUtils {
         }
         return MarkupUtil.styleSpannable(c, ret);
     }
-
-    public static float convertDpToPixel(float dp){
-        DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
-        float px = dp * (metrics.densityDpi / 160f);
-        return Math.round(px);
-    }
 }


### PR DESCRIPTION
## Product Description
For Outgoing message: read/unread icon + message body
For incoming message: message body

When last message was outgoing:
![image](https://github.com/user-attachments/assets/e2945d31-be94-4450-90cf-c47b9e03b97a)

When last message was incoming:
![image](https://github.com/user-attachments/assets/54048bf2-b98a-46e3-8e41-38e9c868fe2a)


## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-711

## Feature Flag
This is kind of feature where display of message preview changed

## Safety Assurance

### Safety story
Limited effect on safety, UI change


### QA Plan
Need general review for message preview

