### PR TITLE
Solved crash while showing drawer in delivery / learning app

### DIFF
--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -5,21 +5,17 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 
 import org.commcare.CommCareApplication;
 import org.commcare.CommCareNoficationManager;
 import org.commcare.connect.ConnectJobHelper;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
-import org.commcare.connect.PersonalIdManager;
-import org.commcare.connect.database.ConnectJobUtils;
 import org.commcare.dalvik.R;
 import org.commcare.google.services.analytics.AnalyticsParamValue;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.interfaces.CommCareActivityUIController;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.navdrawer.BaseDrawerController;
-import org.commcare.navdrawer.DrawerViewRefs;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.ResultAndError;
@@ -31,9 +27,6 @@ import org.javarosa.core.services.locale.Localization;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import kotlin.Unit;
-import kotlin.jvm.functions.Function2;
 
 /**
  * Normal CommCare home screen
@@ -48,6 +41,8 @@ public class StandardHomeActivity
 
     private StandardHomeActivityUIController uiController;
     private Map<Integer, String> menuIdToAnalyticsParam;
+
+    private boolean showDrawer = false;
 
 
     @Override
@@ -274,9 +269,20 @@ public class StandardHomeActivity
         return false;
     }
 
+
+    /**
+     * Its not good idea to have such patches but its seems like no choice here.
+     * BaseDrawerActivity is trying to add the drawer before root view of this activity is created. Reason for this is
+     * this home activity is going through lot of process for sessions and then creating root view from `home_screen.xml`
+     * @param status
+     */
+    protected void toggleDrawerSetUp(boolean status){
+        this.showDrawer = status;
+    }
+
     @Override
     protected boolean shouldShowDrawer() {
-        return true;
+        return showDrawer;
     }
 
     @Override

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -50,7 +50,7 @@ public class StandardHomeActivity
     private Map<Integer, String> menuIdToAnalyticsParam;
     private boolean personalIdManagedLogin = false;
 
-    private boolean showDrawerInRootContent = false;
+    private boolean rootContainerReadyToShowDrawer = false;
 
 
     @Override
@@ -315,13 +315,13 @@ public class StandardHomeActivity
      * @param status
      */
     protected void toggleDrawerSetUp(boolean status){
-        this.showDrawerInRootContent = status;
+        this.rootContainerReadyToShowDrawer = status;
     }
 
     @Override
     protected boolean shouldShowDrawer() {
 
-        if(!showDrawerInRootContent) return false;   // wait for root content to get load through xml
+        if(!rootContainerReadyToShowDrawer) return false;   // wait for root content to get load through xml
 
 
         if(NavDrawerHelper.INSTANCE.drawerShownBefore()) {

--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -57,6 +57,9 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
         setupConnectJobTile();
         adapter = new HomeScreenAdapter(activity, getHiddenButtons(), StandardHomeActivity.isDemoUser());
         setupGridView();
+        activity.toggleDrawerSetUp(true);
+        activity.checkForDrawerSetUp();
+
     }
 
     private void setupConnectJobTile() {

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -33,6 +33,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
     }
 
     private fun setupDrawerController() {
+
         val rootView = findViewById<View>(android.R.id.content)
         val drawerRefs = DrawerViewRefs(rootView)
         drawerController = BaseDrawerController(

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -13,9 +13,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (shouldShowDrawer() && isPersonalIdLoggedIn()) {
-            setupDrawerController()
-        }
+        checkForDrawerSetUp()
     }
 
     private fun isPersonalIdLoggedIn(): Boolean {
@@ -26,6 +24,12 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
 
     protected open fun shouldShowDrawer(): Boolean {
         return false;
+    }
+
+    fun checkForDrawerSetUp(){
+        if (shouldShowDrawer() && isPersonalIdLoggedIn()) {
+            setupDrawerController()
+        }
     }
 
     private fun setupDrawerController() {

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -33,7 +33,6 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
     }
 
     private fun setupDrawerController() {
-
         val rootView = findViewById<View>(android.R.id.content)
         val drawerRefs = DrawerViewRefs(rootView)
         drawerController = BaseDrawerController(


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-1632

Whenever user trying to login into learning / delivery app, StandardHomeActivity was processing the sessions related stuff and than was adding the activity's view from home_screen.xml. BaseDrawerActivity is trying to add the drawer before root view of this activity is created. Now, with fix, after the root view is created from home_screen.xml, drawer is added to the root view. 


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
