### PR TITLE
Revert format of appVersion metadata string

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -208,8 +208,8 @@ post.server.error=Server-side error (code ${0}) received from network request.
 post.gone.error=Case is not present on server.
 post.conflict.error=You have already claimed this case.
 
-version.id.long=CommCare Android, version "${0}"(${1}). App v${4}. CommCare Version ${0}. Build ${2}, built on: ${3}
-version.id.short=CCDroid:"${0}"(${1}). v${4} CC${0}b[${2}] on ${3}
+version.id.long=CommCare Android, version "${0}"(${1}). App v${5}. CommCare Version ${2}. Build ${3}, built on: ${4}
+version.id.short=CCDroid:"${0}"(${1}). v${5} CC${2}b[${3}] on ${4}
 commcare.version=CommCare Android, version "${0}"(${1}), built on: ${2}
 
 auth.request.not.using.https=${0} is an invalid URL. CommCare can't connect with authentication to an insecure (HTTP) server.

--- a/app/src/org/commcare/AppUtils.java
+++ b/app/src/org/commcare/AppUtils.java
@@ -170,7 +170,7 @@ public class AppUtils {
         String buildNumber = BuildConfig.BUILD_NUMBER;
 
         return Localization.get(application.getString(R.string.app_version_string), new String[]{
-                ccv, String.valueOf(BuildConfig.VERSION_CODE), buildNumber, buildDate, profileVersion});
+                ccv, String.valueOf(BuildConfig.VERSION_CODE), ccv, buildNumber, buildDate, profileVersion});
     }
 
     public static String getCurrentAppId() {


### PR DESCRIPTION
## Product Description
In a previous work (#2978), the formatted string used to populate the `appVersion` metadata in form submissions was optimized to eliminate repetition, the number of parameters was reduced to 5. So from:
- `CommCare Android, version "${0}"(${1}). App v${5}. CommCare Version ${2}. Build ${3}, built on: ${4}` - **6 params**
to
- `CommCare Android, version "${0}"(${1}). App v${4}. CommCare Version ${0}. Build ${2}, built on: ${3}` -  **5 params**

Since only the english version is in the codebase, the change was not applied the formatted string in other languages. These are stored separately and injected into the CommCare app via HQ when a language is added. For the change to work correctly, we would need to update the string in all supported languages so that they all expect 5 parameters instead of 6.
However, there is another issue, even if all strings are updated, older versions of CC will still pass 6 parameters. This mismatch would mess up the `appVersion` string. So this PR reverts that change.

Example of formatted strings in other languages:
- Spanish: 
  - version.id.long: `ODK, version "${0}"(${1}). Kawok v${5}. CommCare v${2}. Compilación ${3}, creada en: ${4}`
  - version.id.short: `CCODK:"${0}"(${1}). v${5} CC${2}b[${3}] en ${4}`
- French:
  - version.id.long: `CommCare ODK, version "${0}"(${1}). App v${5}. CommCare Version ${2}. Construction ${3}, construit: ${4}`
  - version.id.short: `CCODK:"${0}"(${1}). v${5} CC${2}b[${3}] on ${4}`

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
