### PR TITLE
Keep showing sidenav drawer on Login once shown

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -113,6 +113,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
 
     public static final  String LOGIN_MODE = "login-mode";
     public static final String MANUAL_SWITCH_TO_PW_MODE = "manually-swithced-to-password-mode";
+    public static final String SHOWED_SIDE_DRAWER = "showed-side-drawer";
 
     private static final int TASK_KEY_EXCHANGE = 1;
     private static final int TASK_UPGRADE_INSTALL = 2;
@@ -1009,8 +1010,33 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
 
     @Override
     protected boolean shouldShowDrawer() {
+        if(drawerShownBefore()) {
+            return true;
+        }
+
         initPersonaIdManager();
-        return personalIdManager.isloggedIn();
+        boolean showDrawer = personalIdManager.isloggedIn();
+
+        if(showDrawer) {
+            setDrawerShown();
+        }
+
+        return showDrawer;
+    }
+
+    private boolean drawerShownBefore() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        return prefs.getBoolean(LoginActivity.SHOWED_SIDE_DRAWER, false);
+    }
+
+    private void setDrawerShown() {
+        SharedPreferences preferences =
+                PreferenceManager.getDefaultSharedPreferences(CommCareApplication.instance());
+        if (!preferences.getBoolean(SHOWED_SIDE_DRAWER, false)) {
+            SharedPreferences.Editor editor = preferences.edit();
+            editor.putBoolean(SHOWED_SIDE_DRAWER, true);
+            editor.apply();
+        }
     }
 
     protected PersonalIdManager.ConnectAppMangement getConnectAppState() {

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -58,6 +58,7 @@ import org.commcare.interfaces.WithUIController;
 import org.commcare.models.database.user.DemoUserBuilder;
 import org.commcare.navdrawer.BaseDrawerActivity;
 import org.commcare.navdrawer.BaseDrawerController;
+import org.commcare.navdrawer.NavDrawerHelper;
 import org.commcare.preferences.DevSessionRestorer;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.recovery.measures.RecoveryMeasuresHelper;
@@ -114,7 +115,6 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
 
     public static final  String LOGIN_MODE = "login-mode";
     public static final String MANUAL_SWITCH_TO_PW_MODE = "manually-swithced-to-password-mode";
-    public static final String SHOWED_SIDE_DRAWER = "showed-side-drawer";
 
     private static final int TASK_KEY_EXCHANGE = 1;
     private static final int TASK_UPGRADE_INSTALL = 2;
@@ -1009,7 +1009,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
 
     @Override
     protected boolean shouldShowDrawer() {
-        if(drawerShownBefore()) {
+        if(NavDrawerHelper.INSTANCE.drawerShownBefore()) {
             return true;
         }
 
@@ -1017,25 +1017,10 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         boolean showDrawer = personalIdManager.isloggedIn();
 
         if(showDrawer) {
-            setDrawerShown();
+            NavDrawerHelper.INSTANCE.setDrawerShown();
         }
 
         return showDrawer;
-    }
-
-    private boolean drawerShownBefore() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        return prefs.getBoolean(LoginActivity.SHOWED_SIDE_DRAWER, false);
-    }
-
-    private void setDrawerShown() {
-        SharedPreferences preferences =
-                PreferenceManager.getDefaultSharedPreferences(CommCareApplication.instance());
-        if (!preferences.getBoolean(SHOWED_SIDE_DRAWER, false)) {
-            SharedPreferences.Editor editor = preferences.edit();
-            editor.putBoolean(SHOWED_SIDE_DRAWER, true);
-            editor.apply();
-        }
     }
 
     @Override

--- a/app/src/org/commcare/navdrawer/NavDrawerHelper.kt
+++ b/app/src/org/commcare/navdrawer/NavDrawerHelper.kt
@@ -1,0 +1,23 @@
+package org.commcare.navdrawer
+
+import androidx.preference.PreferenceManager
+import org.commcare.CommCareApplication
+import androidx.core.content.edit
+
+object NavDrawerHelper {
+    private const val SIDE_DRAWER_SHOWN: String = "side-drawer-shown"
+
+    fun drawerShownBefore(): Boolean {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(CommCareApplication.instance())
+        return prefs.getBoolean(SIDE_DRAWER_SHOWN, false)
+    }
+
+    fun setDrawerShown() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(CommCareApplication.instance())
+        if (!prefs.getBoolean(SIDE_DRAWER_SHOWN, false)) {
+            prefs.edit {
+                putBoolean(SIDE_DRAWER_SHOWN, true)
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-1615

## Product Description
Once the user is shown the sidenav drawer on the Login page, the app will never stop showing it (specifically if user forgets their PersonalID account on the device).

## Technical Summary
Added a SharedPreference to track once we start showing the sidenav drawer on Login page
Checking for the new pref to automatically show the drawer.
Setting the pre the first time the drawer is shown.

## Feature Flag
PersonalID, side navigation drawer

## Safety Assurance

### Safety story
Simple change, easy to test.

### Automated test coverage
Nonce

### QA Plan
- Verify that the sidenav drawer is not enabled on Login before configuring PersonalID
- Verify that the sidenav drawer is enabled on Login after configuring PersonalID
- Verify that the sidenav drawer is still enabled on Login after forgetting PersonalID
- Restart app after forgetting PersonalID and verify again