### PR TITLE
Add audio recording foreground service

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -36,6 +36,7 @@
         android:usesPermissionFlags="neverForLocation"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
 
     <uses-feature
         android:name="android.hardware.telephony"
@@ -330,6 +331,11 @@
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="Service that maintains an encryption key in memory to securely submit data to the server" />
+        </service>
+        <service
+            android:enabled="true"
+            android:foregroundServiceType="microphone"
+            android:name="org.commcare.views.widgets.AudioRecordingService">
         </service>
         <activity
             android:launchMode="singleTop"

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -334,6 +334,8 @@
         </service>
         <service
             android:enabled="true"
+            android:exported="false"
+            android:stopWithTask="true"
             android:foregroundServiceType="microphone"
             android:name="org.commcare.views.widgets.AudioRecordingService">
         </service>

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -42,7 +42,7 @@ verify.retry=Retry
 verify.checking=Verifying media...
 exception.during.verification=Verification could not complete due to the following exception. This error must be resolved before verification can proceed:\n\n${0}
 
-barcode.reader.missing=No barcode reader available! You can install one from the android market.
+barcode.reader.missing=No barcode reader available! You can install one from the Android market.
 
 upgrade.button.retry=Retry Upgrade
 upgrade.button.startover=Restart Upgrade
@@ -79,7 +79,7 @@ home.menu.validate=Validate Media
 home.menu.locale.change=Change Language
 home.menu.locale.select=Choose your Language
 home.menu.formdump=Manage SD
-home.menu.wifi.direct=Wifi Direct
+home.menu.wifi.direct=Wi-Fi Direct
 home.menu.connection.diagnostic=Connection Test
 home.menu.saved.forms=Saved Forms
 home.menu.about=About CommCare
@@ -118,7 +118,7 @@ sync.success.synced=Sync Successful! Your information is up to date.
 sync.fail.unsent=Having issues communicating with the server to send forms. Will try again later.
 sync.fail.timeout=CommCare didn't receive a response from the remote service in time, it may be busy! Please wait a while and try your request again later.
 sync.fail.auth.loggedin=Password has changed. Please log in with updated credentials
-sync.fail.empty.url=Sync url is not set. Please contact CommCare Support.
+sync.fail.empty.url=Sync URL is not set. Please contact CommCare Support.
 sync.fail.bad.data=Server provided improperly formatted data, please try again or contact your supervisor.
 sync.fail.bad.local=Your information was fetched, but a problem occurred with the log in. Please try again.
 sync.fail.bad.network=Couldn't contact server. Please make sure an internet connection is available or try again later.
@@ -405,7 +405,7 @@ connection.captive_portal.action=The current network is not connected to the int
 
 notification.sync.connections.title=No Connection
 notification.sync.connections.detail=No active data connections
-notification.sync.connections.action=You don't have any active data connections configured. Try connecting your phone to wifi or turning mobile data on.
+notification.sync.connections.action=You don't have any active data connections configured. Try connecting your phone to Wi-Fi or turning mobile data on.
 
 multiple.apps.unverified.title=Missing Multimedia for all Apps
 multiple.apps.unverified.message=All of your available apps are missing their associated multimedia resources. Please notify your supervisor so that he/she can fix this via the CommCare App Manager page.
@@ -516,8 +516,8 @@ refresh.build.settings.error=No refresh occurred. In order to use this utility, 
 login.attempt.fail.auth.title=Invalid Username or Password
 login.attempt.fail.auth.detail=Your username or password was not recognized, please type them again and retry.
 
-login.attempt.fail.empty.url.title=Url not set
-login.attempt.fail.empty.url.detail=Sync url is empty. Please contact CommCare Support.
+login.attempt.fail.empty.url.title=URL not set
+login.attempt.fail.empty.url.detail=Sync URL is empty. Please contact CommCare Support.
 
 login.attempt.fail.pin.title=Invalid PIN
 login.attempt.fail.pin.detail=Please enter the 4 digit PIN number that you chose, or select "Forgot PIN?" in the options menu to login with your password instead.
@@ -772,7 +772,7 @@ wifi.direct.submit.forms=Submit
 wifi.direct.send.forms=Sending Forms
 wifi.direct.change.state.title=Send, Receive, Submit
 wifi.direct.change.state.text=Do you want to send, receive, or submit forms?
-wifi.direct.wifi.direct.off=WiFi Direct is Off - Please turn it on to use this feature
+wifi.direct.wifi.direct.off=Wi-Fi Direct is Off - Please turn it on to use this feature
 wifi.direct.enter.send.mode=Entered Send Mode
 wifi.direct.enter.receive.mode=Entered Receive Mode
 wifi.direct.enter.submit.mode=Entered Submit Mode
@@ -783,9 +783,9 @@ wifi.direct.no.group=This device is not connected to any Wi-Fi Direct group.
 wifi.direct.receive.successful=Received ${0} files successfully!
 wifi.direct.send.successful=File Send Successful!
 wifi.direct.send.unsuccessful=Error sending files: ${0}
-wifi.direct.error.no.forms=Phone has received no forms via Wi-fi direct for Submitting; did you mean to Send forms?
+wifi.direct.error.no.forms=Phone has received no forms via Wi-Fi direct for Submitting; did you mean to Send forms?
 wifi.direct.discovery.start=Discovery Initiated
-wifi.direct.discovery.failed.generic=Discovery failed due to bad Wi-fi state; turn Wi-fi on and off, then retry
+wifi.direct.discovery.failed.generic=Discovery failed due to bad Wi-Fi state; turn Wi-Fi on and off, then retry
 wifi.direct.discovery.failed.specific=Discovery failed with reason code ${0}
 wifi.direct.connect.failed=Connecting failed, please retry
 wifi.direct.error.wiping.forms=Error wiping forms: ${0}

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -466,6 +466,7 @@ recording.paused.due.another.app.recording.title=CommCare Audio Recording
 recording.paused.due.another.app.recording.message=Recording paused as another app started recording. Click here to resume the recording!
 recording.notification.title=Audio recording
 recording.notification.in.progress=Recording in progress...
+recording.notification.paused=Recording paused
 
 callout.failure.dialer=Device is not currently configured to make telephone calls
 callout.failure.sms=SMS app not found

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -464,6 +464,8 @@ recording.prompt.without.file.chooser=Record sound below
 recording.custom=Recorded Sound
 recording.paused.due.another.app.recording.title=CommCare Audio Recording
 recording.paused.due.another.app.recording.message=Recording paused as another app started recording. Click here to resume the recording!
+recording.notification.title=Audio recording
+recording.notification.in.progress=Recording in progress...
 
 callout.failure.dialer=Device is not currently configured to make telephone calls
 callout.failure.sms=SMS app not found

--- a/app/instrumentation-tests/src/org/commcare/androidTests/MenuTests.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/MenuTests.kt
@@ -37,7 +37,7 @@ class MenuTests: BaseTest() {
                 "Advanced",
                 "Settings")
 
-        val advancedOptions = arrayOf("Wifi Direct",
+        val advancedOptions = arrayOf("Wi-Fi Direct",
                 "Manage SD",
                 "Report Problem",
                 "Force Log Submission",

--- a/app/src/org/commcare/views/widgets/AudioRecordingHelper.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingHelper.java
@@ -1,0 +1,82 @@
+package org.commcare.views.widgets;
+
+import android.media.MediaCodecInfo;
+import android.media.MediaCodecList;
+import android.media.MediaRecorder;
+import android.os.Build;
+
+import org.commcare.util.LogTypes;
+import org.javarosa.core.services.Logger;
+
+import java.io.IOException;
+
+import static android.media.MediaFormat.MIMETYPE_AUDIO_AAC;
+
+public class AudioRecordingHelper {
+    private static final int HEAAC_SAMPLE_RATE = 44100;
+    private static final int AMRNB_SAMPLE_RATE = 8000;
+
+    public MediaRecorder setupRecorder(String fileName) {
+        MediaRecorder recorder = new MediaRecorder();
+
+        boolean isHeAacSupported = isHeAacEncoderSupported();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            recorder.setAudioSource(MediaRecorder.AudioSource.VOICE_COMMUNICATION);
+        } else {
+            recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            recorder.setPrivacySensitive(true);
+        }
+        recorder.setAudioSamplingRate(isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE);
+        recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
+        if (isHeAacSupported) {
+            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.HE_AAC);
+        } else {
+            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
+        }
+        recorder.setOutputFile(fileName);
+
+        try {
+            recorder.prepare();
+            Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Preparing recording: " + fileName
+                    + " | " + (isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE)
+                    + " | " + (isHeAacSupported ? MediaRecorder.AudioEncoder.HE_AAC :
+                    MediaRecorder.AudioEncoder.AMR_NB));
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return recorder;
+    }
+
+    // Checks whether the device supports High Efficiency AAC (HE-AAC) audio codec
+    private boolean isHeAacEncoderSupported() {
+        int numCodecs = MediaCodecList.getCodecCount();
+
+        for (int i = 0; i < numCodecs; i++) {
+            MediaCodecInfo codecInfo = MediaCodecList.getCodecInfoAt(i);
+
+            if (!codecInfo.isEncoder()) {
+                continue;
+            }
+
+            for (String supportedType : codecInfo.getSupportedTypes()) {
+                if (supportedType.equalsIgnoreCase(MIMETYPE_AUDIO_AAC)) {
+                    MediaCodecInfo.CodecCapabilities cap = codecInfo.getCapabilitiesForType(MIMETYPE_AUDIO_AAC);
+                    MediaCodecInfo.CodecProfileLevel[] profileLevels = cap.profileLevels;
+                    for (MediaCodecInfo.CodecProfileLevel profileLevel : profileLevels) {
+                        int profile = profileLevel.profile;
+                        if (profile == MediaCodecInfo.CodecProfileLevel.AACObjectHE
+                                || profile == MediaCodecInfo.CodecProfileLevel.AACObjectHE_PS) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -4,6 +4,7 @@ import android.app.Notification;
 import android.app.Service;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
+import android.media.AudioRecordingConfiguration;
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
 import android.media.MediaRecorder;
@@ -20,6 +21,7 @@ import org.javarosa.core.services.locale.Localization;
 import java.io.IOException;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 
 import static android.media.MediaFormat.MIMETYPE_AUDIO_AAC;
@@ -137,5 +139,17 @@ public class AudioRecordingService extends Service {
         }
 
         return false;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.Q)
+    public AudioRecordingConfiguration getActiveRecordingConfiguration() {
+        if (!isRecorderActive()) {
+            return null;
+        }
+        return recorder.getActiveRecordingConfiguration();
+    }
+
+    public boolean isRecorderActive(){
+        return recorder != null;
     }
 }

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -1,5 +1,7 @@
 package org.commcare.views.widgets;
 
+import static android.media.MediaFormat.MIMETYPE_AUDIO_AAC;
+
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -14,6 +16,10 @@ import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
 
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationCompat;
+
 import org.commcare.CommCareNoficationManager;
 import org.commcare.activities.DispatchActivity;
 import org.commcare.dalvik.R;
@@ -23,12 +29,13 @@ import org.javarosa.core.services.locale.Localization;
 
 import java.io.IOException;
 
-import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
-import androidx.core.app.NotificationCompat;
-
-import static android.media.MediaFormat.MIMETYPE_AUDIO_AAC;
-
+/**
+ * A bounded foreground service intended to be bound to the RecordingFragment for managing audio recording
+ * operations. Due to its persistent notification, the system treats it with higher importance, reducing the
+ * likelihood of interruptions during recordings.
+ *
+ * @author avazirna
+ **/
 public class AudioRecordingService extends Service {
     private static final int HEAAC_SAMPLE_RATE = 44100;
     private static final int AMRNB_SAMPLE_RATE = 8000;
@@ -63,7 +70,7 @@ public class AudioRecordingService extends Service {
         this.stopForeground(true);
     }
 
-    private void resetRecording(){
+    private void resetRecording() {
         if (recorder != null) {
             recorder.release();
             recorder = null;
@@ -130,7 +137,8 @@ public class AudioRecordingService extends Service {
             recorder.prepare();
             Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Preparing recording: " + fileName
                     + " | " + (isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE)
-                    + " | " + (isHeAacSupported ? MediaRecorder.AudioEncoder.HE_AAC : MediaRecorder.AudioEncoder.AMR_NB));
+                    + " | " + (isHeAacSupported ? MediaRecorder.AudioEncoder.HE_AAC :
+                    MediaRecorder.AudioEncoder.AMR_NB));
 
         } catch (IOException e) {
             e.printStackTrace();
@@ -174,7 +182,7 @@ public class AudioRecordingService extends Service {
         return recorder.getActiveRecordingConfiguration();
     }
 
-    public boolean isRecorderActive(){
+    public boolean isRecorderActive() {
         return recorder != null;
     }
 

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -1,0 +1,35 @@
+package org.commcare.views.widgets;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.IBinder;
+
+import androidx.annotation.Nullable;
+
+public class AudioRecordingService extends Service {
+    private final IBinder binder = new AudioRecorderBinder();
+
+    @Override
+    public void onCreate() {}
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {}
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return binder;
+    }
+
+    public class AudioRecorderBinder extends Binder {
+        public AudioRecordingService getService() {
+            return AudioRecordingService.this;
+        }
+    }
+}

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -1,17 +1,33 @@
 package org.commcare.views.widgets;
 
+import android.app.Notification;
 import android.app.Service;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 
+import org.commcare.CommCareNoficationManager;
+import org.commcare.dalvik.R;
+import org.javarosa.core.services.locale.Localization;
+
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
 
 public class AudioRecordingService extends Service {
     private final IBinder binder = new AudioRecorderBinder();
 
     @Override
-    public void onCreate() {}
+    public void onCreate() {
+        super.onCreate();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(RecordingFragment.RECORDING_NOTIFICATION_ID, createNotification(),
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE);
+        } else {
+            startForeground(RecordingFragment.RECORDING_NOTIFICATION_ID, createNotification());
+        }
+    }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
@@ -19,7 +35,17 @@ public class AudioRecordingService extends Service {
     }
 
     @Override
-    public void onDestroy() {}
+    public void onDestroy() {
+        this.stopForeground(true);
+    }
+
+    private Notification createNotification() {
+        return new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_USER_SESSION_ID)
+                .setContentTitle(Localization.get("recording.notification.title"))
+                .setContentText(Localization.get("recording.notification.in.progress"))
+                .setSmallIcon(R.drawable.commcare_actionbar_logo)
+                .build();
+    }
 
     @Nullable
     @Override

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -1,7 +1,5 @@
 package org.commcare.views.widgets;
 
-import static android.media.MediaFormat.MIMETYPE_AUDIO_AAC;
-
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -9,8 +7,6 @@ import android.app.Service;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
 import android.media.AudioRecordingConfiguration;
-import android.media.MediaCodecInfo;
-import android.media.MediaCodecList;
 import android.media.MediaRecorder;
 import android.os.Binder;
 import android.os.Build;
@@ -23,14 +19,10 @@ import androidx.core.app.NotificationCompat;
 import org.commcare.CommCareNoficationManager;
 import org.commcare.activities.DispatchActivity;
 import org.commcare.dalvik.R;
-import org.commcare.util.LogTypes;
-import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 
-import java.io.IOException;
-
 /**
- * A bounded foreground service intended to be bound to the RecordingFragment for managing audio recording
+ * A foreground service intended to be bound to the RecordingFragment for managing audio recording
  * operations. Due to its persistent notification, the system treats it with higher importance, reducing the
  * likelihood of interruptions during recordings.
  *
@@ -105,7 +97,11 @@ public class AudioRecordingService extends Service {
         return binder;
     }
 
-    public class AudioRecorderBinder extends Binder {
+    /**
+     * Provides other components with access to the functionality exposed by the AudioRecordingService
+     *
+     **/
+     public class AudioRecorderBinder extends Binder {
         public AudioRecordingService getService() {
             return AudioRecordingService.this;
         }

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -95,6 +95,7 @@ public class AudioRecordingService extends Service {
                         Localization.get("recording.notification.paused"))
                 .setSmallIcon(R.drawable.commcare_actionbar_logo)
                 .setContentIntent(pendingIntent)
+                .setOngoing(true)
                 .build();
     }
 

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -59,7 +59,15 @@ public class AudioRecordingService extends Service {
 
     @Override
     public void onDestroy() {
+        resetRecording();
         this.stopForeground(true);
+    }
+
+    private void resetRecording(){
+        if (recorder != null) {
+            recorder.release();
+            recorder = null;
+        }
     }
 
     private Notification createNotification(boolean recordingRunning) {
@@ -182,5 +190,9 @@ public class AudioRecordingService extends Service {
         recorder.resume();
         notificationManager.notify(RecordingFragment.RECORDING_NOTIFICATION_ID,
                 createNotification(true));
+    }
+
+    public void stopRecording() {
+        recorder.stop();
     }
 }

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -1,6 +1,8 @@
 package org.commcare.views.widgets;
 
 import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
@@ -13,6 +15,7 @@ import android.os.Build;
 import android.os.IBinder;
 
 import org.commcare.CommCareNoficationManager;
+import org.commcare.activities.DispatchActivity;
 import org.commcare.dalvik.R;
 import org.commcare.util.LogTypes;
 import org.javarosa.core.services.Logger;
@@ -32,15 +35,17 @@ public class AudioRecordingService extends Service {
     private MediaRecorder recorder;
     private final IBinder binder = new AudioRecorderBinder();
     public static final String RECORDING_FILENAME_EXTRA_KEY = "recording-filename-extra-key";
+    private NotificationManager notificationManager;
 
     @Override
     public void onCreate() {
         super.onCreate();
+        notificationManager = (NotificationManager)getSystemService(NOTIFICATION_SERVICE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            startForeground(RecordingFragment.RECORDING_NOTIFICATION_ID, createNotification(),
+            startForeground(RecordingFragment.RECORDING_NOTIFICATION_ID, createNotification(true),
                     ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE);
         } else {
-            startForeground(RecordingFragment.RECORDING_NOTIFICATION_ID, createNotification());
+            startForeground(RecordingFragment.RECORDING_NOTIFICATION_ID, createNotification(true));
         }
     }
 
@@ -57,11 +62,23 @@ public class AudioRecordingService extends Service {
         this.stopForeground(true);
     }
 
-    private Notification createNotification() {
+    private Notification createNotification(boolean recordingRunning) {
+        Intent activityToLaunch = new Intent(this, DispatchActivity.class);
+        activityToLaunch.setAction("android.intent.action.MAIN");
+        activityToLaunch.addCategory("android.intent.category.LAUNCHER");
+
+        int pendingIntentFlags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            pendingIntentFlags = pendingIntentFlags | PendingIntent.FLAG_IMMUTABLE;
+        }
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, activityToLaunch, pendingIntentFlags);
+
         return new NotificationCompat.Builder(this, CommCareNoficationManager.NOTIFICATION_CHANNEL_USER_SESSION_ID)
                 .setContentTitle(Localization.get("recording.notification.title"))
-                .setContentText(Localization.get("recording.notification.in.progress"))
+                .setContentText(recordingRunning ? Localization.get("recording.notification.in.progress") :
+                        Localization.get("recording.notification.paused"))
                 .setSmallIcon(R.drawable.commcare_actionbar_logo)
+                .setContentIntent(pendingIntent)
                 .build();
     }
 
@@ -151,5 +168,19 @@ public class AudioRecordingService extends Service {
 
     public boolean isRecorderActive(){
         return recorder != null;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public void pauseRecording() {
+        recorder.pause();
+        notificationManager.notify(RecordingFragment.RECORDING_NOTIFICATION_ID,
+                createNotification(false));
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public void resumeRecording() {
+        recorder.resume();
+        notificationManager.notify(RecordingFragment.RECORDING_NOTIFICATION_ID,
+                createNotification(true));
     }
 }

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -29,6 +29,7 @@ public class AudioRecordingService extends Service {
     private static final int AMRNB_SAMPLE_RATE = 8000;
     private MediaRecorder recorder;
     private final IBinder binder = new AudioRecorderBinder();
+    public static final String RECORDING_FILENAME_EXTRA_KEY = "recording-filename-extra-key";
 
     @Override
     public void onCreate() {
@@ -43,6 +44,9 @@ public class AudioRecordingService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        String fileName = intent.getExtras().getString(RECORDING_FILENAME_EXTRA_KEY);
+        setupRecorder(fileName);
+        recorder.start();
         return START_STICKY;
     }
 
@@ -71,7 +75,7 @@ public class AudioRecordingService extends Service {
         }
     }
 
-    private void setupRecorder() {
+    private void setupRecorder(String fileName) {
         if (recorder == null) {
             recorder = new MediaRecorder();
         }

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -4,18 +4,30 @@ import android.app.Notification;
 import android.app.Service;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
+import android.media.MediaCodecInfo;
+import android.media.MediaCodecList;
+import android.media.MediaRecorder;
 import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
 
 import org.commcare.CommCareNoficationManager;
 import org.commcare.dalvik.R;
+import org.commcare.util.LogTypes;
+import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
+
+import java.io.IOException;
 
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
+import static android.media.MediaFormat.MIMETYPE_AUDIO_AAC;
+
 public class AudioRecordingService extends Service {
+    private static final int HEAAC_SAMPLE_RATE = 44100;
+    private static final int AMRNB_SAMPLE_RATE = 8000;
+    private MediaRecorder recorder;
     private final IBinder binder = new AudioRecorderBinder();
 
     @Override
@@ -57,5 +69,69 @@ public class AudioRecordingService extends Service {
         public AudioRecordingService getService() {
             return AudioRecordingService.this;
         }
+    }
+
+    private void setupRecorder() {
+        if (recorder == null) {
+            recorder = new MediaRecorder();
+        }
+
+        boolean isHeAacSupported = isHeAacEncoderSupported();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            recorder.setAudioSource(MediaRecorder.AudioSource.VOICE_COMMUNICATION);
+        } else {
+            recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            recorder.setPrivacySensitive(true);
+        }
+        recorder.setAudioSamplingRate(isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE);
+        recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
+        if (isHeAacSupported) {
+            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.HE_AAC);
+        } else {
+            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
+        }
+        recorder.setOutputFile(fileName);
+
+        try {
+            recorder.prepare();
+            Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Preparing recording: " + fileName
+                    + " | " + (isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE)
+                    + " | " + (isHeAacSupported ? MediaRecorder.AudioEncoder.HE_AAC : MediaRecorder.AudioEncoder.AMR_NB));
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // Checks whether the device supports High Efficiency AAC (HE-AAC) audio codec
+    private boolean isHeAacEncoderSupported() {
+        int numCodecs = MediaCodecList.getCodecCount();
+
+        for (int i = 0; i < numCodecs; i++) {
+            MediaCodecInfo codecInfo = MediaCodecList.getCodecInfoAt(i);
+
+            if (!codecInfo.isEncoder()) {
+                continue;
+            }
+
+            for (String supportedType : codecInfo.getSupportedTypes()) {
+                if (supportedType.equalsIgnoreCase(MIMETYPE_AUDIO_AAC)) {
+                    MediaCodecInfo.CodecCapabilities cap = codecInfo.getCapabilitiesForType(MIMETYPE_AUDIO_AAC);
+                    MediaCodecInfo.CodecProfileLevel[] profileLevels = cap.profileLevels;
+                    for (MediaCodecInfo.CodecProfileLevel profileLevel : profileLevels) {
+                        int profile = profileLevel.profile;
+                        if (profile == MediaCodecInfo.CodecProfileLevel.AACObjectHE
+                                || profile == MediaCodecInfo.CodecProfileLevel.AACObjectHE_PS) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -37,12 +37,11 @@ import java.io.IOException;
  * @author avazirna
  **/
 public class AudioRecordingService extends Service {
-    private static final int HEAAC_SAMPLE_RATE = 44100;
-    private static final int AMRNB_SAMPLE_RATE = 8000;
     private MediaRecorder recorder;
     private final IBinder binder = new AudioRecorderBinder();
     public static final String RECORDING_FILENAME_EXTRA_KEY = "recording-filename-extra-key";
     private NotificationManager notificationManager;
+    private AudioRecordingHelper audioRecordingHelper = new AudioRecordingHelper();
 
     @Override
     public void onCreate() {
@@ -59,18 +58,20 @@ public class AudioRecordingService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         String fileName = intent.getExtras().getString(RECORDING_FILENAME_EXTRA_KEY);
-        setupRecorder(fileName);
+        if (recorder == null) {
+            recorder = audioRecordingHelper.setupRecorder(fileName);
+        }
         recorder.start();
         return START_NOT_STICKY;
     }
 
     @Override
     public void onDestroy() {
-        resetRecording();
+        resetRecorder();
         this.stopForeground(true);
     }
 
-    private void resetRecording() {
+    private void resetRecorder() {
         if (recorder != null) {
             recorder.release();
             recorder = null;
@@ -107,71 +108,6 @@ public class AudioRecordingService extends Service {
         public AudioRecordingService getService() {
             return AudioRecordingService.this;
         }
-    }
-
-    private void setupRecorder(String fileName) {
-        if (recorder == null) {
-            recorder = new MediaRecorder();
-        }
-
-        boolean isHeAacSupported = isHeAacEncoderSupported();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            recorder.setAudioSource(MediaRecorder.AudioSource.VOICE_COMMUNICATION);
-        } else {
-            recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            recorder.setPrivacySensitive(true);
-        }
-        recorder.setAudioSamplingRate(isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE);
-        recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
-        if (isHeAacSupported) {
-            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.HE_AAC);
-        } else {
-            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
-        }
-        recorder.setOutputFile(fileName);
-
-        try {
-            recorder.prepare();
-            Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Preparing recording: " + fileName
-                    + " | " + (isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE)
-                    + " | " + (isHeAacSupported ? MediaRecorder.AudioEncoder.HE_AAC :
-                    MediaRecorder.AudioEncoder.AMR_NB));
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    // Checks whether the device supports High Efficiency AAC (HE-AAC) audio codec
-    private boolean isHeAacEncoderSupported() {
-        int numCodecs = MediaCodecList.getCodecCount();
-
-        for (int i = 0; i < numCodecs; i++) {
-            MediaCodecInfo codecInfo = MediaCodecList.getCodecInfoAt(i);
-
-            if (!codecInfo.isEncoder()) {
-                continue;
-            }
-
-            for (String supportedType : codecInfo.getSupportedTypes()) {
-                if (supportedType.equalsIgnoreCase(MIMETYPE_AUDIO_AAC)) {
-                    MediaCodecInfo.CodecCapabilities cap = codecInfo.getCapabilitiesForType(MIMETYPE_AUDIO_AAC);
-                    MediaCodecInfo.CodecProfileLevel[] profileLevels = cap.profileLevels;
-                    for (MediaCodecInfo.CodecProfileLevel profileLevel : profileLevels) {
-                        int profile = profileLevel.profile;
-                        if (profile == MediaCodecInfo.CodecProfileLevel.AACObjectHE
-                                || profile == MediaCodecInfo.CodecProfileLevel.AACObjectHE_PS) {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-
-        return false;
     }
 
     @RequiresApi(api = Build.VERSION_CODES.Q)

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -54,7 +54,7 @@ public class AudioRecordingService extends Service {
         String fileName = intent.getExtras().getString(RECORDING_FILENAME_EXTRA_KEY);
         setupRecorder(fileName);
         recorder.start();
-        return START_STICKY;
+        return START_NOT_STICKY;
     }
 
     @Override

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -462,4 +462,20 @@ public class RecordingFragment extends DialogFragment {
             return false;
         }
     }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        unbindAudioRecordingService();
+    }
+
+    private void unbindAudioRecordingService() {
+        if (audioRecordingServiceBounded) {
+            audioRecordingServiceBounded = false;
+
+            requireActivity().unbindService(audioRecordingServiceConnection);
+            requireActivity()
+                    .stopService(new Intent(requireActivity(), AudioRecordingService.class));
+        }
+    }
 }

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -304,9 +304,6 @@ public class RecordingFragment extends DialogFragment {
     }
 
     private void saveRecording() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            unregisterAudioRecordingConfigurationChangeCallback();
-        }
         if (inPausedState) {
             stopRecording();
         }
@@ -467,6 +464,9 @@ public class RecordingFragment extends DialogFragment {
     public void onDestroyView() {
         super.onDestroyView();
         unbindAudioRecordingService();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            unregisterAudioRecordingConfigurationChangeCallback();
+        }
     }
 
     private void unbindAudioRecordingService() {

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -176,7 +176,8 @@ public class RecordingFragment extends DialogFragment {
     private void startRecording() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             if (MediaUtil.isRecordingActive(getContext())) {
-                Toast.makeText(getContext(), Localization.get("start.recording.failed"), Toast.LENGTH_SHORT).show();
+                Toast.makeText(getContext(), Localization.get("start.recording.failed"), Toast.LENGTH_SHORT)
+                        .show();
                 Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording cancelled due to an ongoing recording");
                 return;
             }
@@ -192,7 +193,8 @@ public class RecordingFragment extends DialogFragment {
         } else {
             requireActivity().startService(serviceIntent);
         }
-        requireActivity().bindService(serviceIntent, getAudioRecordingServiceConnection(), Context.BIND_AUTO_CREATE);
+        requireActivity().bindService(serviceIntent, getAudioRecordingServiceConnection(),
+                Context.BIND_AUTO_CREATE);
     }
 
     private ServiceConnection getAudioRecordingServiceConnection() {
@@ -209,8 +211,8 @@ public class RecordingFragment extends DialogFragment {
                 recordingInProgress();
                 Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording started");
 
-                // Extend the user extension if about to expire, this is to prevent the session from expiring in the
-                // middle of a recording
+                // Extend the user extension if about to expire, this is to prevent the session from expiring
+                // in the middle of a recording
                 CommCareApplication.instance().getSession().extendUserSessionIfNeeded();
 
                 audioRecordingServiceBounded = true;
@@ -450,8 +452,8 @@ public class RecordingFragment extends DialogFragment {
             }
 
             Optional<AudioRecordingConfiguration> currentAudioConfig = configs.stream().filter(config ->
-                            config.getClientAudioSessionId() == audioRecordingService.getActiveRecordingConfiguration()
-                                    .getClientAudioSessionId())
+                    config.getClientAudioSessionId() == audioRecordingService.getActiveRecordingConfiguration()
+                            .getClientAudioSessionId())
                     .findAny();
             return currentAudioConfig.isPresent() ? currentAudioConfig.get().isClientSilenced() : false;
         } else {

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -269,7 +269,8 @@ public class RecordingFragment extends DialogFragment {
         inPausedState = true;
         recordingDuration.stop();
         chronoPause();
-        recorder.pause();
+
+        audioRecordingService.pauseRecording();
         recordingProgress.setVisibility(View.INVISIBLE);
         enableSave();
         toggleRecording.setBackgroundResource(R.drawable.record_add);
@@ -291,7 +292,8 @@ public class RecordingFragment extends DialogFragment {
         Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording resuming");
         inPausedState = false;
         chronoResume();
-        recorder.resume();
+
+        audioRecordingService.resumeRecording();
         recordingInProgress();
         Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording resumed");
     }

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -158,11 +158,6 @@ public class RecordingFragment extends DialogFragment {
     }
 
     private void resetRecordingView() {
-        if (recorder != null) {
-            recorder.release();
-            recorder = null;
-        }
-
         if (player != null) {
             resetAudioPlayer();
         }
@@ -252,10 +247,10 @@ public class RecordingFragment extends DialogFragment {
 
         // resume first just in case we were paused
         if (inPausedState) {
-            recorder.resume();
+            audioRecordingService.resumeRecording();
         }
 
-        recorder.stop();
+        audioRecordingService.stopRecording();
         toggleRecording.setBackgroundResource(R.drawable.play);
         toggleRecording.setOnClickListener(v -> playAudio());
         instruction.setText(Localization.get("after.recording"));
@@ -333,10 +328,6 @@ public class RecordingFragment extends DialogFragment {
     public void onDismiss(DialogInterface dialog) {
         super.onDismiss(dialog);
         enableScreenRotation((AppCompatActivity) getContext());
-        if (recorder != null) {
-            recorder.release();
-            this.recorder = null;
-        }
 
         if (player != null) {
             try {

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -221,6 +221,7 @@ public class RecordingFragment extends DialogFragment {
             @Override
             public void onServiceDisconnected(ComponentName name) {
                 audioRecordingService = null;
+                audioRecordingServiceBounded = false;
             }
         };
     }
@@ -473,8 +474,6 @@ public class RecordingFragment extends DialogFragment {
 
     private void unbindAudioRecordingService() {
         if (audioRecordingServiceBounded) {
-            audioRecordingServiceBounded = false;
-
             requireActivity().unbindService(audioRecordingServiceConnection);
             requireActivity()
                     .stopService(new Intent(requireActivity(), AudioRecordingService.class));

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -68,7 +68,7 @@ public class RecordingFragment extends DialogFragment {
 
     private static final int HEAAC_SAMPLE_RATE = 44100;
     private static final int AMRNB_SAMPLE_RATE = 8000;
-    private final int RECORDING_NOTIFICATION_ID = R.string.audio_recording_notification;
+    public static final int RECORDING_NOTIFICATION_ID = R.string.audio_recording_notification;
 
     private String fileName;
     private static final String FILE_EXT = ".mp3";

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -316,6 +316,9 @@ public class RecordingFragment extends DialogFragment {
         dismiss();
     }
 
+    /**
+     * A listener interface for handling post-recording events
+     */
     public interface RecordingCompletionListener {
         void onRecordingCompletion(String audioFile);
     }

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -412,7 +412,7 @@ public class RecordingFragment extends DialogFragment {
             @Override
             public void onRecordingConfigChanged(List<AudioRecordingConfiguration> configs) {
                 super.onRecordingConfigChanged(configs);
-                if (recorder == null) {
+                if (audioRecordingService == null || !audioRecordingService.isRecorderActive()) {
                     return;
                 }
 
@@ -450,17 +450,17 @@ public class RecordingFragment extends DialogFragment {
     }
 
     private boolean hasRecordingGoneSilent(List<AudioRecordingConfiguration> configs) {
-        if (recorder == null) {
+        if (audioRecordingService == null || !audioRecordingService.isRecorderActive()) {
             return false;
         }
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-            if (recorder.getActiveRecordingConfiguration() == null) {
+            if (audioRecordingService.getActiveRecordingConfiguration() == null) {
                 return false;
             }
 
             Optional<AudioRecordingConfiguration> currentAudioConfig = configs.stream().filter(config ->
-                            config.getClientAudioSessionId() == recorder.getActiveRecordingConfiguration()
+                            config.getClientAudioSessionId() == audioRecordingService.getActiveRecordingConfiguration()
                                     .getClientAudioSessionId())
                     .findAny();
             return currentAudioConfig.isPresent() ? currentAudioConfig.get().isClientSilenced() : false;


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/SAAS-16641

This PR adds a bounded foreground service to the Audio recording feature. This service will ensure that the recording will continue when the device enters sleep or doze mode.
Users will now see a notification when the recording is in progress and another when it gets paused:
<video src="https://github.com/user-attachments/assets/c03c4729-453c-4584-8f03-3e3ea322c450" width="200px"/>


## Safety Assurance

### Safety story
Successfully tested locally.

### QA Plan
I've requested QA to run regression tests around this feature. 
QA ticket: https://dimagi.atlassian.net/browse/QA-7692

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change

cross-request: https://github.com/dimagi/commcare-core/pull/1477