### PR TITLE
Better "unavailable" handling in PersonalID biometric config page

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -594,6 +594,9 @@
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"
             android:value="false" />
+        <meta-data
+            android:name="firebase_performance_collection_enabled"
+            android:value="false" />
 
         <!-- Somehow this receiver is getting triggered in Android 8+ devices and causing
             IllegalStateException while trying to start map downloader service from background.

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           android:versionCode="106"
-          android:versionName="2.58">
+          android:versionName="2.59">
 
     <uses-permission android:name="android.permission.NFC"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,6 @@ dependencies {
     testImplementation 'io.mockk:mockk:1.12.7'
     testImplementation 'org.json:json:20231013'
     testImplementation 'org.mockito:mockito-core:5.5.0'
-    testImplementation 'org.json:json:20140107'
     testImplementation project(path: ':commcare-core', configuration: 'testsAsJar')
 
     androidTestImplementation 'androidx.test:runner:1.4.0'
@@ -107,7 +106,6 @@ dependencies {
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
     implementation 'com.google.firebase:firebase-analytics:20.1.2'
     implementation 'com.google.firebase:firebase-messaging:21.1.0'
-    implementation 'com.google.firebase:firebase-crashlytics:17.2.1'
     implementation 'com.google.firebase:firebase-perf:21.0.1'
     implementation 'com.google.firebase:firebase-crashlytics:18.3.7'
     

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -189,8 +189,8 @@ ext {
                     'HJ+F335hm/lVdaFQzvBmeq64MUMbumheVLDJaSUiAVzqSHDKJWH01ZQRowqBYjwo' +
                     'ycVSQSeO2glc6XZZ+CJudAPXe8iFWLQp3kBBnBmVcBXCOQFO7aLgQMv4nqKZsLW0' +
                     'HaAJkjpnc165Os+aYwIDAQAB'
-    GOOGLE_SERVICES_API_KEY = project.properties['GOOGLE_SERVICES_API_KEY'] ?: ''
-    GOOGLE_CLOUD_PROJECT_NUMBER = project.properties['GOOGLE_CLOUD_PROJECT_NUMBER'] ?: -1L
+    //GOOGLE_SERVICES_API_KEY = project.properties['GOOGLE_SERVICES_API_KEY'] ?: ''
+    GOOGLE_CLOUD_PROJECT_NUMBER = '768065119425L'
     QA_BETA_APP_ID = ''
     STANDALONE_APP_ID = ''
     LTS_APP_ID = ''
@@ -198,7 +198,10 @@ ext {
     HQ_API_USERNAME = project.properties['HQ_API_USERNAME'] ?: ''
     HQ_API_PASSWORD = project.properties['HQ_API_PASSWORD'] ?: ''
     TEST_BUILD_TYPE = project.properties['TEST_BUILD_TYPE'] ?: 'debug'
-    FIREBASE_DATABASE_URL = project.properties['FIREBASE_DATABASE_URL'] ?: ''
+    //FIREBASE_DATABASE_URL = project.properties['FIREBASE_DATABASE_URL'] ?: ''
+    GOOGLE_SERVICES_API_KEY='AIzaSyBV76f3obt9IgMDfvphWX8ZM91z8d7rK2w'
+    FIREBASE_DATABASE_URL='https://commcare-a57e4.firebaseio.com'
+
 }
 
 afterEvaluate {

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -441,7 +441,8 @@
     <string name="personalid_name_empty_error">El campo Nombre no puede estar vacío</string>
     <string name="personalid_configuration_process_failed_title">Proceso fallido</string>
     <string name="personalid_configuration_process_failed_subtitle">Tu dispositivo no es compatible con PersonalID en este momento. Por favor, inténtalo de nuevo en otro dispositivo.</string>
-    <string name="personalid_configuration_process_failed_security_subtitle">Tu dispositivo no es compatible con PersonalID en este momento debido a la falta de disponibilidad de la función de seguridad. Por favor, inténtalo de nuevo en otro dispositivo.</string>
+    <string name="personalid_configuration_process_pin_unavailable_message">El mecanismo de seguridad del PIN no está disponible; solucione este problema o inténtelo nuevamente con un dispositivo diferente.</string>
+    <string name="personalid_configuration_process_biometric_unavailable_message">El mecanismo de seguridad biométrica no está disponible, solucione este problema o inténtelo nuevamente con un dispositivo diferente.</string>
     <string name="personalid_configuration_process_failed_play_services">Asegúrate de que Play Store esté disponible en tu dispositivo y que esté actualizado.</string>
     <string name="personalid_configuration_process_failed_temporary_unavailable">Error temporal al verificar la elegibilidad de tu dispositivo. Por favor, inténtalo de nuevo después de un día.</string>
     <string name="personalid_configuration_process_failed_network_error">Error de red al verificar la elegibilidad de tu dispositivo. Asegúrate de tener una buena conexión de red e inténtalo de nuevo.</string>

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -187,7 +187,7 @@
     <string name="busy_message">Todavía estamos procesando tu solicitud anterior. Inténtalo de nuevo más tarde.</string>
     <string name="connect_button_logged_in">Ir al menú Conectar</string>
     <string name="personalid_generic_error">Ocurrió un problema con la base de datos, recupera tu cuenta.</string>
-    <string name="connect_registration_title">Registro de PersonalId</string>
+    <string name="connect_registration_title">Comience a usar PersonalID</string>
     <string name="connect_consent_message_1">He leído y acepto la <a href="https://www.dimagi.com/terms/latest/privacy/">Política de Privacidad</a>, los <a href="https://www.dimagi.com/terms/latest/tos/">Términos de Servicio</a>, el <a href="https://www.dimagi.com/terms/latest/ba/">Acuerdo Comercial</a> y la <a href="https://www.dimagi.com/terms/latest/aup/">Política de Uso Aceptable</a> de Dimagi.</string>
     <string name="connect_phone_country_code_default">+1</string>
     <string name="connect_phone_number_hint">0000000000</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -249,7 +249,7 @@ License.
     <string name="busy_message">Nous sommes encore en train de traiter votre demande précédente. Veuillez réessayer plus tard.</string>
     <string name="connect_button_logged_in">Accéder au menu Connecter</string>
     <string name="personalid_generic_error">Un problème est survenu avec la base de données, veuillez récupérer votre compte.</string>
-    <string name="connect_registration_title">Inscription PersonalId</string>
+    <string name="connect_registration_title">Démarrer avec PersonalID</string>
     <string name="connect_consent_message_1">J\'ai lu et j\'accepte la <a href="https://www.dimagi.com/terms/latest/privacy/">politique de confidentialité</a>, les <a href="https://www.dimagi.com/terms/latest/tos/">conditions de service</a>, l\'<a href="https://www.dimagi.com/terms/latest/ba/">accord commercial</a> et la <a href="https://www.dimagi.com/terms/latest/aup/">politique d\'utilisation acceptable</a> de Dimagi.</string>
     <string name="connect_phone_country_code_default">+1</string>
     <string name="connect_phone_number_hint">0000000000</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -442,7 +442,8 @@ License.
     <string name="personalid_configuration_process_failed_title">Échec du processus</string>
     <string name="personalid_configuration_locked_account">Votre compte a été bloqué. Veuillez contacter le support</string>
     <string name="personalid_configuration_process_failed_subtitle">Votre appareil n\'est pas compatible avec PersonalID pour le moment. Veuillez réessayer sur un autre appareil.</string>
-    <string name="personalid_configuration_process_failed_security_subtitle">Votre appareil n\'est pas compatible avec PersonalID pour le moment en raison de l\'indisponibilité de la fonctionnalité de sécurité. Veuillez réessayer sur un autre appareil.</string>
+    <string name="personalid_configuration_process_pin_unavailable_message">Le mécanisme de sécurité PIN n\'est pas disponible, veuillez résoudre ce problème ou réessayer avec un autre appareil.</string>
+    <string name="personalid_configuration_process_biometric_unavailable_message">Le mécanisme de sécurité biométrique n\'est pas disponible, veuillez résoudre ce problème ou réessayer avec un autre appareil.</string>
     <string name="personalid_configuration_process_failed_play_services">Veuillez vous assurer que le Play Store est disponible sur votre appareil et qu\'il est à jour.</string>
     <string name="personalid_configuration_process_failed_temporary_unavailable">Erreur temporaire lors de la vérification de l\'éligibilité de votre appareil. Veuillez réessayer après un jour.</string>
     <string name="personalid_configuration_process_failed_network_error">Erreur réseau lors de la vérification de l\'éligibilité de votre appareil. Veuillez vous assurer que vous disposez d\'une bonne connexion réseau et réessayez.</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -441,7 +441,8 @@ License.
     <string name="personalid_name_empty_error">नाम फ़ील्ड खाली नहीं हो सकता</string>
     <string name="personalid_configuration_process_failed_title">प्रक्रिया विफल</string>
     <string name="personalid_configuration_process_failed_subtitle">आपका डिवाइस अभी PersonalID के साथ संगत नहीं है। कृपया किसी अन्य डिवाइस पर पुनः प्रयास करें।</string>
-    <string name="personalid_configuration_process_failed_security_subtitle">सुरक्षा सुविधा की अनुपलब्धता के कारण आपका डिवाइस अभी PersonalID के साथ संगत नहीं है। कृपया किसी अन्य डिवाइस पर पुनः प्रयास करें।</string>
+    <string name="personalid_configuration_process_pin_unavailable_message">पिन सुरक्षा तंत्र उपलब्ध नहीं है, कृपया इस समस्या को ठीक करें या किसी अन्य डिवाइस के साथ पुनः प्रयास करें।</string>
+    <string name="personalid_configuration_process_biometric_unavailable_message">बायोमेट्रिक सुरक्षा तंत्र उपलब्ध नहीं है, कृपया इस समस्या को ठीक करें या किसी अन्य डिवाइस के साथ पुनः प्रयास करें।</string>
     <string name="personalid_configuration_process_failed_play_services">कृपया सुनिश्चित करें कि Play Store आपके डिवाइस पर उपलब्ध है और यह अद्यतित है।</string>
     <string name="personalid_configuration_process_failed_temporary_unavailable">आपके डिवाइस की पात्रता की जांच करते समय अस्थायी त्रुटि। कृपया एक दिन बाद पुनः प्रयास करें।</string>
     <string name="personalid_configuration_process_failed_network_error">आपके डिवाइस की पात्रता की जांच करते समय नेटवर्क त्रुटि। कृपया सुनिश्चित करें कि आपके पास एक अच्छा नेटवर्क कनेक्शन है और पुनः प्रयास करें।</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -249,7 +249,7 @@ License.
     <string name="busy_message">हम अभी भी आपके पिछले अनुरोध को संसाधित कर रहे हैं। कृपया बाद में पुनः प्रयास करें।</string>
     <string name="connect_button_logged_in">कनेक्ट मेनू पर जाएं</string>
     <string name="personalid_generic_error">डेटाबेस के साथ कोई समस्या हुई है, कृपया अपना खाता पुनर्प्राप्त करें।</string>
-    <string name="connect_registration_title">PersonalId पंजीकरण</string>
+    <string name="connect_registration_title">पर्सनलआईडी के साथ शुरुआत करें</string>
     <string name="connect_consent_message_1">मैंने डिमागी की <a href="https://www.dimagi.com/terms/latest/privacy/">गोपनीयता नीति</a>, <a href="https://www.dimagi.com/terms/latest/tos/">सेवा की शर्तें</a>, <a href="https://www.dimagi.com/terms/latest/ba/">व्यावसायिक समझौता</a> और <a href="https://www.dimagi.com/terms/latest/aup/">स्वीकार्य उपयोग नीति</a> पढ़ ली है और मैं उनसे सहमत हूं।</string>
     <string name="connect_phone_country_code_default">+91</string>
     <string name="connect_phone_number_hint">0000000000</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -251,7 +251,7 @@
     <string name="busy_message">Ainda estamos ocupados processando sua solicitação anterior. Por favor, tente novamente em alguns momentos.</string>
     <string name="connect_button_logged_in">Vá para o Conectar menu</string>
     <string name="personalid_generic_error">Ocorreu um problema. Configure sua conta PersonalID novamente.</string>
-    <string name="connect_registration_title">Inscrição no Connect ID</string>
+    <string name="connect_registration_title">Comece a usar o PersonalID</string>
     <string name="connect_consent_message_1">Li e concordo com a <a href="https://www.dimagi.com/terms/latest/privacy/">Política de Privacidade</a>, os <a href="https://www.dimagi.com/terms/latest/tos/">Termos de Serviço</a>, o <a href="https://www.dimagi.com/terms/latest/ba/">Contrato Comercial</a> e a <a href="https://www.dimagi.com/terms/latest/aup/">Política de Uso Aceitável</a> da Dimagi.</string>
     <string name="connect_phone_country_code_default">+1</string>
     <string name="connect_phone_number_hint">0000000000</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -448,7 +448,8 @@
     <string name="personalid_configuration_process_failed_title">Falha no processo</string>
     <string name="personalid_configuration_locked_account">A sua conta foi bloqueada. Entre em contacto com o suporte</string>
     <string name="personalid_configuration_process_failed_subtitle">De momento, o seu dispositivo não está qualificado para se inscrever no PersonalID. Tente novamente noutro dispositivo.</string>
-    <string name="personalid_configuration_process_failed_security_subtitle">De momento, o seu dispositivo não está qualificado para se inscrever no PersonalID devido à indisponibilidade da funcionalidade de segurança %s. Tente novamente noutro dispositivo.</string>
+    <string name="personalid_configuration_process_pin_unavailable_message">O mecanismo de segurança do PIN não está disponível. Corrija o problema ou tente novamente com um dispositivo diferente.</string>
+    <string name="personalid_configuration_process_biometric_unavailable_message">O mecanismo de segurança biométrica não está disponível. Corrija o problema ou tente novamente com um dispositivo diferente.</string>
     <string name="personalid_configuration_process_failed_play_services">Certifique-se de que a Play Store está disponível no seu dispositivo e está atualizada.</string>
     <string name="personalid_configuration_process_failed_temporary_unavailable">Erro temporário ao verificar a elegibilidade do seu dispositivo. Por favor, tente novamente depois de um dia.</string>
     <string name="personalid_configuration_process_failed_network_error">Erro de rede ao verificar a elegibilidade do seu dispositivo. Por favor, certifique-se de que tem uma boa conexão de rede e tente novamente.</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -448,7 +448,8 @@
     <string name="personalid_configuration_process_failed_title">Mchakato Umeshindwa</string>
     <string name="personalid_configuration_locked_account">Akaunti yako imefungwa. Tafadhali wasiliana na usaidizi</string>
     <string name="personalid_configuration_process_failed_subtitle">Kifaa chako hakijatimiza masharti ya kujisajili kwa Kitambulisho cha Kibinafsi kwa wakati huu. Tafadhali jaribu tena kwenye kifaa tofauti.</string>
-    <string name="personalid_configuration_process_failed_security_subtitle">Kifaa chako hakijatimiza masharti ya kujisajili kwa Kitambulisho cha Kibinafsi kwa wakati huu kwa sababu ya kutopatikana kwa kipengele cha usalama cha %s. Tafadhali jaribu tena kwenye kifaa tofauti.</string>
+    <string name="personalid_configuration_process_pin_unavailable_message">Utaratibu wa usalama wa PIN haupatikani, tafadhali suluhisha suala hili au ujaribu tena ukitumia kifaa tofauti.</string>
+    <string name="personalid_configuration_process_biometric_unavailable_message">Utaratibu wa usalama wa kibayometriki haupatikani, tafadhali suluhisha suala hili au ujaribu tena ukitumia kifaa tofauti.</string>
     <string name="personalid_configuration_process_failed_play_services">Tafadhali hakikisha kuwa Play Store inapatikana kwenye kifaa chako na imesasishwa.</string>
     <string name="personalid_configuration_process_failed_temporary_unavailable">Hitilafu ya muda katika kuthibitisha ustahiki wa kifaa chako. Tafadhali jaribu tena baada ya siku moja.</string>
     <string name="personalid_configuration_process_failed_network_error">Hitilafu ya mtandao katika kuthibitisha ustahiki wa kifaa chako. Tafadhali hakikisha una muunganisho mzuri wa mtandao na jaribu tena.</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -250,7 +250,7 @@
     <string name="busy_message">Bado tunashughulika kuchakata ombi lako la awali. Tafadhali jaribu tena baada ya muda fulani.</string>
     <string name="connect_button_logged_in">Nenda kwenye menyu ya Unganisha</string>
     <string name="personalid_generic_error">Tatizo limetokea, tafadhali sanidi akaunti yako ya Kitambulisho cha Kibinafsi tena.</string>
-    <string name="connect_registration_title">Usajili wa PersonalId</string>
+    <string name="connect_registration_title">Anza na PersonalID</string>
     <string name="connect_consent_message_1">Nimesoma na kukubaliana na <a href="https://www.dimagi.com/terms/latest/privacy/">Sera ya Faragha</a> ya Dimagi, <a href="https://www.dimagi.com/terms/latest/tos/">Sheria na Masharti</a>, <a href="https://www.dimagi.com/terms/latest/ba/">Makubaliano ya Biashara</a> na <a href="https://www.dimagi.com/terms/latest/aup/">Sera ya Matumizi Yanayokubalika</a>.</string>
     <string name="connect_phone_country_code_default">+1</string>
     <string name="connect_phone_number_hint">0000000000</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -434,7 +434,8 @@
     <string name="personalid_configuration_process_failed_title">መስርሕ ፈሺሉ።</string>
     <string name="personalid_configuration_locked_account">ኣካውንትካ ተዓጽዩ ኣሎ። በጃኹም ንደገፍ ተወከሱ</string>
     <string name="personalid_configuration_process_failed_subtitle">መሳርሒኻ ኣብዚ እዋን\'ዚ ን PersonalID ንምምዝጋብ ብቑዕ ኣይኮነን። በጃኹም ኣብ ካልእ መሳርሒ እንደገና ፈትኑ።</string>
-    <string name="personalid_configuration_process_failed_security_subtitle">መሳርሒኻ ኣብዚ እዋን እዚ ብሰንኪ %s ናይ ጸጥታ ባህሪ ዘይምህላዉ ንPersonalID ክምዝገብ ብቑዕ ኣይኮነን። በጃኹም ኣብ ካልእ መሳርሒ እንደገና ፈትኑ።</string>
+    <string name="personalid_configuration_process_pin_unavailable_message">እቲ ናይ ፒን ድሕነት መካኒዝም የለን፣ በጃኻ ነዚ ጸገም ኣዐርዮ ወይ ብኻልእ መሳርሒ እንደገና ፈትን።</string>
+    <string name="personalid_configuration_process_biometric_unavailable_message">እቲ ናይ ባዮሜትሪክ ድሕነት መካኒዝም የለን፣ በጃኻ ነዚ ጉዳይ ኣዐርዮ ወይ ብኻልእ መሳርሒ እንደገና ፈትን።</string>
     <string name="personalid_configuration_process_failed_play_services">እባኮም ኣረጋግጹ ፡ እቲ ፕሌይ ስቶር ኣብ መሳርሒ እትርከቡ እንተሎ እና ትሓዘ እንተኾነ።</string>
     <string name="personalid_configuration_process_failed_temporary_unavailable">ሓፋሽ ጸገብ ኣብ ምርግጋን ብትኽክል መሳርሒ እንተሃለወ። እባኮም ኣብ ሓደ መዓልቲ ደጊሞ ፈትኑ።</string>
     <string name="personalid_configuration_process_failed_network_error">ጸገኒ መረብ ኣብ ምርግጋን ብትኽክል መሳርሒ እንተሃለወ። እባኮም ዝሓለፈ መርበብ ክርከቡ እንተኾነ ኣረጋግጹ እና ደጊሞ ፈትኑ።</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -239,7 +239,7 @@
     <string name="busy_message">ሕጂ ውን ቅድሚ ሕጂ ዝገበርካዮ ሕቶ ኣብ ምስራሕ ተጸሚድና ኣለና። በጃኻ ድሕሪ ውሱን ግዜ ደጊምካ ፈትን።</string>
     <string name="connect_button_logged_in">ናብ Connect መማረፂ ኪድ</string>
     <string name="personalid_generic_error">ጸገም ኣጋጢሙ፡ በጃኻ PersonalID ኣካውንትካ እንደገና ኣወሃህቦ።</string>
-    <string name="connect_registration_title">PersonalId ምዝገባ</string>
+    <string name="connect_registration_title">ብ PersonalID ጀምር</string>
     <string name="connect_consent_message_1">ኣነ <a href="https://www.dimagi.com/terms/latest/privacy/">ፖሊሲ ውልቃዊ ሓበሬታ</a>፡ <a href="https://www.dimagi.com/terms/latest/tos/">ውዕል ኣገልግሎት</a>፡ <a href="https://www.dimagi.com/terms/latest/ba/">ስምምዕ ንግዲ</a>ን <a href="https://www.dimagi.com/terms/latest/aup/">ፖሊሲ ቅቡል ኣጠቓቕማን</a> Dimagi\'s/ ዲማጊ ኣንቢበን ተሰማሚዐን ኣለኹ።</string>
     <string name="connect_phone_country_code_default">1</string>
     <string name="connect_phone_number_hint">0</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -604,7 +604,8 @@
     <string name="personalid_configuration_process_failed_temporary_unavailable">Temporary error in establishing your device eligibility. Please try again after a day.</string>
     <string name="personalid_configuration_process_failed_network_error">Network error in establishing your device eligibility. Please make sure you have a good network connection and try again.</string>
     <string name="personalid_configuration_process_failed_unexpected_error">Unable to establish device eligibility due to an unexpected error. Please contact customer support if the problem persists</string>
-    <string name="personalid_configuration_process_failed_security_subtitle">Your device isn\'t eligible to sign up for PersonalID at this time due to non availability of %s security feature. Please try again on a different device.</string>
+    <string name="personalid_configuration_process_pin_unavailable_message">The PIN security mechanism is unavailable, please fix this issue or try again with a different device.</string>
+    <string name="personalid_configuration_process_biometric_unavailable_message">The biometric security mechanism is unavailable, please fix this issue or try again with a different device.</string>
     <string name="personalid_photo_capture_title">Welcome %1$s</string>
     <string name="personalid_photo_capture_subtitle">Please take a photo of yourself to complete your account setup</string>
     <string name="personalid_photo_capture_take_photo_button">Take Photo</string>

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -36,6 +36,7 @@ import androidx.work.WorkManager;
 
 import com.google.common.collect.Multimap;
 import com.google.firebase.analytics.FirebaseAnalytics;
+import com.google.firebase.perf.FirebasePerformance;
 
 import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteException;
@@ -218,6 +219,9 @@ public class CommCareApplication extends Application implements LifecycleEventOb
         CommCareApplication.app = this;
         CrashUtil.init();
         DataChangeLogger.init(this);
+        if (!BuildConfig.DEBUG) {
+            FirebasePerformance.getInstance().setPerformanceCollectionEnabled(true);
+        }
 
         logFirstCommCareRun();
         CommCarePreferenceManagerFactory.init(new AndroidPreferenceManager());

--- a/app/src/org/commcare/activities/connect/PersonalIdActivity.java
+++ b/app/src/org/commcare/activities/connect/PersonalIdActivity.java
@@ -27,7 +27,7 @@ public class PersonalIdActivity extends NavigationHostCommCareActivity<PersonalI
         if (requestCode == ConnectConstants.PERSONALID_UNLOCK_PIN
                 || requestCode == ConnectConstants.CONFIGURE_BIOMETRIC_REQUEST_CODE) {
             //PIN unlock should only be requested while BiometricConfig fragment is active, else this will crash
-            getCurrentFragment().handleFinishedPinActivity(requestCode, resultCode, data);
+            getCurrentFragment().handleFinishedPinActivity(requestCode, resultCode);
         }
     }
 

--- a/app/src/org/commcare/fragments/personalId/PersonalIdMessageFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdMessageFragment.java
@@ -136,7 +136,6 @@ public class PersonalIdMessageFragment extends BottomSheetDialogFragment {
                 }
 
                 break;
-            case ConnectConstants.PERSONALID_DEVICE_CONFIGURATION_FAILED:
             case ConnectConstants.PERSONALID_RECOVERY_ACCOUNT_LOCKED:
                 activity.finish();
                 break;

--- a/app/src/org/commcare/utils/BiometricsHelper.java
+++ b/app/src/org/commcare/utils/BiometricsHelper.java
@@ -217,41 +217,27 @@ public class BiometricsHelper {
 
     //// start: min security requirements
 
-    public static String getMinHardwareErrorForSecurityIfAny(BiometricManager biometricManager, Activity activity, String requiredLock) {
-
+    public static void checkForValidSecurityType(String requiredLock) {
         if (TextUtils.isEmpty(requiredLock)) {
-            crashWithInvalidSecurityTypeException(activity, requiredLock);
+            crashWithInvalidSecurityTypeException(requiredLock);
         }
 
-        BiometricsHelper.ConfigurationStatus fingerprintStatus = BiometricsHelper.checkFingerprintStatus(
-                activity, biometricManager);
-        BiometricsHelper.ConfigurationStatus pinStatus = BiometricsHelper.checkPinStatus(activity,
-                biometricManager);
-
-        return switch (requiredLock) {
-            case PIN ->
-                    getMinPinHardwareErrorForSecurityIfAny(activity, fingerprintStatus, pinStatus);
-            case BIOMETRIC_TYPE ->
-                    getMinBioMetricHardwareErrorForSecurityIfAny(activity, fingerprintStatus);
-            default -> {
-                crashWithInvalidSecurityTypeException(activity, requiredLock);
-                yield null;
-            }
-        };
+        if (!requiredLock.equals(PIN) && !requiredLock.equals(BIOMETRIC_TYPE)) {
+            crashWithInvalidSecurityTypeException(requiredLock);
+        }
     }
 
-    private static void crashWithInvalidSecurityTypeException(Activity activity, String requiredLock) {
+    private static void crashWithInvalidSecurityTypeException(String requiredLock) {
         throw new IllegalStateException("Invalid device security requirements from server: " + requiredLock);
     }
 
-    private static String getMinPinHardwareErrorForSecurityIfAny(Activity activity, BiometricsHelper.ConfigurationStatus fingerprintStatus, BiometricsHelper.ConfigurationStatus pinStatus) {
-        return (fingerprintStatus != BiometricsHelper.ConfigurationStatus.NotAvailable ||
-                pinStatus != BiometricsHelper.ConfigurationStatus.NotAvailable) ? null : activity.getString(R.string.personalid_configuration_process_failed_security_subtitle, PIN);
+    public static String getPinHardwareUnavailableError(Activity activity) {
+        return activity.getString(R.string.personalid_configuration_process_pin_unavailable_message);
     }
 
-    private static String getMinBioMetricHardwareErrorForSecurityIfAny(Activity activity, BiometricsHelper.ConfigurationStatus fingerprintStatus) {
-        return fingerprintStatus != BiometricsHelper.ConfigurationStatus.NotAvailable ? null : activity.getString(R.string.personalid_configuration_process_failed_security_subtitle, BIOMETRIC_TYPE);
+    public static String getBiometricHardwareUnavailableError(Activity activity) {
+        return activity.getString(R.string.personalid_configuration_process_biometric_unavailable_message);
     }
 
-    //// end: min secruity requirements
+    //// end: min security requirements
 }


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CI-178

## Product Description
When there is an issue with the user's biometric or PIN hardware being unavailable to the app, the user will see the error message when they click the button corresponding to each option, rather than when the page loads.

## Technical Summary
Changed biometric config page not to report "unavailable" errors until relevant PIN/biometric button is pressed.
Split the two error messages apart for better localization.
Cleaned up a couple code warnings in biometric config page along the way.

## Feature Flag
PersonalID

## Safety Assurance

### Safety story
Tested locally, although I don't have a device that fails the hardware check so could only test greenlight path.

### Automated test coverage
None

### QA Plan
Would be great to test recovery as a Connect user with a device that gives the "fingerprint unavailable" error to make sure the user can successfully proceed with the PIN option, but that may not be possible since this error is not easily reproducible.
