### PR TITLE
Pm qa 7928 fix

### DIFF
--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -142,9 +142,10 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment {
         binding.connectPaymentConfirmYesButton.setOnClickListener(v -> {
             if (paymentToConfirm != null) {
                 FirebaseAnalyticsUtil.reportCccPaymentConfirmationInteraction(true);
-                ConnectJobHelper.INSTANCE.updatePaymentConfirmed(getContext(), paymentToConfirm, true, success -> {});
+                ConnectJobHelper.INSTANCE.updatePaymentConfirmed(getContext(), paymentToConfirm, true, success -> {
+                    updatePaymentConfirmationTile(true);
+                });
             }
-            updatePaymentConfirmationTile(true);
         });
     }
 


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/QA-7928
Fixed this, it was updating the tile 2nd time before the api response 

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
