### PR TITLE
Remove connect enable setting

### DIFF
--- a/app/res/xml/app_manager_developer_preferences.xml
+++ b/app/res/xml/app_manager_developer_preferences.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <Preference android:key="enable-mobile-privilege"/>
-    <Preference android:key="enable-connect-id"/>
 </PreferenceScreen>

--- a/app/src/org/commcare/connect/ConnectIDManager.java
+++ b/app/src/org/commcare/connect/ConnectIDManager.java
@@ -149,7 +149,7 @@ public class ConnectIDManager {
     }
 
     private void scheduleHearbeat() {
-        if (AppManagerDeveloperPreferences.isConnectIdEnabled()) {
+        if (isloggedIn()) {
             Constraints constraints = new Constraints.Builder()
                     .setRequiredNetworkType(NetworkType.CONNECTED)
                     .setRequiresBatteryNotLow(true)
@@ -177,8 +177,7 @@ public class ConnectIDManager {
 
 
     public boolean isloggedIn() {
-        return AppManagerDeveloperPreferences.isConnectIdEnabled()
-                && connectStatus == ConnectIdStatus.LoggedIn;
+        return connectStatus == ConnectIdStatus.LoggedIn;
     }
 
     public void unlockConnect(CommCareActivity<?> activity, ConnectActivityCompleteListener callback) {

--- a/app/src/org/commcare/preferences/AppManagerDeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/AppManagerDeveloperPreferences.java
@@ -22,14 +22,11 @@ import androidx.preference.Preference;
 public class AppManagerDeveloperPreferences extends CommCarePreferenceFragment {
 
     private static final String ENABLE_PRIVILEGE = "enable-mobile-privilege";
-    private static final String ENABLE_CONNECT_ID = "enable-connect-id";
     private static final String DEVELOPER_PREFERENCES_ENABLED = "developer-preferences-enabled";
-    private static final String CONNECT_ID_ENABLED = "connect_id-enabled";
     private static final Map<String, String> keyToTitleMap = new HashMap<>();
 
     static {
         keyToTitleMap.put(ENABLE_PRIVILEGE, "menu.enable.privileges");
-        keyToTitleMap.put(ENABLE_CONNECT_ID, "menu.enable.connect.id");
     }
 
     @NonNull
@@ -58,19 +55,6 @@ public class AppManagerDeveloperPreferences extends CommCarePreferenceFragment {
             launchPrivilegeClaimActivity();
             return true;
         });
-
-        Preference enableConectIdButton = findPreference(ENABLE_CONNECT_ID);
-        enableConectIdButton.setOnPreferenceClickListener(preference -> {
-            FirebaseAnalyticsUtil.reportAdvancedActionSelected(
-                    AnalyticsParamValue.ENABLE_CONNECT_ID);
-            toggleConnectIdEnabled();
-            return true;
-        });
-    }
-
-    private void toggleConnectIdEnabled() {
-        AppManagerDeveloperPreferences.setConnectIdEnabled(true);
-        Toast.makeText(getContext(), getString(R.string.connect_id_enabled), Toast.LENGTH_SHORT).show();
     }
 
     private void launchPrivilegeClaimActivity() {
@@ -87,16 +71,5 @@ public class AppManagerDeveloperPreferences extends CommCarePreferenceFragment {
 
     public static boolean isDeveloperPreferencesEnabled() {
         return GlobalPrivilegesManager.getGlobalPrefsRecord().getBoolean(DEVELOPER_PREFERENCES_ENABLED, false);
-    }
-
-    public static void setConnectIdEnabled(boolean enabled) {
-        GlobalPrivilegesManager.getGlobalPrefsRecord()
-                .edit()
-                .putBoolean(CONNECT_ID_ENABLED, enabled)
-                .apply();
-    }
-
-    public static boolean isConnectIdEnabled() {
-        return GlobalPrivilegesManager.getGlobalPrefsRecord().getBoolean(CONNECT_ID_ENABLED, true);
     }
 }


### PR DESCRIPTION
## Product Description
Removes pref setting to enable connect ID as with GA we want it to be enabled by default. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
