### PR TITLE
Fixed button spacing issue

### DIFF
--- a/app/res/layout/fragment_connect_delivery_details.xml
+++ b/app/res/layout/fragment_connect_delivery_details.xml
@@ -160,16 +160,16 @@
                         android:background="@color/connect_darker_blue_color"
                         android:padding="16dp">
 
-                        <androidx.constraintlayout.widget.ConstraintLayout
+                        <LinearLayout
                             android:id="@+id/linearLayout"
-                            android:layout_width="0dp"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:orientation="vertical"
+                            app:layout_constraintTop_toTopOf="parent"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
                             android:layout_marginEnd="2dp"
-                            app:layout_constraintEnd_toStartOf="@+id/connect_delivery_button"
-                            app:layout_constraintTop_toTopOf="parent">
+                            android:background="@color/connect_darker_blue_color">
 
                             <TextView
                                 android:id="@+id/connect_delivery_action_title"
@@ -192,21 +192,20 @@
                                 android:textColor="@color/grey"
                                 android:textSize="14sp" />
 
-                        </androidx.constraintlayout.widget.ConstraintLayout>
-
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/connect_delivery_button"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/connect_job_info_download"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
-                            android:backgroundTint= "@color/white"
-                            android:drawableEnd= "@drawable/ic_connect_arrow_forward_20px"
-                            android:textColor= "@color/cc_brand_color"
-                            app:iconTint="@color/cc_brand_color"
-                            />
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/connect_delivery_button"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/connect_job_info_download"
+                                app:layout_constraintTop_toBottomOf="@id/connect_delivery_action_details"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                android:layout_gravity="end"
+                                android:backgroundTint= "@color/white"
+                                android:drawableEnd= "@drawable/ic_connect_arrow_forward_20px"
+                                android:textColor= "@color/cc_brand_color"
+                                app:iconTint="@color/cc_brand_color"
+                                />
+                        </LinearLayout>
                     </androidx.constraintlayout.widget.ConstraintLayout>
                 </androidx.cardview.widget.CardView>
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/res/layout/fragment_connect_job_intro.xml
+++ b/app/res/layout/fragment_connect_job_intro.xml
@@ -73,37 +73,30 @@
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
+                        android:orientation="vertical"
                         android:padding="16dp">
 
-                        <LinearLayout
+                        <TextView
+                            android:id="@+id/connect_job_intro_start_label"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/connect_learn_start"
+                            android:textColor="@color/white"
+                            android:textSize="14sp" />
+
+                        <TextView
+                            android:id="@+id/connect_job_intro_learning_summary"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:orientation="vertical">
-
-                            <TextView
-                                android:id="@+id/connect_job_intro_start_label"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/connect_learn_start"
-                                android:textColor="@color/white"
-                                android:textSize="14sp" />
-
-                            <TextView
-                                android:id="@+id/connect_job_intro_learning_summary"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_marginTop="16dp"
-                                android:textColor="@color/white"
-                                android:textSize="12sp" />
-                        </LinearLayout>
+                            android:layout_marginTop="16dp"
+                            android:textColor="@color/white"
+                            android:textSize="12sp" />
 
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/connect_job_intro_start_button"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="center"
+                            android:layout_gravity="end"
                             android:layout_marginStart="20dp"
                             android:gravity="center"
                             android:text="@string/connect_recovery_button_phone"

--- a/app/res/layout/fragment_connect_learning_progress.xml
+++ b/app/res/layout/fragment_connect_learning_progress.xml
@@ -162,7 +162,6 @@
                             android:text="@string/connect_click_to_sync_progress"
                             android:textColor="@color/black"
                             android:textSize="15sp"
-                            app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
@@ -173,7 +172,7 @@
                             android:text="@string/sync"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintTop_toBottomOf="@id/connectRegularTextView"
                             app:iconSize="24dp"
                             app:icon="@drawable/ic_connect_directory_sync"
                             app:iconGravity="end"

--- a/app/res/layout/fragment_connect_progress_delivery.xml
+++ b/app/res/layout/fragment_connect_progress_delivery.xml
@@ -150,7 +150,6 @@
                             android:text="@string/connect_click_to_sync_progress"
                             android:textColor="@color/black"
                             android:textSize="15sp"
-                            app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
@@ -161,7 +160,7 @@
                             android:text="@string/sync"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintTop_toBottomOf="@id/connectRegularTextView"
                             android:drawableRight= "@drawable/ic_connect_directory_sync"
                             android:drawablePadding="5dp" />
 

--- a/app/res/layout/screen_personalid_phone_verify.xml
+++ b/app/res/layout/screen_personalid_phone_verify.xml
@@ -31,38 +31,27 @@
             android:textColor="@color/connect_dark_blue_color"
             android:textSize="16sp" />
 
-        <LinearLayout
+        <TextView
+            android:id="@+id/connect_phone_verify_label"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_gravity="end"
-            android:layout_marginStart="16dp"
-            android:gravity="center"
-            android:layout_marginEnd="16dp"
-            android:orientation="horizontal">
+            android:layout_marginStart="10dp"
+            android:textColor="@color/connect_secondary_text"
+            android:textSize="16sp"
+            tools:text="+91 7748962888"
+            android:textStyle="normal"/>
 
-            <TextView
-                android:id="@+id/connect_phone_verify_label"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:textColor="@color/connect_secondary_text"
-                android:textSize="16sp"
-                tools:text="+91 7748962888"
-                android:textStyle="normal"/>
-
-            <TextView
-                android:id="@+id/connect_phone_verify_change"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="10dp"
-                android:gravity="end"
-                android:text="@string/connect_verify_phone_change"
-                android:textColor="@color/connect_blue_color"
-                android:textSize="16sp"
-                android:visibility="visible"
-                android:textStyle="bold"/>
-        </LinearLayout>
+        <TextView
+            android:id="@+id/connect_phone_verify_change"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:gravity="end"
+            android:text="@string/connect_verify_phone_change"
+            android:textColor="@color/connect_blue_color"
+            android:textSize="16sp"
+            android:visibility="visible"
+            android:textStyle="bold"/>
 
         <LinearLayout
             android:id="@+id/otp_layout"


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/QA-7848
https://dimagi.atlassian.net/browse/QA-7847

On the Job Intro and Job Details pages, the button to proceed was to the right of some text.
On the Learning/Delivery Progress pages, the sync button was similar
On the Phone Verification page, similar again with the Change link

When translated to French it all gets bigger, and causes strange overflows.

I rearranged these components vertically to allow room for them to expand horizontally, such that rollover will be isolated to each component rather than squishing other components.

Example of the new look:
<img src="https://github.com/user-attachments/assets/c7b79b19-49d4-4829-bee5-b5c32b1d322f" width="200">