### PR TITLE
Logging empty push notifications

### DIFF
--- a/app/src/org/commcare/services/CommCareFirebaseMessagingService.java
+++ b/app/src/org/commcare/services/CommCareFirebaseMessagingService.java
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
+import com.google.android.gms.common.util.Strings;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -217,6 +218,11 @@ public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
 
             PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, flags);
 
+            if (Strings.isEmptyOrWhitespace(notificationTitle) && Strings.isEmptyOrWhitespace(notificationText)) {
+                Logger.exception("Empty push notification",
+                        new Throwable(String.format("Empty notification for action '%s'", action)));
+            }
+
             NotificationCompat.Builder fcmNotification = new NotificationCompat.Builder(this,
                     notificationChannel)
                     .setContentTitle(notificationTitle)
@@ -227,7 +233,7 @@ public class CommCareFirebaseMessagingService extends FirebaseMessagingService {
                     .setPriority(priority)
                     .setWhen(System.currentTimeMillis());
 
-            if(largeIcon != null) {
+            if (largeIcon != null) {
                 fcmNotification.setLargeIcon(largeIcon);
             }
 


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-786

cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Technical Summary
As shown in the ticket, users are sometimes shown "empty" push notifications, i.e. with no title or text. It seems this is possible if the server sends certain payloads, so this PR adds some logging to help us better understand more about when it happens.

## Feature Flag
ConnectID Messaging

## Safety Assurance

### Safety story
Simple under-the-hood logging, very little risk

### Automated test coverage
No automated tests for ConnectID yet.

### QA Plan
No testing required or useful.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
