### PR TITLE
Delivery progress scrolling fix

### DIFF
--- a/app/res/layout/fragment_connect_delivery_progress.xml
+++ b/app/res/layout/fragment_connect_delivery_progress.xml
@@ -1,189 +1,157 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#e1e0e0"
-    android:orientation="vertical">
+    android:fillViewport="true">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/app_bar_layout"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/connect_background_color"
-        android:fitsSystemWindows="true"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+        android:orientation="vertical">
 
-        <com.google.android.material.appbar.CollapsingToolbarLayout
-            android:id="@+id/collapsing_toolbar"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:fitsSystemWindows="true"
-            app:contentScrim="@color/connect_background_color"
-            app:expandedTitleMarginEnd="64dp"
-            app:expandedTitleMarginStart="48dp"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+            android:background="#fff"
+            android:orientation="vertical">
 
-            <LinearLayout
+            <ImageView
+                android:id="@+id/connect_delivery_refresh"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:contentDescription="@string/refresh"
+                android:src="@drawable/cloud_backup"
+                android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/connect_delivery_last_update"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:visibility="gone" />
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/connect_delivery_progress_alert_tile"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="#fff"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="10dp"
+                android:layout_marginBottom="2dp"
+                android:clickable="true"
+                android:focusable="true"
+                app:cardBackgroundColor="@color/white"
+                app:cardCornerRadius="10dp"
+                app:cardElevation="5dp">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="5dp"
+                    android:layout_marginTop="2dp"
+                    android:layout_marginEnd="5dp">
+
+                    <ImageView
+                        android:id="@+id/connect_payment_confirm_icon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/monetary_support"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"/>
+
+                    <org.commcare.views.connect.connecttextview.ConnectRegularTextView
+                        android:id="@+id/connect_payment_confirm_label"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:textColor="@color/black"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toEndOf="@id/connect_payment_confirm_icon" />
+
+                    <org.commcare.views.connect.RoundedButton
+                        android:id="@+id/connect_payment_confirm_yes_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="35dp"
+                        android:layout_marginTop="10dp"
+                        android:text="@string/connect_payment_confirm_yes"
+                        android:textColor="@color/blue"
+                        android:textSize="18sp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/connect_payment_confirm_label"
+                        app:roundButtonBackgroundColor="@color/connect_blue_color"
+                        app:roundButtonBorderRadius="@dimen/dp48"
+                        app:roundButtonTextColor="@color/white"
+                        app:roundButtonTextSize="5.0sp" />
+
+                    <org.commcare.views.connect.RoundedButton
+                        android:id="@+id/connect_payment_confirm_no_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="35dp"
+                        android:layout_marginEnd="10dp"
+                        android:text="@string/connect_payment_confirm_no"
+                        android:textColor="@color/blue"
+                        android:textSize="18sp"
+                        app:layout_constraintEnd_toStartOf="@id/connect_payment_confirm_yes_button"
+                        app:layout_constraintTop_toTopOf="@id/connect_payment_confirm_yes_button"
+                        app:roundButtonBorderColor="@color/connect_blue_color"
+                        app:roundButtonBorderVisible="true"
+                        app:roundButtonBorderWidth="0.5dp"
+                        app:roundButtonTextColor="@color/connect_blue_color"
+                        app:roundButtonTextSize="5.0sp" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.cardview.widget.CardView>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <ImageView
-                    android:id="@+id/connect_delivery_refresh"
-                    android:layout_width="32dp"
-                    android:layout_height="32dp"
-                    android:contentDescription="@string/refresh"
-                    android:src="@drawable/cloud_backup"
-                    android:visibility="gone"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <TextView
-                    android:id="@+id/connect_delivery_last_update"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="3dp"
-                    android:visibility="gone"
-                    app:layout_constraintEnd_toStartOf="@id/connect_delivery_refresh"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-
                 <androidx.cardview.widget.CardView
-                    android:id="@+id/connect_delivery_progress_alert_tile"
+                    android:id="@+id/cvConnectMessage"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/viewJobCard"
+                    android:layout_marginLeft="10dp"
+                    android:layout_marginTop="-35dp"
+                    android:layout_marginRight="10dp"
+                    app:cardBackgroundColor="@color/connect_light_orange_color"
+                    app:cardCornerRadius="15dp"
+                    app:cardElevation="10dp">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginBottom="15dp"
+                        android:orientation="horizontal"
+                        android:paddingStart="15dp"
+                        android:paddingTop="35dp"
+                        android:paddingEnd="15dp">
+
+                        <org.commcare.views.connect.connecttextview.ConnectMediumTextView
+                            android:id="@+id/tvConnectMessage"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="10dp"
+                            android:text="@string/connect_job_tile_daily_limit_description"
+                            android:textColor="@color/connect_warning_color"
+                            android:textSize="14sp"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </androidx.cardview.widget.CardView>
+
+                <include
+                    android:id="@+id/viewJobCard"
+                    layout="@layout/view_job_card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="10dp"
                     android:layout_marginEnd="10dp"
-                    android:layout_marginBottom="2dp"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:shadowColor="@color/connect_light_grey_transparent"
-                    android:shadowDx="30"
-                    android:shadowDy="30"
-                    android:shadowRadius="50"
-                    app:cardBackgroundColor="@color/white"
-                    app:cardCornerRadius="10dp"
-                    app:cardElevation="5dp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/connect_delivery_refresh">
-
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="5dp"
-                        android:layout_marginTop="2dp"
-                        android:layout_marginEnd="5dp"
-                        android:visibility="visible"
-                        app:layout_constraintTop_toBottomOf="@id/connect_delivery_refresh">
-
-                        <ImageView
-                            android:id="@+id/connect_payment_confirm_icon"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:src="@drawable/monetary_support"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent" />
-
-                        <org.commcare.views.connect.connecttextview.ConnectRegularTextView
-                            android:id="@+id/connect_payment_confirm_label"
-                            android:layout_width="0dp"
-                            android:layout_height="match_parent"
-                            android:textColor="@color/black"
-                            app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintStart_toEndOf="@id/connect_payment_confirm_icon"
-                            app:layout_constraintTop_toTopOf="parent" />
-
-                        <org.commcare.views.connect.RoundedButton
-                            android:id="@+id/connect_payment_confirm_yes_button"
-                            android:layout_width="wrap_content"
-                            android:layout_height="35dp"
-                            android:layout_marginTop="10dp"
-                            android:text="@string/connect_payment_confirm_yes"
-                            android:textColor="@color/blue"
-                            android:textSize="18sp"
-                            app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/connect_payment_confirm_label"
-                            app:roundButtonBackgroundColor="@color/connect_blue_color"
-                            app:roundButtonBorderRadius="@dimen/dp48"
-                            app:roundButtonIconLeftAlign="false"
-                            app:roundButtonTextColor="@color/white"
-                            app:roundButtonTextSize="5.0sp" />
-
-                        <org.commcare.views.connect.RoundedButton
-                            android:id="@+id/connect_payment_confirm_no_button"
-                            android:layout_width="wrap_content"
-                            android:layout_height="35dp"
-                            android:layout_marginTop="10dp"
-                            android:layout_marginEnd="10dp"
-                            android:text="@string/connect_payment_confirm_no"
-                            android:textColor="@color/blue"
-                            android:textSize="18sp"
-                            app:layout_constraintEnd_toStartOf="@id/connect_payment_confirm_yes_button"
-                            app:layout_constraintTop_toBottomOf="@id/connect_payment_confirm_label"
-                            app:roundButtonBorderColor="@color/connect_blue_color"
-                            app:roundButtonBorderVisible="true"
-                            app:roundButtonBorderWidth="0.5dp"
-                            app:roundButtonIconTintColor="@color/white"
-                            app:roundButtonTextColor="@color/connect_blue_color"
-                            app:roundButtonTextSize="5.0sp" />
-                    </androidx.constraintlayout.widget.ConstraintLayout>
-                </androidx.cardview.widget.CardView>
-
-                <RelativeLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                    <androidx.cardview.widget.CardView
-                        android:id="@+id/cvConnectMessage"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_below="@+id/viewJobCard"
-                        android:layout_marginLeft="10dp"
-                        android:layout_marginTop="-35dp"
-                        android:layout_marginRight="10dp"
-                        app:cardBackgroundColor="@color/connect_light_orange_color"
-                        app:cardCornerRadius="15dp"
-                        app:cardElevation="10dp">
-
-                        <androidx.constraintlayout.widget.ConstraintLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="match_parent"
-                            android:layout_marginBottom="15dp"
-                            android:orientation="horizontal"
-                            android:paddingStart="15dp"
-                            android:paddingTop="35dp"
-                            android:paddingEnd="15dp">
-
-                            <org.commcare.views.connect.connecttextview.ConnectMediumTextView
-                                android:id="@+id/tvConnectMessage"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_marginEnd="10dp"
-                                android:text="@string/connect_job_tile_daily_limit_description"
-                                android:textColor="@color/connect_warning_color"
-                                android:textSize="14sp"
-                                app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintTop_toTopOf="parent" />
-                        </androidx.constraintlayout.widget.ConstraintLayout>
-                    </androidx.cardview.widget.CardView>
-
-                    <include
-                        android:id="@+id/viewJobCard"
-                        layout="@layout/view_job_card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="10dp"
-                        android:layout_marginTop="10dp"
-                        android:layout_marginEnd="10dp"
-                        android:layout_marginBottom="10dp" />
-                </RelativeLayout>
-            </LinearLayout>
-        </com.google.android.material.appbar.CollapsingToolbarLayout>
+                    android:layout_marginBottom="10dp" />
+            </RelativeLayout>
+        </LinearLayout>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/connect_delivery_progress_tabs"
@@ -205,26 +173,9 @@
             android:layout_height="1dp"
             android:background="@color/connect_divider_color" />
 
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/layoutNestedScroll"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/connect_background_color"
-        android:fillViewport="true"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-        <LinearLayout
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/connect_delivery_progress_view_pager"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:descendantFocusability="blocksDescendants"
-            android:orientation="vertical">
-
-            <androidx.viewpager2.widget.ViewPager2
-                android:id="@+id/connect_delivery_progress_view_pager"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/res/layout/fragment_connect_delivery_progress.xml
+++ b/app/res/layout/fragment_connect_delivery_progress.xml
@@ -61,11 +61,12 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"/>
 
-                    <org.commcare.views.connect.connecttextview.ConnectRegularTextView
+                    <TextView
                         android:id="@+id/connect_payment_confirm_label"
                         android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:textColor="@color/black"
+                        android:textStyle="normal"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toEndOf="@id/connect_payment_confirm_icon" />
 
@@ -128,7 +129,7 @@
                         android:paddingTop="35dp"
                         android:paddingEnd="15dp">
 
-                        <org.commcare.views.connect.connecttextview.ConnectMediumTextView
+                        <TextView
                             android:id="@+id/tvConnectMessage"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
@@ -136,6 +137,7 @@
                             android:text="@string/connect_job_tile_daily_limit_description"
                             android:textColor="@color/connect_warning_color"
                             android:textSize="14sp"
+                            android:textStyle="bold"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
                     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-729
cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Product Description
Replaced complex scrolling in the delivery progress page with simple whole page scrolling. The previous implementation tried to have the top cards scroll away separately than the bottom sections of the page, but users found the experience confusing.

## Technical Summary
Replaced the more complex UI elements that supported the additional scrolling behavior with one big NestedScrollView.

## Feature Flag
Connect

## Safety Assurance

### Safety story
Tested manually by scrolling the page from various points with my finger and verifying that it always worked as expected.

### Automated test coverage
No automated tests for Connect yet.

### QA Plan
Scrolling on the page should not do anything fancy, just scroll all the contents up and down together.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
