### PR TITLE
Add device model and android version to device logs

### DIFF
--- a/app/src/org/commcare/android/logging/ForceCloseLogEntry.java
+++ b/app/src/org/commcare/android/logging/ForceCloseLogEntry.java
@@ -26,6 +26,7 @@ public class ForceCloseLogEntry extends AndroidLogEntry {
     public static final String STORAGE_KEY = "forcecloses";
 
     private int appBuildNumber;
+    // TODO: Drop android_version and device_model as these are part of the report header now
     private String androidVersion;
     private String deviceModel;
     private String readableSessionString;

--- a/app/src/org/commcare/android/logging/ForceCloseLogEntry.java
+++ b/app/src/org/commcare/android/logging/ForceCloseLogEntry.java
@@ -26,7 +26,6 @@ public class ForceCloseLogEntry extends AndroidLogEntry {
     public static final String STORAGE_KEY = "forcecloses";
 
     private int appBuildNumber;
-    // TODO: Drop android_version and device_model as these are part of the report header now
     private String androidVersion;
     private String deviceModel;
     private String readableSessionString;

--- a/app/src/org/commcare/android/logging/ForceCloseLogSerializer.java
+++ b/app/src/org/commcare/android/logging/ForceCloseLogSerializer.java
@@ -65,11 +65,6 @@ public class ForceCloseLogSerializer extends StreamLogSerializer implements Devi
                     forceCloseEntry.getMessage(), serializer);
             AndroidLogSerializer.writeText("app_build",
                     forceCloseEntry.getAppBuildNumber() + "", serializer);
-            // TODO: android_version and device_model are part of the report header now, so might no longer be needed here
-            AndroidLogSerializer.writeText("android_version",
-                    forceCloseEntry.getAndroidVersion(), serializer);
-            AndroidLogSerializer.writeText("device_model",
-                    forceCloseEntry.getDeviceModel(), serializer);
             AndroidLogSerializer.writeText("session_readable",
                     forceCloseEntry.getReadableSession(), serializer);
             AndroidLogSerializer.writeText("session_serialized",

--- a/app/src/org/commcare/android/logging/ForceCloseLogSerializer.java
+++ b/app/src/org/commcare/android/logging/ForceCloseLogSerializer.java
@@ -65,6 +65,7 @@ public class ForceCloseLogSerializer extends StreamLogSerializer implements Devi
                     forceCloseEntry.getMessage(), serializer);
             AndroidLogSerializer.writeText("app_build",
                     forceCloseEntry.getAppBuildNumber() + "", serializer);
+            // TODO: android_version and device_model are part of the report header now, so might no longer be needed here
             AndroidLogSerializer.writeText("android_version",
                     forceCloseEntry.getAndroidVersion(), serializer);
             AndroidLogSerializer.writeText("device_model",

--- a/app/src/org/commcare/logging/DeviceReportWriter.java
+++ b/app/src/org/commcare/logging/DeviceReportWriter.java
@@ -1,5 +1,7 @@
 package org.commcare.logging;
 
+import android.os.Build;
+
 import org.commcare.AppUtils;
 import org.commcare.CommCareApplication;
 import org.commcare.android.javarosa.DeviceReportRecord;
@@ -97,6 +99,8 @@ public class DeviceReportWriter {
         writeText("device_id", did);
         writeText("report_date", DateUtils.formatDateTime(new Date(), DateUtils.FORMAT_ISO8601));
         writeText("app_version", AppUtils.getCurrentVersionString());
+        writeText("device_model", Build.MODEL);
+        writeText("android_version", Build.VERSION.RELEASE);
     }
 
     private void writeUserReport() throws IllegalArgumentException, IllegalStateException, IOException {

--- a/app/src/org/commcare/logging/DeviceReportWriter.java
+++ b/app/src/org/commcare/logging/DeviceReportWriter.java
@@ -129,7 +129,8 @@ public class DeviceReportWriter {
         }
     }
 
-    private void writeText(String element, String text) throws IllegalArgumentException, IllegalStateException, IOException {
+    private void writeText(String element, String text) throws IllegalArgumentException, IllegalStateException,
+            IOException {
         serializer.startTag(XMLNS, element);
         try {
             serializer.text(text);


### PR DESCRIPTION
## Product Description
This small PR includes two more pieces of data to the normal device logs, `Device model` and `Android version`. These are already included in the forced close logs, and this is just to make them standard across the different types of logs.

Note: This will require HQ work to parse these new data elements, store and forward them to the necessary cloud storages (if applicable).

Tickets: https://dimagi.atlassian.net/browse/SAAS-16657
HQ PR: https://github.com/dimagi/commcare-hq/pull/35956

## Safety Assurance
### Safety story
Deployed the HQ branch on Staging and was able to test this there, there are 2 scenarios:
Log message from CommCare versions with this change (2.57+):
```
[log_date=2025-04-02T17:19:26.999000Z] [log_submission_date=2025-04-02 17:19:28.961561] [log_type=user] 
[domain=test-65] [username=bio_test] [device_id=commcare_b371b5a4-45a5-4f72-8abf-4242f7f68f1b] 
[app_version=187] [cc_version=2.56.0] [msg=login|bio_test|cd3a3f5caff94bc383207652fb4ce5a5] 
[device_model=TECNO BG7n] [android_version=13]
```

Log message from CommCare version without this change (up to 2.56):
```
[log_date=2025-04-02T06:30:42.162000Z] [log_submission_date=2025-04-02 06:30:42.124944] [log_type=user 
[domain=qateam] [username=08] [device_id=commcare_546f53ae-b563-4b98-b32c-b9b3ad459f2e] [app_version=57]
[cc_version=2.56.0] [msg=login|08|fdb5274523124460915ef4c49205c32f] [device_model=None] 
[android_version=None]
```

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
