### PR TITLE
fix crash requestFeature() must be called before adding content

### DIFF
--- a/app/src/org/commcare/activities/GeoPointMapActivity.java
+++ b/app/src/org/commcare/activities/GeoPointMapActivity.java
@@ -68,8 +68,8 @@ public class GeoPointMapActivity extends AppCompatActivity
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
+        super.onCreate(savedInstanceState);
         setContentView(R.layout.geopoint_layout);
 
         loadViewModeState();


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/QA-7829

Fixes crash: 

````
 Caused by: android.util.AndroidRuntimeException: requestFeature() must be called before adding content
at com.android.internal.policy.PhoneWindow.requestFeature(PhoneWindow.java:549)
at android.app.Activity.requestWindowFeature(Activity.java:5675)
at org.commcare.activities.GeoPointMapActivity.onCreate(SourceFile:72)
````



## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
