### PR TITLE
Cancelling config workflow when device isn't compatible

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdMessageFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdMessageFragment.java
@@ -138,7 +138,7 @@ public class PersonalIdMessageFragment extends BottomSheetDialogFragment {
 
                 break;
             case ConnectConstants.PERSONALID_DEVICE_CONFIGURATION_FAILED:
-                directions = navigateToPhoneFragment();
+                requireActivity().finish();
                 break;
             case ConnectConstants.PERSONALID_RECOVERY_ACCOUNT_ORPHANED:
                 personalIdSessionData.setAccountExists(false);


### PR DESCRIPTION
## Product Description
After showing the user an error message indicating that their device doesn't meet the security requirements for biometric, the configuration workflow will close.

## Technical Summary
Finishing the activity instead of navigating to phone fragment.
Note: Popping back to phone would have also fixed the error, instead of navigating forward to phone fragment.
But once we know they can't enroll, might as well drop them back at home

## Feature Flag
PersonalID

## Safety Assurance

### Safety story
Tested by forcing the error in code.
I was able to reproduce the bad behavior before the fix.

### Automated test coverage
None

### QA Plan
Reported by QA already.
