### PR TITLE
- Solved crash on changing language

### DIFF
--- a/app/src/org/commcare/activities/connect/PersonalIdActivity.java
+++ b/app/src/org/commcare/activities/connect/PersonalIdActivity.java
@@ -2,16 +2,14 @@ package org.commcare.activities.connect;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 
 import org.commcare.activities.NavigationHostCommCareActivity;
-import org.commcare.fragments.personalId.PersonalIdBiometricConfigFragment;
 import org.commcare.connect.ConnectConstants;
 import org.commcare.connect.PersonalIdManager;
 import org.commcare.dalvik.R;
+import org.commcare.fragments.personalId.PersonalIdBiometricConfigFragment;
 import org.commcare.fragments.personalId.PersonalIdPhoneFragmentDirections;
 import org.commcare.views.dialogs.CustomProgressDialog;
-import org.javarosa.core.services.Logger;
 
 import java.util.Objects;
 


### PR DESCRIPTION
Solved crash on changing language
https://dimagi.atlassian.net/browse/QA-7844
## Crash Description
Crash was because it was navigating to `PersonalIdPhoneFragment `screen everytime when we are changing the language and coming back and after changing language user comes back app tries to find `PersonalIdPhoneFragment `in stack and we have minimized app from `PersonalIdBiometricConfigFragment `So it in stack app was not able to find `PersonalIdPhoneFragment  `as user minimized from `PersonalIdBiometricConfigFragment  `So I did not changed any other logic just added a sure check that if current fragment is `PersonalIdPhoneFragment  `then only it should take that navigation and checked with multiple scenarios it is not crashing now

**Crash StackTrace**
                                                                                                    Caused by: java.lang.IllegalArgumentException: Navigation action/destination org.commcare.dalvik.debug:id/action_personalid_phone_fragment_self cannot be found from the current destination Destination(org.commcare.dalvik.debug:id/personalid_otp_page) label=fragment_personalid_phone_verify class=org.commcare.fragments.personalId.PersonalIdPhoneVerificationFragment


## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
