### PR TITLE
Fixes a NPE with Connect ID Flow

### DIFF
--- a/app/src/org/commcare/activities/NavigationHostCommCareActivity.java
+++ b/app/src/org/commcare/activities/NavigationHostCommCareActivity.java
@@ -22,18 +22,27 @@ public abstract class NavigationHostCommCareActivity<R> extends CommCareActivity
         setContentView(getLayoutResource());
         destinationListener = FirebaseAnalyticsUtil.getNavControllerPageChangeLoggingListener();
         navController = getHostFragment().getNavController();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
         navController.addOnDestinationChangedListener(destinationListener);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        navController.removeOnDestinationChangedListener(destinationListener);
     }
 
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        NavController navController = getHostFragment().getNavController();
-        navController.removeOnDestinationChangedListener(destinationListener);
         destinationListener = null;
     }
 
-   protected abstract int getLayoutResource();
+    protected abstract int getLayoutResource();
 
     protected abstract NavHostFragment getHostFragment();
 }


### PR DESCRIPTION
## Product Description
Earlier we were cleaning the listener in onDestroy by which time there is no guarantee that the fragment will be alive or not. It's anyway better for UI listeners to be tied to onResume and onPause instead which is what this PR does to correct this behavior. 


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
