### PR TITLE
Pm-fixed bug for job status button click and landing page for connect

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -581,7 +581,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     protected void userPressedOpportunityStatus() {
         Intent i = new Intent();
         i.putExtra(REDIRECT_TO_CONNECT_OPPORTUNITY_INFO, true);
-        setResult(RESULT_OK);
+        setResult(RESULT_OK, i);
         finish();
     }
 

--- a/app/src/org/commcare/activities/connect/ConnectIdActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectIdActivity.java
@@ -46,7 +46,7 @@ public class ConnectIdActivity extends CommCareActivity<ConnectIdActivity> {
         if (requestCode == ConnectConstants.CONNECT_UNLOCK_PIN) {
             //PIN unlock should only be requested while BiometricConfig fragment is active, else this will crash
             getCurrentFragment().handleFinishedPinActivity(requestCode, resultCode, data);
-        } else if (requestCode == ConnectConstants.CONNECTID_REQUEST_CODE) {
+        } else if (requestCode == ConnectConstants.CONNECT_JOB_INFO) {
             handleRedirection(data);
         }
         if (requestCode == RESULT_OK) {

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -462,13 +462,10 @@ public class ConnectJobRecord extends Persisted implements Serializable {
 
         try {
             SimpleDateFormat utcFormat = new SimpleDateFormat(WORKING_HOURS_SOURCE_FORMAT, Locale.getDefault());
-            utcFormat.setTimeZone(TimeZone.getTimeZone("UTC")); // input is in UTC
-
-            Date startTime = utcFormat.parse(dailyStart); // parsed as UTC
-            Date endTime = utcFormat.parse(dailyFinish); // parsed as UTC
-
+            utcFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date startTime = utcFormat.parse(dailyStart);
+            Date endTime = utcFormat.parse(dailyFinish);
             SimpleDateFormat localFormat = new SimpleDateFormat(WORKING_HOURS_TARGET_FORMAT, Locale.getDefault());
-            localFormat.setTimeZone(TimeZone.getDefault()); // convert to local time zone
 
             String startTimeLocal = localFormat.format(startTime);
             String endTimeLocal = localFormat.format(endTime);

--- a/app/src/org/commcare/connect/ConnectConstants.java
+++ b/app/src/org/commcare/connect/ConnectConstants.java
@@ -8,7 +8,6 @@ package org.commcare.connect;
 public class ConnectConstants {
     public static final int CONNECT_ID_TASK_ID_OFFSET = 1000;
     public final static int CREDENTIAL_PICKER_REQUEST = 2000;
-    public static final int CONNECTID_REQUEST_CODE = 1034;
     public static final int LOGIN_CONNECT_LAUNCH_REQUEST_CODE = 1050;
     public static final int COMMCARE_SETUP_CONNECT_LAUNCH_REQUEST_CODE = 1051;
     public static final int STANDARD_HOME_CONNECT_LAUNCH_REQUEST_CODE = 1052;


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/QA-7705
bug  fix for connect landing page 
https://dimagi.atlassian.net/browse/CCCT-988

cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
In this the impact will be time shown as working hours on the connect job screens 
we have to show the time n local time zone 
I have manually checked the times it showing correct on all job screen 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
