### PR TITLE
Using CommCare BuildConfig

### DIFF
--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -18,9 +18,9 @@ import androidx.navigation.NavController;
 import androidx.navigation.NavDestination;
 import androidx.navigation.fragment.FragmentNavigator;
 
-import com.google.firebase.BuildConfig;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
+import org.commcare.dalvik.BuildConfig;
 import org.commcare.CommCareApplication;
 import org.commcare.DiskUtils;
 import org.commcare.connect.ConnectManager;


### PR DESCRIPTION
## Technical Summary
Using CommCare BuildConfig instead of Firebase for reporting build number in analytics events.
Old code was reporting -1, and then broke the build recently.

## Feature Flag
None

## Safety Assurance

### Safety story
Simple change, not visible to user but will improve our reporting

### Automated test coverage
None

### QA Plan
None

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
