### PR TITLE
Safety try-catch in analytics

### DIFF
--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -13,6 +13,7 @@ import org.commcare.preferences.MainConfigurablePreferences;
 import org.commcare.suite.model.OfflineUserRestore;
 import org.commcare.utils.EncryptionUtils;
 import org.commcare.utils.FormUploadResult;
+import org.javarosa.core.services.Logger;
 
 import java.util.Date;
 
@@ -39,16 +40,20 @@ public class FirebaseAnalyticsUtil {
     }
 
     private static void reportEvent(String eventName, String[] paramKeys, String[] paramVals) {
-        Bundle b = new Bundle();
-        for (int i = 0; i < paramKeys.length; i++) {
-            // https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Param
-            // Param values can only be up to 100 characters.
-            if (paramVals[i].length() > 100) {
-                paramVals[i] = paramVals[i].substring(0, 100);
+        try {
+            Bundle b = new Bundle();
+            for (int i = 0; i < paramKeys.length; i++) {
+                // https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Param
+                // Param values can only be up to 100 characters.
+                if (paramVals[i].length() > 100) {
+                    paramVals[i] = paramVals[i].substring(0, 100);
+                }
+                b.putString(paramKeys[i], paramVals[i]);
             }
-            b.putString(paramKeys[i], paramVals[i]);
+            reportEvent(eventName, b);
+        } catch(Exception e) {
+            Logger.exception("Error logging analytics event", e);
         }
-        reportEvent(eventName, b);
     }
 
     private static void reportEvent(String eventName, Bundle params) {


### PR DESCRIPTION
## Technical Summary
Wrapped the function in analytics that packs parameters into a bundle in a try-catch.
This was causing an occasional crash when code tried to log a form entry event with a null form ID.
[Firebase crash](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/72de9c0c2770c333cdb78585fd00bd41?time=last-seven-days&types=crash&sessionEventKey=68091A4C0218000175CF2159E44778BF_2075003108423650723)

## Feature Flag
None

## Safety Assurance

### Safety story
Simple try-catch with logging, pretty safe stuff.

### Automated test coverage
None
