### PR TITLE
Correct error handling for network requests

### DIFF
--- a/app/src/org/commcare/connect/network/PersonalIdApiHandler.java
+++ b/app/src/org/commcare/connect/network/PersonalIdApiHandler.java
@@ -39,7 +39,7 @@ public abstract class PersonalIdApiHandler {
 
         public boolean shouldAllowRetry(){
             return this == NETWORK_ERROR || this == TOKEN_UNAVAILABLE_ERROR || this == SERVER_ERROR
-                    || this == RATE_LIMIT_EXCEEDED_ERROR;
+                    || this == UNKNOWN_ERROR;
         }
     }
 


### PR DESCRIPTION
## Product Description

Any network response codes we are not handling specifically crashes today but instead they should be failing with an error message and should allow user to retry the network request. Therefore I am failing them with `UNKNOWN_ERROR` instead. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
