### PR TITLE
Fix bug in HQ-triggered integrity reporting

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           android:versionCode="106"
-          android:versionName="2.59.0">
+          android:versionName="2.59.1">
 
     <uses-permission android:name="android.permission.NFC"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           android:versionCode="106"
-          android:versionName="2.59">
+          android:versionName="2.59.0">
 
     <uses-permission android:name="android.permission.NFC"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -16,12 +16,14 @@ import org.commcare.CommCareNoficationManager;
 import org.commcare.connect.ConnectJobHelper;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
 import org.commcare.connect.ConnectNavHelper;
+import org.commcare.connect.PersonalIdManager;
 import org.commcare.dalvik.R;
 import org.commcare.google.services.analytics.AnalyticsParamValue;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.interfaces.CommCareActivityUIController;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.navdrawer.BaseDrawerController;
+import org.commcare.navdrawer.NavDrawerHelper;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.tasks.DataPullTask;
 import org.commcare.tasks.ResultAndError;
@@ -306,7 +308,17 @@ public class StandardHomeActivity
 
     @Override
     protected boolean shouldShowDrawer() {
-        return true;
+        if(NavDrawerHelper.INSTANCE.drawerShownBefore()) {
+            return true;
+        }
+
+        boolean showDrawer = PersonalIdManager.getInstance().isloggedIn();
+
+        if(showDrawer) {
+            NavDrawerHelper.INSTANCE.setDrawerShown();
+        }
+
+        return showDrawer;
     }
 
     @Override

--- a/app/src/org/commcare/android/integrity/IntegrityTokenViewModel.kt
+++ b/app/src/org/commcare/android/integrity/IntegrityTokenViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
+import androidx.lifecycle.asFlow
 import com.google.android.play.core.integrity.IntegrityManagerFactory
 import com.google.android.play.core.integrity.StandardIntegrityException
 import com.google.android.play.core.integrity.StandardIntegrityManager
@@ -12,6 +13,7 @@ import com.google.android.play.core.integrity.StandardIntegrityManager.PrepareIn
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenProvider
 import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenRequest
 import com.google.android.play.core.integrity.model.StandardIntegrityErrorCode
+import kotlinx.coroutines.flow.Flow
 import org.commcare.dalvik.BuildConfig
 import org.commcare.util.LogTypes
 import org.javarosa.core.services.Logger
@@ -21,7 +23,9 @@ class IntegrityTokenViewModel(application: Application) : AndroidViewModel(appli
     private val _providerState = MutableLiveData<TokenProviderState>()
     val providerState: LiveData<TokenProviderState> = _providerState
 
-    var integrityTokenProvider: StandardIntegrityTokenProvider? = null
+    private var integrityTokenProvider: StandardIntegrityTokenProvider? = null
+
+    val providerStateFlow: Flow<TokenProviderState>  =_providerState.asFlow()
 
     init {
         prepareTokenProvider()


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-1658

Product Description
No user visible changes.

Technical Summary
Fixes a crash that was coming out of the integrity reporting code that gets triggered by a flag in the HQ heartbeat.
The code was trying to observer a LiveData object while waiting to retrieve a token.
But calling observeForever from a background thread caused an IllegalStateException.
I exposed the view model state as a Flow and reworked the request helper to use the flow in the coroutine.

Feature Flag
HQ Heartbeat, Integrity Reporting

Safety Assurance
Safety story
Forced a test locally first to observe the crash, then to confirm it didn't happen after the fix.

Automated test coverage
None

QA Plan
None