### PR TITLE
Fix crash due to view being null on calling triggerSync

### DIFF
--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -179,6 +179,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     private String selectedEntityPostSync = null;
 
     private FirebaseMessagingDataSyncer dataSyncer;
+    private boolean isVisible;
 
     {
         dataSyncer = new FirebaseMessagingDataSyncer(this);
@@ -1311,8 +1312,9 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                     SimpleDateFormat.getDateTimeInstance().format(lastUploadSyncAttempt);
             Logger.log(LogTypes.TYPE_USER, "autosync triggered. Last Sync|" + footer);
         }
-
-        refreshUI();
+        if (isVisible) {
+            refreshUI();
+        }
         sendFormsOrSync(false);
     }
 
@@ -1333,6 +1335,18 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
         redirectedInOnCreate = false;
         sessionNavigationProceedingAfterOnResume = false;
         shouldTriggerBackgroundSync = true;
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        isVisible = true;
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        isVisible = false;
     }
 
     private void attemptDispatchHomeScreen() {


### PR DESCRIPTION
## Product Description

Fixes a crash with login sync: 

````
 Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.View android.view.View.findViewById(int)' on a null object reference
       at org.commcare.activities.StandardHomeActivityUIController.updateConnectProgress(StandardHomeActivityUIController.java:194)
       at org.commcare.activities.StandardHomeActivityUIController.refreshView(StandardHomeActivityUIController.java:190)
       at org.commcare.activities.StandardHomeActivity.refreshUI(StandardHomeActivity.java:269)
       at org.commcare.activities.HomeScreenBaseActivity.triggerSync(HomeScreenBaseActivity.java:1315)
       at org.commcare.activities.HomeScreenBaseActivity.doLoginLaunchChecksInOrder(HomeScreenBaseActivity.java:351)
       at org.commcare.activities.HomeScreenBaseActivity.processFromLoginLaunch(HomeScreenBaseActivity.java:311)
       at org.commcare.activities.HomeScreenBaseActivity.onCreateSessionSafe(HomeScreenBaseActivity.java:199)
````

## Technical Summary

We are calling `triggerSync` even before calling `setContentView` in some cases and we only want to refresh the UI if the acitivity is already visible to the user. This is only impacting Connect Beta users and happens when [post update sync](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/activities/HomeScreenBaseActivity.java#L348) is turned on in the app. 


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
