### PR TITLE
Side nav drawer in App Home page

### DIFF
--- a/app/res/layout/nav_drawer_sublist_item.xml
+++ b/app/res/layout/nav_drawer_sublist_item.xml
@@ -3,11 +3,20 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:paddingStart="48dp"
+    android:paddingStart="24dp"
     android:paddingTop="12dp"
     android:paddingBottom="12dp"
     android:gravity="center_vertical"
     android:background="@color/cc_brand_color">
+
+    <ImageView
+        android:id="@+id/sublist_highlight_icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginEnd="12dp"
+        android:src="@drawable/icon_chevron_right_white"
+        android:contentDescription="@null"
+        android:visibility="gone"/>
 
     <ImageView
         android:layout_width="24dp"

--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -44,8 +44,6 @@ import org.commcare.google.services.analytics.AnalyticsParamValue;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.logic.DetailCalloutListenerDefaultImpl;
-import org.commcare.navdrawer.BaseDrawerController;
-import org.commcare.navdrawer.DrawerViewRefs;
 import org.commcare.preferences.LocalePreferences;
 import org.commcare.services.DataSyncCompleteBroadcastReceiver;
 import org.commcare.services.FCMMessageData;

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -43,7 +43,6 @@ import org.commcare.interfaces.RuntimePermissionRequester;
 import org.commcare.logging.DataChangeLog;
 import org.commcare.logging.DataChangeLogger;
 import org.commcare.navdrawer.BaseDrawerActivity;
-import org.commcare.navdrawer.BaseDrawerController;
 import org.commcare.preferences.GlobalPrivilegesManager;
 import org.commcare.resources.ResourceManager;
 import org.commcare.resources.model.InvalidResourceException;

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -2,6 +2,8 @@ package org.commcare.activities;
 
 import static org.commcare.commcaresupportlibrary.CommCareLauncher.SESSION_ENDPOINT_APP_ID;
 import static org.commcare.connect.ConnectAppUtils.IS_LAUNCH_FROM_CONNECT;
+import static org.commcare.connect.ConnectConstants.CONNECT_MANAGED_LOGIN;
+import static org.commcare.connect.ConnectConstants.PERSONALID_MANAGED_LOGIN;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -68,7 +70,7 @@ public class DispatchActivity extends AppCompatActivity {
     private boolean startFromLogin;
     private LoginMode lastLoginMode;
     private boolean userManuallyEnteredPasswordMode;
-    private boolean connectIdManagedLogin;
+    private boolean personalIdManagedLogin;
     private boolean connectManagedLogin;
     private boolean shouldFinish;
     private boolean userTriggeredLogout;
@@ -85,6 +87,7 @@ public class DispatchActivity extends AppCompatActivity {
     static final String REBUILD_SESSION = "rebuild_session";
     private boolean redirectToConnectHome = false;
     private boolean redirectToConnectOpportunityInfo = false;
+    private String redirectToLoginAppId = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -296,9 +299,13 @@ public class DispatchActivity extends AppCompatActivity {
             i.putExtra(LoginActivity.USER_TRIGGERED_LOGOUT, userTriggeredLogout);
             i.putExtra(IS_LAUNCH_FROM_CONNECT, getLaunchedFromConnect());
 
-            String sesssionEndpointAppID = getSessionEndpointAppId();
-            if (sesssionEndpointAppID != null) {
-                i.putExtra(LoginActivity.EXTRA_APP_ID, sesssionEndpointAppID);
+            String sessionEndpointAppID = getSessionEndpointAppId();
+            if(sessionEndpointAppID == null && redirectToLoginAppId != null) {
+                sessionEndpointAppID = redirectToLoginAppId;
+                redirectToLoginAppId = null;
+            }
+            if (sessionEndpointAppID != null) {
+                i.putExtra(LoginActivity.EXTRA_APP_ID, sessionEndpointAppID);
             }
 
             startActivityForResult(i, LOGIN_USER);
@@ -335,7 +342,7 @@ public class DispatchActivity extends AppCompatActivity {
         i.putExtra(START_FROM_LOGIN, startFromLogin);
         i.putExtra(LoginActivity.LOGIN_MODE, lastLoginMode);
         i.putExtra(LoginActivity.MANUAL_SWITCH_TO_PW_MODE, userManuallyEnteredPasswordMode);
-        i.putExtra(LoginActivity.PERSONALID_MANAGED_LOGIN, connectIdManagedLogin);
+        i.putExtra(PERSONALID_MANAGED_LOGIN, personalIdManagedLogin);
         startFromLogin = false;
         clearSessionEndpointAppId();
         startActivityForResult(i, HOME_SCREEN);
@@ -456,6 +463,7 @@ public class DispatchActivity extends AppCompatActivity {
         if (intent != null) {
             needToExecuteRecoveryMeasures = intent.getBooleanExtra(EXECUTE_RECOVERY_MEASURES, false);
             redirectToConnectOpportunityInfo = intent.getBooleanExtra(REDIRECT_TO_CONNECT_OPPORTUNITY_INFO, false);
+            redirectToLoginAppId = intent.getStringExtra(SESSION_ENDPOINT_APP_ID);
         }
 
         // if handling new return code (want to return to home screen) but a return at the end of your statement
@@ -483,8 +491,8 @@ public class DispatchActivity extends AppCompatActivity {
                     lastLoginMode = (LoginMode)intent.getSerializableExtra(LoginActivity.LOGIN_MODE);
                     userManuallyEnteredPasswordMode =
                             intent.getBooleanExtra(LoginActivity.MANUAL_SWITCH_TO_PW_MODE, false);
-                    connectIdManagedLogin = intent.getBooleanExtra(LoginActivity.PERSONALID_MANAGED_LOGIN, false);
-                    connectManagedLogin = intent.getBooleanExtra(LoginActivity.CONNECT_MANAGED_LOGIN, false);
+                    personalIdManagedLogin = intent.getBooleanExtra(PERSONALID_MANAGED_LOGIN, false);
+                    connectManagedLogin = intent.getBooleanExtra(CONNECT_MANAGED_LOGIN, false);
                     startFromLogin = true;
                 }
                 return;

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -1,5 +1,6 @@
 package org.commcare.activities;
 
+import static org.commcare.activities.LoginActivity.EXTRA_APP_ID;
 import static org.commcare.commcaresupportlibrary.CommCareLauncher.SESSION_ENDPOINT_APP_ID;
 import static org.commcare.connect.ConnectAppUtils.IS_LAUNCH_FROM_CONNECT;
 import static org.commcare.connect.ConnectConstants.CONNECT_MANAGED_LOGIN;
@@ -305,7 +306,7 @@ public class DispatchActivity extends AppCompatActivity {
                 redirectToLoginAppId = null;
             }
             if (sessionEndpointAppID != null) {
-                i.putExtra(LoginActivity.EXTRA_APP_ID, sessionEndpointAppID);
+                i.putExtra(EXTRA_APP_ID, sessionEndpointAppID);
             }
 
             startActivityForResult(i, LOGIN_USER);
@@ -463,7 +464,7 @@ public class DispatchActivity extends AppCompatActivity {
         if (intent != null) {
             needToExecuteRecoveryMeasures = intent.getBooleanExtra(EXECUTE_RECOVERY_MEASURES, false);
             redirectToConnectOpportunityInfo = intent.getBooleanExtra(REDIRECT_TO_CONNECT_OPPORTUNITY_INFO, false);
-            redirectToLoginAppId = intent.getStringExtra(SESSION_ENDPOINT_APP_ID);
+            redirectToLoginAppId = intent.getStringExtra(EXTRA_APP_ID);
         }
 
         // if handling new return code (want to return to home screen) but a return at the end of your statement

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -1012,6 +1012,11 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         return personalIdManager.isloggedIn();
     }
 
+    @Override
+    protected boolean shouldHighlightSeatedApp() {
+        return true;
+    }
+
     protected PersonalIdManager.ConnectAppMangement getConnectAppState() {
         return connectAppState;
     }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -2,6 +2,8 @@ package org.commcare.activities;
 
 import static org.commcare.activities.DispatchActivity.REDIRECT_TO_CONNECT_OPPORTUNITY_INFO;
 import static org.commcare.connect.ConnectAppUtils.IS_LAUNCH_FROM_CONNECT;
+import static org.commcare.connect.ConnectConstants.CONNECT_MANAGED_LOGIN;
+import static org.commcare.connect.ConnectConstants.PERSONALID_MANAGED_LOGIN;
 import static org.commcare.connect.PersonalIdManager.ConnectAppMangement.Connect;
 import static org.commcare.connect.PersonalIdManager.ConnectAppMangement.PersonalId;
 import static org.commcare.connect.PersonalIdManager.ConnectAppMangement.Unmanaged;
@@ -56,7 +58,6 @@ import org.commcare.interfaces.WithUIController;
 import org.commcare.models.database.user.DemoUserBuilder;
 import org.commcare.navdrawer.BaseDrawerActivity;
 import org.commcare.navdrawer.BaseDrawerController;
-import org.commcare.navdrawer.DrawerViewRefs;
 import org.commcare.preferences.DevSessionRestorer;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.recovery.measures.RecoveryMeasuresHelper;
@@ -127,8 +128,6 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
     private int selectedAppIndex = -1;
     private boolean appLaunchedFromConnect = false;
     private String presetAppId;
-    public static final String PERSONALID_MANAGED_LOGIN = "personalid-managed-login";
-    public static final String CONNECT_MANAGED_LOGIN = "connect-managed-login";
     private PersonalIdManager personalIdManager;
     private PersonalIdManager.ConnectAppMangement connectAppState = Unmanaged;
     private boolean connectLaunchPerformed;
@@ -1017,6 +1016,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         return connectAppState;
     }
 
+    @Override
     protected void handleDrawerItemClick(@NonNull BaseDrawerController.NavItemType itemType, String recordId) {
         if (itemType == BaseDrawerController.NavItemType.COMMCARE_APPS) {
             if (recordId != null) {
@@ -1024,6 +1024,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
                     selectedAppIndex = appIdDropdownList.indexOf(recordId);
                 }
                 seatAppIfNeeded(recordId);
+                closeDrawer();
             }
         } else {
             super.handleDrawerItemClick(itemType, recordId);

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -1,5 +1,6 @@
 package org.commcare.activities;
 
+import static org.commcare.activities.LoginActivity.EXTRA_APP_ID;
 import static org.commcare.connect.ConnectConstants.PERSONALID_MANAGED_LOGIN;
 
 import android.content.Intent;
@@ -7,18 +8,14 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 
 import androidx.annotation.NonNull;
 
 import org.commcare.CommCareApplication;
 import org.commcare.CommCareNoficationManager;
-import org.commcare.commcaresupportlibrary.CommCareLauncher;
 import org.commcare.connect.ConnectJobHelper;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
 import org.commcare.connect.ConnectNavHelper;
-import org.commcare.connect.PersonalIdManager;
-import org.commcare.connect.database.ConnectJobUtils;
 import org.commcare.dalvik.R;
 import org.commcare.google.services.analytics.AnalyticsParamValue;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
@@ -36,9 +33,6 @@ import org.javarosa.core.services.locale.Localization;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import kotlin.Unit;
-import kotlin.jvm.functions.Function2;
 
 /**
  * Normal CommCare home screen
@@ -256,7 +250,7 @@ public class StandardHomeActivity
                         //Navigate to LoginActivity for selected app
                         CommCareApplication.instance().closeUserSession();
                         Intent i = new Intent();
-                        i.putExtra(CommCareLauncher.SESSION_ENDPOINT_APP_ID, recordId);
+                        i.putExtra(EXTRA_APP_ID, recordId);
                         setResult(RESULT_OK, i);
                         finish();
                     }

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -25,7 +25,6 @@ import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.interfaces.CommCareActivityUIController;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.navdrawer.BaseDrawerController;
-import org.commcare.navdrawer.DrawerViewRefs;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.ResultAndError;
@@ -313,6 +312,11 @@ public class StandardHomeActivity
 
     @Override
     protected boolean shouldShowDrawer() {
+        return true;
+    }
+
+    @Override
+    protected boolean shouldHighlightSeatedApp() {
         return true;
     }
 

--- a/app/src/org/commcare/connect/ConnectConstants.java
+++ b/app/src/org/commcare/connect/ConnectConstants.java
@@ -12,6 +12,8 @@ public class ConnectConstants {
     public static final int COMMCARE_SETUP_CONNECT_LAUNCH_REQUEST_CODE = 1051;
     public static final int CONFIGURE_BIOMETRIC_REQUEST_CODE = 1053;
     public static final int NETWORK_ACTIVITY_ID = 7000;
+    public static final String PERSONALID_MANAGED_LOGIN = "personalid-managed-login";
+    public static final String CONNECT_MANAGED_LOGIN = "connect-managed-login";
 
     public static final String PIN = "PIN";
     public static final String CONNECT_KEY_TOKEN = "access_token";

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -53,7 +53,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
         }
     }
 
-    private fun navigateToConnectMenu() {
+    protected fun navigateToConnectMenu() {
         unlockAndGoToConnectJobsList(this, object : ConnectActivityCompleteListener {
             override fun connectActivityComplete(success: Boolean) {
                 if (success) {
@@ -63,7 +63,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
         })
     }
 
-    private fun navigateToMessaging() {
+    protected fun navigateToMessaging() {
         unlockAndGoToMessaging(this, object : ConnectActivityCompleteListener {
             override fun connectActivityComplete(success: Boolean) {
                 if (success) {
@@ -73,7 +73,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
         })
     }
 
-    private fun closeDrawer() {
+    protected fun closeDrawer() {
         drawerController?.closeDrawer()
     }
 }

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -23,12 +23,17 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
         return false
     }
 
+    protected open fun shouldHighlightSeatedApp(): Boolean {
+        return false
+    }
+
     private fun setupDrawerController() {
         val rootView = findViewById<View>(android.R.id.content)
         val drawerRefs = DrawerViewRefs(rootView)
         drawerController = BaseDrawerController(
             this,
-            drawerRefs
+            drawerRefs,
+            shouldHighlightSeatedApp()
         ) { navItemType: NavItemType, recordId: String? ->
             handleDrawerItemClick(navItemType, recordId)
         }

--- a/app/src/org/commcare/navdrawer/BaseDrawerController.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerController.kt
@@ -1,7 +1,6 @@
 package org.commcare.navdrawer
 import android.text.SpannableString
 import android.text.style.UnderlineSpan
-import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.ActionBarDrawerToggle
@@ -10,8 +9,8 @@ import androidx.core.view.GravityCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
+import org.commcare.CommCareApplication
 import org.commcare.activities.CommCareActivity
-import org.commcare.activities.LoginActivity
 import org.commcare.connect.ConnectConstants
 import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectMessagingDatabaseHelper
@@ -26,6 +25,7 @@ import org.commcare.views.dialogs.DialogCreationHelpers
 class BaseDrawerController(
     private val activity: CommCareActivity<*>,
     private val binding: DrawerViewRefs,
+    private val highlightSeatedApp: Boolean,
     private val onItemClicked: (NavItemType, String?) -> Unit
 ) {
     private lateinit var drawerToggle: ActionBarDrawerToggle
@@ -129,8 +129,12 @@ class BaseDrawerController(
                         .error(R.drawable.nav_drawer_person_avatar)
                 ).into(binding.imageUserProfile)
 
+            val seatedApp = if(highlightSeatedApp)
+                CommCareApplication.instance().currentApp.uniqueId else null
+
             val commcareApps = MultipleAppsUtil.getUsableAppRecords().map {
-                NavDrawerItem.ChildItem(it.displayName, it.uniqueId, NavItemType.COMMCARE_APPS)
+                NavDrawerItem.ChildItem(it.displayName, it.uniqueId, NavItemType.COMMCARE_APPS,
+                    it.uniqueId == seatedApp)
             }
 
             val channels = ConnectMessagingDatabaseHelper.getMessagingChannels(activity)

--- a/app/src/org/commcare/navdrawer/NavDrawerAdapter.kt
+++ b/app/src/org/commcare/navdrawer/NavDrawerAdapter.kt
@@ -109,12 +109,14 @@ class NavDrawerAdapter(
      */
     inner class ChildViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val childText = itemView.findViewById<TextView>(R.id.sublist_title)
+        private val highlight = itemView.findViewById<ImageView>(R.id.sublist_highlight_icon)
 
         /**
          * Binds a child item and sets up click listener.
          */
         fun bind(item: NavDrawerItem.ChildItem) {
             childText.text = item.childTitle
+            highlight.visibility = if (item.isHighlighted) View.VISIBLE else View.INVISIBLE
             itemView.setOnClickListener { onChildClick(item.parentType, item) }
         }
     }

--- a/app/src/org/commcare/navdrawer/NavDrawerParentItem.kt
+++ b/app/src/org/commcare/navdrawer/NavDrawerParentItem.kt
@@ -15,6 +15,7 @@ sealed class NavDrawerItem {
     data class ChildItem(
         val childTitle: String,
         val recordId: String,
-        val parentType: BaseDrawerController.NavItemType
+        val parentType: BaseDrawerController.NavItemType,
+        val isHighlighted: Boolean = false
     ) : NavDrawerItem()
 }


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-1614

## Product Description
Showing the side navigation drawer in the App Home page when PersonalID is configured on the device.
Seated app highlighted in side nav menu on Login and App Home pages.
Navigating to Opportunities/Messages from App Home only requires unlock if it wasn't performed to access the current app.


## Feature Flag
PersonalID, Side Navigation Drawer

## Safety Assurance

### Safety story
Dev tested

### Automated test coverage
None

### QA Plan
- Verify the side navigation drawer appears on App Home whenever PersonalID is configured (otherwise does not appear)
- Verify clicking Opportunities/Messages from App Home requires unlock when app was logged in via username/password
- Verify clicking Opportunities/Messages from App Home does not require unlock when app was logged in via PersonalID unlock (including access to Connect apps from opportunity list)
- Verify the seated app is indicated with a Chevron in the side menu when on Login and App Home pages
- Verify clicking an app other than the seated one when in App Home logs the user out and goes to the Login page with the newly selected app seated