### PR TITLE
-put extra check for getHq token

### DIFF
--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -621,7 +621,7 @@ public class PersonalIdManager {
 
         String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
         ConnectLinkedAppRecord appRecord = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(manager.parentActivity, seatedAppId, username);
-        if(appRecord == null) {
+        if(appRecord == null || !appRecord.getPersonalIdLinked()) {
             return null;
         }
 

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -621,9 +621,7 @@ public class PersonalIdManager {
     public boolean isSeatedAppLinkedToPersonalId(String username) {
         if (isloggedIn()) {
             String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
-            ConnectLinkedAppRecord appRecord = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
-                    CommCareApplication.instance(), seatedAppId, username);
-            return appRecord != null && appRecord.getPersonalIdLinked();
+            return isPersonalIdLinkedApp(seatedAppId, username);
         }
         return false;
     }
@@ -641,7 +639,7 @@ public class PersonalIdManager {
 
         String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
 
-        if (!manager.isPersonalIdLinkedApp(seatedAppId, username)) {
+        if(!getInstance().isSeatedAppLinkedToPersonalId(username)){
             return null;
         }
 

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -621,7 +621,7 @@ public class PersonalIdManager {
 
         String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
         ConnectLinkedAppRecord appRecord = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(manager.parentActivity, seatedAppId, username);
-        if(appRecord == null || !appRecord.getPersonalIdLinked()) {
+        if (appRecord == null || !appRecord.getPersonalIdLinked()) {
             return null;
         }
 

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -474,7 +474,7 @@ public class PersonalIdManager {
     public AuthInfo.ProvidedAuth getCredentialsForApp(String appId, String userId) {
         ConnectLinkedAppRecord record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(parentActivity, appId,
                 userId);
-        if (isConnectLinkedApp(appId, userId) && !record.getPassword().isEmpty()) {
+        if (isPersonalIdLinkedApp(appId, userId) && !record.getPassword().isEmpty()) {
             return new AuthInfo.ProvidedAuth(record.getUserId(), record.getPassword(), false);
         }
         return null;
@@ -609,7 +609,7 @@ public class PersonalIdManager {
         return isloggedIn() && isConnectApp(context, appId);
     }
 
-    private boolean isConnectLinkedApp(String appId, String username) {
+    private boolean isPersonalIdLinkedApp(String appId, String username) {
         ConnectLinkedAppRecord record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(manager.parentActivity, appId, username);
         return record != null && record.getPersonalIdLinked();
     }
@@ -627,7 +627,7 @@ public class PersonalIdManager {
 
         String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
 
-        if (!manager.isConnectLinkedApp(seatedAppId, username)) {
+        if (!manager.isPersonalIdLinkedApp(seatedAppId, username)) {
             return null;
         }
 

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -575,7 +575,7 @@ public class PersonalIdManager {
         activeJob = job;
     }
 
-    public boolean isSeatedAppLinkedToPersonalId(String username) {
+    public boolean isSeatedAppCongigureWithPersonalId(String username) {
         try {
             if (isloggedIn()) {
                 String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
@@ -610,8 +610,22 @@ public class PersonalIdManager {
     }
 
     private boolean isPersonalIdLinkedApp(String appId, String username) {
-        ConnectLinkedAppRecord record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(manager.parentActivity, appId, username);
-        return record != null && record.getPersonalIdLinked();
+        if (isloggedIn()) {
+            ConnectLinkedAppRecord record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
+                    manager.parentActivity, appId, username);
+            return record != null && record.getPersonalIdLinked();
+        }
+        return false;
+    }
+
+    public boolean isSeatedAppLinkedToPersonalId(String username) {
+        if (isloggedIn()) {
+            String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
+            ConnectLinkedAppRecord appRecord = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
+                    CommCareApplication.instance(), seatedAppId, username);
+            return appRecord != null && appRecord.getPersonalIdLinked();
+        }
+        return false;
     }
 
     public static AuthInfo.TokenAuth getHqTokenIfLinked(String username)

--- a/app/src/org/commcare/network/CommcareRequestGenerator.java
+++ b/app/src/org/commcare/network/CommcareRequestGenerator.java
@@ -180,7 +180,7 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
             if (tokenAuth != null) {
                 return tokenAuth;
             } else {
-                if (PersonalIdManager.getInstance().isSeatedAppLinkedToPersonalId(username)) {
+                if (PersonalIdManager.getInstance().isSeatedAppCongigureWithPersonalId(username)) {
                     Logger.exception("Token auth error for connect managed app",
                             new Throwable("No token Auth available for a connect managed app"));
                 }


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/CI-76
as a part of this we found an issue 
There's a bug in the mobile code such that the app will attempt to use token auth when syncing forms from a trad’l app after the user declines to link the app login to ConnectID. In other words, this happens when they press “No thanks” in the dialog that offers to link their app login to ConnectID. 

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
I have tested this code locally and was working fine

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
