### PR TITLE
Solved back button issue while coming back to message channel list from message screen

### DIFF
--- a/app/src/org/commcare/fragments/connectMessaging/ConnectMessageChannelListFragment.java
+++ b/app/src/org/commcare/fragments/connectMessaging/ConnectMessageChannelListFragment.java
@@ -16,6 +16,7 @@ import androidx.navigation.NavDirections;
 import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
+import org.commcare.activities.CommCareActivity;
 import org.commcare.adapters.ChannelAdapter;
 import org.commcare.android.database.connect.models.ConnectMessagingChannelRecord;
 import org.commcare.connect.database.ConnectDatabaseHelper;
@@ -82,6 +83,11 @@ public class ConnectMessageChannelListFragment extends Fragment {
         MessageManager.retrieveMessages(requireActivity(), success -> {
             refreshUi();
         });
+
+        if(getActivity()!=null && getActivity() instanceof CommCareActivity && ((CommCareActivity)getActivity()).getSupportActionBar()!=null){
+            ((CommCareActivity)getActivity()).getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
     }
 
     @Override


### PR DESCRIPTION

## Product Description
Back button on message channel list will be present while coming back from message screen

## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-924

## Feature Flag
No

## Safety Assurance

### Safety story
This has been tested on local setup


### QA Plan
QE team should be able to view the back button whenever coming from message screen to message channel list

