### PR TITLE
Only init cache if cache is enabled

### DIFF
--- a/app/src/org/commcare/tasks/EntityLoaderHelper.kt
+++ b/app/src/org/commcare/tasks/EntityLoaderHelper.kt
@@ -35,7 +35,8 @@ class EntityLoaderHelper(
         evalCtx.addFunctionHandler(EntitySelectActivity.getHereFunctionHandler())
         if (factory == null) {
             if (detail.shouldOptimize()) {
-                val entityStorageCache: EntityStorageCache = CommCareEntityStorageCache("case")
+                val entityStorageCache: EntityStorageCache? =
+                    if (detail.isCacheEnabled) CommCareEntityStorageCache("case") else null
                 factory =
                     AndroidAsyncNodeEntityFactory(detail, sessionDatum, evalCtx, entityStorageCache, inBackground)
             } else if (detail.useAsyncStrategy()) {


### PR DESCRIPTION
## Technical Summary
This is a  small fix to only init cache when cache is enabled in detail config. Earlier it was getting initialised for the case when cache is disabled but lazy loading is enabled. 

## Feature Flag
Cache and Lazy Load 

## Safety Assurance

### Safety story

Small no-op change

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
None
### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
None

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
