### PR TITLE
Job status fix for learning

### DIFF
--- a/app/src/org/commcare/connect/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/ConnectDatabaseHelper.java
@@ -341,6 +341,12 @@ public class ConnectDatabaseHelper {
             for (ConnectJobRecord incoming : jobs) {
                 if (existing.getJobId() == incoming.getJobId()) {
                     incoming.setID(existing.getID());
+
+                    //Could be the case that app has transitioned to learn and server doesn't know yet
+                    if(existing.getStatus() > incoming.getStatus()) {
+                        incoming.setStatus(existing.getStatus());
+                    }
+
                     stillExists = true;
                     break;
                 }


### PR DESCRIPTION
No ticket, fixing a quick bug for Jon.

## Product Description
Fixes a special case where the user has transitioned to learning but hasn't completed a learn module yet. This ensures that the status stays in "learning" and doesn't revert to "available".

## Technical Summary
The underlying issue is that the server doesn't send a status along with each job when we retrieve the jobs. So when parsing and storing the job data, we use a [couple checks](https://github.com/dimagi/commcare-android/blob/489b81a863d341b500b1170d6ce690a0368a9a4f/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java#L270) to determine the current status. Unfortunately, the check to determine whether we're in learning state is whether the user has >0 learn completion (i.e. they've completed at least one learn module).

When the user starts learning, the mobile code changes the status for the job locally to learning, but when the job gets downloaded again we calculate the status fresh from the payload, resulting in "available" status again. This is handled by taking whichever status is later in the workflow when comparing newly received jobs to what's already in storage. So if local knows we're in learning, we'll override available to learning before storing the job in the DB.

## Feature Flag
Connect

## Safety Assurance

### Safety story
Small change to enforce expected behavior

### Automated test coverage
None

### QA Plan
Not required

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
