### PR TITLE
Drawer Init NPE Fix

### DIFF
--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -1,6 +1,5 @@
 package org.commcare.navdrawer
 
-import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
 import org.commcare.activities.CommCareActivity
@@ -11,8 +10,8 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
 
     protected var drawerController: BaseDrawerController? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onResume() {
+        super.onResume()
         if (shouldShowDrawer() && isPersonalIdLoggedIn()) {
             setupDrawerController()
         }


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/QA-7982

## Technical Summary

Fix for [Crash](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/7bdcbc6f90552403fcf7f7446fbb2350)

````
      Caused by java.lang.NullPointerException: rootView.findViewById(R.id.drawer_layout) must not be null
       at org.commcare.navdrawer.DrawerViewRefs.<init>(DrawerViewRefs.kt:14)
       at org.commcare.navdrawer.BaseDrawerActivity.setupDrawerController(BaseDrawerActivity.kt:33)
       at org.commcare.navdrawer.BaseDrawerActivity.onCreate(BaseDrawerActivity.kt:17)
       at org.commcare.activities.SessionAwareCommCareActivity.onCreate(SessionAwareCommCareActivity.java:20)
````

Not all activities have their view set when we were calling drawing init. I therefore decided to move drawer setup to `onResume` instead as we can be sure there that the view has been set on the activity. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
