### PR TITLE
Fix input lag on saved forms with multimedia in list questions

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -756,12 +756,10 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                 continue;
             }
 
-            if (oldWidgets.get(i) instanceof ImageWidget) {
+            if ((i == indexOfLastChangedWidget) && oldWidgets.get(i) instanceof ImageWidget) {
                 // If there was change(in particular image-remove) in an image widget,
                 // only then update the form to disk.
-                if (i == indexOfLastChangedWidget) {
-                    activity.onExternalAttachmentUpdated();
-                }
+                activity.onExternalAttachmentUpdated();
             }
 
             FormEntryPrompt oldPrompt = oldWidgets.get(i).getPrompt();


### PR DESCRIPTION
## Product Description
This small PR addresses an issue with saved forms that contain list questions with Image widgets. The logic to resave the form to disk is triggered whenever any question within the same list changes, leading to a poor UX due to slowness - especially when typing in a text question. This logic was implemented to update the form on disk when the image file changes, either replaced or removed.

JIRA ticket: https://dimagi.atlassian.net/browse/SAAS-17653

## Technical Summary
This change ensures that the form is resaved only when the Image widget is changed.

## Safety Assurance

### Safety story
Successfully tested locally.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
