### PR TITLE
Fixed double callback in after PersonalID API failure

### DIFF
--- a/app/src/org/commcare/connect/network/ApiPersonalId.java
+++ b/app/src/org/commcare/connect/network/ApiPersonalId.java
@@ -233,10 +233,9 @@ public class ApiPersonalId {
                 } else {
                     // Handle validation errors
                     logNetworkError(response);
-                    if (response.errorBody() != null){
-                        callback.processFailure(response.code(), response.errorBody().byteStream());
-                    }
-                    callback.processFailure(response.code(), null);
+                    InputStream stream = response.errorBody() != null ?
+                            response.errorBody().byteStream() : null;
+                    callback.processFailure(response.code(), stream);
                 }
             }
 


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/QA-7849

## Product Description
Fixes an issue that could occur after failed PersonalID API calls.

## Technical Summary
Fixed a corner-case where a PersonalID API call fails and returns an error body, and the mobile code would erroneously call the processFailure callback twice.

## Feature Flag
PersonalID

## Safety Assurance

### Safety story
Tested locally. Crashed before on failed device configuration (i.e. bad integrity token), now it doesn't

### Automated test coverage
None

### QA Plan
Already tested (bug identified by QA)
