### PR TITLE
Fix sync buttons in learn and delivery progress pages

### DIFF
--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -181,17 +181,9 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
             return true;
         }
 
-        getCurrentFragment().onOptionsItemSelected(item);
+        //NOTE: Fragments will handle the sync button individually (via MenuProviders)
 
         return super.onOptionsItemSelected(item);
-    }
-
-    private Fragment getCurrentFragment() {
-        NavHostFragment navHostFragment =
-                (NavHostFragment)getSupportFragmentManager().findFragmentById(R.id.nav_host_fragment_connect);
-        Fragment currentFragment =
-                navHostFragment.getChildFragmentManager().getPrimaryNavigationFragment();
-       return  currentFragment;
     }
 
     @Override

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -3,6 +3,8 @@ package org.commcare.fragments.connect;
 import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,6 +13,8 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.cardview.widget.CardView;
+import androidx.core.view.MenuHost;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.Lifecycle;
@@ -159,6 +163,24 @@ public class ConnectDeliveryProgressFragment extends Fragment {
             }
         });
 
+        MenuHost host = (MenuHost)requireActivity();
+        host.addMenuProvider(new MenuProvider() {
+            @Override
+            public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+                //Activity loads the menu
+            }
+
+            @Override
+            public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+                if (menuItem.getItemId() == R.id.action_sync) {
+                    refreshData();
+                    return true;
+                }
+
+                return false;
+            }
+        }, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
+
         updateConnectWarningMessage(view);
         updatePaymentConfirmationTile(getContext(), false);
 
@@ -263,16 +285,6 @@ public class ConnectDeliveryProgressFragment extends Fragment {
                 tv.setText(warningText);
             }
         }
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.action_sync) {
-            refreshData();
-            return true;
-        }
-
-        return super.onOptionsItemSelected(item);
     }
 
     public void refreshData() {

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -3,6 +3,7 @@ package org.commcare.fragments.connect;
 import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -262,6 +263,16 @@ public class ConnectDeliveryProgressFragment extends Fragment {
                 tv.setText(warningText);
             }
         }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_sync) {
+            refreshData();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
     }
 
     public void refreshData() {

--- a/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
@@ -15,14 +15,20 @@ import static org.commcare.connect.ConnectManager.isAppInstalled;
 import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.cardview.widget.CardView;
+import androidx.core.view.MenuHost;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -96,6 +102,24 @@ public class ConnectJobsListsFragment extends Fragment {
             ConnectManager.launchApp(getActivity(), isLearning, appId);
         };
 
+        MenuHost host = (MenuHost)requireActivity();
+        host.addMenuProvider(new MenuProvider() {
+            @Override
+            public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+                //Activity loads the menu
+            }
+
+            @Override
+            public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+                if (menuItem.getItemId() == R.id.action_sync) {
+                    refreshData();
+                    return true;
+                }
+
+                return false;
+            }
+        }, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
+
         refreshUi();
         refreshData();
         return view;
@@ -105,16 +129,6 @@ public class ConnectJobsListsFragment extends Fragment {
     public void onResume() {
         super.onResume();
         refreshUi();
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.action_sync) {
-            refreshData();
-            return true;
-        }
-
-        return super.onOptionsItemSelected(item);
     }
 
     public void refreshData() {

--- a/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
@@ -107,6 +107,7 @@ public class ConnectJobsListsFragment extends Fragment {
         refreshUi();
     }
 
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.action_sync) {
             refreshData();

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
@@ -2,6 +2,7 @@ package org.commcare.fragments.connect;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
@@ -85,6 +86,16 @@ public class ConnectLearningProgressFragment extends Fragment {
         if(ConnectManager.isConnectIdConfigured()) {
             refreshData();
         }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_sync) {
+            refreshData();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
     }
 
     private void refreshData() {

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
@@ -2,6 +2,8 @@ package org.commcare.fragments.connect;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -24,8 +26,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
+import androidx.annotation.NonNull;
 import androidx.cardview.widget.CardView;
+import androidx.core.view.MenuHost;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 import androidx.navigation.NavDirections;
 import androidx.navigation.Navigation;
 
@@ -75,6 +81,24 @@ public class ConnectLearningProgressFragment extends Fragment {
         updateUi(view);
         refreshData();
 
+        MenuHost host = (MenuHost)requireActivity();
+        host.addMenuProvider(new MenuProvider() {
+            @Override
+            public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+                //Activity loads the menu
+            }
+
+            @Override
+            public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+                if (menuItem.getItemId() == R.id.action_sync) {
+                    refreshData();
+                    return true;
+                }
+
+                return false;
+            }
+        }, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
+
         jobCardDataHandle(view, job);
         return view;
     }
@@ -86,16 +110,6 @@ public class ConnectLearningProgressFragment extends Fragment {
         if(ConnectManager.isConnectIdConfigured()) {
             refreshData();
         }
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.action_sync) {
-            refreshData();
-            return true;
-        }
-
-        return super.onOptionsItemSelected(item);
     }
 
     private void refreshData() {


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-839

cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Product Description
Sync button in top-right corner now functional in Learn Progress and Delivery Progress pages.

## Technical Summary
The two fragments needed to override the onMenuItemSelected function and, when the sync action was selected by the user, initiate a data refresh.

## Feature Flag
Connect

## Safety Assurance

### Safety story
The added code is similar to what's already in the opportunity list page to do a refresh there.

### Automated test coverage
No automated tests for Connect yet.

### QA Plan
To add to the test plan if not already there:
- Learning progress: Click the sync button in the top-right corner and verify that the page performs a sync with the server
- Delivery progress: Repeat the above test

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
