### PR TITLE
Shown opportunities from local DB in case internet connectivity issue

### DIFF
--- a/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
@@ -101,7 +101,7 @@ public class ConnectJobsListsFragment extends Fragment
 
     private void navigateFailure() {
         reportApiCall(false, 0, 0);
-        setJobListData(ConnectJobUtils.getCompositeJobs(getActivity(), -1, null));
+        setJobListData(ConnectJobUtils.getCompositeJobs(getActivity(), ConnectJobRecord.STATUS_ALL_JOBS, null));
     }
 
     private void reportApiCall(boolean success, int totalJobs, int newJobs) {


### PR DESCRIPTION
## Product Description
Application was failing to load the opportunities from local DB incase of internet issue. Now, it will load from local DB

## Technical Summary
https://dimagi.atlassian.net/browse/CI-132

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
