### PR TITLE
Cache Prime Fix: Reuse entity factory for cache prime

### DIFF
--- a/app/src/org/commcare/entity/AndroidAsyncNodeEntityFactory.kt
+++ b/app/src/org/commcare/entity/AndroidAsyncNodeEntityFactory.kt
@@ -57,7 +57,8 @@ class AndroidAsyncNodeEntityFactory(
                         getCurrentCommandId(),
                         detail,
                         entityDatum,
-                        entities
+                        entities,
+                        this
                     )
                     schedulePrimeEntityCacheWorker()
                 } else {
@@ -70,7 +71,8 @@ class AndroidAsyncNodeEntityFactory(
                     getCurrentCommandId(),
                     detail,
                     entityDatum,
-                    entities
+                    entities,
+                    this
                 )
             }
         }

--- a/app/src/org/commcare/tasks/EntityLoaderTask.java
+++ b/app/src/org/commcare/tasks/EntityLoaderTask.java
@@ -42,7 +42,7 @@ public class EntityLoaderTask
      * @param evalCtx     evaluation context
      */
     public EntityLoaderTask(Detail detail, @Nullable EntityDatum entityDatum, EvaluationContext evalCtx) {
-        entityLoaderHelper = new EntityLoaderHelper(detail, entityDatum, evalCtx, false);
+        entityLoaderHelper = new EntityLoaderHelper(detail, entityDatum, evalCtx, false, null);
         // we only want to provide progress updates for the new caching config
         provideDetailProgressUpdates = detail.shouldOptimize();
     }


### PR DESCRIPTION
## Technical Summary

https://dimagi.atlassian.net/browse/SC-4402

This is necessary to be able to populate cache correctly in primeCache as otherwise we don't have values like [mTemplateIsCachable and mCacheHost correctly initialized](https://github.com/dimagi/commcare-core/blob/master/src/main/java/org/commcare/cases/entity/AsyncNodeEntityFactory.java#L94) which results into the  `primeCache` method to exit early and not populate cache into memory resulting into a performance hit. 

## Feature Flag
Cache and Lazy Load 

## Safety Assurance

### Safety story

The change allows us to reuse the factory class which should be harmless for normal use cases that doesn't involve entity caching. The pass on integration test should confirm this further. 

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
None
## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
