### PR TITLE
Send Firebase user ID to PersonalID

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -221,6 +221,7 @@ public class PersonalIdPhoneFragment extends Fragment implements CommCareLocatio
         body.put("phone_number", phone);
         body.put("application_id", requireContext().getPackageName());
         body.put("gps_location", GeoUtils.locationToString(location));
+        body.put("firebase_user_id", FirebaseAnalyticsUtil.getFirebaseUserId());
 
         integrityTokenApiRequestHelper.withIntegrityToken(body,
                 new IntegrityTokenViewModel.IntegrityTokenCallback() {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -34,6 +34,7 @@ import org.commcare.activities.connect.viewmodel.PersonalIdSessionDataViewModel;
 import org.commcare.android.database.connect.models.PersonalIdSessionData;
 import org.commcare.android.integrity.IntegrityTokenApiRequestHelper;
 import org.commcare.android.integrity.IntegrityTokenViewModel;
+import org.commcare.android.logging.ReportingUtils;
 import org.commcare.connect.ConnectConstants;
 import org.commcare.connect.network.connectId.PersonalIdApiErrorHandler;
 import org.commcare.connect.network.connectId.PersonalIdApiHandler;
@@ -221,7 +222,7 @@ public class PersonalIdPhoneFragment extends Fragment implements CommCareLocatio
         body.put("phone_number", phone);
         body.put("application_id", requireContext().getPackageName());
         body.put("gps_location", GeoUtils.locationToString(location));
-        body.put("firebase_user_id", FirebaseAnalyticsUtil.getFirebaseUserId());
+        body.put("cc_device_id", ReportingUtils.getDeviceId());
 
         integrityTokenApiRequestHelper.withIntegrityToken(body,
                 new IntegrityTokenViewModel.IntegrityTokenCallback() {

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -3,11 +3,8 @@ package org.commcare.google.services.analytics;
 import android.os.Bundle;
 import android.os.Environment;
 import android.text.TextUtils;
-import android.util.Log;
 
-import com.google.android.gms.tasks.Task;
 import com.google.firebase.analytics.FirebaseAnalytics;
-import com.google.firebase.installations.FirebaseInstallations;
 
 import org.commcare.CommCareApplication;
 import org.commcare.DiskUtils;
@@ -43,24 +40,6 @@ public class FirebaseAnalyticsUtil {
     // constant to approximate time taken by an user to go to the video playing app after clicking on the video
     private static final long VIDEO_USAGE_ERROR_APPROXIMATION = 3;
     private static final int MAX_USER_PROPERTY_VALUE_LENGTH = 36;
-
-    public static String getFirebaseUserId() {
-        try {
-            FirebaseInstallations.getInstance().getId()
-                    .addOnCompleteListener((result) -> {
-                        Logger.log("TEST", "Success");
-                    })
-                    .addOnCanceledListener(() -> {
-                        Logger.log("TEST", "Canceled");
-                    })
-                    .addOnFailureListener((e) -> {
-                        Logger.log("TEST", "Failed");
-                    });
-            return "";
-        } catch (Exception e) {
-            return "";
-        }
-    }
 
     private static void reportEvent(String eventName) {
         reportEvent(eventName, new Bundle());

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.analytics.FirebaseAnalytics;
+import com.google.firebase.installations.FirebaseInstallations;
 
 import org.commcare.CommCareApplication;
 import org.commcare.DiskUtils;
@@ -44,7 +45,7 @@ public class FirebaseAnalyticsUtil {
 
     public static String getFirebaseUserId() {
         try {
-            Task<String> task = CommCareApplication.instance().getAnalyticsInstance().getAppInstanceId();
+            Task<String> task = FirebaseInstallations.getInstance().getId();
             synchronized(task)
             {
                 task.wait();

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -41,7 +41,7 @@ public class FirebaseAnalyticsUtil {
     private static final long VIDEO_USAGE_ERROR_APPROXIMATION = 3;
     private static final int MAX_USER_PROPERTY_VALUE_LENGTH = 36;
 
-    
+
     private static void reportEvent(String eventName) {
         reportEvent(eventName, new Bundle());
     }

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -41,6 +41,7 @@ public class FirebaseAnalyticsUtil {
     private static final long VIDEO_USAGE_ERROR_APPROXIMATION = 3;
     private static final int MAX_USER_PROPERTY_VALUE_LENGTH = 36;
 
+    
     private static void reportEvent(String eventName) {
         reportEvent(eventName, new Bundle());
     }

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -3,6 +3,7 @@ package org.commcare.google.services.analytics;
 import android.os.Bundle;
 import android.os.Environment;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.analytics.FirebaseAnalytics;
@@ -45,12 +46,17 @@ public class FirebaseAnalyticsUtil {
 
     public static String getFirebaseUserId() {
         try {
-            Task<String> task = FirebaseInstallations.getInstance().getId();
-            synchronized(task)
-            {
-                task.wait();
-            }
-            return task.getResult();
+            FirebaseInstallations.getInstance().getId()
+                    .addOnCompleteListener((result) -> {
+                        Logger.log("TEST", "Success");
+                    })
+                    .addOnCanceledListener(() -> {
+                        Logger.log("TEST", "Canceled");
+                    })
+                    .addOnFailureListener((e) -> {
+                        Logger.log("TEST", "Failed");
+                    });
+            return "";
         } catch (Exception e) {
             return "";
         }

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.text.TextUtils;
 
+import com.google.android.gms.tasks.Task;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.commcare.CommCareApplication;
@@ -41,6 +42,18 @@ public class FirebaseAnalyticsUtil {
     private static final long VIDEO_USAGE_ERROR_APPROXIMATION = 3;
     private static final int MAX_USER_PROPERTY_VALUE_LENGTH = 36;
 
+    public static String getFirebaseUserId() {
+        try {
+            Task<String> task = CommCareApplication.instance().getAnalyticsInstance().getAppInstanceId();
+            synchronized(task)
+            {
+                task.wait();
+            }
+            return task.getResult();
+        } catch (Exception e) {
+            return "";
+        }
+    }
 
     private static void reportEvent(String eventName) {
         reportEvent(eventName, new Bundle());


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-1464

## Product Description
No user visible change

## Technical Summary
Added a method to retrieve the Firebase "user pseudo ID" when available (else empty string).
Calling the method in the PersonalID phone fragment and attaching result to start_configuration call.

## Feature Flag
PersonalID
