### PR TITLE
Corrected the app crash after downloading the learning/delivery app

### DIFF
--- a/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDownloadingFragment.java
@@ -107,7 +107,6 @@ public class ConnectDownloadingFragment extends ConnectJobFragment implements Re
         setBackButtonAndActionBarState(true);
         View view = getView();
         if (view != null) {
-            Navigation.findNavController(view).popBackStack();
 
             //Launch the learn/deliver app
             ConnectAppRecord appToLaunch = getLearnApp ? job.getLearnAppInfo() : job.getDeliveryAppInfo();


### PR DESCRIPTION


## Technical Summary
https://dimagi.atlassian.net/browse/QA-7932

### QA Plan
App shouldn't crash after downloading learn/delivery app

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
