### PR TITLE
Handling Next and Done keys in Backup Code Fragment

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
@@ -103,24 +103,22 @@ public class PersonalIdBackupCodeFragment extends Fragment {
 
     private void setupDoneKeys() {
         binding.connectBackupCodeInput.setOnEditorActionListener((v, actionId, event) -> {
-            if (actionId == EditorInfo.IME_ACTION_NEXT || actionId == EditorInfo.IME_ACTION_DONE) {
-                if(isRecovery) {
-                    handleBackupCodeSubmission();
-                } else {
-                    binding.connectBackupCodeRepeatInput.requestFocus();
-                }
+            if ((actionId == EditorInfo.IME_ACTION_NEXT || actionId == EditorInfo.IME_ACTION_DONE)
+                    && isRecovery && binding.connectBackupCodeButton.isEnabled()) {
+                handleBackupCodeSubmission();
                 return true;
             }
+
             return false;
         });
 
         binding.connectBackupCodeRepeatInput.setOnEditorActionListener((v, actionId, event) -> {
-            if (actionId == EditorInfo.IME_ACTION_NEXT || actionId == EditorInfo.IME_ACTION_DONE) {
-                if(binding.connectBackupCodeButton.isEnabled()) {
-                    handleBackupCodeSubmission();
-                }
+            if (actionId == EditorInfo.IME_ACTION_NEXT || actionId == EditorInfo.IME_ACTION_DONE
+                    && binding.connectBackupCodeButton.isEnabled()) {
+                handleBackupCodeSubmission();
                 return true;
             }
+
             return false;
         });
     }

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
@@ -9,6 +9,7 @@ import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
 
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
@@ -55,6 +56,7 @@ public class PersonalIdBackupCodeFragment extends Fragment {
         configureUiByMode();
         setupInputFilters();
         setupListeners();
+        setupDoneKeys();
         clearBackupCodeFields();
         activity.setTitle(getString(titleId));
         return binding.getRoot();
@@ -97,6 +99,30 @@ public class PersonalIdBackupCodeFragment extends Fragment {
         InputFilter[] filters = new InputFilter[]{new InputFilter.LengthFilter(BACKUP_CODE_LENGTH)};
         binding.connectBackupCodeInput.setFilters(filters);
         binding.connectBackupCodeRepeatInput.setFilters(filters);
+    }
+
+    private void setupDoneKeys() {
+        binding.connectBackupCodeInput.setOnEditorActionListener((v, actionId, event) -> {
+            if (actionId == EditorInfo.IME_ACTION_NEXT || actionId == EditorInfo.IME_ACTION_DONE) {
+                if(isRecovery) {
+                    handleBackupCodeSubmission();
+                } else {
+                    binding.connectBackupCodeRepeatInput.requestFocus();
+                }
+                return true;
+            }
+            return false;
+        });
+
+        binding.connectBackupCodeRepeatInput.setOnEditorActionListener((v, actionId, event) -> {
+            if (actionId == EditorInfo.IME_ACTION_NEXT || actionId == EditorInfo.IME_ACTION_DONE) {
+                if(binding.connectBackupCodeButton.isEnabled()) {
+                    handleBackupCodeSubmission();
+                }
+                return true;
+            }
+            return false;
+        });
     }
 
     private void setupListeners() {


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/QA-7850

Added key handlers for the Next and Done keys when showing the numeric keypad in the backup code fragment.

When pressed:
-If in recovery: submits the code
-If new registration, first input: proceeds to second input
-If new registration, second input: proceeds to next page