### PR TITLE
Add HQ credentials to build configuration when running AGP connected tasks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -563,7 +563,8 @@ tasks.configureEach { task ->
             && "true" == isConsumerApp && "true" == runDownloadScripts) {
         task.dependsOn downloadRestoreFile
     }
-    if (task.name == 'assembleCommcareReleaseAndroidTest' || task.name == 'assembleCommcareDebugAndroidTest') {
+    if (task.name == 'assembleCommcareReleaseAndroidTest' || task.name == 'assembleCommcareDebugAndroidTest' ||
+            task.name == 'connectedCommcareReleaseAndroidTest' || task.name == 'connectedCommcareDebugAndroidTest') {
         android.defaultConfig.buildConfigField "String", "HQ_API_USERNAME", "\"${project.ext.HQ_API_USERNAME}\""
         android.defaultConfig.buildConfigField "String", "HQ_API_PASSWORD", "\"${project.ext.HQ_API_PASSWORD}\""
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -563,8 +563,7 @@ tasks.configureEach { task ->
             && "true" == isConsumerApp && "true" == runDownloadScripts) {
         task.dependsOn downloadRestoreFile
     }
-    if (task.name == 'assembleCommcareReleaseAndroidTest' || task.name == 'assembleCommcareDebugAndroidTest' ||
-            task.name == 'connectedCommcareReleaseAndroidTest' || task.name == 'connectedCommcareDebugAndroidTest') {
+    if (isInstrumentationTestTask(task)) {
         android.defaultConfig.buildConfigField "String", "HQ_API_USERNAME", "\"${project.ext.HQ_API_USERNAME}\""
         android.defaultConfig.buildConfigField "String", "HQ_API_PASSWORD", "\"${project.ext.HQ_API_PASSWORD}\""
     }
@@ -646,4 +645,9 @@ def getConsumerAppPassword(isConsumerApp) {
 downloadLicenses {
     includeProjectDependencies = true
     dependencyConfiguration = 'compile'
+}
+
+static def isInstrumentationTestTask(task){
+    def instrumentationTestTaskNamePattern = /^(assemble|connected).*AndroidTest/
+    return task.name ==~ instrumentationTestTaskNamePattern
 }


### PR DESCRIPTION
## Product Description
This PR fixes an issue with instrumentation tests failing locally due to missing HQ credentials in the BuildConfig class, which are required by some of the tests.

Ticket: https://dimagi.atlassian.net/browse/SAAS-16708

## Safety Assurance

### Safety story
Successfully tested locally.


## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
