### PR TITLE
Android 15 compatibility changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -254,7 +254,7 @@ static def getDate() {
 
 android {
     namespace 'org.commcare.dalvik'
-    compileSdk 35
+    compileSdk 36
 
     lintOptions {
         abortOnError false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -283,7 +283,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
 
         applicationId 'org.commcare.dalvik'
         testNamespace 'org.commcare.dalvik.test'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,8 +102,7 @@ dependencies {
     implementation('org.apache.httpcomponents:httpmime:4.5.6')
     implementation 'net.sourceforge.htmlcleaner:htmlcleaner:2.26'
     implementation 'org.jsoup:jsoup:1.21.1'
-    implementation 'com.scottyab:rootbeer-lib:0.1.0'
-
+    implementation 'com.scottyab:rootbeer-lib:0.1.1'
     implementation 'com.carrotsearch:hppc:0.9.1'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'

--- a/app/res/values/themes.xml
+++ b/app/res/values/themes.xml
@@ -37,6 +37,9 @@
         <item name="materialCalendarStyle">@style/Widget.MaterialComponents.MaterialCalendar</item>
         <item name="materialCalendarFullscreenTheme">@style/ThemeOverlay.MaterialComponents.MaterialCalendar.Fullscreen</item>
         <item name="materialCalendarTheme">@style/ThemeOverlay.MaterialComponents.MaterialCalendar</item>
+
+        <!-- Opt-out of edge-to-edge enforcement for Android 15 -->
+        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
     </style>
 
     <style name="AppBaseTheme" parent="CommonTheme" />

--- a/commcare-support-library/build.gradle
+++ b/commcare-support-library/build.gradle
@@ -43,7 +43,7 @@ android {
     compileSdk 35
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/commcare-support-library/build.gradle
+++ b/commcare-support-library/build.gradle
@@ -40,7 +40,7 @@ afterEvaluate {
 
 android {
     namespace "org.commcare.commcaresupportlibrary"
-    compileSdk 35
+    compileSdk 36
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 35


### PR DESCRIPTION
## Product Description
This PR makes the necessary changes to ensure compatibility with Android 15. The changes were mainly to:
- Ensure that all native libraries used by CommCare support the 16KB page requirement - there are 3 libraries that required updates: SQLCipher, RootBeer and Kujaku. Kujaku doesn't have a suitable option so we decided to remove it from CommCare and kill all related feature;
- Edge-to-Edge mode handling for devices running Android 15 - we've decided to opt out for now and thoroughly test the related changed outside the scope of a release;

## Safety Assurance

### Safety story
These changes will have to go through regression testing.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
