### PR TITLE
Auto login fix for Connect apps

### DIFF
--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -1,6 +1,7 @@
 package org.commcare.activities;
 
 import static org.commcare.commcaresupportlibrary.CommCareLauncher.SESSION_ENDPOINT_APP_ID;
+import static org.commcare.connect.ConnectAppUtils.IS_LAUNCH_FROM_CONNECT;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -290,10 +291,13 @@ public class DispatchActivity extends AppCompatActivity {
             // AMS 06/09/16: This check is needed due to what we believe is a bug in the Android platform
             Intent i = new Intent(this, LoginActivity.class);
             i.putExtra(LoginActivity.USER_TRIGGERED_LOGOUT, userTriggeredLogout);
+            i.putExtra(IS_LAUNCH_FROM_CONNECT, getLaunchedFromConnect());
+
             String sesssionEndpointAppID = getSessionEndpointAppId();
             if (sesssionEndpointAppID != null) {
                 i.putExtra(LoginActivity.EXTRA_APP_ID, sesssionEndpointAppID);
             }
+
             startActivityForResult(i, LOGIN_USER);
             waitingForActivityResultFromLogin = true;
         } else {
@@ -307,6 +311,10 @@ public class DispatchActivity extends AppCompatActivity {
     @Nullable
     private String getSessionEndpointAppId() {
         return getIntent().getStringExtra(SESSION_ENDPOINT_APP_ID);
+    }
+
+    private boolean getLaunchedFromConnect() {
+        return getIntent().getBooleanExtra(IS_LAUNCH_FROM_CONNECT, false);
     }
 
     private void launchHomeScreen() {

--- a/app/src/org/commcare/connect/ConnectAppUtils.kt
+++ b/app/src/org/commcare/connect/ConnectAppUtils.kt
@@ -16,7 +16,7 @@ import java.security.SecureRandom
 
 object ConnectAppUtils {
     private const val APP_DOWNLOAD_TASK_ID: Int = 4
-    private const val IS_LAUNCH_FROM_CONNECT = "is_launch_from_connect"
+    const val IS_LAUNCH_FROM_CONNECT = "is_launch_from_connect"
 
     @Volatile
     private var isAppDownloading = false


### PR DESCRIPTION
## Product Description
Fixes a recent breaking change to auto-login code

## Technical Summary
We pass a flag back to Dispatch when launching a Connect app indicating that the app was launched from Connect.
Dispatch then launches the LoginActivity, which should auto-login.
But Dispatch wasn't passing the IS_LAUNCH_FROM_CONNECT flag through from one intent to the other.

## Feature Flag
Connect

## Safety Assurance

### Safety story
Tested manually to verify that auto-login works again