### PR TITLE
Additional tweaks to delivery progress text

### DIFF
--- a/app/res/layout/view_job_card.xml
+++ b/app/res/layout/view_job_card.xml
@@ -25,7 +25,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <org.commcare.views.connect.connecttextview.ConnectMediumTextView
-            android:id="@+id/tv_job_discrepation"
+            android:id="@+id/tv_job_description"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
@@ -44,7 +44,7 @@
             android:textColor="@color/connect_dark_blue_color"
             android:textSize="14sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_job_discrepation" />
+            app:layout_constraintTop_toBottomOf="@+id/tv_job_description" />
 
 
         <org.commcare.views.connect.connecttextview.ConnectBoldTextView
@@ -55,7 +55,7 @@
             android:textColor="@color/connect_grey"
             android:textSize="12sp"
             android:visibility="visible"
-            app:layout_constraintTop_toBottomOf="@+id/tv_job_discrepation"
+            app:layout_constraintTop_toBottomOf="@+id/tv_job_description"
             app:layout_constraintEnd_toEndOf="parent"
             tools:visibility="visible" />
 

--- a/app/res/layout/view_progress_job_card.xml
+++ b/app/res/layout/view_progress_job_card.xml
@@ -25,7 +25,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <org.commcare.views.connect.connecttextview.ConnectMediumTextView
-            android:id="@+id/tv_job_discrepation"
+            android:id="@+id/tv_job_description"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
@@ -45,7 +45,7 @@
             android:textColor="@color/connect_dark_blue_color"
             android:textSize="14sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_job_discrepation" />
+            app:layout_constraintTop_toBottomOf="@+id/tv_job_description" />
 
         <org.commcare.views.connect.connecttextview.ConnectBoldTextView
             android:id="@+id/tvDailyVisitTitle"
@@ -55,7 +55,7 @@
             android:textColor="@color/connect_grey"
             android:textSize="12sp"
             android:visibility="visible"
-            app:layout_constraintTop_toBottomOf="@+id/tv_job_discrepation"
+            app:layout_constraintTop_toBottomOf="@+id/tv_job_description"
             app:layout_constraintEnd_toEndOf="parent"
             tools:visibility="visible" />
 

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -507,6 +507,10 @@
     <string name="connect_results_summary_all">Todos</string>
     <string name="connect_results_summary_remaining">Restante</string>
     <string name="connect_results_summary_remaining_days">%d em %d dias</string>
+    <string name="connect_results_summary_remaining_tomorrow">%d até Amanhã</string>
+    <string name="connect_results_summary_remaining_today">%d até Hoje</string>
+    <string name="connect_results_summary_visits_done">Todas as Visitas Realizadas</string>
+    <string name="connect_results_summary_days_over">Dias Acima</string>
     <string name="connect_results_payment_confirm">Confirmar</string>
     <string name="connect_results_payment_confirm_undo">Desfazer confirmação</string>
     <string name="connect_results_payment_confirmed">Confirmado</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -593,6 +593,10 @@
     <string name="connect_results_summary_approved">Imeidhinishwa</string>
     <string name="connect_results_summary_remaining">Iliyosalia</string>
     <string name="connect_results_summary_remaining_days">%d ndani ya siku %d</string>
+    <string name="connect_results_summary_remaining_tomorrow">%d hadi Kesho</string>
+    <string name="connect_results_summary_remaining_today">%d ifikapo Leo</string>
+    <string name="connect_results_summary_visits_done">Ziara Zote Zimefanywa</string>
+    <string name="connect_results_summary_days_over">Siku Zimeisha</string>
     <string name="back">Nyuma</string>
     <string name="recover">Pata nafuu</string>
     <string name="connect_job_info_per_visit">kwa ziara</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -491,6 +491,10 @@
     <string name="connect_results_summary_all">ኩሎም</string>
     <string name="connect_results_summary_remaining">ዝተረፈ</string>
     <string name="connect_results_summary_remaining_days">%d ኣብ ውሽጢ %d መዓልቲ</string>
+    <string name="connect_results_summary_remaining_tomorrow">%d ብ ጽባሕ</string>
+    <string name="connect_results_summary_remaining_today">%d ብ ሎሚ</string>
+    <string name="connect_results_summary_visits_done">ኩሉ ዝተገብረ ምብጻሕ</string>
+    <string name="connect_results_summary_days_over">መዓልታት ተወዲኡ</string>
     <string name="connect_results_payment_confirm">ኣረጋግፅ</string>
     <string name="connect_results_payment_confirm_undo">ምርፅጋፅ መልስ</string>
     <string name="connect_results_payment_confirmed">ተረጋጊፁ</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -611,6 +611,10 @@
     <string name="connect_results_summary_earned">Earned</string>
     <string name="connect_results_summary_remaining">Remaining</string>
     <string name="connect_results_summary_remaining_days">%d in %d days</string>
+    <string name="connect_results_summary_remaining_tomorrow">%d by tomorrow</string>
+    <string name="connect_results_summary_remaining_today">%d by today</string>
+    <string name="connect_results_summary_visits_done">All Visits Done</string>
+    <string name="connect_results_summary_days_over">Days Over</string>
 
     <string name="connect_results_summary_transferred">Transferred</string>
 

--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -82,14 +82,14 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
         if (show) {
             ConnectBoldTextView tvJobTitle = viewJobCard.findViewById(R.id.tv_job_title);
             ConnectMediumTextView tvViewMore = viewJobCard.findViewById(R.id.tv_view_more);
-            ConnectMediumTextView tvJobDiscrepation = viewJobCard.findViewById(R.id.tv_job_discrepation);
+            ConnectMediumTextView tvJobDescription = viewJobCard.findViewById(R.id.tv_job_description);
             ConnectBoldTextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
             ConnectBoldTextView tv_job_time = viewJobCard.findViewById(R.id.tv_job_time);
             ConnectRegularTextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
 
             tvJobTitle.setText(job.getTitle());
             tvViewMore.setVisibility(View.GONE);
-            tvJobDiscrepation.setText(job.getDescription());
+            tvJobDescription.setText(job.getDescription());
             connectJobEndDate.setText(activity.getString(R.string.connect_learn_complete_by, ConnectManager.formatDate(job.getProjectEndDate())));
 
             String workingHours = job.getWorkingHours();

--- a/app/src/org/commcare/adapters/ConnectDeliveryProgressReportAdapter.java
+++ b/app/src/org/commcare/adapters/ConnectDeliveryProgressReportAdapter.java
@@ -45,9 +45,26 @@ public class ConnectDeliveryProgressReportAdapter extends RecyclerView.Adapter<C
         holder.binding.tvDeliveryTitle.setText(String.valueOf(connectDeliveryDetails.getDeliveryName()));
         holder.binding.tvApproved.setText(String.valueOf(connectDeliveryDetails.getApprovedCount()));
         holder.binding.tvDeliveryTotalAmount.setText(String.valueOf(connectDeliveryDetails.getTotalAmount()));
-        String remaining = context.getString(R.string.connect_results_summary_remaining_days,
-                connectDeliveryDetails.getPendingCount(), connectDeliveryDetails.getRemainingDays());
+
+        int pending = connectDeliveryDetails.getPendingCount();
+        String remaining;
+        if(pending > 0) {
+            remaining = switch ((int) connectDeliveryDetails.getRemainingDays()) {
+                case 0 ->
+                        context.getString(R.string.connect_results_summary_days_over);
+                case 1 ->
+                        context.getString(R.string.connect_results_summary_remaining_today, pending);
+                case 2 ->
+                        context.getString(R.string.connect_results_summary_remaining_tomorrow, pending);
+                default ->
+                        context.getString(R.string.connect_results_summary_remaining_days,
+                                pending, connectDeliveryDetails.getRemainingDays());
+            };
+        } else {
+            remaining = context.getString(R.string.connect_results_summary_visits_done);
+        }
         holder.binding.tvRemaining.setText(remaining);
+
         holder.binding.rootView.setOnClickListener(view -> {
             deliveryItemOnClickListener.onClick(connectDeliveryDetails.getDeliveryName());
         });

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -200,7 +200,7 @@ public class ConnectDeliveryProgressFragment extends Fragment {
         ConnectBoldTextView tvJobTitle = viewJobCard.findViewById(R.id.tv_job_title);
         ConnectBoldTextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
         ConnectBoldTextView tv_job_time = viewJobCard.findViewById(R.id.tv_job_time);
-        ConnectMediumTextView tvJobDescription = viewJobCard.findViewById(R.id.tv_job_discrepation);
+        ConnectMediumTextView tvJobDescription = viewJobCard.findViewById(R.id.tv_job_description);
         ConnectRegularTextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
 
         viewMore.setOnClickListener(view1 -> {

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -28,7 +28,6 @@ import org.commcare.android.database.connect.models.ConnectJobPaymentRecord;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
 import org.commcare.android.database.connect.models.ConnectPaymentUnitRecord;
 import org.commcare.connect.ConnectManager;
-import org.commcare.connect.network.ConnectNetworkHelper;
 import org.commcare.dalvik.R;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.utils.ConnectivityStatus;
@@ -52,7 +51,7 @@ public class ConnectDeliveryProgressFragment extends Fragment {
     private TextView updateText;
 
     private CardView paymentAlertTile;
-    private ConnectRegularTextView paymentAlertText;
+    private TextView paymentAlertText;
     private ConnectJobPaymentRecord paymentToConfirm = null;
     private String tabPosition = "";
     boolean isTabChange = false;
@@ -201,7 +200,7 @@ public class ConnectDeliveryProgressFragment extends Fragment {
         ConnectBoldTextView tvJobTitle = viewJobCard.findViewById(R.id.tv_job_title);
         ConnectBoldTextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
         ConnectBoldTextView tv_job_time = viewJobCard.findViewById(R.id.tv_job_time);
-        ConnectMediumTextView tvJobDiscrepation = viewJobCard.findViewById(R.id.tv_job_discrepation);
+        ConnectMediumTextView tvJobDescription = viewJobCard.findViewById(R.id.tv_job_discrepation);
         ConnectRegularTextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
 
         viewMore.setOnClickListener(view1 -> {
@@ -209,7 +208,7 @@ public class ConnectDeliveryProgressFragment extends Fragment {
         });
 
         tvJobTitle.setText(job.getTitle());
-        tvJobDiscrepation.setText(job.getDescription());
+        tvJobDescription.setText(job.getDescription());
         connectJobEndDate.setText(getString(R.string.connect_learn_complete_by, ConnectManager.formatDate(job.getProjectEndDate())));
 
         String workingHours = job.getWorkingHours();

--- a/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
@@ -137,7 +137,7 @@ public class ConnectJobIntroFragment extends Fragment {
         ConnectBoldTextView tvJobTitle = viewJobCard.findViewById(R.id.tv_job_title);
         ConnectBoldTextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
         ConnectBoldTextView tv_job_time = viewJobCard.findViewById(R.id.tv_job_time);
-        ConnectMediumTextView tvJobDiscrepation = viewJobCard.findViewById(R.id.tv_job_discrepation);
+        ConnectMediumTextView tvJobDescription = viewJobCard.findViewById(R.id.tv_job_description);
         ConnectRegularTextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
 
         viewMore.setOnClickListener(view1 -> {
@@ -145,7 +145,7 @@ public class ConnectJobIntroFragment extends Fragment {
         });
 
         tvJobTitle.setText(job.getTitle());
-        tvJobDiscrepation.setText(job.getDescription());
+        tvJobDescription.setText(job.getDescription());
         connectJobEndDate.setText(getString(R.string.connect_learn_complete_by, ConnectManager.formatDate(job.getProjectEndDate())));
 
         String workingHours = job.getWorkingHours();

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
@@ -303,13 +303,13 @@ public class ConnectLearningProgressFragment extends Fragment {
         ConnectBoldTextView tvJobTitle = viewJobCard.findViewById(R.id.tv_job_title);
         ConnectBoldTextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
         ConnectBoldTextView tv_job_time = viewJobCard.findViewById(R.id.tv_job_time);
-        ConnectMediumTextView tvJobDiscrepation = viewJobCard.findViewById(R.id.tv_job_discrepation);
+        ConnectMediumTextView tvJobDescription = viewJobCard.findViewById(R.id.tv_job_description);
         ConnectRegularTextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
 
         viewMore.setVisibility(View.GONE);
 
         tvJobTitle.setText(job.getTitle());
-        tvJobDiscrepation.setText(job.getDescription());
+        tvJobDescription.setText(job.getDescription());
         connectJobEndDate.setText(getString(R.string.connect_learn_complete_by, ConnectManager.formatDate(job.getProjectEndDate())));
 
         String workingHours = job.getWorkingHours();


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-897
cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Product Description
Changed the displayed text in payment unit progress cards for special situations:
- Final 2 days of delivery: showing "by today" and "by tomorrow"
- Delivery ended: showing "Days Over"
- All visits completed: showing "All Visits Done"

## Technical Summary
Some additional logic and new strings to handle the additional displays.
Also saw a misidentified class that I should have change in a commit yesterday.
It was low-risk since all we call is setText and both classes implement the method the same way, but good to fix.

## Feature Flag
Connect

## Safety Assurance

### Safety story
Tested display manually.

### Automated test coverage
No automated tests for Connect yet.

### QA Plan
Verify the text is displayed correctly for each of the scenarios described above.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
