### PR TITLE
Fixes a crash on Connect ID signup due to incorrect View Model constructor

### DIFF
--- a/app/src/org/commcare/android/integrity/IntegrityTokenViewModel.kt
+++ b/app/src/org/commcare/android/integrity/IntegrityTokenViewModel.kt
@@ -1,19 +1,18 @@
 package org.commcare.android.integrity
 
+import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import com.google.android.play.core.integrity.IntegrityManagerFactory
 import com.google.android.play.core.integrity.StandardIntegrityManager.PrepareIntegrityTokenRequest
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenProvider
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenRequest
-import org.apache.commons.lang3.StringUtils
 import org.commcare.CommCareApplication
 import org.commcare.dalvik.BuildConfig
 import org.javarosa.core.services.Logger
 
-class IntegrityTokenViewModel() : AndroidViewModel(application = CommCareApplication.instance()) {
+class IntegrityTokenViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _providerState = MutableLiveData<TokenProviderState>()
     val providerState: LiveData<TokenProviderState> = _providerState
@@ -32,7 +31,7 @@ class IntegrityTokenViewModel() : AndroidViewModel(application = CommCareApplica
      * Also note that each app instance can only prepare the integrity token up to 5 times per minute.
      */
     fun prepareTokenProvider() {
-        val standardIntegrityManager = IntegrityManagerFactory.createStandard(CommCareApplication.instance())
+        val standardIntegrityManager = IntegrityManagerFactory.createStandard(getApplication())
         val cloudProjectNumber = BuildConfig.GOOGLE_CLOUD_PROJECT_NUMBER
         require(cloudProjectNumber!= -1L) { "Google Cloud Project Number is not defined" }
 


### PR DESCRIPTION
## Technical Summary

Fixes `Caused by: java.lang.NoSuchMethodException: org.commcare.android.integrity.IntegrityTokenViewModel.<init> [class android.app.Application]`


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
