### PR TITLE
Biometric config cleanup and error handling

### DIFF
--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -418,6 +418,7 @@
     <string name="connect_unlock_message">Por favor, desbloqueie para continuar</string>
     <string name="connect_unlock_button_pin">Desbloqueio com PIN</string>
     <string name="connect_unlock_button_password">Desbloqueie com senha</string>
+    <string name="connect_unlock_unavailable">Por favor configure um mecanismo de desbloqueio de tela</string>
     <string name="connect_unlock_trouble_message">Problemas para desbloquear?</string>
     <string name="connect_unlock_fingerprint_title">Desbloqueio através de impressão digital</string>
     <string name="connect_unlock_fingerprint_message">Utilize a sua impressão digital para continuar</string>
@@ -436,6 +437,7 @@
     <string name="connect_verify_configure_fingerprint">Configurar impressão digital</string>
     <string name="connect_verify_use_pin_long">Utilizar o PIN para ligar</string>
     <string name="connect_verify_pin_configured">O seu PIN já foi configurado e será utilizado para desbloquear o ConnectID.</string>
+    <string name="connect_verify_configuration_failed">A configuração falhou, tente novamente</string>
     <string name="connect_verify_configure_pin">Configurar PIN</string>
     <string name="connect_verify_agree">Concordo &amp; Continuar</string>
     <string name="connect_verify_phone_title">Código de verificação</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -415,6 +415,7 @@
     <string name="connect_unlock_message">Tafadhali fungua ili kuendelea</string>
     <string name="connect_unlock_button_pin">Fungua kwa PIN</string>
     <string name="connect_unlock_button_password">Fungua kwa Nenosiri</string>
+    <string name="connect_unlock_unavailable">Tafadhali sanidi utaratibu wa kufungua skrini</string>
     <string name="connect_unlock_trouble_message">Je, una tatizo la kufungua?</string>
     <string name="connect_unlock_fingerprint_title">Fungua kupitia alama ya vidole</string>
     <string name="connect_unlock_fingerprint_message">Tumia alama ya vidole ili kuendelea</string>
@@ -433,6 +434,7 @@
     <string name="connect_verify_configure_fingerprint">Sanidi Alama ya Kidole</string>
     <string name="connect_verify_use_pin_long">Tumia PIN Kuunganisha</string>
     <string name="connect_verify_pin_configured">PIN yako tayari imesanidiwa na itatumika kufungua ConnectID.</string>
+    <string name="connect_verify_configuration_failed">Usanidi haukufaulu, tafadhali jaribu tena</string>
     <string name="connect_verify_configure_pin">Sanidi PIN</string>
     <string name="connect_verify_agree">Kubali na Uendelee</string>
     <string name="connect_verify_phone_title">Nambari ya Uthibitishaji</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -406,6 +406,7 @@
     <string name="connect_unlock_message">ንኽትቅጽል በጃኹም ክትከፍቱ ንላቦ</string>
     <string name="connect_unlock_button_pin">ብፒን ኽፈት።</string>
     <string name="connect_unlock_button_password">ብ Password ኽፈት።</string>
+    <string name="connect_unlock_unavailable">በጃኹም ናይ ስክሪን ምኽፋት መካኒዝም ኣዋቕሩ</string>
     <string name="connect_unlock_trouble_message">ፀገም ምኽፋት?</string>
     <string name="connect_unlock_fingerprint_title">ብመንገዲ ኣሰር ኣፃብዕቲ ምኽፋት።</string>
     <string name="connect_unlock_fingerprint_message">ንምቕፃል ኣሰር ኣፃብዕትኻ ተጠቐም</string>
@@ -424,6 +425,7 @@
     <string name="connect_verify_configure_fingerprint">ኣሰር ኣፃብዕቲ ምውቃር</string>
     <string name="connect_verify_use_pin_long">ንምትእስሳር ፒን ተጠቐም</string>
     <string name="connect_verify_pin_configured">ፒንካ በቃ ተዋቒሩ ኣሎ፡ ንConnectID ንምኽፋት ድማ ክጥቀመሉ እዩ።</string>
+    <string name="connect_verify_configuration_failed">ውቅር ኣይተዓወተን፣ በጃኻ እንደገና ፈትን።</string>
     <string name="connect_verify_configure_pin">ፒን ምውቃር</string>
     <string name="connect_verify_agree">ስምምዕ &amp; ቀፅል</string>
     <string name="connect_verify_phone_title">ናይ ምርግጋፅ ኮድ</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -492,6 +492,7 @@
     <string name="connect_unlock_message">Please unlock to continue</string>
     <string name="connect_unlock_button_pin">Unlock with PIN</string>
     <string name="connect_unlock_button_password">Unlock with Password</string>
+    <string name="connect_unlock_unavailable">Please configure a screen unlock mechanism</string>
 
     <string name="connect_unlock_trouble_message">Trouble unlocking?</string>
     <string name="connect_unlock_fingerprint_title">Unlock via fingerprint</string>
@@ -514,6 +515,7 @@
     <string name="connect_verify_configure_fingerprint">Configure Fingerprint</string>
     <string name="connect_verify_use_pin_long">Use PIN to Connect</string>
     <string name="connect_verify_pin_configured">Your PIN has already been configured and will be used to unlock ConnectID.</string>
+    <string name="connect_verify_configuration_failed">Configuration failed, please try again</string>
 
     <string name="connect_verify_configure_pin">Configure PIN</string>
     <string name="connect_verify_agree">Agree &amp; Continue</string>

--- a/app/src/org/commcare/activities/connect/ConnectIdActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdActivity.java
@@ -34,7 +34,8 @@ public class ConnectIdActivity extends CommCareActivity<ConnectIdActivity> {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == ConnectConstants.CONNECT_UNLOCK_PIN) {
-            getCurrentFragment().onActivityResult(requestCode, resultCode, data);
+            //PIN unlock should only be requested while BiometricConfig fragment is active, else this will crash
+            getCurrentFragment().handleFinishedPinActivity(requestCode, resultCode, data);
         } else if (requestCode == ConnectConstants.CONNECT_JOB_INFO) {
             handleRedirection(data);
         }

--- a/app/src/org/commcare/connect/ConnectManager.java
+++ b/app/src/org/commcare/connect/ConnectManager.java
@@ -259,6 +259,8 @@ public class ConnectManager {
         } else {
             callback.connectActivityComplete(false);
             Logger.exception("No unlock method available when trying to unlock ConnectID", new Exception("No unlock option"));
+
+            Toast.makeText(activity, activity.getString(R.string.connect_unlock_unavailable), Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
@@ -233,7 +233,6 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
         if (fingerprint == BiometricsHelper.ConfigurationStatus.Configured) {
             performFingerprintUnlock();
         } else if (!BiometricsHelper.configureFingerprint(getActivity())) {
-            //Non-fatal exception already reported in the call above
             finish(true, true);
         }
     }
@@ -243,7 +242,6 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
         if (pin == BiometricsHelper.ConfigurationStatus.Configured) {
             performPinUnlock();
         } else if (!BiometricsHelper.configurePin(getActivity())) {
-            //Non-fatal exception already reported in the call above
             finish(true, true);
         }
     }

--- a/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
@@ -140,7 +140,6 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
             Logger.exception("No biometrics", new Exception(
                     "No biometric options available during biometric config"));
 
-            //Skip to password-only workflow (except that no longer exists... TODO)
             finish(true, true);
             return;
         }

--- a/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
@@ -119,7 +119,6 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
             @Override
             public void onAuthenticationFailed() {
                 super.onAuthenticationFailed();
-                Logger.exception("Fingerprint failed", new Exception("Fingerprint authentication failed"));
                 Toast.makeText(requireActivity().getApplicationContext(), "Authentication failed",
                                 Toast.LENGTH_SHORT)
                         .show();

--- a/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
@@ -69,8 +69,6 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
             allowPassword = ConnectIdBiometricConfigFragmentArgs.fromBundle(getArguments()).getAllowPassword();
         }
 
-        updateState();
-
         binding.connectVerifyFingerprintButton.setOnClickListener(v -> handleFingerprintButton());
         binding.connectVerifyPinButton.setOnClickListener(v -> handlePinButton());
         handleAppBar(view);

--- a/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
@@ -35,9 +35,7 @@ import org.javarosa.core.services.Logger;
 import java.util.Locale;
 
 /**
- * A simple {@link Fragment} subclass.
- * Use the {@link ConnectIdBiometricConfigFragment#newInstance} factory method to
- * create an instance of this fragment.
+ * {@link Fragment} subclass for helping the user choose or configure their biometric.
  */
 public class ConnectIdBiometricConfigFragment extends Fragment {
     private BiometricManager biometricManager;
@@ -53,20 +51,13 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
         // Required empty public constructor
     }
 
-    public static ConnectIdBiometricConfigFragment newInstance(String param1, String param2) {
-        ConnectIdBiometricConfigFragment fragment = new ConnectIdBiometricConfigFragment();
-        Bundle args = new Bundle();
-        fragment.setArguments(args);
-        return fragment;
-    }
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         binding = ScreenConnectVerifyBinding.inflate(inflater, container, false);
@@ -77,16 +68,8 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
             callingActivity = ConnectIdBiometricConfigFragmentArgs.fromBundle(getArguments()).getCallingClass();
             allowPassword = ConnectIdBiometricConfigFragmentArgs.fromBundle(getArguments()).getAllowPassword();
         }
-        BiometricsHelper.ConfigurationStatus fingerprint = BiometricsHelper.checkFingerprintStatus(getActivity(),
-                biometricManager);
-        BiometricsHelper.ConfigurationStatus pin = BiometricsHelper.checkPinStatus(getActivity(), biometricManager);
-        if (fingerprint == BiometricsHelper.ConfigurationStatus.NotAvailable &&
-                pin == BiometricsHelper.ConfigurationStatus.NotAvailable) {
-            //Skip to password-only workflow
-            finish(true, true);
-        } else {
-            updateState(fingerprint, pin);
-        }
+
+        updateState();
 
         binding.connectVerifyFingerprintButton.setOnClickListener(v -> handleFingerprintButton());
         binding.connectVerifyPinButton.setOnClickListener(v -> handlePinButton());
@@ -113,13 +96,16 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
                     attemptingFingerprint = false;
                     if (BiometricsHelper.isPinConfigured(context, biometricManager) &&
                             allowPassword) {
-                        //Automatically try password, it's the only option
+                        //Automatically try PIN
                         performPinUnlock();
-                    } else {
-                        //Automatically try password, it's the only option
-                        performPasswordUnlock();
+                        return;
                     }
                 }
+
+                Logger.exception("Exhausted biometrics", new Exception(
+                        "Fingerprint error and PIN isn't configured/allowed: " + allowPassword));
+
+                Toast.makeText(context, R.string.connect_verify_configuration_failed, Toast.LENGTH_SHORT).show();
             }
 
             @Override
@@ -133,6 +119,7 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
             @Override
             public void onAuthenticationFailed() {
                 super.onAuthenticationFailed();
+                Logger.exception("Fingerprint failed", new Exception("Fingerprint authentication failed"));
                 Toast.makeText(requireActivity().getApplicationContext(), "Authentication failed",
                                 Toast.LENGTH_SHORT)
                         .show();
@@ -146,30 +133,43 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
         FirebaseAnalyticsUtil.reportCccSignIn(method);
     }
 
-    public void updateState(BiometricsHelper.ConfigurationStatus fingerprintStatus,
-                            BiometricsHelper.ConfigurationStatus pinStatus) {
+    public void updateState() {
+        BiometricsHelper.ConfigurationStatus fingerprint = BiometricsHelper.checkFingerprintStatus(getActivity(),
+                biometricManager);
+        BiometricsHelper.ConfigurationStatus pin = BiometricsHelper.checkPinStatus(getActivity(), biometricManager);
+
+        if (fingerprint == BiometricsHelper.ConfigurationStatus.NotAvailable &&
+                pin == BiometricsHelper.ConfigurationStatus.NotAvailable) {
+            Logger.exception("No biometrics", new Exception(
+                    "No biometric options available during biometric config"));
+
+            //Skip to password-only workflow (except that no longer exists... TODO)
+            finish(true, true);
+            return;
+        }
+
         String titleText = getString(R.string.connect_verify_title);
         String messageText = getString(R.string.connect_verify_message);
         String fingerprintButtonText = null;
         String pinButtonText = null;
-        if (fingerprintStatus == BiometricsHelper.ConfigurationStatus.Configured) {
+        if (fingerprint == BiometricsHelper.ConfigurationStatus.Configured) {
             //Show fingerprint but not PIN
             titleText = getString(R.string.connect_verify_use_fingerprint_long);
             messageText = getString(R.string.connect_verify_fingerprint_configured);
             fingerprintButtonText = getString(R.string.connect_verify_agree);
-        } else if (pinStatus == BiometricsHelper.ConfigurationStatus.Configured) {
+        } else if (pin == BiometricsHelper.ConfigurationStatus.Configured) {
             //Show PIN, and fingerprint if configurable
             titleText = getString(R.string.connect_verify_use_pin_long);
             messageText = getString(R.string.connect_verify_pin_configured);
             pinButtonText = getString(R.string.connect_verify_agree);
-            fingerprintButtonText = fingerprintStatus == BiometricsHelper.ConfigurationStatus.NotConfigured ?
+            fingerprintButtonText = fingerprint == BiometricsHelper.ConfigurationStatus.NotConfigured ?
                     getString(R.string.connect_verify_configure_fingerprint) : null;
         } else {
             //Show anything configurable
-            if (fingerprintStatus == BiometricsHelper.ConfigurationStatus.NotConfigured) {
+            if (fingerprint == BiometricsHelper.ConfigurationStatus.NotConfigured) {
                 fingerprintButtonText = getString(R.string.connect_verify_configure_fingerprint);
             }
-            if (pinStatus == BiometricsHelper.ConfigurationStatus.NotConfigured) {
+            if (pin == BiometricsHelper.ConfigurationStatus.NotConfigured) {
                 pinButtonText = getString(R.string.connect_verify_configure_pin);
             }
         }
@@ -205,33 +205,19 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        BiometricsHelper.ConfigurationStatus fingerprint = BiometricsHelper.checkFingerprintStatus(getActivity(),
-                biometricManager);
-        BiometricsHelper.ConfigurationStatus pin = BiometricsHelper.checkPinStatus(getActivity(), biometricManager);
-        updateState(fingerprint, pin);
+        updateState();
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent intent) {
-        super.onActivityResult(requestCode, resultCode, intent);
+    public void handleFinishedPinActivity(int requestCode, int resultCode, Intent intent) {
         if (requestCode == PASSWORD_LOCK) {
+            //This route was for when the user failed to enter the correct password several times
+            //Obsolete now, should be removed
+            Logger.exception("Biometric enrollment failed", new Exception(
+                    "Hit the PASSWORD_LOCK path, should never happen"));
             finish(true, true);
         }
         if (requestCode == ConnectConstants.CONNECT_UNLOCK_PIN) {
             finish(true, false);
-        }
-    }
-
-    public void callAuthentication() {
-        if (BiometricsHelper.isFingerprintConfigured(requireActivity(), biometricManager)) {
-            //Automatically try fingerprint first
-            performFingerprintUnlock();
-        } else if (BiometricsHelper.isPinConfigured(requireActivity(), biometricManager)) {
-            performPinUnlock();
-        } else if (allowPassword) {
-            performPasswordUnlock();
-        } else {
-            Logger.exception("No unlock method available when trying to unlock ConnectID", new Exception("No unlock option"));
         }
     }
 
@@ -240,21 +226,17 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
         BiometricsHelper.authenticateFingerprint(requireActivity(), biometricManager, biometricPromptCallbacks);
     }
 
-    public void performPasswordUnlock() {
-    }
-
     public void performPinUnlock() {
         BiometricsHelper.authenticatePin(requireActivity(), biometricManager, biometricPromptCallbacks);
     }
-
 
     public void handleFingerprintButton() {
         BiometricsHelper.ConfigurationStatus fingerprint = BiometricsHelper.checkFingerprintStatus(getActivity(),
                 biometricManager);
         if (fingerprint == BiometricsHelper.ConfigurationStatus.Configured) {
             performFingerprintUnlock();
-//            finish(true, true);
         } else if (!BiometricsHelper.configureFingerprint(getActivity())) {
+            //Non-fatal exception already reported in the call above
             finish(true, true);
         }
     }
@@ -264,6 +246,7 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
         if (pin == BiometricsHelper.ConfigurationStatus.Configured) {
             performPinUnlock();
         } else if (!BiometricsHelper.configurePin(getActivity())) {
+            //Non-fatal exception already reported in the call above
             finish(true, true);
         }
     }
@@ -305,6 +288,5 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
         if (directions != null) {
             Navigation.findNavController(binding.connectVerifyMessage).navigate(directions);
         }
-
     }
 }


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-941
cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Product Description
Better error handling and reporting for issues encountered during biometric configuration (during registration/recovery)

## Technical Summary
Deleted some obsolete code (uncalled functions).
Added non-fatal exceptions for error-cases (like an option isn't available as we start trying to configure it).
Added a couple toast messages to give the user an indication of certain problems  (along with reporting a non-fatal exception).

## Feature Flag
ConnectID

## Safety Assurance

### Safety story
Tested locally in various situations

### Automated test coverage
No automated tests for ConnectID yet.

### QA Plan
- Test various options in the biometric configuration page during registration or recovery workflow
- Include testing on device without fingerprint reader
- Test PIN config/unlock on SDKs <23, <30, >=30
- Test fingerprint config/unlock on SDKs <28, <30, >=30
- Test not having a screen unlock configured and trying to configure/recover
- Try unconfiguring screen lock after reg./recovery is complete, and then unlocking ConnectID (i.e. to get to jobs list)

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
