### PR TITLE
fix issue with connect hearbeat due to incorrect sequencing

### DIFF
--- a/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
+++ b/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
@@ -12,18 +12,14 @@ class ConnectHeartbeatWorker(val context: Context, workerParams: WorkerParameter
         CoroutineWorker(context, workerParams) {
 
     override suspend fun doWork(): Result {
+        val personalIdManager = PersonalIdManager.getInstance()
+        if (!personalIdManager.isloggedIn()) {
+            return Result.failure()
+        }
+        val user = personalIdManager.getUser(applicationContext)
 
-        return suspendCoroutine{ continuation ->
-
-            if (!PersonalIdManager.getInstance().isloggedIn()) {
-                continuation.resume(Result.failure())
-            }
-
-            val user = PersonalIdManager.getInstance().getUser(context)
-
+        return suspendCoroutine { continuation ->
             object : PersonalIdApiHandler<Boolean>() {
-
-
                 override fun onFailure(errorCode: PersonalIdOrConnectApiErrorCodes, t: Throwable?) {
                     continuation.resume(Result.failure())
                 }
@@ -32,7 +28,6 @@ class ConnectHeartbeatWorker(val context: Context, workerParams: WorkerParameter
                     continuation.resume(Result.success())
                 }
             }.heartbeatRequest(context, user)
-
         }
     }
 }


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/CCCT-1657

## Technical Summary

If `isloggedIn()` is false, we were immediately calling `continuation.resume(Result.failure())` without exiting the code which in turn call heartbeatRequest, and will eventually invoke onSuccess or onFailure resulting into another call to `continuation.resume` and hence the exception `java.lang.IllegalStateException: Already resumed`

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
