### PR TITLE
Corrects Map Icon Changes and minor cleanup

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -365,7 +365,6 @@ select.detail.bypass=Done
 select.address.show=Show Address
 select.menu.sort=Sort By...
 select.menu.map=View on Map
-select.menu.scan=Scan Barcode
 select.menu.settings=Settings
 select.detail.title=Details
 select.list.title=Select

--- a/app/res/menu/action_bar_search_view.xml
+++ b/app/res/menu/action_bar_search_view.xml
@@ -7,7 +7,7 @@
         app:showAsAction="collapseActionView|ifRoom"
         app:actionViewClass="androidx.appcompat.widget.SearchView"/>
     <item
-        android:id="@+id/highlight_action_bar"
+        android:id="@+id/barcode_scan_action_bar"
         android:title="Scan Barcode"
         android:icon="@drawable/startup_barcode"
         app:showAsAction="ifRoom"/>

--- a/app/src/org/commcare/activities/BlankLoginActivityUIController.java
+++ b/app/src/org/commcare/activities/BlankLoginActivityUIController.java
@@ -12,12 +12,12 @@ import java.util.ArrayList;
 /**
  * UIController for running LoginActivity without showing anything on the screen
  */
-public class BlankLoginActivityUiController extends LoginActivityUIController {
+public class BlankLoginActivityUIController extends LoginActivityUIController {
 
     private EditText username;
     private EditText password;
 
-    public BlankLoginActivityUiController(LoginActivity activity) {
+    public BlankLoginActivityUIController(LoginActivity activity) {
         super(activity);
     }
 

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -749,7 +749,7 @@ public abstract class CommCareActivity<R> extends AppCompatActivity
 
         MenuItem searchMenuItem = menu.findItem(org.commcare.dalvik.R.id.search_action_bar);
         SearchView searchView = (SearchView)searchMenuItem.getActionView();
-        MenuItem barcodeItem = menu.findItem(org.commcare.dalvik.R.id.highlight_action_bar);
+        MenuItem barcodeItem = menu.findItem(org.commcare.dalvik.R.id.barcode_scan_action_bar);
         if (searchView != null) {
             if (instantiator != null) {
                 instantiator.onActionBarFound(searchMenuItem, searchView, barcodeItem);

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -108,7 +108,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     public static final int CALLOUT = 3;
 
     private static final int MENU_SORT = Menu.FIRST + 1;
-    private static final int MENU_SCAN = Menu.FIRST + 2;
+    private static final int MENU_MAP = Menu.FIRST + 2;
     private static final int MENU_ACTION = Menu.FIRST + 3;
 
     private static final int MENU_ACTION_GROUP = Menu.FIRST + 1;
@@ -719,8 +719,8 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         menu.add(0, MENU_SORT, MENU_SORT, Localization.get("select.menu.sort")).setIcon(
                 android.R.drawable.ic_menu_sort_alphabetically);
         if (isMappingEnabled) {
-            menu.add(0, MENU_SCAN, MENU_SCAN, Localization.get("select.menu.scan")).setIcon(
-                   R.drawable.startup_barcode);
+            menu.add(0, MENU_MAP, MENU_MAP, Localization.get("select.menu.map")).setIcon(
+                   R.drawable.ic_marker);
         }
 
         if (entitySelectSearchUI != null) {
@@ -757,10 +757,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         menu.findItem(MENU_SORT).setEnabled(adapter != null);
         // hide sorting menu when using async loading strategy
         menu.findItem(MENU_SORT).setVisible((shortSelect == null || shortSelect.hasSortField()));
-        if(isMappingEnabled) {
-            menu.findItem(R.id.highlight_action_bar).setIcon(R.drawable.ic_marker);
-        }
-
         if (menu.findItem(R.id.menu_settings) != null) {
             // For the same reason as in onCreateOptionsMenu(), we may be trying to call this
             // before we're ready
@@ -779,19 +775,15 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             case MENU_SORT:
                 createSortMenu();
                 return true;
-            case MENU_SCAN:
-                barcodeScanOnClickListener.onClick(null);
+            case MENU_MAP:
+                Intent intent = new Intent(this,
+                        HiddenPreferences.shouldUseMapboxMap() ? EntityMapboxActivity.class : EntityMapActivity.class);
+                this.startActivityForResult(intent, MAP_SELECT);
                 return true;
             // handling click on the barcode scanner's actionbar
             // trying to set the onclicklistener in its view in the onCreateOptionsMenu method does not work because it returns null
-            case R.id.highlight_action_bar:
-                if(isMappingEnabled){
-                    Intent intent = new Intent(this,
-                            HiddenPreferences.shouldUseMapboxMap() ? EntityMapboxActivity.class : EntityMapActivity.class);
-                    this.startActivityForResult(intent, MAP_SELECT);
-                }else {
-                    barcodeScanOnClickListener.onClick(null);
-                }
+            case R.id.barcode_scan_action_bar:
+                barcodeScanOnClickListener.onClick(null);
                 return true;
             // this is needed because superclasses do not implement the menu_settings click
             case R.id.menu_settings:

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -720,7 +720,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
                 android.R.drawable.ic_menu_sort_alphabetically);
         if (isMappingEnabled) {
             menu.add(0, MENU_MAP, MENU_MAP, Localization.get("select.menu.map")).setIcon(
-                   R.drawable.ic_marker);
+                   R.drawable.ic_marker).setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
         }
 
         if (entitySelectSearchUI != null) {

--- a/app/src/org/commcare/activities/FormRecordListActivity.java
+++ b/app/src/org/commcare/activities/FormRecordListActivity.java
@@ -579,7 +579,7 @@ public class FormRecordListActivity extends SessionAwareCommCareActivity<FormRec
             case MENU_SUBMIT_QUARANTINE_REPORT:
                 generateQuarantineReport();
                 return true;
-            case R.id.highlight_action_bar:
+            case R.id.barcode_scan_action_bar:
                 barcodeScanOnClickListener.onClick(null);
                 return true;
             case R.id.menu_settings:

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -11,7 +11,6 @@ import android.content.Intent;
 import android.content.RestrictionsManager;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
@@ -779,7 +778,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     @Override
     public void initUIController() {
         if (CommCareApplication.instance().isConsumerApp()) {
-            uiController = new BlankLoginActivityUiController(this);
+            uiController = new BlankLoginActivityUIController(this);
         } else {
             uiController = new LoginActivityUIController(this);
         }

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -268,7 +268,7 @@ public class ConnectActivity extends CommCareActivity<ResourceEngineListener> {
 
     public void startAppValidation() {
         Intent i = new Intent(this, CommCareVerificationActivity.class);
-        i.putExtra(CommCareVerificationActivity.KEY_LAUNCH_FROM_SETTINGS, true);
+        i.putExtra(CommCareVerificationActivity.KEY_LAUNCH_FROM_CONNECT, true);
         verificationLauncher.launch(i);
     }
 }


### PR DESCRIPTION
## Product Description

A couple smallish clean up for connect and master synergy, but mostly corrects the implementation of map icon from the PR - https://github.com/dimagi/commcare-android/pull/2943 where the only change we need to show the map icon on the bar is ser the `setShowAsAction` flag. 

## Safety Assurance

### Safety story

- Tested that the map icon shows as before on the action bar after the change. 
- Impact should be limited to the apps with map icon enabled i.e quite a limited # of apps

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
