### PR TITLE
Add photo and isDemo fields to Connect User Record

### DIFF
--- a/app/src/org/commcare/android/database/connect/models/ConnectUserRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectUserRecord.java
@@ -66,6 +66,9 @@ public class ConnectUserRecord extends Persisted {
     @Persisting(value = 13, nullable = true)
     private String photo;
 
+    @Persisting(value = 14)
+    private boolean isDemo;
+
     public ConnectUserRecord() {
         registrationPhase = ConnectConstants.CONNECT_NO_ACTIVITY;
         lastPasswordDate = new Date();
@@ -239,6 +242,7 @@ public class ConnectUserRecord extends Persisted {
         newRecord.connectTokenExpiration = oldRecord.getConnectTokenExpiration();
         newRecord.secondaryPhoneVerified = true;
         newRecord.photo = null;
+        newRecord.isDemo = false;
         return newRecord;
     }
 }

--- a/app/src/org/commcare/android/database/connect/models/ConnectUserRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectUserRecord.java
@@ -63,6 +63,9 @@ public class ConnectUserRecord extends Persisted {
     @MetaField(META_VERIFY_SECONDARY_PHONE_DATE)
     private Date verifySecondaryPhoneByDate;
 
+    @Persisting(value = 13, nullable = true)
+    private String photo;
+
     public ConnectUserRecord() {
         registrationPhase = ConnectConstants.CONNECT_NO_ACTIVITY;
         lastPasswordDate = new Date();
@@ -223,9 +226,8 @@ public class ConnectUserRecord extends Persisted {
         return connectTokenExpiration;
     }
 
-    public static ConnectUserRecord fromV5(ConnectUserRecordV5 oldRecord) {
+    public static ConnectUserRecord fromV13(ConnectUserRecordV13 oldRecord) {
         ConnectUserRecord newRecord = new ConnectUserRecord();
-
         newRecord.userId = oldRecord.getUserId();
         newRecord.password = oldRecord.getPassword();
         newRecord.name = oldRecord.getName();
@@ -236,7 +238,7 @@ public class ConnectUserRecord extends Persisted {
         newRecord.connectToken = oldRecord.getConnectToken();
         newRecord.connectTokenExpiration = oldRecord.getConnectTokenExpiration();
         newRecord.secondaryPhoneVerified = true;
-
+        newRecord.photo = null;
         return newRecord;
     }
 }

--- a/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV13.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV13.java
@@ -1,0 +1,118 @@
+package org.commcare.android.database.connect.models;
+
+import org.commcare.android.storage.framework.Persisted;
+import org.commcare.connect.ConnectConstants;
+import org.commcare.models.framework.Persisting;
+import org.commcare.modern.database.Table;
+import org.commcare.modern.models.MetaField;
+
+import java.util.Date;
+
+@Table(ConnectUserRecordV13.STORAGE_KEY)
+public class ConnectUserRecordV13 extends Persisted {
+
+    public static final String STORAGE_KEY = "user_info";
+    public static final String META_PIN = "pin";
+    public static final String META_SECONDARY_PHONE_VERIFIED = "secondary_phone_verified";
+    public static final String META_VERIFY_SECONDARY_PHONE_DATE = "verify_secondary_phone_by_date";
+
+    @Persisting(1)
+    private String userId;
+
+    @Persisting(2)
+    private String password;
+
+    @Persisting(3)
+    private String name;
+
+    @Persisting(4)
+    private String primaryPhone;
+
+    @Persisting(5)
+    private String alternatePhone;
+
+    @Persisting(6)
+    private int registrationPhase;
+
+    @Persisting(7)
+    private Date lastPasswordDate;
+
+    @Persisting(value = 8, nullable = true)
+    private String connectToken;
+
+    @Persisting(value = 9, nullable = true)
+    private Date connectTokenExpiration;
+    @Persisting(value = 10, nullable = true)
+    @MetaField(META_PIN)
+    private String pin;
+    @Persisting(11)
+    @MetaField(META_SECONDARY_PHONE_VERIFIED)
+    private boolean secondaryPhoneVerified;
+
+    @Persisting(12)
+    @MetaField(META_VERIFY_SECONDARY_PHONE_DATE)
+    private Date verifySecondaryPhoneByDate;
+
+    public ConnectUserRecordV13() {
+        registrationPhase = ConnectConstants.CONNECT_NO_ACTIVITY;
+        lastPasswordDate = new Date();
+        connectTokenExpiration = new Date();
+        secondaryPhoneVerified = true;
+        verifySecondaryPhoneByDate = new Date();
+    }
+
+    public static ConnectUserRecordV13 fromV5(ConnectUserRecordV5 oldRecord) {
+        ConnectUserRecordV13 newRecord = new ConnectUserRecordV13();
+        newRecord.userId = oldRecord.getUserId();
+        newRecord.password = oldRecord.getPassword();
+        newRecord.name = oldRecord.getName();
+        newRecord.primaryPhone = oldRecord.getPrimaryPhone();
+        newRecord.alternatePhone = oldRecord.getAlternatePhone();
+        newRecord.registrationPhase = oldRecord.getRegistrationPhase();
+        newRecord.lastPasswordDate = oldRecord.getLastPasswordDate();
+        newRecord.connectToken = oldRecord.getConnectToken();
+        newRecord.connectTokenExpiration = oldRecord.getConnectTokenExpiration();
+        newRecord.secondaryPhoneVerified = true;
+        return newRecord;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPrimaryPhone() {
+        return primaryPhone;
+    }
+
+    public String getAlternatePhone() {
+        return alternatePhone;
+    }
+
+    public int getRegistrationPhase() {
+        return registrationPhase;
+    }
+
+    public Date getLastPasswordDate() {
+        return lastPasswordDate;
+    }
+
+    public String getConnectToken() {
+        return connectToken;
+    }
+
+    public Date getConnectTokenExpiration() {
+        return connectTokenExpiration;
+    }
+
+    public String getPin() {
+        return pin;
+    }
+}

--- a/app/src/org/commcare/models/database/connect/ConnectDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/connect/ConnectDatabaseUpgrader.java
@@ -26,6 +26,7 @@ import org.commcare.android.database.connect.models.ConnectMessagingChannelRecor
 import org.commcare.android.database.connect.models.ConnectMessagingMessageRecord;
 import org.commcare.android.database.connect.models.ConnectPaymentUnitRecord;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
+import org.commcare.android.database.connect.models.ConnectUserRecordV13;
 import org.commcare.android.database.connect.models.ConnectUserRecordV5;
 import org.commcare.models.database.ConcreteAndroidDbHelper;
 import org.commcare.models.database.DbUtil;
@@ -100,6 +101,11 @@ public class ConnectDatabaseUpgrader {
         if (oldVersion == 12) {
             upgradeTwelveThirteen(db);
             oldVersion = 13;
+        }
+
+        if (oldVersion == 13) {
+            upgradeThirteenFourteen(db);
+            oldVersion = 14;
         }
     }
 
@@ -329,12 +335,12 @@ public class ConnectDatabaseUpgrader {
 
             SqlStorage<Persistable> newStorage = new SqlStorage<>(
                     ConnectUserRecord.STORAGE_KEY,
-                    ConnectUserRecordV5.class,
+                    ConnectUserRecordV13.class,
                     new ConcreteAndroidDbHelper(c, db));
 
             for (Persistable r : oldStorage) {
                 ConnectUserRecordV5 oldRecord = (ConnectUserRecordV5)r;
-                ConnectUserRecord newRecord = ConnectUserRecord.fromV5(oldRecord);
+                ConnectUserRecordV13 newRecord = ConnectUserRecordV13.fromV5(oldRecord);
                 //set this new record to have same ID as the old one
                 newRecord.setID(oldRecord.getID());
                 newStorage.write(newRecord);
@@ -520,6 +526,31 @@ public class ConnectDatabaseUpgrader {
 
     private void upgradeTwelveThirteen(SQLiteDatabase db) {
         addTableForNewModel(db, ConnectJobDeliveryFlagRecord.STORAGE_KEY, new ConnectJobDeliveryFlagRecord());
+    }
+
+    private void upgradeThirteenFourteen(SQLiteDatabase db) {
+        db.beginTransaction();
+        try {
+            SqlStorage<ConnectUserRecordV13> oldStorage = new SqlStorage<>(
+                    ConnectUserRecord.STORAGE_KEY,
+                    ConnectUserRecordV13.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            SqlStorage<Persistable> newStorage = new SqlStorage<>(
+                    ConnectUserRecord.STORAGE_KEY,
+                    ConnectUserRecord.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            for (ConnectUserRecordV13 oldRecord : oldStorage) {
+                ConnectUserRecord newRecord = ConnectUserRecord.fromV13(oldRecord);
+                //set this new record to have same ID as the old one
+                newRecord.setID(oldRecord.getID());
+                newStorage.write(newRecord);
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
     }
 
     private static void addTableForNewModel(SQLiteDatabase db, String storageKey,

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -51,8 +51,9 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
      * V.11 - Added daily start and finish times to ConnectJobRecord
      * V.12 - Added ConnectMessagingChannelRecord table and ConnectMessagingMessageRecord table
      * V.13 - Added ConnectJobDeliveryFlagRecord table
+     * V.14 - Added a photo field to ConnectUserRecord
      */
-    private static final int CONNECT_DB_VERSION = 13;
+    private static final int CONNECT_DB_VERSION = 14;
 
     private static final String CONNECT_DB_LOCATOR = "database_connect";
 

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -51,7 +51,7 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
      * V.11 - Added daily start and finish times to ConnectJobRecord
      * V.12 - Added ConnectMessagingChannelRecord table and ConnectMessagingMessageRecord table
      * V.13 - Added ConnectJobDeliveryFlagRecord table
-     * V.14 - Added a photo field to ConnectUserRecord
+     * V.14 - Added a photo and isDemo field to ConnectUserRecord
      */
     private static final int CONNECT_DB_VERSION = 14;
 

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -390,6 +390,7 @@ public class FormStorageTest {
             //Added in 2.57
             , "org.javarosa.xpath.expr.XPathClosestPointOnPolygonFunc"
             , "org.javarosa.xpath.expr.XPathIsPointInsidePolygonFunc"
+            , "org.commcare.android.database.connect.models.ConnectUserRecordV13"
     );
 
 


### PR DESCRIPTION
## Technical Summary

Add photo and isDemo fields to Connect User Record. These are to be used to store base 64 encoded photo String and whether a user is a demo user. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
