### PR TITLE
Lock screen to portrait during photo activity

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -580,7 +580,9 @@
         <activity android:name="org.commcare.activities.TargetMismatchErrorActivity"/>
         <activity android:name="org.commcare.recovery.measures.ExecuteRecoveryMeasuresActivity"/>
         <activity android:name="org.commcare.activities.PromptCCReinstallActivity"/>
-        <activity android:name="org.commcare.fragments.MicroImageActivity" />
+        <activity
+            android:name="org.commcare.fragments.MicroImageActivity"
+            android:screenOrientation="portrait"/>
         <!-- Start Collect Manifest -->
 
         <meta-data


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/QA-7835

Screen rotation locked to portrait while user is taking a photo

## Technical Summary
Added it to the manifest for MicroImageActivity.

## Feature Flag
None

## Safety Assurance

### Safety story
Tested, screen doesn't rotate

### Automated test coverage
None

### QA Plan
Try to rotate the screen during photo capture