### PR TITLE
Additional logging for failed HQ token auth in ConnectID-managed apps.

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -878,8 +878,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
                 raiseLoginMessage(StockMessages.Empty_Url, true);
                 break;
             case AUTH_FAILED:
-                String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
-                if(ConnectManager.checkForFailedConnectIdAuth(seatedAppId, uiController.getEnteredUsername())) {
+                if(ConnectManager.checkForFailedConnectIdAuth(uiController.getEnteredUsername())) {
                     Logger.exception("Token auth error for connect managed app",
                             new Throwable("Token Auth failed during login for a ConnectID managed app"));
                 }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -878,6 +878,11 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
                 raiseLoginMessage(StockMessages.Empty_Url, true);
                 break;
             case AUTH_FAILED:
+                String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
+                if(ConnectManager.checkForFailedConnectIdAuth(seatedAppId, uiController.getEnteredUsername())) {
+                    Logger.exception("Token auth error for connect managed app",
+                            new Throwable("Token Auth failed during login for a ConnectID managed app"));
+                }
                 raiseLoginMessage(StockMessages.Auth_BadCredentials, false);
                 break;
             case BAD_DATA_REQUIRES_INTERVENTION:

--- a/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
+++ b/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
@@ -30,6 +30,7 @@ import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.StandardAlertDialog;
 import org.commcare.views.notifications.NotificationActionButtonInfo;
 import org.commcare.views.notifications.NotificationMessageFactory;
+import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 
 public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCareActivity<T>
@@ -105,7 +106,12 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
             case AUTH_FAILED:
                 String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
                 String username = CommCareApplication.instance().getRecordForCurrentUser().getUsername();
-                ConnectManager.forgetAppCredentials(seatedAppId, username);
+
+                if(ConnectManager.checkForFailedConnectIdAuth(seatedAppId, username)) {
+                    Logger.exception("Token auth error for connect managed app",
+                            new Throwable("Token Auth failed during sync for a ConnectID managed app"));
+                }
+
                 updateUiAfterDataPullOrSend(Localization.get("sync.fail.auth.loggedin"), FAIL);
                 break;
             case BAD_DATA:

--- a/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
+++ b/app/src/org/commcare/activities/SyncCapableCommCareActivity.java
@@ -104,10 +104,9 @@ public abstract class SyncCapableCommCareActivity<T> extends SessionAwareCommCar
                 updateUiAfterDataPullOrSend(Localization.get("sync.fail.empty.url"), FAIL);
                 break;
             case AUTH_FAILED:
-                String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
                 String username = CommCareApplication.instance().getRecordForCurrentUser().getUsername();
 
-                if(ConnectManager.checkForFailedConnectIdAuth(seatedAppId, username)) {
+                if(ConnectManager.checkForFailedConnectIdAuth(username)) {
                     Logger.exception("Token auth error for connect managed app",
                             new Throwable("Token Auth failed during sync for a ConnectID managed app"));
                 }

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -566,6 +566,20 @@ public class ConnectManager {
         callback.connectActivityComplete(false);
     }
 
+    public static boolean checkForFailedConnectIdAuth(String seatedAppId, String username) {
+        try {
+            if (isConnectIdConfigured()) {
+                ConnectLinkedAppRecord appRecord = ConnectDatabaseHelper.getAppData(
+                        CommCareApplication.instance(), seatedAppId, username);
+                return appRecord != null && appRecord.getWorkerLinked();
+            }
+        } catch (Exception e){
+            Logger.exception("Error while checking ConnectId status after failed token auth", e);
+        }
+
+        return false;
+    }
+
     public static ConnectAppMangement getAppManagement(Context context, String appId, String userId) {
         ConnectAppRecord record = getAppRecord(context, appId);
         if(record != null) {

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -566,9 +566,10 @@ public class ConnectManager {
         callback.connectActivityComplete(false);
     }
 
-    public static boolean checkForFailedConnectIdAuth(String seatedAppId, String username) {
+    public static boolean checkForFailedConnectIdAuth(String username) {
         try {
             if (isConnectIdConfigured()) {
+                String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
                 ConnectLinkedAppRecord appRecord = ConnectDatabaseHelper.getAppData(
                         CommCareApplication.instance(), seatedAppId, username);
                 return appRecord != null && appRecord.getWorkerLinked();

--- a/app/src/org/commcare/network/CommcareRequestGenerator.java
+++ b/app/src/org/commcare/network/CommcareRequestGenerator.java
@@ -183,8 +183,7 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
                     Logger.log(LogTypes.TYPE_MAINTENANCE, "Applying token auth");
                     return tokenAuth;
                 } else {
-                    String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
-                    if(ConnectManager.checkForFailedConnectIdAuth(seatedAppId, username)) {
+                    if(ConnectManager.checkForFailedConnectIdAuth(username)) {
                         Logger.exception("Token auth error for connect managed app",
                                 new Throwable("No token Auth available for a connect managed app"));
                     }

--- a/app/src/org/commcare/network/CommcareRequestGenerator.java
+++ b/app/src/org/commcare/network/CommcareRequestGenerator.java
@@ -183,19 +183,10 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
                     Logger.log(LogTypes.TYPE_MAINTENANCE, "Applying token auth");
                     return tokenAuth;
                 } else {
-                    try {
-                        if (ConnectManager.isConnectIdConfigured()) {
-                            String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
-                            ConnectLinkedAppRecord appRecord = ConnectDatabaseHelper.getAppData(
-                                    CommCareApplication.instance(), seatedAppId, username);
-                            if (appRecord != null && appRecord.getWorkerLinked()) {
-                                Logger.exception("Critical auth error for connect managed app",
-                                        new Throwable("No token Auth available for a connect managed app"));
-                            }
-                        }
-                        Logger.log(LogTypes.TYPE_MAINTENANCE, "Applying current auth");
-                    } catch (Exception e){
-                        Logger.exception("error while checking connect status when trying to build auth", e);
+                    String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
+                    if(ConnectManager.checkForFailedConnectIdAuth(seatedAppId, username)) {
+                        Logger.exception("Token auth error for connect managed app",
+                                new Throwable("No token Auth available for a connect managed app"));
                     }
 
                     CommCareApplication.instance().getSession().getLoggedInUser();


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-668

cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Technical Summary
Some additional logging to help capture the failed token auths related to ConnectID-managed apps.
We're already logging the case where we're unable to get an HQ token just before making an HQ call.
But currently we still make the call anyway, which is guaranteed to fail.
Even once that's fixed, we still may get surprise failures due to tokens we thought were good actually not being good.
So this PR adds logging after HQ calls fail (key record or data pull requests) due to bad authorization when they should be managed by ConnectID via tokens.

## Feature Flag
ConnectID

## Safety Assurance

### Safety story
Simple addition that silently logs a condition, and checks happen in a try-catch in case something goes wrong.

### Automated test coverage
No automated tests for ConnectID yet

### QA Plan
No extra QA plan necessary, this is for dev tracking.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
