### PR TITLE
 fix encryption sync error

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -117,7 +117,7 @@ public class LoginActivity extends CommCareActivity<LoginActivity>
     private LoginActivityUIController uiController;
     private FormAndDataSyncer formAndDataSyncer;
     private int selectedAppIndex = -1;
-    private boolean appLaunchedFromConnect;
+    private boolean appLaunchedFromConnect = false;
     private String presetAppId;
     public static final String PERSONALID_MANAGED_LOGIN = "personalid-managed-login";
     public static final String CONNECT_MANAGED_LOGIN = "connect-managed-login";

--- a/app/src/org/commcare/connect/ConnectAppUtils.kt
+++ b/app/src/org/commcare/connect/ConnectAppUtils.kt
@@ -21,7 +21,7 @@ object ConnectAppUtils {
     fun wasAppLaunchedFromConnect(appId: String?): Boolean {
         val primed = primedAppIdForAutoLogin
         primedAppIdForAutoLogin = null
-        return primed == appId
+        return primed != null && primed == appId
     }
 
     fun isAppInstalled(appId: String): Boolean {


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/QA-7905
Fix encryption error when clicking on login with personal id

## Technical Summary
This issue was the login was checking that it was ConnectBasedLogin not the PersonalIdmanged login because appId and primedId both was null and it should not be the case if primedId is null it should be the PersonalId managed login  and earlier this check was there it was removed in refactoring

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
