### PR TITLE
Translation changed for start registration string

### DIFF
--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -187,7 +187,7 @@
     <string name="busy_message">Todavía estamos procesando tu solicitud anterior. Inténtalo de nuevo más tarde.</string>
     <string name="connect_button_logged_in">Ir al menú Conectar</string>
     <string name="personalid_generic_error">Ocurrió un problema con la base de datos, recupera tu cuenta.</string>
-    <string name="connect_registration_title">Registro de PersonalId</string>
+    <string name="connect_registration_title">Comience a usar PersonalID</string>
     <string name="connect_consent_message_1">He leído y acepto la <a href="https://www.dimagi.com/terms/latest/privacy/">Política de Privacidad</a>, los <a href="https://www.dimagi.com/terms/latest/tos/">Términos de Servicio</a>, el <a href="https://www.dimagi.com/terms/latest/ba/">Acuerdo Comercial</a> y la <a href="https://www.dimagi.com/terms/latest/aup/">Política de Uso Aceptable</a> de Dimagi.</string>
     <string name="connect_phone_country_code_default">+1</string>
     <string name="connect_phone_number_hint">0000000000</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -249,7 +249,7 @@ License.
     <string name="busy_message">Nous sommes encore en train de traiter votre demande précédente. Veuillez réessayer plus tard.</string>
     <string name="connect_button_logged_in">Accéder au menu Connecter</string>
     <string name="personalid_generic_error">Un problème est survenu avec la base de données, veuillez récupérer votre compte.</string>
-    <string name="connect_registration_title">Inscription PersonalId</string>
+    <string name="connect_registration_title">Démarrer avec PersonalID</string>
     <string name="connect_consent_message_1">J\'ai lu et j\'accepte la <a href="https://www.dimagi.com/terms/latest/privacy/">politique de confidentialité</a>, les <a href="https://www.dimagi.com/terms/latest/tos/">conditions de service</a>, l\'<a href="https://www.dimagi.com/terms/latest/ba/">accord commercial</a> et la <a href="https://www.dimagi.com/terms/latest/aup/">politique d\'utilisation acceptable</a> de Dimagi.</string>
     <string name="connect_phone_country_code_default">+1</string>
     <string name="connect_phone_number_hint">0000000000</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -249,7 +249,7 @@ License.
     <string name="busy_message">हम अभी भी आपके पिछले अनुरोध को संसाधित कर रहे हैं। कृपया बाद में पुनः प्रयास करें।</string>
     <string name="connect_button_logged_in">कनेक्ट मेनू पर जाएं</string>
     <string name="personalid_generic_error">डेटाबेस के साथ कोई समस्या हुई है, कृपया अपना खाता पुनर्प्राप्त करें।</string>
-    <string name="connect_registration_title">PersonalId पंजीकरण</string>
+    <string name="connect_registration_title">पर्सनलआईडी के साथ शुरुआत करें</string>
     <string name="connect_consent_message_1">मैंने डिमागी की <a href="https://www.dimagi.com/terms/latest/privacy/">गोपनीयता नीति</a>, <a href="https://www.dimagi.com/terms/latest/tos/">सेवा की शर्तें</a>, <a href="https://www.dimagi.com/terms/latest/ba/">व्यावसायिक समझौता</a> और <a href="https://www.dimagi.com/terms/latest/aup/">स्वीकार्य उपयोग नीति</a> पढ़ ली है और मैं उनसे सहमत हूं।</string>
     <string name="connect_phone_country_code_default">+91</string>
     <string name="connect_phone_number_hint">0000000000</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -251,7 +251,7 @@
     <string name="busy_message">Ainda estamos ocupados processando sua solicitação anterior. Por favor, tente novamente em alguns momentos.</string>
     <string name="connect_button_logged_in">Vá para o Conectar menu</string>
     <string name="personalid_generic_error">Ocorreu um problema. Configure sua conta PersonalID novamente.</string>
-    <string name="connect_registration_title">Inscrição no Connect ID</string>
+    <string name="connect_registration_title">Comece a usar o PersonalID</string>
     <string name="connect_consent_message_1">Li e concordo com a <a href="https://www.dimagi.com/terms/latest/privacy/">Política de Privacidade</a>, os <a href="https://www.dimagi.com/terms/latest/tos/">Termos de Serviço</a>, o <a href="https://www.dimagi.com/terms/latest/ba/">Contrato Comercial</a> e a <a href="https://www.dimagi.com/terms/latest/aup/">Política de Uso Aceitável</a> da Dimagi.</string>
     <string name="connect_phone_country_code_default">+1</string>
     <string name="connect_phone_number_hint">0000000000</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -250,7 +250,7 @@
     <string name="busy_message">Bado tunashughulika kuchakata ombi lako la awali. Tafadhali jaribu tena baada ya muda fulani.</string>
     <string name="connect_button_logged_in">Nenda kwenye menyu ya Unganisha</string>
     <string name="personalid_generic_error">Tatizo limetokea, tafadhali sanidi akaunti yako ya Kitambulisho cha Kibinafsi tena.</string>
-    <string name="connect_registration_title">Usajili wa PersonalId</string>
+    <string name="connect_registration_title">Anza na PersonalID</string>
     <string name="connect_consent_message_1">Nimesoma na kukubaliana na <a href="https://www.dimagi.com/terms/latest/privacy/">Sera ya Faragha</a> ya Dimagi, <a href="https://www.dimagi.com/terms/latest/tos/">Sheria na Masharti</a>, <a href="https://www.dimagi.com/terms/latest/ba/">Makubaliano ya Biashara</a> na <a href="https://www.dimagi.com/terms/latest/aup/">Sera ya Matumizi Yanayokubalika</a>.</string>
     <string name="connect_phone_country_code_default">+1</string>
     <string name="connect_phone_number_hint">0000000000</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -239,7 +239,7 @@
     <string name="busy_message">ሕጂ ውን ቅድሚ ሕጂ ዝገበርካዮ ሕቶ ኣብ ምስራሕ ተጸሚድና ኣለና። በጃኻ ድሕሪ ውሱን ግዜ ደጊምካ ፈትን።</string>
     <string name="connect_button_logged_in">ናብ Connect መማረፂ ኪድ</string>
     <string name="personalid_generic_error">ጸገም ኣጋጢሙ፡ በጃኻ PersonalID ኣካውንትካ እንደገና ኣወሃህቦ።</string>
-    <string name="connect_registration_title">PersonalId ምዝገባ</string>
+    <string name="connect_registration_title">ብ PersonalID ጀምር</string>
     <string name="connect_consent_message_1">ኣነ <a href="https://www.dimagi.com/terms/latest/privacy/">ፖሊሲ ውልቃዊ ሓበሬታ</a>፡ <a href="https://www.dimagi.com/terms/latest/tos/">ውዕል ኣገልግሎት</a>፡ <a href="https://www.dimagi.com/terms/latest/ba/">ስምምዕ ንግዲ</a>ን <a href="https://www.dimagi.com/terms/latest/aup/">ፖሊሲ ቅቡል ኣጠቓቕማን</a> Dimagi\'s/ ዲማጊ ኣንቢበን ተሰማሚዐን ኣለኹ።</string>
     <string name="connect_phone_country_code_default">1</string>
     <string name="connect_phone_number_hint">0</string>


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/QA-7924
https://dimagi.atlassian.net/browse/QA-7922

-Corrected translation of get start with personal id  string in other languages

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
