### PR TITLE
Set CC version in form metadata in SemVer format

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -204,8 +204,8 @@ post.server.error=Server-side error (code ${0}) received from network request.
 post.gone.error=Case is not present on server.
 post.conflict.error=You have already claimed this case.
 
-version.id.long=CommCare Android, version "${0}"(${1}). App v${5}. CommCare Version ${2}. Build ${3}, built on: ${4}
-version.id.short=CCDroid:"${0}"(${1}). v${5} CC${2}b[${3}] on ${4}
+version.id.long=CommCare Android, version "${0}"(${1}). App v${4}. CommCare Version ${0}. Build ${2}, built on: ${3}
+version.id.short=CCDroid:"${0}"(${1}). v${4} CC${0}b[${2}] on ${3}
 commcare.version=CommCare Android, version "${0}"(${1}), built on: ${2}
 
 auth.request.not.using.https=${0} is an invalid URL. CommCare can't connect with authentication to an insecure (HTTP) server.

--- a/app/src/org/commcare/AppUtils.java
+++ b/app/src/org/commcare/AppUtils.java
@@ -173,7 +173,7 @@ public class AppUtils {
         String buildNumber = BuildConfig.BUILD_NUMBER;
 
         return Localization.get(application.getString(R.string.app_version_string), new String[]{
-                ccv, String.valueOf(BuildConfig.VERSION_CODE), ccv, buildNumber, buildDate, profileVersion});
+                ccv, String.valueOf(BuildConfig.VERSION_CODE), buildNumber, buildDate, profileVersion});
     }
 
     public static String getCurrentAppId() {

--- a/app/src/org/commcare/AppUtils.java
+++ b/app/src/org/commcare/AppUtils.java
@@ -173,9 +173,7 @@ public class AppUtils {
         String buildNumber = BuildConfig.BUILD_NUMBER;
 
         return Localization.get(application.getString(R.string.app_version_string), new String[]{
-                BuildConfig.VERSION_NAME,
-                String.valueOf(BuildConfig.VERSION_CODE),
-                ccv, buildNumber, buildDate, profileVersion});
+                ccv, String.valueOf(BuildConfig.VERSION_CODE), ccv, buildNumber, buildDate, profileVersion});
     }
 
     public static String getCurrentAppId() {


### PR DESCRIPTION
## Product Description
This is a small change to ensure that the CommCare versions that appear in the form submission `appVersion` metadata follow the SemVer format. They are currently being computed differently but from the same source, resulting in values such as:
```
<n1:appVersion xmlns:n1="http://commcarehq.org/xforms">CommCare Android, version "2.56"(1). App v16. CommCare Version 2.56.0. Build 1, built on: 2025-03-05</n1:appVersion>
```
These differences are causing discrepancies in the Enterprise Dashboard, more info [here](https://dimagi.atlassian.net/browse/SAAS-16383).

## Technical Summary
It seems that in the past, one used to be sourced from the `PackageManager` and the other from the `BuildConfig.VERSION_NAME`, the latter is the current source for both. The change was done [here](https://github.com/dimagi/commcare-android/commit/9ce804477231844805bf5bd545aabf223ad3cb5b).

## Safety Assurance

### Safety story
Successfully tested locally. However, it was flagged during review that there might be apps with form control logic based on the `appVersion` metadata field. To assess the potential impact of the change, steps were taken to identify such apps and document any required updates, but no apps were found. So the decision is to proceed and monitor potential issues that may arise from this once released, the AEs team will be responsible for that.

### Release Note
Minor change to the format of the `appVersion` metadata in forms - this change can cause unexpected behaviors in apps that use this field to control form logic.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
