### PR TITLE
Potential Fix for CyclicPurgeTest

### DIFF
--- a/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
+++ b/app/src/org/commcare/views/dialogs/AlertDialogFragment.java
@@ -4,7 +4,6 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
-import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.DialogFragment;
 
 /**
@@ -68,11 +67,5 @@ public class AlertDialogFragment extends DialogFragment {
             getDialog().setDismissMessage(null);
         }
         super.onDestroyView();
-    }
-
-
-    @VisibleForTesting
-    public CommCareAlertDialog getUnderlyingDialog() {
-        return underlyingDialog;
     }
 }

--- a/app/unit-tests/src/org/commcare/android/tests/formsave/CyclicCasesPurgeTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formsave/CyclicCasesPurgeTest.java
@@ -1,7 +1,14 @@
 package org.commcare.android.tests.formsave;
 
+import static org.commcare.android.database.user.models.FormRecord.STATUS_QUARANTINED;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Dialog;
 import android.view.View;
 import android.widget.TextView;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.commcare.CommCareApplication;
 import org.commcare.CommCareTestApplication;
@@ -17,14 +24,9 @@ import org.commcare.session.CommCareSession;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowDialog;
 import org.robolectric.shadows.ShadowLooper;
-
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import static org.commcare.android.database.user.models.FormRecord.STATUS_QUARANTINED;
 
 /**
  * Test Scenarios related to cyclic case relationships encountered during the case purge process.
@@ -54,10 +56,15 @@ public class CyclicCasesPurgeTest {
         FormEntryActivity formEntryActivity = ActivityLaunchUtils.launchFormEntry();
         View finishButton = formEntryActivity.findViewById(R.id.nav_btn_finish);
         finishButton.performClick();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
         ShadowLooper.idleMainLooper();
-        ShadowLooper.idleMainLooper();
+
         // verify that form save results into an error
-        String message = ((TextView)formEntryActivity.getCurrentAlertDialog().getUnderlyingDialog().getDialog().findViewById(R.id.dialog_message)).getText().toString();
+        Dialog latestDialog = ShadowDialog.getLatestDialog();
+        assertNotNull(latestDialog);
+        assertTrue(latestDialog.isShowing());
+
+        String message = ((TextView)latestDialog.findViewById(R.id.dialog_message)).getText().toString();
         assert message.contentEquals(formEntryActivity.getString(R.string.invalid_case_graph_error));
 
         // Verify that the form record was quarantined


### PR DESCRIPTION
## Technical Summary

Noticing quite a lot of  Jenkins failures with `CyclicPurgeTest` recently and trying to see if this will make a difference. The current test on Jenkins fails with a NPE on `formEntryActivity.getCurrentAlertDialog()` and it only happens some times which strongly suggests it's a timing issue and test runner is not waiting for dialog to be shown.  Use of `ShadowDialog` should bypass these issues. 


## Safety Assurance

### Safety story

Test Fix only


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
