### PR TITLE
Fixing obsolete app selector code

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -557,15 +557,10 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
 
         if(appState == ConnectManager.ConnectAppMangement.ConnectId) {
             int selectorIndex = uiController.getSelectedAppIndex();
-            if (selectorIndex > 0) {
-                String selectedAppId = appIdDropdownList.size() > 0 ? appIdDropdownList.get(selectorIndex) : "";
+            String selectedAppId = !appIdDropdownList.isEmpty() ? appIdDropdownList.get(selectorIndex) : "";
 
-                if (uiController.isAppSelectorVisible() && !selectedAppId.equals(seatedAppId)) {
-                    appState = ConnectManager.ConnectAppMangement.Unmanaged;
-                }
-            } else {
-                //Connect jobs selected from dropdown
-                appState = ConnectManager.ConnectAppMangement.Connect;
+            if (uiController.isAppSelectorVisible() && !selectedAppId.equals(seatedAppId)) {
+                appState = ConnectManager.ConnectAppMangement.Unmanaged;
             }
         }
 


### PR DESCRIPTION
cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Product Description
Fixes a bug where the app would attempt to navigate the user to the Connect menu if they select the first app in the dropdown list, instead of the selected app. This code should have been removed when we removed the "Go to Connect Menu" option as the first item in the dropdown list.

## Technical Summary
Removed obsolete code that redirects to Connect menu when first item in app selector is selected.

## Feature Flag
ConnectID

## Safety Assurance

### Safety story
Discovered via local testing, and fix verifide the same way.

### Automated test coverage
No automated tests for ConnectID yet.

### QA Plan
This was a pretty specific bug, but generally QA might be able to improve the testing by trying more single- and multi-app configurations from the login page.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
