### PR TITLE
Make 'Clear user data' visibility depend on session status

### DIFF
--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -42,7 +42,7 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
         setTitle();
         initPrefsFile();
         loadPrefs();
-        conditionallyHideSpecificPrefs();
+        updateConditionallyVisibleSpecificPrefs();
     }
 
     @CallSuper
@@ -61,7 +61,7 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
         setupLocalizedText();
     }
 
-    protected void conditionallyHideSpecificPrefs() {
+    protected void updateConditionallyVisibleSpecificPrefs() {
         // default implementation does nothing
     }
 

--- a/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
+++ b/app/src/org/commcare/fragments/CommCarePreferenceFragment.java
@@ -42,7 +42,6 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
         setTitle();
         initPrefsFile();
         loadPrefs();
-        updateConditionallyVisibleSpecificPrefs();
     }
 
     @CallSuper
@@ -113,6 +112,13 @@ public abstract class CommCarePreferenceFragment extends PreferenceFragmentCompa
         } else {
             super.onDisplayPreferenceDialog(preference);
         }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        updateConditionallyVisibleSpecificPrefs();
     }
 
     @Override

--- a/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
+++ b/app/src/org/commcare/preferences/AdvancedActionsPreferences.java
@@ -105,7 +105,7 @@ public class AdvancedActionsPreferences extends CommCarePreferenceFragment {
     }
 
     @Override
-    protected void conditionallyHideSpecificPrefs() {
+    protected void updateConditionallyVisibleSpecificPrefs() {
         Preference reportProblemButton = findPreference(REPORT_PROBLEM);
         if (reportProblemButton != null && DeveloperPreferences.shouldHideReportIssue()) {
             getPreferenceScreen().removePreference(reportProblemButton);

--- a/app/src/org/commcare/preferences/AppManagerAdvancedPreferences.java
+++ b/app/src/org/commcare/preferences/AppManagerAdvancedPreferences.java
@@ -54,6 +54,14 @@ public class AppManagerAdvancedPreferences extends CommCarePreferenceFragment {
     }
 
     @Override
+    public void updateConditionallyVisibleSpecificPrefs(){
+        Preference clearUserDataButton = findPreference(CLEAR_USER_DATA);
+        if (clearUserDataButton != null) {
+            clearUserDataButton.setVisible(!"".equals(CommCareApplication.instance().getCurrentUserId()));
+        }
+    }
+
+    @Override
     protected void setupPrefClickListeners() {
         Preference clearUserDataButton = findPreference(CLEAR_USER_DATA);
         clearUserDataButton.setVisible(!"".equals(CommCareApplication.instance().getCurrentUserId()));

--- a/app/src/org/commcare/preferences/AppManagerAdvancedPreferences.java
+++ b/app/src/org/commcare/preferences/AppManagerAdvancedPreferences.java
@@ -64,8 +64,6 @@ public class AppManagerAdvancedPreferences extends CommCarePreferenceFragment {
     @Override
     protected void setupPrefClickListeners() {
         Preference clearUserDataButton = findPreference(CLEAR_USER_DATA);
-        clearUserDataButton.setVisible(!"".equals(CommCareApplication.instance().getCurrentUserId()));
-
         clearUserDataButton.setOnPreferenceClickListener(preference -> {
             FirebaseAnalyticsUtil.reportAdvancedActionSelected(
                     AnalyticsParamValue.CLEAR_USER_DATA);

--- a/app/src/org/commcare/preferences/AppManagerAdvancedPreferences.java
+++ b/app/src/org/commcare/preferences/AppManagerAdvancedPreferences.java
@@ -56,14 +56,13 @@ public class AppManagerAdvancedPreferences extends CommCarePreferenceFragment {
     @Override
     protected void setupPrefClickListeners() {
         Preference clearUserDataButton = findPreference(CLEAR_USER_DATA);
-        clearUserDataButton.setEnabled(!"".equals(CommCareApplication.instance().getCurrentUserId()));
+        clearUserDataButton.setVisible(!"".equals(CommCareApplication.instance().getCurrentUserId()));
 
         clearUserDataButton.setOnPreferenceClickListener(preference -> {
             FirebaseAnalyticsUtil.reportAdvancedActionSelected(
                     AnalyticsParamValue.CLEAR_USER_DATA);
-            AdvancedActionsPreferences.clearUserData((AppCompatActivity)getActivity());
+            AdvancedActionsPreferences.clearUserData((AppCompatActivity) getActivity());
             return true;
-
         });
 
         Preference dataChangeLogs = findPreference(DATA_CHANGE_LOGS);


### PR DESCRIPTION
## Product Description
This PR hides/shows the Clear User Data preference of the AppManager according to the user session status. This also accounts for when the session status changes (see video below).
<video src="https://github.com/user-attachments/assets/714b86c6-7e44-4973-8a53-98d7635b59fa" width="300px" />

Ticket: https://dimagi.atlassian.net/browse/SAAS-16440

## Safety Assurance

### Safety story
Tested locally.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
