### PR TITLE
Show fingerprint failure error string

### DIFF
--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -437,7 +437,7 @@
     <string name="connect_verify_configure_fingerprint">Configurar impressão digital</string>
     <string name="connect_verify_use_pin_long">Utilizar o PIN para ligar</string>
     <string name="connect_verify_pin_configured">O seu PIN já foi configurado e será utilizado para desbloquear o ConnectID.</string>
-    <string name="connect_verify_configuration_failed">A configuração falhou, tente novamente</string>
+    <string name="connect_verify_configuration_failed">A configuração falhou, tente novamente. %s</string>
     <string name="connect_verify_configure_pin">Configurar PIN</string>
     <string name="connect_verify_agree">Concordo &amp; Continuar</string>
     <string name="connect_verify_phone_title">Código de verificação</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -434,7 +434,7 @@
     <string name="connect_verify_configure_fingerprint">Sanidi Alama ya Kidole</string>
     <string name="connect_verify_use_pin_long">Tumia PIN Kuunganisha</string>
     <string name="connect_verify_pin_configured">PIN yako tayari imesanidiwa na itatumika kufungua ConnectID.</string>
-    <string name="connect_verify_configuration_failed">Usanidi haukufaulu, tafadhali jaribu tena</string>
+    <string name="connect_verify_configuration_failed">Usanidi haukufaulu, tafadhali jaribu tena. %s</string>
     <string name="connect_verify_configure_pin">Sanidi PIN</string>
     <string name="connect_verify_agree">Kubali na Uendelee</string>
     <string name="connect_verify_phone_title">Nambari ya Uthibitishaji</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -425,7 +425,7 @@
     <string name="connect_verify_configure_fingerprint">ኣሰር ኣፃብዕቲ ምውቃር</string>
     <string name="connect_verify_use_pin_long">ንምትእስሳር ፒን ተጠቐም</string>
     <string name="connect_verify_pin_configured">ፒንካ በቃ ተዋቒሩ ኣሎ፡ ንConnectID ንምኽፋት ድማ ክጥቀመሉ እዩ።</string>
-    <string name="connect_verify_configuration_failed">ውቅር ኣይተዓወተን፣ በጃኻ እንደገና ፈትን።</string>
+    <string name="connect_verify_configuration_failed">ውቅር ኣይተዓወተን፣ በጃኻ እንደገና ፈትን።  %s</string>
     <string name="connect_verify_configure_pin">ፒን ምውቃር</string>
     <string name="connect_verify_agree">ስምምዕ &amp; ቀፅል</string>
     <string name="connect_verify_phone_title">ናይ ምርግጋፅ ኮድ</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -515,7 +515,7 @@
     <string name="connect_verify_configure_fingerprint">Configure Fingerprint</string>
     <string name="connect_verify_use_pin_long">Use PIN to Connect</string>
     <string name="connect_verify_pin_configured">Your PIN has already been configured and will be used to unlock ConnectID.</string>
-    <string name="connect_verify_configuration_failed">Configuration failed, please try again</string>
+    <string name="connect_verify_configuration_failed">Configuration failed, please try again. %s</string>
 
     <string name="connect_verify_configure_pin">Configure PIN</string>
     <string name="connect_verify_agree">Agree &amp; Continue</string>

--- a/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdBiometricConfigFragment.java
@@ -100,10 +100,12 @@ public class ConnectIdBiometricConfigFragment extends Fragment {
                     }
                 }
 
-                Logger.exception("Exhausted biometrics", new Exception(
-                        "Fingerprint error and PIN isn't configured/allowed: " + allowPassword));
+                String whyNoPin = allowPassword ? "configured" : "allowed";
+                Logger.exception("Exhausted biometrics", new Exception(String.format(Locale.getDefault(),
+                        "Fingerprint error and PIN isn't %s: %s (%d)", whyNoPin, errString, errorCode)));
 
-                Toast.makeText(context, R.string.connect_verify_configuration_failed, Toast.LENGTH_SHORT).show();
+                String message = context.getString(R.string.connect_verify_configuration_failed, errString);
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show();
             }
 
             @Override


### PR DESCRIPTION
Quick change to include the error string returned by the OS when the user fails fingerprint authentication, both in the reported non-fatal exception and the toast message shown to the user.