### PR TITLE
Handling failed biometric config properly

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdBiometricConfigFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBiometricConfigFragment.java
@@ -223,11 +223,11 @@ public class PersonalIdBiometricConfigFragment extends Fragment {
         if (requestCode == ConnectConstants.PERSONALID_UNLOCK_PIN) {
             PersonalIdManager.getInstance().setStatus(PersonalIdManager.PersonalIdStatus.LoggedIn);
             ConnectDatabaseHelper.setRegistrationPhase(getActivity(), ConnectConstants.PERSONALID_NO_ACTIVITY);
-            requireActivity().setResult(RESULT_OK);
+            requireActivity().setResult(resultCode);
             requireActivity().finish();
         }
         if (requestCode == ConnectConstants.CONFIGURE_BIOMETRIC_REQUEST_CODE) {
-            navigateForward(false);
+            navigateForward(resultCode != RESULT_OK);
         }
     }
 


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/QA-7836

## Product Description
User will see an error message if biometric config fails or is aborted (instead of incorrectly proceeding to the next step in the device configuration workflow).

## Technical Summary
We were ignoring the result code that came back from the biometric config activity.
Passing the result code through so it can be handled properly now.

## Feature Flag
PersonalID

## Safety Assurance

### Safety story
Tested the change out and I see the on-screen error message now.

### Automated test coverage
None

### QA Plan
This is in the QA plan already, the bug came from QA testing