### PR TITLE
Worst-case Error Messaging for Connect

### DIFF
--- a/app/res/layout/screen_login.xml
+++ b/app/res/layout/screen_login.xml
@@ -75,6 +75,17 @@
 
                             <TextView
                                 android:textStyle="bold"
+                                android:id="@+id/connect_error_msg"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center"
+                                android:layout_margin="@dimen/content_min_margin"
+                                android:textColor="@color/red_500"
+                                android:visibility="gone"
+                                android:textSize="@dimen/text_medium" />
+
+                            <TextView
+                                android:textStyle="bold"
                                 android:id="@+id/welcome_msg"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"

--- a/app/res/layout/select_install_mode_fragment.xml
+++ b/app/res/layout/select_install_mode_fragment.xml
@@ -29,6 +29,17 @@
                 android:orientation="vertical">
 
                 <TextView
+                    android:textStyle="bold"
+                    android:id="@+id/connect_error_msg"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_margin="@dimen/content_min_margin"
+                    android:textColor="@color/red_500"
+                    android:visibility="gone"
+                    android:textSize="@dimen/text_medium" />
+
+                <TextView
                     android:id="@+id/str_setup_message"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -224,7 +224,7 @@ License.
     <string name="connect_job_no_learning_required">Aucun apprentissage requis</string>
     <string name="connect_job_go_to_learn_app">Accédez à l\'application Apprendre</string>
     <string name="connect_button_logged_in">Allez dans le menu Connecter</string>
-    <string name="connect_db_corrupt">Un problème est survenu avec la base de données, veuillez récupérer votre compte.</string>
+    <string name="connect_db_corrupt">Un problème est survenu, veuillez reconfigurer votre compte PersonalID.</string>
     <string name="connect_job_list_api_failure">Une erreur s\'est produite lors de la connexion au serveur.</string>
     <string name="connect_payment_acknowledge_notification_yes">Oui</string>
     <string name="connect_payment_acknowledge_notification_no">Non</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -359,7 +359,7 @@
     <string name="choice_or">OU</string>
     <string name="busy_message">Ainda estamos ocupados processando sua solicitação anterior. Por favor, tente novamente em alguns momentos.</string>
     <string name="connect_button_logged_in">Vá para o Conectar menu</string>
-    <string name="connect_db_corrupt">Ocorreu um problema com a base de dados, Por favor recupere a sua conta.</string>
+    <string name="connect_db_corrupt">Ocorreu um problema. Configure sua conta PersonalID novamente.</string>
     <string name="connect_registration_title">Inscrição no Connect ID</string>
     <string name="connect_signup">Inscrição</string>
     <string name="connect_recover">Recuperar</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -358,7 +358,7 @@
     <string name="choice_or">____________ AU _____________</string>
     <string name="busy_message">Bado tunashughulika kuchakata ombi lako la awali. Tafadhali jaribu tena baada ya muda fulani.</string>
     <string name="connect_button_logged_in">Nenda kwenye menyu ya Unganisha</string>
-    <string name="connect_db_corrupt">Tatizo limetokea kwenye hifadhidata, tafadhali rudisha akaunti yako.</string>
+    <string name="connect_db_corrupt">Tatizo limetokea, tafadhali sanidi akaunti yako ya Kitambulisho cha Kibinafsi tena.</string>
     <string name="connect_registration_title">Usajili wa ConnectID</string>
     <string name="connect_signup">Jisajili</string>
     <string name="connect_recover">Pata nafuu</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -347,7 +347,7 @@
     <string name="choice_or">_____________ ወይ _____________</string>
     <string name="busy_message">ሕጂ ውን ቅድሚ ሕጂ ዝገበርካዮ ሕቶ ኣብ ምስራሕ ተጸሚድና ኣለና። በጃኻ ድሕሪ ውሱን ግዜ ደጊምካ ፈትን።</string>
     <string name="connect_button_logged_in">ናብ Connect መማረፂ ኪድ</string>
-    <string name="connect_db_corrupt">ኣብቲ ዳታቤዝ/ ማእከል ሓበርታ ፀገም ኣጋጢሙ፡ በጃኻ ኣካውንትካ ናብ ናይ ቅድም ከነታት መልስ።</string>
+    <string name="connect_db_corrupt">ጸገም ኣጋጢሙ፡ በጃኻ PersonalID ኣካውንትካ እንደገና ኣወሃህቦ።</string>
     <string name="connect_registration_title">ConnectID ምዝገባ</string>
     <string name="connect_signup">ምዝገባ</string>
     <string name="connect_recover">ናብ ንቡር ኩነታት ምምላስ</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -893,7 +893,7 @@
     <string name="connect_biometric_error">Authentication Failed</string>
     <string name="login_input_auto">AUTO</string>
     <string name="connect_consent_title">Consent</string>
-    <string name="connect_db_corrupt" cc:translatable="true">A problem occurred with the database, please recover your account.</string>
+    <string name="connect_db_corrupt" cc:translatable="true">A problem occurred, please configure your PersonalID account again.</string>
     <string name="ConnectOpportunitiesURL" translatable="false">https://%s/api/opportunity/</string>
     <string name="ConnectStartLearningURL" translatable="false">https://%s/users/start_learn_app/</string>
     <string name="ConnectLearnProgressURL" translatable="false">https://%s/api/opportunity/%d/learn_progress</string>

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -165,6 +165,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     private final SelectInstallModeFragment installFragment = new SelectInstallModeFragment();
     private final InstallPermissionsFragment permFragment = new InstallPermissionsFragment();
     private ContainerViewModel<CommCareApp> containerViewModel;
+    private String connectError = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -174,7 +175,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             return;
         }
         if (!fromManager) {
-            PersonalIdManager.getInstance().init(this);
+            connectError = PersonalIdManager.getInstance().init(this);
         }
         loadIntentAndInstanceState(savedInstanceState);
         persistCommCareAppState();
@@ -356,6 +357,11 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
             ft.commit();
             fm.executePendingTransactions();
         }
+
+        if(connectError != null) {
+            installFragment.showConnectErrorMessage(connectError);
+        }
+
         updateConnectButton();
     }
 

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -138,7 +138,11 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         formAndDataSyncer = new FormAndDataSyncer();
         personalIdManager = PersonalIdManager.getInstance();
 
-        personalIdManager.init(this);
+        String connectError = personalIdManager.init(this);
+        if(connectError != null) {
+            uiController.setConnectErrorMessageUI(connectError);
+        }
+
         presetAppId = getIntent().getStringExtra(EXTRA_APP_ID);
         ///TODO: connect uncomment with connect merge
 //        appLaunchedFromConnect = PersonalIDManager.wasAppLaunchedFromConnect(presetAppId);

--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -94,6 +94,9 @@ public class LoginActivityUIController implements CommCareActivityUIController {
     @UiElement(R.id.app_selection_spinner)
     private Spinner spinner;
 
+    @UiElement(R.id.connect_error_msg)
+    private TextView connectErrorMessage;
+
     @UiElement(R.id.welcome_msg)
     private TextView welcomeMessage;
 
@@ -400,6 +403,11 @@ public class LoginActivityUIController implements CommCareActivityUIController {
 
     protected LoginMode getLoginMode() {
         return loginMode;
+    }
+
+    protected void setConnectErrorMessageUI(String errorMessage) {
+        connectErrorMessage.setVisibility(View.VISIBLE);
+        connectErrorMessage.setText(errorMessage);
     }
 
     protected void setErrorMessageUI(String message, boolean showNotificationButton) {

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecordV7.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecordV7.java
@@ -5,18 +5,16 @@ import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
 import org.commcare.modern.models.MetaField;
 
-import kotlin.Metadata;
-
 /**
  * DB model for storing the encrypted/encoded Connect DB passphrase
+ * Used up to global DB V6
  *
  * @author dviggiano
  */
-@Table(ConnectKeyRecord.STORAGE_KEY)
-public class ConnectKeyRecord extends Persisted {
+@Table(ConnectKeyRecordV7.STORAGE_KEY)
+public class ConnectKeyRecordV7 extends Persisted {
     public static final String STORAGE_KEY = "connect_key";
     public static final String IS_LOCAL = "is_local";
-    public static final String LOGOUT_MESSAGE = "logout_message";
     @Persisting(1)
     String encryptedPassphrase;
 
@@ -24,14 +22,10 @@ public class ConnectKeyRecord extends Persisted {
     @MetaField(IS_LOCAL)
     boolean isLocal;
 
-    @Persisting(3)
-    @MetaField(LOGOUT_MESSAGE)
-    int logoutErrorMessage = -1;
-
-    public ConnectKeyRecord() {
+    public ConnectKeyRecordV7() {
     }
 
-    public ConnectKeyRecord(String encryptedPassphrase, boolean isLocal) {
+    public ConnectKeyRecordV7(String encryptedPassphrase, boolean isLocal) {
         this.encryptedPassphrase = encryptedPassphrase;
         this.isLocal = isLocal;
     }
@@ -39,22 +33,12 @@ public class ConnectKeyRecord extends Persisted {
     public String getEncryptedPassphrase() {
         return encryptedPassphrase;
     }
-    public void setEncryptedPassphrase(String passphrase) {
-        encryptedPassphrase = passphrase;
-    }
+
     public boolean getIsLocal() {
         return isLocal;
     }
 
-    public int getLogoutErrorMessage() {
-        return logoutErrorMessage;
-    }
-
-    public void setLogoutErrorMessage(int message) {
-        logoutErrorMessage = message;
-    }
-
-    public static ConnectKeyRecord fromV7(ConnectKeyRecordV7 oldVersion) {
-        return new ConnectKeyRecord(oldVersion.getEncryptedPassphrase(), oldVersion.getIsLocal());
+    public static ConnectKeyRecordV7 fromV6(ConnectKeyRecordV6 oldVersion) {
+        return new ConnectKeyRecordV7(oldVersion.getEncryptedPassphrase(), true);
     }
 }

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -24,6 +24,7 @@ import org.commcare.android.database.connect.models.ConnectAppRecord;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
+import org.commcare.android.database.global.models.ConnectKeyRecord;
 import org.commcare.connect.database.ConnectAppDatabaseUtil;
 import org.commcare.connect.database.ConnectDatabaseHelper;
 import org.commcare.connect.database.ConnectDatabaseUtils;
@@ -111,9 +112,14 @@ public class PersonalIdManager {
         return manager;
     }
 
-    public void init(Context parent) {
+    public String init(Context parent) {
         parentActivity = parent;
         if (personalIdSatus == PersonalIdStatus.NotIntroduced) {
+            String errorMessage = checkForLogoutErrorMessage(parent);
+            if(errorMessage != null) {
+                return errorMessage;
+            }
+
             ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(parentActivity);
             if (user != null) {
                 boolean registering = user.getRegistrationPhase() != ConnectConstants.PERSONALID_NO_ACTIVITY;
@@ -125,11 +131,26 @@ public class PersonalIdManager {
                 }
             } else if (ConnectDatabaseHelper.isDbBroken()) {
                 //Corrupt DB, inform user to recover
-                ConnectDatabaseHelper.handleCorruptDb(parent);
+                ConnectDatabaseHelper.crashDb();
             }
         }
+
+        return null;
     }
 
+    private String checkForLogoutErrorMessage(Context context) {
+        ConnectKeyRecord keyRecord = ConnectDatabaseUtils.getKeyRecord(true);
+        if(keyRecord != null) {
+            int message = keyRecord.getLogoutErrorMessage();
+            if(message > 0) {
+                String reason = context.getString(message);
+                forgetUser(reason);
+                return reason;
+            }
+        }
+
+        return null;
+    }
 
     public String generatePassword() {
         int passwordLength = 20;

--- a/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
@@ -41,7 +41,7 @@ public class ConnectDatabaseUtils {
     }
 
 
-    static ConnectKeyRecord getKeyRecord(boolean local) {
+    public static ConnectKeyRecord getKeyRecord(boolean local) {
         Vector<ConnectKeyRecord> records = CommCareApplication.instance()
                 .getGlobalStorage(ConnectKeyRecord.class)
                 .getRecordsForValue(ConnectKeyRecord.IS_LOCAL, local);

--- a/app/src/org/commcare/fragments/SelectInstallModeFragment.java
+++ b/app/src/org/commcare/fragments/SelectInstallModeFragment.java
@@ -197,6 +197,13 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
             }
         }
     }
+
+    public void showConnectErrorMessage(String message) {
+        TextView view = getActivity().findViewById(R.id.connect_error_msg);
+        view.setText(message);
+        view.setVisibility(View.VISIBLE);
+    }
+
     /**
      * Updates the visibility and click listener of the Connect button and related UI elements.
      * @param connectEnabled Whether the connect feature should be enabled

--- a/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
+++ b/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
@@ -32,8 +32,9 @@ public class DatabaseGlobalOpenHelper extends SQLiteOpenHelper {
      * V.5 - Add table for storing apps available for install
      * V.6 - Add table for storing (encrypted) passphrase for ConnectId DB
      * V.7 - Add is_local column to ConnectKeyRecord table (to store both local and server passphrase)
+     * V.8 - Add logout_error_message column to ConnectKeyRecord table
      */
-    private static final int GLOBAL_DB_VERSION = 7;
+    private static final int GLOBAL_DB_VERSION = 8;
 
     private static final String GLOBAL_DB_LOCATOR = "database_global";
 


### PR DESCRIPTION
## Product Description
In the "worst-case scenario" for Connect (where we need to de-configure the user on the device and have them complete the Device Configuration workflow again), the user will now be shown an error message on the Setup or Login page (depending on which gets shown at app startup) when they restart the CommCare app.

## Technical Summary
Added a column to ConnectKeyRecord (global DB) to hold the ID for a localized error message string.
Added a function to "crash the DB": set an error message and crash the app
Added init code to check for the error message and, if found, delete all Connect-related storage
Added TextViews in LoginActivity and SelectInstallModeFragment (used by SetupActivity) to display the error message when encountered

## Feature Flag
PersonalID

## Safety Assurance

### Safety story
Tested locally by manually forcing a DB crash and observing the message on restart.
Restarted the app again and observed no error message.

### Automated test coverage
None

### QA Plan
This may be tricky for QA to test since it handles worst-case scenarios that shouldn't be encountered in normal usage.