### PR TITLE
Payment id key bug fix

### DIFF
--- a/app/src/org/commcare/android/database/connect/models/ConnectPaymentUnitRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectPaymentUnitRecord.java
@@ -19,6 +19,8 @@ public class ConnectPaymentUnitRecord extends Persisted implements Serializable 
     public static final String STORAGE_KEY = "connect_payment_units";
 
     public static final String META_JOB_ID = "job_id";
+    //NOTE: Server sends id, but local DB already using unit_id
+    public static final String META_ID = "id";
     public static final String META_UNIT_ID = "unit_id";
     public static final String META_NAME = "name";
     public static final String META_TOTAL = "max_total";
@@ -58,7 +60,7 @@ public class ConnectPaymentUnitRecord extends Persisted implements Serializable 
             ConnectPaymentUnitRecord paymentUnit = new ConnectPaymentUnitRecord();
 
             paymentUnit.jobId = jobId;
-            paymentUnit.unitId = json.getInt(META_UNIT_ID);
+            paymentUnit.unitId = json.getInt(META_ID);
             paymentUnit.name = json.getString(META_NAME);
             paymentUnit.maxTotal = json.getInt(META_TOTAL);
             paymentUnit.maxDaily = json.getInt(META_DAILY);


### PR DESCRIPTION
## Product Description
Repairs an issue with the key used to identify the payment unit ID. The server sends the info under the "id" key, but legacy mobile code has been using the "unit_id" for local storage for quite a while. Rather than force a DB upgrade just to rename the column, the existing code used the two different keys for their perspective uses.

## Technical Summary
Restored definition of two keys for the payment unit ID, one for the server and one for local storage.
[Commit that broke this](https://github.com/dimagi/commcare-android/commit/b1e4eff4e615744ebfeb8c7626713d9f5f83cf9f#diff-888501c47960fffa9c0b837558400f5cfe1dc3dc149596a8b9de5084ee331ef6)

## Feature Flag
Connect

## Safety Assurance

### Safety story
Discovered while working on a different ticket.
Once the problem was identified, I traced back to see it was introduced as part of the merge work back in late January.

### Automated test coverage
No automated tests for Connect yet.

### QA Plan
Existing QA should catch this when checking the delivery progress page for delivery summaries by payment types.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
