### PR TITLE
Set Crashlytics user to ConnectID

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -390,6 +390,8 @@ public class CommCareApplication extends Application implements LifecycleEventOb
 
             // Switch loggers back over to using global storage, now that we don't have a session
             setupLoggerStorage(false);
+
+            CrashUtil.registerUserData();
         }
     }
 

--- a/app/src/org/commcare/android/logging/ReportingUtils.java
+++ b/app/src/org/commcare/android/logging/ReportingUtils.java
@@ -144,13 +144,16 @@ public class ReportingUtils {
     }
 
     public static String getUserForCrashes() {
-        try {
-            if(ConnectIDManager.getInstance().isloggedIn()) {
-                return ConnectIDManager.getInstance().getUser(CommCareApplication.instance()).getUserId();
+        String user = getUser();
+        if(user.isEmpty()) {
+            try {
+                if (ConnectIDManager.getInstance().isloggedIn()) {
+                    return ConnectIDManager.getInstance().getUser(CommCareApplication.instance()).getUserId();
+                }
+            } catch (Exception ignored) {
             }
-        } catch(Exception ignored) {
         }
 
-        return getUser();
+        return "";
     }
 }

--- a/app/src/org/commcare/android/logging/ReportingUtils.java
+++ b/app/src/org/commcare/android/logging/ReportingUtils.java
@@ -154,6 +154,6 @@ public class ReportingUtils {
             }
         }
 
-        return "";
+        return null;
     }
 }

--- a/app/src/org/commcare/android/logging/ReportingUtils.java
+++ b/app/src/org/commcare/android/logging/ReportingUtils.java
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager;
 import org.commcare.AppUtils;
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
+import org.commcare.connect.ConnectIDManager;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.preferences.ServerUrls;
@@ -140,5 +141,16 @@ public class ReportingUtils {
         } catch (Exception e) {
             return "";
         }
+    }
+
+    public static String getUserForCrashes() {
+        try {
+            if(ConnectIDManager.getInstance().isloggedIn()) {
+                return ConnectIDManager.getInstance().getUser(CommCareApplication.instance()).getUserId();
+            }
+        } catch(Exception ignored) {
+        }
+
+        return getUser();
     }
 }

--- a/app/src/org/commcare/connect/ConnectIDManager.java
+++ b/app/src/org/commcare/connect/ConnectIDManager.java
@@ -131,10 +131,6 @@ public class ConnectIDManager {
                 boolean registering = user.getRegistrationPhase() != ConnectConstants.CONNECT_NO_ACTIVITY;
                 connectStatus = registering ? ConnectIdStatus.Registering : ConnectIdStatus.LoggedIn;
 
-                if(connectStatus == ConnectIdStatus.LoggedIn) {
-                    CrashUtil.registerConnectUser();
-                }
-
                 String remotePassphrase = ConnectDatabaseUtils.getConnectDbEncodedPassphrase(parent, false);
                 if (remotePassphrase == null) {
                     getRemoteDbPassphrase(parent, user);
@@ -233,7 +229,6 @@ public class ConnectIDManager {
     public void completeSignin() {
         connectStatus = ConnectIdStatus.LoggedIn;
         scheduleHearbeat();
-        CrashUtil.registerConnectUser();
     }
 
     public void handleFinishedActivity(CommCareActivity<?> activity, int resultCode) {

--- a/app/src/org/commcare/connect/ConnectIDManager.java
+++ b/app/src/org/commcare/connect/ConnectIDManager.java
@@ -131,6 +131,8 @@ public class ConnectIDManager {
                 boolean registering = user.getRegistrationPhase() != ConnectConstants.CONNECT_NO_ACTIVITY;
                 connectStatus = registering ? ConnectIdStatus.Registering : ConnectIdStatus.LoggedIn;
 
+                CrashUtil.registerUserData();
+
                 String remotePassphrase = ConnectDatabaseUtils.getConnectDbEncodedPassphrase(parent, false);
                 if (remotePassphrase == null) {
                     getRemoteDbPassphrase(parent, user);
@@ -229,6 +231,7 @@ public class ConnectIDManager {
     public void completeSignin() {
         connectStatus = ConnectIdStatus.LoggedIn;
         scheduleHearbeat();
+        CrashUtil.registerUserData();
     }
 
     public void handleFinishedActivity(CommCareActivity<?> activity, int resultCode) {

--- a/app/src/org/commcare/connect/ConnectIDManager.java
+++ b/app/src/org/commcare/connect/ConnectIDManager.java
@@ -131,6 +131,10 @@ public class ConnectIDManager {
                 boolean registering = user.getRegistrationPhase() != ConnectConstants.CONNECT_NO_ACTIVITY;
                 connectStatus = registering ? ConnectIdStatus.Registering : ConnectIdStatus.LoggedIn;
 
+                if(connectStatus == ConnectIdStatus.LoggedIn) {
+                    CrashUtil.registerConnectUser();
+                }
+
                 String remotePassphrase = ConnectDatabaseUtils.getConnectDbEncodedPassphrase(parent, false);
                 if (remotePassphrase == null) {
                     getRemoteDbPassphrase(parent, user);

--- a/app/src/org/commcare/utils/CrashUtil.java
+++ b/app/src/org/commcare/utils/CrashUtil.java
@@ -46,7 +46,10 @@ public class CrashUtil {
 
     public static void registerUserData() {
         if (crashlyticsEnabled) {
-            FirebaseCrashlytics.getInstance().setUserId(ReportingUtils.getUser());
+            String user = ConnectIDManager.getInstance().isloggedIn() ?
+                    ConnectIDManager.getInstance().getUser(CommCareApplication.instance()).getUserId() :
+                    ReportingUtils.getUser();
+            FirebaseCrashlytics.getInstance().setUserId(user);
         }
     }
 
@@ -61,6 +64,7 @@ public class CrashUtil {
      * <p>
      * If Crashlytics is enabled and a Connect ID is configured, this method retrieves
      * the user ID from ConnectManager and sets it as a custom key in Crashlytics.
+     * The method also calls registerUserData, which sets the Firebase user as the Connect ID
      * <p>
      * In case of any exceptions during this process, the exception is recorded in
      * Crashlytics to aid debugging.
@@ -68,6 +72,7 @@ public class CrashUtil {
     public static void registerConnectUser() {
         if (crashlyticsEnabled && ConnectIDManager.getInstance().isloggedIn()) {
             try {
+                registerUserData();
                 String userId = ConnectIDManager.getInstance().getUser(CommCareApplication.instance()).getUserId();
                 FirebaseCrashlytics.getInstance().setCustomKey(CCC_USER, userId);
             } catch (Exception e) {

--- a/app/src/org/commcare/utils/CrashUtil.java
+++ b/app/src/org/commcare/utils/CrashUtil.java
@@ -17,7 +17,6 @@ public class CrashUtil {
     private static final String APP_NAME = "app_name";
     private static final String DOMAIN = "domain";
     private static final String DEVICE_ID = "device_id";
-    private static final String CCC_USER = "ccc_user_id";
 
     private static boolean crashlyticsEnabled = BuildConfig.USE_CRASHLYTICS;
 
@@ -54,28 +53,6 @@ public class CrashUtil {
     public static void log(String message) {
         if (crashlyticsEnabled) {
             FirebaseCrashlytics.getInstance().log(message);
-        }
-    }
-
-    /**
-     * Registers the current Connect user with Firebase Crashlytics for error tracking.
-     * <p>
-     * If Crashlytics is enabled and a Connect ID is configured, this method retrieves
-     * the user ID from ConnectManager and sets it as a custom key in Crashlytics.
-     * The method also calls registerUserData, which sets the Firebase user as the Connect ID
-     * <p>
-     * In case of any exceptions during this process, the exception is recorded in
-     * Crashlytics to aid debugging.
-     */
-    public static void registerConnectUser() {
-        if (crashlyticsEnabled && ConnectIDManager.getInstance().isloggedIn()) {
-            try {
-                registerUserData();
-                String userId = ConnectIDManager.getInstance().getUser(CommCareApplication.instance()).getUserId();
-                FirebaseCrashlytics.getInstance().setCustomKey(CCC_USER, userId);
-            } catch (Exception e) {
-                FirebaseCrashlytics.getInstance().recordException(e);
-            }
         }
     }
 }

--- a/app/src/org/commcare/utils/CrashUtil.java
+++ b/app/src/org/commcare/utils/CrashUtil.java
@@ -46,9 +46,7 @@ public class CrashUtil {
 
     public static void registerUserData() {
         if (crashlyticsEnabled) {
-            String user = ConnectIDManager.getInstance().isloggedIn() ?
-                    ConnectIDManager.getInstance().getUser(CommCareApplication.instance()).getUserId() :
-                    ReportingUtils.getUser();
+            String user = ReportingUtils.getUserForCrashes();
             FirebaseCrashlytics.getInstance().setUserId(user);
         }
     }

--- a/app/src/org/commcare/utils/CrashUtil.java
+++ b/app/src/org/commcare/utils/CrashUtil.java
@@ -46,7 +46,9 @@ public class CrashUtil {
     public static void registerUserData() {
         if (crashlyticsEnabled) {
             String user = ReportingUtils.getUserForCrashes();
-            FirebaseCrashlytics.getInstance().setUserId(user);
+            if(user != null) {
+                FirebaseCrashlytics.getInstance().setUserId(user);
+            }
         }
     }
 


### PR DESCRIPTION
## Product Description
No visible change

## Technical Summary
When a ConnectID user is logged in, override the Crashlytics user to the user's ConnectID

## Feature Flag
ConnectID

## Safety Assurance

### Safety story
Crash logging change, only gets run when user is logged in.

### Automated test coverage
None

### QA Plan
None