### PR TITLE
Fix intent callout for scanner

### DIFF
--- a/app/src/org/commcare/views/widgets/WidgetUtils.java
+++ b/app/src/org/commcare/views/widgets/WidgetUtils.java
@@ -66,7 +66,7 @@ public class WidgetUtils {
      */
     public static Intent createScanIntent(Context context, String... formats) {
         if (MainConfigurablePreferences.useIntentCalloutForScanner()) {
-            Intent scanIntent = new Intent(Intents.Scan.ACTION);
+            Intent scanIntent = new Intent(Intents.Scan.ACTION).addCategory(Intent.CATEGORY_DEFAULT);
             if (scanIntent.resolveActivity(context.getPackageManager()) != null) {
                 if (formats != null) {
                     scanIntent.putExtra(Intents.Scan.FORMATS, TextUtils.join(",", formats));


### PR DESCRIPTION
## Product Description
Android 15 brought new restrictions around implicit intents, requiring now an exact match with the component's manifest filters. This PR adds the DEFAULT category to the scan intent, allowing it to resolve correctly to more scanner apps. 

Ticket: https://dimagi.atlassian.net/browse/QA-7995

## Safety Assurance

### Safety story
Successfully tested locally.

### QA Plan
QA will test this as part of the regression testing for `2.59`.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
