### PR TITLE
Passthrough EXIF properties while scaling image

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,7 @@ configurations {
 }
 
 dependencies {
+    implementation 'androidx.exifinterface:exifinterface:1.3.6'
     testImplementation 'junit:junit:4.13.2'
     testImplementation('org.robolectric:robolectric:4.8.2') {
         exclude(group: 'org.bouncycastle', module: 'bcprov-jdk15on')

--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -22,7 +22,6 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
-import org.commcare.dalvik.BuildConfig;
 import org.commcare.resources.model.MissingMediaException;
 import org.commcare.resources.model.Resource;
 import org.commcare.util.LogTypes;

--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -635,12 +635,6 @@ public class FileUtil {
         destExif.setAttribute(ExifInterface.TAG_IMAGE_LENGTH, String.valueOf(scaledBitmap.getHeight()));
     }
 
-    private static void logExifAttributesToCheckRetention(ExifInterface src, ExifInterface dest) {
-        for (String tag : EXIF_TAGS) {
-            Log.i(LOG_TOKEN, tag + " : " + src.getAttribute(tag) + " -> " + dest.getAttribute(tag));
-        }
-    }
-
     /**
      * @return whether or not originalImage was scaled down according to maxDimen, and saved to
      * the location given by finalFilePath
@@ -678,9 +672,6 @@ public class FileUtil {
                 writeBitmapToDiskAndCleanupHandles(scaledBitmap, type, scaledFile);
                 ExifInterface newExif = new ExifInterface(scaledFile.getAbsolutePath());
                 copyExifData(originalExif, newExif, scaledBitmap);
-                if (BuildConfig.DEBUG) {
-                    logExifAttributesToCheckRetention(originalExif, newExif);
-                }
                 newExif.saveAttributes();
                 return true;
             } catch (Exception e) {

--- a/app/src/org/commcare/utils/FileUtil.java
+++ b/app/src/org/commcare/utils/FileUtil.java
@@ -67,16 +67,25 @@ public class FileUtil {
     private static final String LOG_TOKEN = "cc-file-util";
 
     private static final String[] EXIF_TAGS = {
-            ExifInterface.TAG_DATETIME,
-            ExifInterface.TAG_MAKE,
-            ExifInterface.TAG_MODEL,
-            ExifInterface.TAG_ORIENTATION,
             ExifInterface.TAG_GPS_LATITUDE,
-            ExifInterface.TAG_GPS_LONGITUDE,
             ExifInterface.TAG_GPS_LATITUDE_REF,
+            ExifInterface.TAG_GPS_LONGITUDE,
             ExifInterface.TAG_GPS_LONGITUDE_REF,
-            ExifInterface.TAG_FLASH,
-            ExifInterface.TAG_EXPOSURE_TIME
+            ExifInterface.TAG_GPS_TIMESTAMP,
+            ExifInterface.TAG_GPS_DATESTAMP,
+            ExifInterface.TAG_GPS_ALTITUDE,
+            ExifInterface.TAG_GPS_ALTITUDE_REF,
+            ExifInterface.TAG_GPS_AREA_INFORMATION,
+            ExifInterface.TAG_DATETIME,
+            ExifInterface.TAG_DATETIME_DIGITIZED,
+            ExifInterface.TAG_DATETIME_ORIGINAL,
+            ExifInterface.TAG_OFFSET_TIME,
+            ExifInterface.TAG_OFFSET_TIME_ORIGINAL,
+            ExifInterface.TAG_OFFSET_TIME_DIGITIZED,
+            ExifInterface.TAG_COPYRIGHT,
+            ExifInterface.TAG_IMAGE_DESCRIPTION,
+            ExifInterface.TAG_EXIF_VERSION,
+            ExifInterface.TAG_ORIENTATION
     };
 
     public static boolean deleteFileOrDir(String path) {
@@ -611,6 +620,9 @@ public class FileUtil {
     }
 
     private static void copyExifData(ExifInterface sourceExif, ExifInterface destExif, Bitmap scaledBitmap) {
+        if (sourceExif == null || destExif == null) {
+          return;
+        }
         for (String tag : EXIF_TAGS) {
             String value = sourceExif.getAttribute(tag);
             if (value != null) {
@@ -644,11 +656,11 @@ public class FileUtil {
         }
 
         // Read original EXIF data form the original image file
-        ExifInterface originalExif;
+        ExifInterface originalExif = null;
         try {
             originalExif = new ExifInterface(originalImage.getAbsolutePath());
         } catch (IOException e) {
-            return false;
+            Logger.exception("Failed to read EXIF data", e);
         }
 
         Pair<Bitmap, Boolean> bitmapAndScaledBool = MediaUtil.inflateImageSafe(originalImage.getAbsolutePath());


### PR DESCRIPTION
/claim #2689

## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
This PR ensures that EXIF metadata (like orientation, timestamp, GPS, etc.) is preserved when an image is scaled down in the CommCare Android app. This improves user experience in workflows that rely on image metadata.

## Technical Summary
[Passthrough EXIF metadata while scaling images](https://github.com/dimagi/commcare-android/issues/2689)

Modified the image scaling logic to preserve EXIF metadata by copying it from the original image to the scaled-down version as can be seen in the following screenshot

![Screenshot from 2025-04-06 18-04-38](https://github.com/user-attachments/assets/e6a47539-ee2a-4327-835f-00958b337e3d)

Values on the left side of `->` are coming from original image and those on the right side are coming from the scaled image.

## Feature Flag
Not behind a feature flag.

## Safety Assurance

### Safety story
- The changes were tested locally with various images containing different EXIF metadata.
- Verified that the metadata is retained correctly after scaling, and that existing image handling workflows remain unaffected.
- The change is safe because it does not modify the core image input/output logic, only appends metadata after scaling.

### Automated test coverage
- No new unit tests added due to the nature of the change (image files), but tested locally with debug logs to verify correct metadata retention.

### QA Plan
- A manual QA test is recommended using images with EXIF metadata (e.g., orientation, GPS location).
- Verify that the metadata is preserved in the scaled version.
- No regression expected in image capture or submission workflows.

## Labels and Review

- [x] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
