### PR TITLE
request hash for integrity token needs padding

### DIFF
--- a/app/src/org/commcare/utils/HashUtils.kt
+++ b/app/src/org/commcare/utils/HashUtils.kt
@@ -17,6 +17,6 @@ object HashUtils {
     fun computeHash(message: String, algorithm: HashAlgorithm = HashAlgorithm.SHA256): String {
         val digest = MessageDigest.getInstance(algorithm.algorithmName)
         val hashBytes = digest.digest(message.toByteArray(StandardCharsets.UTF_8))
-        return Base64.encodeToString(hashBytes, Base64.NO_WRAP or Base64.NO_PADDING)
+        return Base64.encodeToString(hashBytes, Base64.NO_WRAP)
     }
 }


### PR DESCRIPTION
## Product Description

Fixes request hash for integrity token by not removing padding `=`


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
