### PR TITLE
make biometric available for api version less than 28

### DIFF
--- a/app/res/navigation/nav_graph_connectid.xml
+++ b/app/res/navigation/nav_graph_connectid.xml
@@ -166,7 +166,7 @@
             app:argType="string"
             app:nullable="true" />
         <argument
-            android:name="isDismissible"
+            android:name="isCancellable"
             android:defaultValue="true"
             app:argType="boolean" />
     </dialog>

--- a/app/res/navigation/nav_graph_connectid.xml
+++ b/app/res/navigation/nav_graph_connectid.xml
@@ -165,6 +165,10 @@
             android:name="password"
             app:argType="string"
             app:nullable="true" />
+        <argument
+            android:name="isDismissible"
+            android:defaultValue="true"
+            app:argType="boolean" />
     </dialog>
 
     <fragment

--- a/app/src/org/commcare/fragments/connectId/ConnectIdMessageFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdMessageFragment.java
@@ -34,6 +34,7 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
     private String button2Text;
     private String userName;
     private String password;
+    private boolean isDismissible = true;
     private int callingClass;
     private static final String KEY_TITLE = "title";
     private static final String KEY_MESSAGE = "message";
@@ -41,18 +42,19 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
     private static final String KEY_USER_NAME = "user_name";
     private static final String KEY_PASSWORD = "password";
     private static final String KEY_CALLING_CLASS = "calling_class";
+    private static final String KEY_IS_DISMISSIBLE = "is_dismissible";
     private ScreenConnectMessageBinding binding;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        this.setCancelable(false);
         binding = ScreenConnectMessageBinding.inflate(inflater, container, false);
         View view = binding.getRoot();
         loadSavedState(savedInstanceState);
         binding.connectMessageButton.setOnClickListener(v -> handleContinueButtonPress(false));
         binding.connectMessageButton2.setOnClickListener(v -> handleContinueButtonPress(true));
         loadArguments();
+        this.setCancelable(isDismissible);
         return view;
     }
 
@@ -73,6 +75,7 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
             userName = savedInstanceState.getString(KEY_USER_NAME);
             password = savedInstanceState.getString(KEY_PASSWORD);
             callingClass = savedInstanceState.getInt(KEY_CALLING_CLASS);
+            isDismissible = savedInstanceState.getBoolean(KEY_IS_DISMISSIBLE);
         }
     }
 
@@ -85,6 +88,7 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
         outState.putString(KEY_USER_NAME, userName);
         outState.putString(KEY_PASSWORD, password);
         outState.putInt(KEY_CALLING_CLASS, callingClass);
+        outState.putBoolean(KEY_IS_DISMISSIBLE, isDismissible);
     }
 
     private void loadArguments() {
@@ -94,6 +98,7 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
         callingClass = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getCallingClass();
         userName = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getPhone();
         password = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getPassword();
+        isDismissible = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getIsDismissible();
         if (ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getButton2Text() != null && !ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getButton2Text().isEmpty()) {
             button2Text = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getButton2Text();
         }

--- a/app/src/org/commcare/fragments/connectId/ConnectIdMessageFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdMessageFragment.java
@@ -34,7 +34,7 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
     private String button2Text;
     private String userName;
     private String password;
-    private boolean isDismissible = true;
+    private boolean isCancellable = true;
     private int callingClass;
     private static final String KEY_TITLE = "title";
     private static final String KEY_MESSAGE = "message";
@@ -42,7 +42,7 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
     private static final String KEY_USER_NAME = "user_name";
     private static final String KEY_PASSWORD = "password";
     private static final String KEY_CALLING_CLASS = "calling_class";
-    private static final String KEY_IS_DISMISSIBLE = "is_dismissible";
+    private static final String KEY_IS_CANCELLABLE = "is_cancellable";
     private ScreenConnectMessageBinding binding;
 
     @Override
@@ -54,7 +54,7 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
         binding.connectMessageButton.setOnClickListener(v -> handleContinueButtonPress(false));
         binding.connectMessageButton2.setOnClickListener(v -> handleContinueButtonPress(true));
         loadArguments();
-        this.setCancelable(isDismissible);
+        this.setCancelable(isCancellable);
         return view;
     }
 
@@ -75,7 +75,7 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
             userName = savedInstanceState.getString(KEY_USER_NAME);
             password = savedInstanceState.getString(KEY_PASSWORD);
             callingClass = savedInstanceState.getInt(KEY_CALLING_CLASS);
-            isDismissible = savedInstanceState.getBoolean(KEY_IS_DISMISSIBLE);
+            isCancellable = savedInstanceState.getBoolean(KEY_IS_CANCELLABLE);
         }
     }
 
@@ -88,7 +88,7 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
         outState.putString(KEY_USER_NAME, userName);
         outState.putString(KEY_PASSWORD, password);
         outState.putInt(KEY_CALLING_CLASS, callingClass);
-        outState.putBoolean(KEY_IS_DISMISSIBLE, isDismissible);
+        outState.putBoolean(KEY_IS_CANCELLABLE, isCancellable);
     }
 
     private void loadArguments() {
@@ -98,7 +98,7 @@ public class ConnectIdMessageFragment extends BottomSheetDialogFragment {
         callingClass = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getCallingClass();
         userName = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getPhone();
         password = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getPassword();
-        isDismissible = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getIsDismissible();
+        isCancellable = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getIsCancellable();
         if (ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getButton2Text() != null && !ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getButton2Text().isEmpty()) {
             button2Text = ConnectIdMessageFragmentArgs.fromBundle(getArguments()).getButton2Text();
         }

--- a/app/src/org/commcare/fragments/connectId/ConnectIdPasswordVerificationFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdPasswordVerificationFragment.java
@@ -117,7 +117,7 @@ public class ConnectIdPasswordVerificationFragment extends Fragment {
                 if (success) {
                     directions = navigateToConnectidPinForRecoveryChangePin();
                     if (forgot) {
-                        directions = navigateToConnectidMessage(getString(R.string.connect_recovery_alt_title), getString(R.string.connect_recovery_alt_message), ConnectConstants.CONNECT_RECOVERY_ALT_PHONE_MESSAGE, getString(R.string.connect_recovery_alt_button), getString(R.string.connect_deactivate_account), phone, secretKey);
+                        directions = navigateToConnectidMessage(getString(R.string.connect_recovery_alt_title), getString(R.string.connect_recovery_alt_message), ConnectConstants.CONNECT_RECOVERY_ALT_PHONE_MESSAGE, getString(R.string.connect_recovery_alt_button), getString(R.string.connect_deactivate_account), phone, secretKey, true);
                     }
                 } else {
                     directions = navigateToConnectidPhoneVerifyForRecoveryPrimaryPhone();
@@ -135,7 +135,7 @@ public class ConnectIdPasswordVerificationFragment extends Fragment {
                         user.setLastPinDate(new Date());
                         ConnectUserDatabaseUtil.storeUser(activity, user);
                         if (user.shouldRequireSecondaryPhoneVerification()) {
-                            directions = navigateToConnectidMessage(getString(R.string.connect_recovery_alt_title), getString(R.string.connect_recovery_alt_message), ConnectConstants.CONNECT_UNLOCK_ALT_PHONE_MESSAGE, getString(R.string.connect_password_fail_button), getString(R.string.connect_recovery_alt_change_button), phone, secretKey);
+                            directions = navigateToConnectidMessage(getString(R.string.connect_recovery_alt_title), getString(R.string.connect_recovery_alt_message), ConnectConstants.CONNECT_UNLOCK_ALT_PHONE_MESSAGE, getString(R.string.connect_password_fail_button), getString(R.string.connect_recovery_alt_change_button), phone, secretKey,false);
                         } else {
                             ConnectIDManager.getInstance().setStatus(ConnectIDManager.ConnectIdStatus.LoggedIn);
                             ConnectDatabaseHelper.setRegistrationPhase(getActivity(), ConnectConstants.CONNECT_NO_ACTIVITY);
@@ -163,7 +163,7 @@ public class ConnectIdPasswordVerificationFragment extends Fragment {
             requestCode = PASSWORD_LOCK;
             message = R.string.connect_password_recovery_message;
         }
-        NavDirections directions = navigateToConnectidMessage(getString(R.string.connect_password_fail_title), getString(message), ConnectConstants.CONNECT_RECOVERY_WRONG_PASSWORD, getString(R.string.connect_recovery_success_button), null, phone, secretKey);
+        NavDirections directions = navigateToConnectidMessage(getString(R.string.connect_password_fail_title), getString(message), ConnectConstants.CONNECT_RECOVERY_WRONG_PASSWORD, getString(R.string.connect_recovery_success_button), null, phone, secretKey,true);
 
         Navigation.findNavController(binding.connectPasswordVerifyButton).navigate(directions);
 
@@ -260,8 +260,8 @@ public class ConnectIdPasswordVerificationFragment extends Fragment {
         return ConnectIdPasswordVerificationFragmentDirections.actionConnectidPasswordToConnectidPin(ConnectConstants.CONNECT_RECOVERY_CHANGE_PIN, ((ConnectIdActivity)activity).recoverPhone, ((ConnectIdActivity)activity).recoverSecret).setChange(true).setRecover(true);
     }
 
-    private NavDirections navigateToConnectidMessage(String title, String message, int phase, String button1Text, String button2Text, String phone, String secretKey) {
-        return ConnectIdPasswordVerificationFragmentDirections.actionConnectidPasswordToConnectidMessage(title, message, phase, button1Text, button2Text, phone, secretKey);
+    private NavDirections navigateToConnectidMessage(String title, String message, int phase, String button1Text, String button2Text, String phone, String secretKey, boolean isDismissible) {
+        return ConnectIdPasswordVerificationFragmentDirections.actionConnectidPasswordToConnectidMessage(title, message, phase, button1Text, button2Text, phone, secretKey).setIsDismissible(isDismissible);
     }
 
     private NavDirections navigateToConnectidPhoneVerifyForRecoveryPrimaryPhone() {

--- a/app/src/org/commcare/fragments/connectId/ConnectIdPasswordVerificationFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdPasswordVerificationFragment.java
@@ -260,8 +260,8 @@ public class ConnectIdPasswordVerificationFragment extends Fragment {
         return ConnectIdPasswordVerificationFragmentDirections.actionConnectidPasswordToConnectidPin(ConnectConstants.CONNECT_RECOVERY_CHANGE_PIN, ((ConnectIdActivity)activity).recoverPhone, ((ConnectIdActivity)activity).recoverSecret).setChange(true).setRecover(true);
     }
 
-    private NavDirections navigateToConnectidMessage(String title, String message, int phase, String button1Text, String button2Text, String phone, String secretKey, boolean isDismissible) {
-        return ConnectIdPasswordVerificationFragmentDirections.actionConnectidPasswordToConnectidMessage(title, message, phase, button1Text, button2Text, phone, secretKey).setIsDismissible(isDismissible);
+    private NavDirections navigateToConnectidMessage(String title, String message, int phase, String button1Text, String button2Text, String phone, String secretKey, boolean isCancellable) {
+        return ConnectIdPasswordVerificationFragmentDirections.actionConnectidPasswordToConnectidMessage(title, message, phase, button1Text, button2Text, phone, secretKey).setIsCancellable(isCancellable);
     }
 
     private NavDirections navigateToConnectidPhoneVerifyForRecoveryPrimaryPhone() {

--- a/app/src/org/commcare/fragments/connectId/ConnectIdPinFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdPinFragment.java
@@ -410,7 +410,7 @@ public class ConnectIdPinFragment extends Fragment {
                         directions = navigateToConnectidPhoneNo(ConnectConstants.METHOD_RECOVER_PRIMARY, null, ConnectConstants.CONNECT_RECOVERY_PRIMARY_PHONE);
                     } else {
                         if (user.shouldRequireSecondaryPhoneVerification()) {
-                            directions = navigateToConnectidMessage(getString(R.string.connect_recovery_alt_title), getString(R.string.connect_recovery_alt_message), ConnectConstants.CONNECT_UNLOCK_ALT_PHONE_MESSAGE, getString(R.string.connect_password_fail_button), getString(R.string.connect_recovery_alt_change_button), phone, secret);
+                            directions = navigateToConnectidMessage(getString(R.string.connect_recovery_alt_title), getString(R.string.connect_recovery_alt_message), ConnectConstants.CONNECT_UNLOCK_ALT_PHONE_MESSAGE, getString(R.string.connect_password_fail_button), getString(R.string.connect_recovery_alt_change_button), phone, secret,true);
                         } else {
                             ConnectIDManager.getInstance().setStatus(ConnectIDManager.ConnectIdStatus.LoggedIn);
                             ConnectDatabaseHelper.setRegistrationPhase(getActivity(), ConnectConstants.CONNECT_NO_ACTIVITY);
@@ -448,11 +448,11 @@ public class ConnectIdPinFragment extends Fragment {
 
                     } else {
                         ConnectDatabaseHelper.setRegistrationPhase(getActivity(), ConnectConstants.CONNECT_NO_ACTIVITY);
-                        directions = navigateToConnectidMessage(getString(R.string.connect_register_success_title), getString(R.string.connect_register_success_message), ConnectConstants.CONNECT_REGISTRATION_SUCCESS, getString(R.string.connect_register_success_button), null, phone, secret);
+                        directions = navigateToConnectidMessage(getString(R.string.connect_register_success_title), getString(R.string.connect_register_success_message), ConnectConstants.CONNECT_REGISTRATION_SUCCESS, getString(R.string.connect_register_success_button), null, phone, secret,false);
                     }
                 } else {
                     if (!forgot) {
-                        directions = navigateToConnectidMessage(getString(R.string.connect_pin_fail_title), ConnectIDManager.getInstance().getFailureAttempt() > 2 ? getString(R.string.connect_pin_confirm_message) : getString(R.string.connect_pin_fail_message), ConnectConstants.CONNECT_REGISTRATION_WRONG_PIN, getString(R.string.connect_recovery_alt_button), null, phone, secret);
+                        directions = navigateToConnectidMessage(getString(R.string.connect_pin_fail_title), ConnectIDManager.getInstance().getFailureAttempt() > 2 ? getString(R.string.connect_pin_confirm_message) : getString(R.string.connect_pin_fail_message), ConnectConstants.CONNECT_REGISTRATION_WRONG_PIN, getString(R.string.connect_recovery_alt_button), null, phone, secret,false);
                     } else {
                         ConnectDatabaseHelper.setRegistrationPhase(getActivity(), ConnectConstants.CONNECT_REGISTRATION_CHANGE_PIN);
                         directions = navigateToConnectidPinSelf(ConnectConstants.CONNECT_REGISTRATION_CHANGE_PIN, user.getPrimaryPhone(), "", true, false);
@@ -464,15 +464,15 @@ public class ConnectIdPinFragment extends Fragment {
                     connectIdActivity.forgotPin = forgot;
                     if (forgot) {
                         if (connectIdActivity.forgotPassword) {
-                            directions = navigateToConnectidMessage(getString(R.string.connect_recovery_alt_title), getString(R.string.connect_recovery_alt_message), ConnectConstants.CONNECT_REGISTRATION_SUCCESS, getString(R.string.connect_recovery_alt_button), null, phone, secret);
+                            directions = navigateToConnectidMessage(getString(R.string.connect_recovery_alt_title), getString(R.string.connect_recovery_alt_message), ConnectConstants.CONNECT_REGISTRATION_SUCCESS, getString(R.string.connect_recovery_alt_button), null, phone, secret,true);
                         } else {
                             directions = navigateToConnectidPassword(connectIdActivity.recoverPhone, connectIdActivity.recoverSecret, ConnectConstants.CONNECT_RECOVERY_VERIFY_PASSWORD);
                         }
                     } else {
-                        directions = navigateToConnectidMessage(getString(R.string.connect_recovery_success_title), getString(R.string.connect_recovery_success_message), ConnectConstants.CONNECT_RECOVERY_SUCCESS, getString(R.string.connect_recovery_success_button), null, phone, secret);
+                        directions = navigateToConnectidMessage(getString(R.string.connect_recovery_success_title), getString(R.string.connect_recovery_success_message), ConnectConstants.CONNECT_RECOVERY_SUCCESS, getString(R.string.connect_recovery_success_button), null, phone, secret,false);
                     }
                 } else {
-                    directions = navigateToConnectidMessage(getString(R.string.connect_pin_fail_title), ConnectIDManager.getInstance().getFailureAttempt() > 2 ? getString(R.string.connect_pin_recovery_message) : getString(R.string.connect_pin_fail_message), ConnectConstants.CONNECT_RECOVERY_WRONG_PIN, getString(R.string.connect_recovery_alt_button), null, phone, secret);
+                    directions = navigateToConnectidMessage(getString(R.string.connect_pin_fail_title), ConnectIDManager.getInstance().getFailureAttempt() > 2 ? getString(R.string.connect_pin_recovery_message) : getString(R.string.connect_pin_fail_message), ConnectConstants.CONNECT_RECOVERY_WRONG_PIN, getString(R.string.connect_recovery_alt_button), null, phone, secret,false);
                 }
             }
             case ConnectConstants.CONNECT_RECOVERY_CHANGE_PIN -> {
@@ -483,7 +483,7 @@ public class ConnectIdPinFragment extends Fragment {
                         user.setLastPinDate(new Date());
                         ConnectUserDatabaseUtil.storeUser(activity, user);
                     }
-                    directions = navigateToConnectidMessage(getString(R.string.connect_recovery_success_title), getString(R.string.connect_recovery_success_message), ConnectConstants.CONNECT_RECOVERY_SUCCESS, getString(R.string.connect_recovery_success_button), null, phone, secret);
+                    directions = navigateToConnectidMessage(getString(R.string.connect_recovery_success_title), getString(R.string.connect_recovery_success_message), ConnectConstants.CONNECT_RECOVERY_SUCCESS, getString(R.string.connect_recovery_success_button), null, phone, secret,false);
 
                 } else {
                     directions = navigateToConnectidPhoneVerify(ConnectConstants.CONNECT_RECOVERY_VERIFY_ALT_PHONE, String.valueOf(
@@ -508,8 +508,8 @@ public class ConnectIdPinFragment extends Fragment {
         return ConnectIdPinFragmentDirections.actionConnectidPinToConnectidSignupFragment().setCallingClass(phase).setPhone(phone);
     }
 
-    private NavDirections navigateToConnectidMessage(String title, String message, int phase, String button1Text, String button2Text, String phone, String secret) {
-        return ConnectIdPinFragmentDirections.actionConnectidPinToConnectidMessage(title, message, phase, button1Text, button2Text, phone, secret);
+    private NavDirections navigateToConnectidMessage(String title, String message, int phase, String button1Text, String button2Text, String phone, String secret,boolean isDismissible) {
+        return ConnectIdPinFragmentDirections.actionConnectidPinToConnectidMessage(title, message, phase, button1Text, button2Text, phone, secret).setIsDismissible(isDismissible);
     }
 
     private NavDirections navigateToConnectidPhoneVerify(int phase, String method, String phone, String userId, String password, String secretKey, boolean isRecovery) {

--- a/app/src/org/commcare/fragments/connectId/ConnectIdPinFragment.java
+++ b/app/src/org/commcare/fragments/connectId/ConnectIdPinFragment.java
@@ -508,8 +508,8 @@ public class ConnectIdPinFragment extends Fragment {
         return ConnectIdPinFragmentDirections.actionConnectidPinToConnectidSignupFragment().setCallingClass(phase).setPhone(phone);
     }
 
-    private NavDirections navigateToConnectidMessage(String title, String message, int phase, String button1Text, String button2Text, String phone, String secret,boolean isDismissible) {
-        return ConnectIdPinFragmentDirections.actionConnectidPinToConnectidMessage(title, message, phase, button1Text, button2Text, phone, secret).setIsDismissible(isDismissible);
+    private NavDirections navigateToConnectidMessage(String title, String message, int phase, String button1Text, String button2Text, String phone, String secret,boolean isCancellable) {
+        return ConnectIdPinFragmentDirections.actionConnectidPinToConnectidMessage(title, message, phase, button1Text, button2Text, phone, secret).setIsCancellable(isCancellable);
     }
 
     private NavDirections navigateToConnectidPhoneVerify(int phase, String method, String phone, String userId, String password, String secretKey, boolean isRecovery) {

--- a/app/src/org/commcare/utils/BiometricsHelper.java
+++ b/app/src/org/commcare/utils/BiometricsHelper.java
@@ -194,10 +194,9 @@ public class BiometricsHelper {
             //An alternative for fingerprint enroll that might be available
             enrollIntent = new Intent(Settings.ACTION_FINGERPRINT_ENROLL);
         } else {
-            //No way to enroll, have to fail
-            Logger.exception("Biometric config failed", new Exception(String.format(Locale.getDefault(),
-                    "No available enroll activity for authenticator %d", authenticator)));
-            return false;
+            //API < 28 — just open security settings
+            activity.startActivity(new Intent(Settings.ACTION_SECURITY_SETTINGS));
+            return true;
         }
 
         activity.startActivityForResult(enrollIntent, ConnectConstants.CONFIGURE_BIOMETRIC_REQUEST_CODE);

--- a/app/src/org/commcare/utils/BiometricsHelper.java
+++ b/app/src/org/commcare/utils/BiometricsHelper.java
@@ -194,9 +194,10 @@ public class BiometricsHelper {
             //An alternative for fingerprint enroll that might be available
             enrollIntent = new Intent(Settings.ACTION_FINGERPRINT_ENROLL);
         } else {
-            //API < 28 — just open security settings
-            activity.startActivity(new Intent(Settings.ACTION_SECURITY_SETTINGS));
-            return true;
+            //No way to enroll, have to fail
+            Logger.log("Biometric config failed", String.format(Locale.getDefault(),
+                    "No available enroll activity for authenticator %d", authenticator));
+            return false;
         }
 
         activity.startActivityForResult(enrollIntent, ConnectConstants.CONFIGURE_BIOMETRIC_REQUEST_CODE);


### PR DESCRIPTION
## Product Description
Make Biometric available for version less than 28 
https://dimagi.atlassian.net/browse/QA-7707
cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Technical Summary
Till now we have configure till android 28 but we support till android 21 so we have placed the check for that

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
Tested on android 7 , 12 and 14 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
