### PR TITLE
Additional delivery progress tweak

### DIFF
--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -435,10 +435,13 @@ public class ConnectJobRecord extends Persisted implements Serializable {
 
     public int getDaysRemaining() {
         long millis = projectEndDate.getTime() - (startDate).getTime();
-        //(since the end date has 00:00 time, but project is valid until midnight)
+        //End date has 00:00 time, but project is valid until midnight
+        //So add just under one day to the difference
+        millis += 86399999; //one ms less than 24 hours
         int days = (int)TimeUnit.MILLISECONDS.toDays(millis);
         //Now plus 1 so we report i.e. 1 day remaining on the last day
-        return days >= 0 ? (days + 1) : 0;
+        //But for any negative difference, we return 0
+        return millis >= 0 ? (days + 1) : 0;
     }
 
     public String getWorkingHours() {


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/QA-7609?linkSource=email

## Product Description
Small additional change to make sure "today" and "tomorrow" are used properly when reporting time remaining near the end of the opportunity.

## Technical Summary
This change is about making sure we report 0 days remaining when the end date has passed, 1 day remaining when today is the last day, and 2 days remaining when tomorrow is the last day. Mostly, it's about dealing with the fact that the end date doesn't include a time (so it defaults to 00:00).

## Feature Flag
Connect

## Safety Assurance

### Safety story
Simple math change.

### Automated test coverage
None

### QA Plan
QA already aware of and testing for this.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
