### PR TITLE
Nav Drawer Enhacements

### DIFF
--- a/app/res/layout/nav_drawer_footer.xml
+++ b/app/res/layout/nav_drawer_footer.xml
@@ -68,6 +68,13 @@
             android:textAppearance="@style/TextAppearance.NavDrawerItem"
             android:layout_marginStart="8dp"/>
     </LinearLayout>
+    <TextView
+        android:id="@+id/app_version"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.NavDrawerItem"
+        android:layout_marginTop="8dp"
+        android:layout_marginStart="16dp"/>
 
 </LinearLayout>
 </layout>

--- a/app/res/layout/nav_drawer_footer.xml
+++ b/app/res/layout/nav_drawer_footer.xml
@@ -72,7 +72,8 @@
         android:id="@+id/app_version"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.NavDrawerItem"
+        android:textAppearance="@style/TextAppearance.NavDrawerItem.SubTitle"
+        android:enabled="false"
         android:layout_marginTop="8dp"
         android:layout_marginStart="16dp"/>
 

--- a/app/res/layout/nav_drawer_header.xml
+++ b/app/res/layout/nav_drawer_header.xml
@@ -7,30 +7,13 @@
     android:layout_height="wrap_content"
     android:padding="16dp"
     android:background="@color/cc_brand_color">
-
-    <LinearLayout
+    <ImageView
+        android:contentDescription="@null"
+        android:layout_gravity="center"
+        android:layout_height="32dp"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="start"
-        android:layout_gravity="start"
-        android:orientation="horizontal">
-        <ImageButton
-            android:id="@+id/close_button"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:tint="@color/white"
-            android:src="@drawable/ic_connect_close"
-            android:contentDescription="@null"/>
-        <ImageView
-            android:layout_width="130dp"
-            android:layout_height="32dp"
-            android:layout_gravity="center"
-            android:layout_marginStart="16dp"
-            android:src="@drawable/commcare_by_dimagi"
-            app:tint="@color/white"
-            android:contentDescription="@null"/>
-    </LinearLayout>
+        android:src="@drawable/commcare_by_dimagi"
+        app:tint="@color/white" />
     <androidx.cardview.widget.CardView
         android:id="@+id/profile_card"
         android:layout_width="match_parent"

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -367,7 +367,7 @@
 
     <style name="TextAppearance.NavDrawerItem.SubTitle" parent="@android:style/TextAppearance">
         <item name="android:textSize">12sp</item>
-        <item name="android:textColor">@color/white</item>
+        <item name="android:textColor">@color/nav_drawer_text</item>
     </style>
 
 </resources>

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -8,12 +8,13 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.util.Log;
+import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.FrameLayout;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -42,6 +43,7 @@ import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.interfaces.RuntimePermissionRequester;
 import org.commcare.logging.DataChangeLog;
 import org.commcare.logging.DataChangeLogger;
+import org.commcare.navdrawer.BaseDrawerActivity;
 import org.commcare.preferences.GlobalPrivilegesManager;
 import org.commcare.resources.ResourceManager;
 import org.commcare.resources.model.InvalidResourceException;
@@ -82,7 +84,7 @@ import java.util.Map;
  * @author ctsims
  */
 @ManagedUi(R.layout.first_start_screen_modern)
-public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivity>
+public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActivity>
         implements ResourceEngineListener, SetupEnterURLFragment.URLInstaller,
         InstallConfirmFragment.StartStopInstallCommands, RetrieveParseVerifyMessageListener,
         RuntimePermissionRequester {
@@ -134,6 +136,7 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
 
     // dialog ID
     private static final int DIALOG_INSTALL_PROGRESS = 4;
+    private static final int DRAWER_MENU = android.R.id.home;
 
     private boolean startAllowed = true;
     private String incomingRef;
@@ -274,12 +277,6 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
     @Override
     public void onAttachFragment(Fragment fragment) {
         super.onAttachFragment(fragment);
-
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            // removes the back button from the action bar
-            actionBar.setDisplayHomeAsUpEnabled(false);
-        }
     }
 
     public boolean shouldShowNotificationErrorButton() {
@@ -647,6 +644,10 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
                 PersonalIdManager.getInstance().forgetUser(AnalyticsParamValue.PERSONAL_ID_FORGOT_USER_SETUP_PAGE);
                 updateConnectButton();
                 break;
+            case DRAWER_MENU:
+                super.onOptionsItemSelected(item);
+                break;
+
         }
         return true;
     }
@@ -816,6 +817,11 @@ public class CommCareSetupActivity extends CommCareActivity<CommCareSetupActivit
         } else {
             return generateNormalInstallDialog(taskId);
         }
+    }
+
+    @Override
+    public void injectScreenLayout(@NonNull LayoutInflater inflater, @NonNull FrameLayout contentFrame) {
+        inflater.inflate(R.layout.first_start_screen_modern, contentFrame, true);
     }
 
     private CustomProgressDialog generateNormalInstallDialog(int taskId) {

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -136,7 +136,6 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
 
     // dialog ID
     private static final int DIALOG_INSTALL_PROGRESS = 4;
-    private static final int DRAWER_MENU = android.R.id.home;
 
     private boolean startAllowed = true;
     private String incomingRef;
@@ -644,10 +643,8 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
                 PersonalIdManager.getInstance().forgetUser(AnalyticsParamValue.PERSONAL_ID_FORGOT_USER_SETUP_PAGE);
                 updateConnectButton();
                 break;
-            case DRAWER_MENU:
+            default:
                 super.onOptionsItemSelected(item);
-                break;
-
         }
         return true;
     }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -580,7 +580,6 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
     public boolean onOptionsItemSelected(MenuItem item) {
         FirebaseAnalyticsUtil.reportOptionsMenuItemClick(this.getClass(),
                 menuIdToAnalyticsParam.get(item.getItemId()));
-        boolean otherResult = super.onOptionsItemSelected(item);
         switch (item.getItemId()) {
             case MENU_PRACTICE_MODE:
                 loginDemoUser();
@@ -609,7 +608,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
                 uiController.refreshView();
                 return true;
             default:
-                return otherResult;
+                 return super.onOptionsItemSelected(item);
         }
     }
 

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -24,7 +24,7 @@ import android.widget.FrameLayout;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.ActionBar;
+import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.core.util.Pair;
 import androidx.preference.PreferenceManager;
@@ -1004,4 +1004,23 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
     public void injectScreenLayout(@NonNull LayoutInflater inflater, @NonNull FrameLayout contentFrame) {
         inflater.inflate(R.layout.screen_login, contentFrame, true);
     }
+    @Override
+    protected void onDrawerItemClicked(@NonNull NavItemType navItemType, @Nullable String recordId) {
+        super.onDrawerItemClicked(navItemType, recordId); // optional: keeps analytics tracking
+        switch (navItemType) {
+            case OPPORTUNITIES:
+                break;
+            case COMMCARE_APPS:
+                if (recordId != null) {
+                    if (!appIdDropdownList.isEmpty()) {
+                        selectedAppIndex = appIdDropdownList.indexOf(recordId);
+                    }
+                    seatAppIfNeeded(recordId);
+                }
+                break;
+            case MESSAGING:
+                break;
+        }
+    }
+
 }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -581,6 +581,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         FirebaseAnalyticsUtil.reportOptionsMenuItemClick(this.getClass(),
                 menuIdToAnalyticsParam.get(item.getItemId()));
         boolean otherResult = super.onOptionsItemSelected(item);
+        final int DRAWER_MENU = android.R.id.home;
         switch (item.getItemId()) {
             case MENU_PRACTICE_MODE:
                 loginDemoUser();
@@ -607,6 +608,9 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
                 uiController.setPasswordOrPin("");
                 setConnectAppState(Unmanaged);
                 uiController.refreshView();
+                return true;
+            case DRAWER_MENU:
+                super.onOptionsItemSelected(item);
                 return true;
             default:
                 return otherResult;

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -581,7 +581,6 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         FirebaseAnalyticsUtil.reportOptionsMenuItemClick(this.getClass(),
                 menuIdToAnalyticsParam.get(item.getItemId()));
         boolean otherResult = super.onOptionsItemSelected(item);
-        final int DRAWER_MENU = android.R.id.home;
         switch (item.getItemId()) {
             case MENU_PRACTICE_MODE:
                 loginDemoUser();
@@ -608,9 +607,6 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
                 uiController.setPasswordOrPin("");
                 setConnectAppState(Unmanaged);
                 uiController.refreshView();
-                return true;
-            case DRAWER_MENU:
-                super.onOptionsItemSelected(item);
                 return true;
             default:
                 return otherResult;

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -12,7 +12,6 @@ import androidx.core.view.GravityCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
-import org.commcare.AppUtils
 import org.commcare.activities.CommCareActivity
 import org.commcare.activities.LoginActivity
 import org.commcare.android.database.global.models.ApplicationRecord
@@ -109,7 +108,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
             }
             override fun onDrawerSlide(drawerView: View, slideOffset: Float) {
                 super.onDrawerSlide(drawerView, slideOffset)
-                supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_connect_close)
+                supportActionBar!!.setHomeAsUpIndicator(R.drawable.ic_connect_close)
                 // Refresh once just as the drawer starts sliding open
                 if (slideOffset > 0 && !hasRefreshed) {
                     setupDrawer()
@@ -165,7 +164,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
                 .placeholder(R.drawable.nav_drawer_person_avatar) // Your default placeholder image
                 .error(R.drawable.nav_drawer_person_avatar)
         ).into(headerBinding.imageUserProfile)
-        val commacreChildItems = loadVisibleCommcareApplications().map {
+        val commacreApps = loadVisibleCommcareApplications().map {
             NavDrawerItem.ChildItem(it.displayName, it.uniqueId, NavItemType.COMMCARE_APPS)
         }
 
@@ -180,8 +179,8 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
                 R.drawable.commcare_actionbar_logo,
                 NavItemType.COMMCARE_APPS,
                 isEnabled = this is LoginActivity,
-                isExpanded = commacreChildItems.size<2,
-                commacreChildItems
+                isExpanded = commacreApps.size<2,
+                commacreApps
             ),
             NavDrawerItem.ParentItem(
                 getString(R.string.nav_drawer_work_history),

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -176,7 +176,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
                 R.drawable.commcare_actionbar_logo,
                 NavItemType.COMMCARE_APPS,
                 isEnabled = true,
-                isExpanded = false,
+                isExpanded = commacreChildItems.size<2,
                 commacreChildItems
             ),
             NavDrawerItem.ParentItem(

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -109,7 +109,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
             }
             override fun onDrawerSlide(drawerView: View, slideOffset: Float) {
                 super.onDrawerSlide(drawerView, slideOffset)
-
+                supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_connect_close)
                 // Refresh once just as the drawer starts sliding open
                 if (slideOffset > 0 && !hasRefreshed) {
                     setupDrawer()
@@ -120,6 +120,9 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
                 if (slideOffset == 0f) {
                     hasRefreshed = false
                 }
+            }
+            override fun onDrawerClosed(drawerView: View) {
+                supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_menu_bar) // Your custom icon
             }
         }
         baseDrawerBinding.drawerLayout.addDrawerListener(drawerToggle)
@@ -210,7 +213,6 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
             closeDrawer()
         }
         footerBinding.aboutView.setOnClickListener { showAboutCommCareDialog() }
-        headerBinding.closeButton.setOnClickListener { closeDrawer() }
         footerBinding.helpView.setOnClickListener { /* Future Help Action */ }
     }
 

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -12,11 +12,13 @@ import androidx.core.view.GravityCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
+import org.commcare.AppUtils
 import org.commcare.activities.CommCareActivity
 import org.commcare.android.database.global.models.ApplicationRecord
 import org.commcare.connect.ConnectConstants
 import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectUserDatabaseUtil
+import org.commcare.dalvik.BuildConfig
 import org.commcare.dalvik.R
 import org.commcare.dalvik.databinding.NavDrawerBaseBinding
 import org.commcare.dalvik.databinding.NavDrawerFooterBinding
@@ -87,6 +89,8 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
         val content = SpannableString(getString(R.string.nav_drawer_signin_register))
         content.setSpan(UnderlineSpan(), 0, content.length, 0);
         baseDrawerBinding.navDrawerSignInText.text = content
+        baseDrawerBinding.navDrawerFooter.appVersion.text = "v ${BuildConfig.VERSION_NAME}"
+
     }
 
     private fun setupActionBarDrawerToggle() {

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -14,6 +14,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import org.commcare.AppUtils
 import org.commcare.activities.CommCareActivity
+import org.commcare.activities.LoginActivity
 import org.commcare.android.database.global.models.ApplicationRecord
 import org.commcare.connect.ConnectConstants
 import org.commcare.connect.PersonalIdManager
@@ -175,7 +176,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
                 getString(R.string.nav_drawer_commcare_apps),
                 R.drawable.commcare_actionbar_logo,
                 NavItemType.COMMCARE_APPS,
-                isEnabled = true,
+                isEnabled = this is LoginActivity,
                 isExpanded = commacreChildItems.size<2,
                 commacreChildItems
             ),

--- a/app/src/org/commcare/navdrawer/NavDrawerAdapter.kt
+++ b/app/src/org/commcare/navdrawer/NavDrawerAdapter.kt
@@ -79,8 +79,8 @@ class NavDrawerAdapter(
             if (item.children.isNotEmpty()) {
                 arrow.visibility = View.VISIBLE
                 arrow.setImageResource(
-                    if (item.isExpanded) R.drawable.ic_blue_forward
-                    else R.drawable.nav_drawer_arrow_down
+                    if (item.isExpanded) R.drawable.nav_drawer_arrow_down
+                    else R.drawable.ic_blue_forward
                 )
             } else {
                 arrow.visibility = View.GONE


### PR DESCRIPTION
## Product Description
Extending the nav_drawer to CommCareSetupActivity
figma :- https://www.figma.com/design/YDgUWZJ9DZPNA6XCZCyO8i/Sidebar-Nav--CCC-PID---DRAFT-?node-id=355-1143&t=u7BaGnGDsZdyxboM-0 
Tech Design :- https://docs.google.com/document/d/1UXgjCAB8H_33YDJTZ0QN9z5f3-WDdHeyWeMiGJlSPsE/edit?tab=t.azvmq4einwjp#heading=h.ipgou4bu0qoj

Show commcare app option when it is login activity
Show app version
Expanded view of commcare apps when there is less than 2 apps
change of arrow icon
Handle the commcare click
Replaced the close icon with the back icon in the actionbar and remoced close from inside the nav drawer


![Screenshot_20250804_141615_CommCare Debug](https://github.com/user-attachments/assets/5fb3c951-b6e5-4993-ade0-bb69bbdc62e9)

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
