### PR TITLE
Solving #2740 layout size is probably 0 when setting bitmap size

### DIFF
--- a/app/src/org/commcare/views/EntityView.java
+++ b/app/src/org/commcare/views/EntityView.java
@@ -12,6 +12,7 @@ import android.text.TextUtils;
 import android.text.style.BackgroundColorSpan;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -353,15 +354,24 @@ public class EntityView extends LinearLayout {
             return;
         }
         if (onMeasureCalled) {
-            int columnWidthInPixels = layout.getLayoutParams().width;
-            Bitmap b = MediaUtil.inflateDisplayImage(getContext(), source, columnWidthInPixels, columnWidthInPixels, true);
-            if (b == null) {
-                // Means the input stream could not be used to derive the bitmap, so showing
-                // error-indicating image
-                iv.setImageDrawable(getResources().getDrawable(R.drawable.ic_menu_archive));
-            } else {
-                iv.setImageBitmap(b);
-            }
+            //this is needed since layout width can be 0 if this function is called before parent called has size
+            layout.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+                @Override
+                public void onGlobalLayout() {
+                    layout.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                    //width is ready
+                    int columnWidthInPixels = layout.getLayoutParams().width;
+                    Bitmap b = MediaUtil.inflateDisplayImage(getContext(), source, columnWidthInPixels, columnWidthInPixels, true);
+                    if (b == null) {
+                        // Means the input stream could not be used to derive the bitmap, so showing
+                        // error-indicating image
+                        iv.setImageDrawable(getResources().getDrawable(R.drawable.ic_menu_archive));
+                    } else {
+                        iv.setImageBitmap(b);
+                    }
+                }
+            });
+
         } else {
             // Since case list images are scaled down based on the width of the column they
             // go into, we cannot set up an image layout until onMeasure() has been called


### PR DESCRIPTION
## Product Description
This solves #2740 
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
The problem probably was that the parent that you was using to get width for the generated bitmap was 0, because it was called before getting a size. Common problem when programming for android, is gets solved most of the time by defining a ViewTreeObserver for the View that returns size 0.
This kind of bug can be really hard to find, most of the time you get noticed that it exists by automated tests, firebase logs or very cluttered app/low phone resources available when executing.
Thats why you was not able to reproduce.
This could have been more easy to solve probably if we had the firebase logs.
Also i dont see the forum related topic, seems like it dont exists anymore.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
