### PR TITLE
Restore Connect buttons in beta

### DIFF
--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -564,8 +564,7 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         setLoginInputsVisibility(appState != Connect);
         if (PersonalIdManager.getInstance().isloggedIn()) {
             connectLoginButton.setText(activity.getString(R.string.connect_button_logged_in));
-            ///TODO: connect set to true after phase 4 merge
-            setConnectButtonVisible(false);
+            setConnectButtonVisible(true);
             String welcomeText = activity.getString(R.string.login_welcome_connect_signed_in,
                     ConnectUserDatabaseUtil.getUser(activity).getName());
             welcomeMessage.setText(welcomeText);

--- a/app/src/org/commcare/fragments/SelectInstallModeFragment.java
+++ b/app/src/org/commcare/fragments/SelectInstallModeFragment.java
@@ -211,9 +211,7 @@ public class SelectInstallModeFragment extends Fragment implements NsdServiceLis
      */
     public void updateConnectButton(boolean connectEnabled, View.OnClickListener listener) {
         if (mConnectButton != null) {
-            ///TODO: connect uncomment after phase 4 merge
-//            boolean enabled = connectEnabled && PersonalIdManager.getInstance().isloggedIn();
-            boolean enabled = false;
+            boolean enabled = connectEnabled && PersonalIdManager.getInstance().isloggedIn();
             if (enabled && listener != null) {
                 mConnectButton.setOnClickListener(listener);
             }


### PR DESCRIPTION
The Connect buttons (in Setup and Login pages) was hard-coded to be invisible.
This is what we want on master, but beta needs the button to behave as usual.