### PR TITLE
Restrict Web users from logging into CC mobile

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -243,6 +243,11 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     }
 
     private void doLogin(LoginMode loginMode, boolean restoreSession, String passwordOrPin) {
+        if (!isUsernameValid(getUniformUsername())) {
+            raiseLoginMessage(StockMessages.Auth_BadCredentials, false);
+            return;
+        }
+
         if ("".equals(passwordOrPin) && loginMode != LoginMode.PRIMED) {
             if (loginMode == LoginMode.PASSWORD) {
                 raiseLoginMessage(StockMessages.Auth_EmptyPassword, false);
@@ -266,6 +271,14 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
         } else {
             localLoginOrPullAndLogin(restoreSession);
         }
+    }
+
+    private boolean isUsernameValid(String username) {
+        if ((username !=null && !username.isEmpty()) &&
+                (!username.contains("@") || username.endsWith("@" + HiddenPreferences.getUserDomain()))) {
+            return true;
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
## Product Description
This PR enforces a restriction in CC mobile to block login attempts from Web users. With this change, Web users will now see a message as follows:
<img src="https://github.com/user-attachments/assets/c71f1686-b4df-41e2-8fbd-f5b4b39510fc" width="250px" />

## Technical Summary
Web users are identified by their email address, so this change checks for the presence of an '@' symbol in the username. Access is allowed if the '@' symbol is not found, or it it's found and the username ends with the project space domain name.

## Safety Assurance

### Safety story
Successfully tested locally.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
