### PR TITLE
Connect Login fix

### DIFF
--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -314,7 +314,11 @@ public class DispatchActivity extends AppCompatActivity {
     }
 
     private boolean getLaunchedFromConnect() {
-        return getIntent().getBooleanExtra(IS_LAUNCH_FROM_CONNECT, false);
+        boolean launchedFromConnect = getIntent().getBooleanExtra(IS_LAUNCH_FROM_CONNECT, false);
+        if(launchedFromConnect) {
+            getIntent().removeExtra(IS_LAUNCH_FROM_CONNECT);
+        }
+        return launchedFromConnect;
     }
 
     private void launchHomeScreen() {

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -315,9 +315,7 @@ public class DispatchActivity extends AppCompatActivity {
 
     private boolean getLaunchedFromConnect() {
         boolean launchedFromConnect = getIntent().getBooleanExtra(IS_LAUNCH_FROM_CONNECT, false);
-        if(launchedFromConnect) {
-            getIntent().removeExtra(IS_LAUNCH_FROM_CONNECT);
-        }
+        getIntent().removeExtra(IS_LAUNCH_FROM_CONNECT);
         return launchedFromConnect;
     }
 


### PR DESCRIPTION
## Product Description
Fixes a bug where once the user logs in to an app from the Connect menu and log out, they won't be prompted to unlock when trying to login to any app from the login page.

## Technical Summary
Consuming the intent that gets passed to DispatchActivity when launching an app from Connect.
We only want that flag to apply once, the next time Dispatch launches the LoginActivity.
On subsequent launches of LoginActivity after that, we don't want to indicate that it was launched from Connect.

## Feature Flag
Connect

## Safety Assurance

### Safety story
Discovered this during local testing and tested the fix once applied.
This was introduced in a recent phase 4 PR and is not part of the latest released beta.

### Automated test coverage
None

### QA Plan
Test to run: Login to an app from the Connect menu, then logout. On the Login page, try to login into any installed app (both managed by PersonalID and not managed by PersonalID).
Managed by PersonalID: User should be required to unlock again before logging into the app
Not managed by PersonalID: Traditional login logic should apply (require user-entered password and use it to login)