### PR TITLE
Show Xpath error details while installing app

### DIFF
--- a/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/XFormAndroidInstaller.java
@@ -32,6 +32,7 @@ import org.javarosa.xform.parse.XFormParseException;
 import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.javarosa.xpath.XPathException;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.DataInputStream;
@@ -95,7 +96,7 @@ public class XFormAndroidInstaller extends FileSystemInstaller {
         FormDef formDef;
         try (InputStream inputStream = local.getStream()) {
             formDef = XFormExtensionUtils.getFormFromInputStream(inputStream);
-        } catch (XFormParseException xfpe) {
+        } catch (XFormParseException | XPathException xfpe) {
             throw new InvalidResourceException(r.getDescriptor(), xfpe.getMessage());
         }
 


### PR DESCRIPTION
## Product Description
Instead of showing "unknown error while installing app", show a detailed user message on Xpath errors while installing apps. Below is a screenshot on how this change results in more error details on the install page - 

<img src="https://github.com/user-attachments/assets/a60e3107-1fd3-407e-8857-99499e1628b7" width="400" height="600">
<img src="https://github.com/user-attachments/assets/e26be744-828f-4156-b786-fa99def2b5b9" width="400" height="600">


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
