### PR TITLE
Fixed logic around receiving and storing Connect DB passphrases.

### DIFF
--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -50,5 +50,6 @@ public class CCAnalyticsEvent {
     static final String CCC_PAYMENT_CONFIRMATION_DISPLAY = "ccc_payment_confirmation_display";
     static final String CCC_PAYMENT_CONFIRMATION_INTERACT = "ccc_payment_confirmation_interact";
     static final String CCC_NOTIFICATION_TYPE = "ccc_notification_type";
+    static final String CCC_REKEYED_DB = "ccc_rekeyed_db";
 
 }

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -511,4 +511,8 @@ public class FirebaseAnalyticsUtil {
         reportEvent(CCAnalyticsEvent.CCC_NOTIFICATION_TYPE,
                 CCAnalyticsParam.NOTIFICATION_TYPE, notificationType);
     }
+
+    public static void reportRekeyedDatabase() {
+        reportEvent(CCAnalyticsEvent.CCC_REKEYED_DB);
+    }
 }


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-950
cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Product Description
Fixes a bug where the app would sometimes crash during registration.

## Technical Summary
Fixed handling for received remote passphrase to properly rekey when necessary, and then store the local passphrase.
Added analytics event when database is rekeyed with new passphrase.
More notes about the crash that caused this [here](https://docs.google.com/document/d/1PvTgJPVidjmaqy4d-kWJKfhPIRan60gmQ8C9RqzF02M/edit?tab=t.0#heading=h.rbd0yudtyzqb)

## Feature Flag
ConnectID

## Safety Assurance

### Safety story
Tested several scenarios locally.
QA plan should make sure to include the testing described below.

### Automated test coverage
None

### QA Plan
Tests that need to be performed around this, all should not crash:
- Register an account
- Recover an account
- Reg/recover on published beta (build 472000), then update to latest and run again
- LEGACY: Reg/recover account on build <467187 (June 18, 2024), then update to latest and run again
