### PR TITLE
-updated formStorageTest file with latest Xpath functions

### DIFF
--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -359,8 +359,6 @@ public class FormStorageTest {
             // Added in 2.55
             , "org.javarosa.core.model.FormIndex"
             , "org.commcare.models.database.InterruptedFormState"
-            , "org.javarosa.xpath.expr.XPathClosestPointOnPolygonFunc"
-            , "org.javarosa.xpath.expr.XPathIsPointInsidePolygonFunc"
             , "org.commcare.android.database.connect.models.ConnectLinkedAppRecordV3"
             , "org.commcare.android.database.connect.models.ConnectLinkedAppRecordV8"
             , "org.commcare.android.database.connect.models.ConnectLinkedAppRecordV9"
@@ -388,6 +386,10 @@ public class FormStorageTest {
             , "org.commcare.android.database.connect.models.ConnectMessagingChannelRecord"
             , "org.commcare.android.database.connect.models.ConnectMessagingMessageRecord"
             , "org.commcare.android.database.connect.models.ConnectJobDeliveryFlagRecord"
+
+            //Added in 2.57
+            , "org.javarosa.xpath.expr.XPathClosestPointOnPolygonFunc"
+            , "org.javarosa.xpath.expr.XPathIsPointInsidePolygonFunc"
     );
 
 

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -359,6 +359,8 @@ public class FormStorageTest {
             // Added in 2.55
             , "org.javarosa.core.model.FormIndex"
             , "org.commcare.models.database.InterruptedFormState"
+            , "org.javarosa.xpath.expr.XPathClosestPointOnPolygonFunc"
+            , "org.javarosa.xpath.expr.XPathIsPointInsidePolygonFunc"
             , "org.commcare.android.database.connect.models.ConnectLinkedAppRecordV3"
             , "org.commcare.android.database.connect.models.ConnectLinkedAppRecordV8"
             , "org.commcare.android.database.connect.models.ConnectLinkedAppRecordV9"


### PR DESCRIPTION
## Product Description
Fixed formstoragetest case with changing the new Xpath function name
cross-request: https://github.com/dimagi/commcare-core/pull/1455

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
I have tested this locally on my device 

### Automated test coverage
We have covered the test cases to test these functions 

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

Release Note: Adds two new Xpath methods [closest-point-on-polygon](https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957589/CommCare+Functions#is-point-inside-polygon) and [is-point-inside-polygon](https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143957589/CommCare+Functions#is-point-inside-polygon)