### PR TITLE
Crash analytics bugs

### DIFF
--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -12,6 +12,8 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
 import org.commcare.CommCareApp;
 import org.commcare.CommCareApplication;
 import org.commcare.adapters.ConnectProgressJobSummaryAdapter;
@@ -45,6 +47,7 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
     private ConnectProgressJobSummaryAdapter connectProgressJobSummaryAdapter;
 
     private HomeScreenAdapter adapter;
+    private boolean isUISetupComplete = false;
 
     public StandardHomeActivityUIController(StandardHomeActivity activity) {
         this.activity = activity;
@@ -57,6 +60,7 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
         setupJobTile();
         adapter = new HomeScreenAdapter(activity, getHiddenButtons(), StandardHomeActivity.isDemoUser());
         setupGridView();
+        isUISetupComplete = true;
     }
 
     private void setupJobTile() {
@@ -115,6 +119,10 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
 
     @Override
     public void refreshView() {
+        if (!isUISetupComplete) {
+            FirebaseCrashlytics.getInstance().log("refreshView called before setupUI");
+            return;
+        }
         if (adapter != null) {
             // adapter can be null if backstack was cleared for memory reasons
             adapter.notifyDataSetChanged();
@@ -124,6 +132,15 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
     }
 
     public void updateConnectProgress() {
+        if (!isUISetupComplete) {
+            FirebaseCrashlytics.getInstance().log("updateConnectProgress called before UI setup complete");
+            return;
+        }
+
+        if (viewJobCard == null || connectProgressJobSummaryAdapter == null) {
+            FirebaseCrashlytics.getInstance().log("viewJobCard or connectProgressJobSummaryAdapter is null in updateConnectProgress");
+            return;
+        }
         ConnectJobRecord job = activity.getActiveJob();
         if (job == null) {
             return;

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -17,6 +17,8 @@ import androidx.work.NetworkType;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
 import org.commcare.CommCareApplication;
 import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.connect.PersonalIdActivity;
@@ -366,8 +368,19 @@ public class PersonalIdManager {
                 }
 
                 public void tokenUnavailable() {
-                    ConnectNetworkHelper.handleTokenUnavailableException(activity);
-                    callback.connectActivityComplete(false);
+                    try {
+                        if (activity != null) {
+                            ConnectNetworkHelper.handleTokenUnavailableException(activity);
+                        } else {
+                            FirebaseCrashlytics.getInstance().recordException(
+                                    new NullPointerException("tokenUnavailable(): activity is null")
+                            );
+                        }
+                    } catch (Exception e) {
+                        FirebaseCrashlytics.getInstance().recordException(e);
+                    } finally {
+                        callback.connectActivityComplete(false);
+                    }
                 }
 
                 public void tokenRequestDenied() {


### PR DESCRIPTION
## Product Description
Ticket -> https://dimagi.atlassian.net/browse/CCCT-1532
https://dimagi.atlassian.net/browse/CCCT-1534
https://dimagi.atlassian.net/browse/CCCT-1533

## Technical Summary
**Bug 1: Crash on notification-based launch (null job)
Cause:**
When ConnectActivity is launched via a notification with GO_TO_JOB_STATUS=true but without a valid OPPORTUNITY_ID, the job remains null, causing a NullPointerException during
job.getStatus().

**Fix:**
Added a null check before accessing job. If it's null, we log the error using Crashlytics and safely default to the job list screen.

**Bug 2: Crash when activity is unexpectedly null in tokenUnavailable()
Cause:**
The activity reference in the tokenUnavailable() callback can be unexpectedly null, especially if the user has backgrounded the app or the activity was destroyed.
Attempting to use it without checking led to a NullPointerException.

**Fix:**
Added a null check for activity.
If null, we log the anomaly using FirebaseCrashlytics for future analysis.

**Bug 3: Crash in StandardHomeActivityUIController due to null ConnectJobRecord and calling updateConnectProgress without before calling setupUI
Cause:**
activity.getActiveJob() could return null if no job was assigned, but code in setupJobTile() and updateConnectProgress() assumed it was non-null, leading to a NullPointerException.

**Fix:**
Added null checks before accessing job fields. The job card is now hidden when no active job is present. Also added Crashlytics logs to track unexpected UI states.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
