### PR TITLE
Fixes for Entity Cache and Lazy loading work

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -466,11 +466,10 @@
     <string name="audio_recording_notification">Audio Recording Notification</string>
 
     <!--    Entity List Progresss Indicators-->
+
     <string name="entity_list_initializing" cc:translatable="true">Initializing list…</string>
-    <string name="entity_list_processing" cc:translatable="true">Processing cases: %s</string>
-    <string name="entity_list_loading_cache" cc:translatable="true">Loading Cache…</string>
-    <string name="entity_list_calculating" cc:translatable="true">Calculating cases %s</string>
-    <string name="entity_list_finishing" cc:translatable="true">Finishing case calculations…</string>
+    <string name="entity_list_loading" cc:translatable="true">Loading list: %s</string>
+    <string name="entity_list_finishing" cc:translatable="true">Finishing list calculations…</string>
 
 
     <string name="connect_db_corrupt" cc:translatable="true">A problem occurred with the database, please recover your account.</string>

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -1013,20 +1013,19 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     public void deliverProgress(Integer[] values) {
         EntityLoadingProgressListener.EntityLoadingProgressPhase phase =
                 EntityLoadingProgressListener.EntityLoadingProgressPhase.fromInt(values[0]);
-        int progress = values[1] * 100 / values[2];
-        if (progress != lastProgress) {
-            lastProgress = progress;
-            String progressDisplay = progress + "%";
-            switch (phase) {
-                case PHASE_PROCESSING -> setProgressText(
-                        StringUtils.getStringRobust(this, R.string.entity_list_processing,
-                                new String[]{progressDisplay}));
-                case PHASE_CACHING -> setProgressText(
-                        StringUtils.getStringRobust(this, R.string.entity_list_loading_cache));
-                case PHASE_UNCACHED_CALCULATION -> setProgressText(
-                        StringUtils.getStringRobust(this, R.string.entity_list_calculating,
-                                new String[]{progressDisplay}));
-            }
+        int phaseProgress = values[1] * 100 / values[2];
+        int totalPhases = 1;
+        if(shortSelect.isCacheEnabled()){
+            // with caching we deliver progress in 3 separate phases
+            totalPhases = 3;
+        }
+        int weightedProgress = (phase.getValue() - 1) * 100 / totalPhases + phaseProgress / totalPhases;
+        if (weightedProgress != lastProgress) {
+            lastProgress = weightedProgress;
+            String progressDisplay = weightedProgress + "%";
+            setProgressText(
+                    StringUtils.getStringRobust(this, R.string.entity_list_loading,
+                            new String[]{progressDisplay}));
         }
     }
 

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -496,7 +496,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             PrimeEntityCacheHelper primeEntityCacheHelper =
                     CommCareApplication.instance().getCurrentApp().getPrimeEntityCacheHelper();
             primeEntityCacheHelper.getProgressState().observe(this, triple -> {
-                if (triple.getFirst().contentEquals(selectDatum.getDataId()) &&
+                if (triple != null && triple.getFirst().contentEquals(selectDatum.getDataId()) &&
                         triple.getSecond().contentEquals(shortSelect.getId())) {
                     deliverProgress(triple.getThird());
                 }

--- a/app/src/org/commcare/tasks/PrimeEntityCache.kt
+++ b/app/src/org/commcare/tasks/PrimeEntityCache.kt
@@ -11,24 +11,24 @@ import org.javarosa.core.services.Logger
  */
 class PrimeEntityCache(appContext: Context, workerParams: WorkerParameters) : Worker(appContext, workerParams) {
 
-    lateinit var primeEntityCacheHelper : PrimeEntityCacheHelper
+    var primeEntityCacheHelper : PrimeEntityCacheHelper? = null
 
     override fun doWork(): Result {
         try {
             if (CommCareApplication.isSessionActive()) {
                 primeEntityCacheHelper = CommCareApplication.instance().currentApp.primeEntityCacheHelper
-                primeEntityCacheHelper.primeEntityCache()
+                primeEntityCacheHelper!!.primeEntityCache()
                 return Result.success()
             }
         } catch (e: Exception) {
             Logger.exception("Error while priming cache in worker", e)
         } finally {
-            primeEntityCacheHelper.clearState()
+            primeEntityCacheHelper?.clearState()
         }
         return Result.failure()
     }
 
     override fun onStopped() {
-        primeEntityCacheHelper.cancel()
+        primeEntityCacheHelper?.cancel()
     }
 }

--- a/app/src/org/commcare/tasks/PrimeEntityCacheHelper.kt
+++ b/app/src/org/commcare/tasks/PrimeEntityCacheHelper.kt
@@ -51,7 +51,7 @@ class PrimeEntityCacheHelper() : Cancellable, EntityLoadingProgressListener {
     val cachedEntitiesState: StateFlow<Triple<String, String, List<Entity<TreeReference>>>?> get() = _cachedEntitiesState
 
     private val _progressState = MutableLiveData<Triple<String, String, Array<Int>>>(null)
-    val progressState: LiveData<Triple<String, String, Array<Int>>> get() = _progressState
+    val progressState: LiveData<Triple<String, String, Array<Int>>?> get() = _progressState
 
 
     companion object {

--- a/app/src/org/commcare/tasks/PrimeEntityCacheHelper.kt
+++ b/app/src/org/commcare/tasks/PrimeEntityCacheHelper.kt
@@ -7,8 +7,12 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import io.reactivex.functions.Cancellable
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.runBlocking
 import org.commcare.AppUtils.getCurrentAppId
 import org.commcare.CommCareApplication
 import org.commcare.cases.entity.Entity
@@ -44,11 +48,11 @@ class PrimeEntityCacheHelper() : Cancellable, EntityLoadingProgressListener {
     private var cancelled = false
 
 
-    private val _completionStatus = MutableStateFlow<Boolean>(false)
-    val completionStatus: StateFlow<Boolean> get() = _completionStatus
+    private val _completionStatus = MutableSharedFlow<Boolean>(replay = 0)
+    val completionStatus = _completionStatus.asSharedFlow()
 
-    private val _cachedEntitiesState = MutableStateFlow<Triple<String, String, List<Entity<TreeReference>>>?>(null)
-    val cachedEntitiesState: StateFlow<Triple<String, String, List<Entity<TreeReference>>>?> get() = _cachedEntitiesState
+    private val _cachedEntitiesState = MutableSharedFlow<Triple<String, String, List<Entity<TreeReference>>>?>(replay = 0)
+    val cachedEntitiesState = _cachedEntitiesState.asSharedFlow()
 
     private val _progressState = MutableLiveData<Triple<String, String, Array<Int>>>(null)
     val progressState: LiveData<Triple<String, String, Array<Int>>?> get() = _progressState
@@ -112,7 +116,9 @@ class PrimeEntityCacheHelper() : Cancellable, EntityLoadingProgressListener {
             primeEntityCacheForApp(CommCareApplication.instance().commCarePlatform)
         } finally {
             clearState()
-            _completionStatus.value = true
+            runBlocking {
+                _completionStatus.emit(true)
+            }
         }
     }
 
@@ -132,7 +138,9 @@ class PrimeEntityCacheHelper() : Cancellable, EntityLoadingProgressListener {
             primeCacheForDetail(commandId, detail, entityDatum, entities)
         } finally {
             clearState()
-            _completionStatus.value = true
+            runBlocking {
+                _completionStatus.emit(true)
+            }
         }
     }
 
@@ -191,7 +199,9 @@ class PrimeEntityCacheHelper() : Cancellable, EntityLoadingProgressListener {
             }
             else -> entityLoaderHelper!!.cacheEntities(entityDatum.nodeset).first
         }
-        _cachedEntitiesState.value = Triple(entityDatum.dataId, detail.id, cachedEntities)
+        runBlocking {
+            _cachedEntitiesState.emit(Triple(entityDatum.dataId, detail.id, cachedEntities))
+        }
         currentDatumInProgress = null
         currentDetailInProgress = null
     }

--- a/app/unit-tests/src/org/commcare/android/tests/DemoUserRestoreTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/DemoUserRestoreTest.java
@@ -33,6 +33,7 @@ import org.robolectric.shadows.ShadowLooper;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.work.WorkManager;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -105,7 +106,8 @@ public class DemoUserRestoreTest {
 
         assertEquals(1, CommCareApplication.instance().getCurrentApp().getStorage(UserKeyRecord.class).getNumRecords());
 
-        EntitySelectActivity entitySelectActivity =
+        ((CommCareTestApplication)CommCareApplication.instance()).initWorkManager();
+         EntitySelectActivity entitySelectActivity =
                 ActivityLaunchUtils.launchEntitySelectActivity("m0-f0");
 
         // check that the demo user has 2 entries in the case list


### PR DESCRIPTION
## Technical Summary
 This PR makes following changes for cache and index work - 
 - Nullability corrections https://github.com/dimagi/commcare-android/pull/2998/commits/cdd44e260f78f3bbec749843effcd9ff7a5079ed
- Instead of showing a progress indictor for 3 phases that each goes from 0 to 100 , shows a weighted progress by giving all possible phases equal ewightage. https://github.com/dimagi/commcare-android/pull/2998/commits/980fcad76c288866dbee3756b74ceeedd26e9f81
- Fixes a bug where a normal case list loading gets blocked on background cache work priming work due to [user db being locked ](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/models/database/user/models/CommCareEntityStorageCache.java#L91)by the background work. This is fixed by explicitly calling cancel on the background work before loading the list https://github.com/dimagi/commcare-android/pull/2998/commits/d9bce47ebce1027fede81e57694834b88d137665
- Fixes an issue where a case list cache prime completion event gets registered from the previously emitted value of State Flow. This caused an entity list to show up ahead of time without really completing calculaitons for all cases. https://github.com/dimagi/commcare-android/pull/2998/commits/9061a3fe5b81d2fbc2d5a6962a9af02799673f21

## Feature Flag

CACHE AND LAZY LOADING

## Safety Assurance

### Safety story

All the impacted areas should be behind the feature flag. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
