### PR TITLE
Fix EntityListCalloutDataTest unit tests

### DIFF
--- a/app/unit-tests/src/org/commcare/android/tests/caselist/EntityListCalloutDataTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/caselist/EntityListCalloutDataTest.java
@@ -50,6 +50,7 @@ public class EntityListCalloutDataTest {
 
     @Before
     public void setup() {
+        ((CommCareTestApplication)CommCareTestApplication.instance()).initWorkManager();
         String appProfileResource =
                 "jr://resource/commcare-apps/case_list_lookup/profile.ccpr";
         TestAppInstaller.installAppAndLogin(appProfileResource, "test", "123");


### PR DESCRIPTION
## Product Description
This PR fixes two unit tests failing with the following error:
```
logger> resources: Tearing down sandbox: 82716c8a55944bae99331152b39b2330
java.lang.RuntimeException: An error occured while executing doInBackground()
	at android.os.AsyncTask$3.done(AsyncTask.java:300)
	at java.base/java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:381)
	at java.base/java.util.concurrent.FutureTask.setException(FutureTask.java:250)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:269)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.IllegalStateException: WorkManager is not initialized properly.  You have explicitly disabled WorkManagerInitializer in your manifest, have not manually called WorkManager#initialize at this point, and your Application does not implement Configuration.Provider.
	at androidx.work.impl.WorkManagerImpl.getInstance(WorkManagerImpl.java:179)
	at androidx.work.WorkManager$Companion.getInstance(WorkManager.kt:173)
	at org.commcare.tasks.PrimeEntityCacheHelper.cancelWork(PrimeEntityCacheHelper.kt:106)
	at org.commcare.tasks.EntityLoaderHelper.loadEntities(EntityLoaderHelper.kt:64)
	at org.commcare.tasks.EntityLoaderTask.doInBackground(EntityLoaderTask.java:53)
	at org.commcare.tasks.EntityLoaderTask.doInBackground(EntityLoaderTask.java:24)
	at android.os.AsyncTask$2.call(AsyncTask.java:288)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	... 3 more
```
The unit tests are:
```
org.commcare.android.tests.caselist.EntityListCalloutDataTest > testCalloutResultWithNoColumnTest FAILED
07:11:39     junit.framework.AssertionFailedError at Assert.java:57
07:11:40 

07:11:41 org.commcare.android.tests.caselist.EntityListCalloutDataTest > testAttachCalloutResultToListTest FAILED
07:11:41     junit.framework.AssertionFailedError at Assert.java:57
```
The problem here seems to be with the initialization of WorkManager in the testing environment.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
