### PR TITLE
Update Firebase dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
-    implementation 'com.google.firebase:firebase-analytics:17.5.0'
+    implementation 'com.google.firebase:firebase-analytics:20.1.2'
     implementation 'com.google.firebase:firebase-messaging:21.1.0'
     implementation 'com.google.firebase:firebase-crashlytics:17.2.1'
     implementation 'androidx.legacy:legacy-support-core-ui:1.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,7 +103,8 @@ dependencies {
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
     implementation 'com.google.firebase:firebase-analytics:20.1.2'
     implementation 'com.google.firebase:firebase-messaging:21.1.0'
-    implementation 'com.google.firebase:firebase-crashlytics:17.2.1'
+    implementation 'com.google.firebase:firebase-crashlytics:18.3.7'
+
     implementation 'androidx.legacy:legacy-support-core-ui:1.0.0'
     implementation('com.github.bumptech.glide:glide:4.9.0') {
         exclude group: 'com.android.support'


### PR DESCRIPTION
## Product Description
This PR is to update Firebase Analytics and Crashlytics to 20.1.2 and 18.3.7, respectively. The main motivation is to make ANRs available in Crashlytics, this will give better insight into the affected users and domains. Crashlytics started supporting ANR collection in 18.4.2. The Firebase Analytics bump is more opportunistic, the current version is from 2020 and from the release notes, this bump seems safe to make.

## Safety Assurance

### Safety story
Caused a crash and was able to confirm its report in `Crashlytics` as well as the Analytics events.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
