### PR TITLE
Not immediately failing when retrieving an integrity token fails.

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -2,7 +2,6 @@ package org.commcare.fragments.personalId;
 
 import android.Manifest;
 import android.app.Activity;
-import android.app.Dialog;
 import android.content.DialogInterface;
 import android.location.Location;
 import android.os.Bundle;
@@ -268,8 +267,9 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
 
                     @Override
                     public void onTokenFailure(@NotNull Exception exception) {
-                        onConfigurationFailure(AnalyticsParamValue.START_CONFIGURATION_INTEGRITY_DEVICE_FAILURE,
-                                integrityTokenApiRequestHelper.getErrorForException(requireActivity(), exception));
+                        FirebaseAnalyticsUtil.reportPersonalIdConfigurationFailure(
+                                AnalyticsParamValue.START_CONFIGURATION_INTEGRITY_DEVICE_FAILURE);
+                        makeStartConfigurationCall(null, body, null);
                     }
                 });
     }
@@ -385,7 +385,12 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
 
     private void makeStartConfigurationCall(String requestHash,
                                             HashMap<String, String> body,
-                                            StandardIntegrityManager.@NotNull StandardIntegrityToken integrityTokenResponse) {
+                                            StandardIntegrityManager.StandardIntegrityToken integrityTokenResponse) {
+        String token = integrityTokenResponse != null ? integrityTokenResponse.token() : "";
+        if(requestHash == null) {
+            requestHash = "";
+        }
+
         new PersonalIdApiHandler<PersonalIdSessionData>() {
             @Override
             public void onSuccess(PersonalIdSessionData sessionData) {
@@ -425,7 +430,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                         break;
                 }
             }
-        }.makeStartConfigurationCall(requireActivity(), body, integrityTokenResponse.token(), requestHash);
+        }.makeStartConfigurationCall(requireActivity(), body, token, requestHash);
     }
 
     private void handleIntegritySubError(StandardIntegrityManager.StandardIntegrityToken tokenResponse,


### PR DESCRIPTION
## Product Description
App no longer immediately blocks the user if retrieving an integrity token fails at the start of the device configuration workflow.
Instead, the server can decide whether the user can still proceed (i.e. for Connect vs. non-Connect users).

## Technical Summary
Changing behavior so workflow proceeds after integrity token error and sends empty strings for the hash and token

## Feature Flag
PersonalID

## Safety Assurance

### Safety story
Tested locally to verify:
1. Normal functionality when integrity token retrieval succeeds
2. Connect user can proceed with empty token values (manually overrode the code to test)
3. Non-Connect user can NOT proceed with empty token values (manually overrode the code to test)

### Automated test coverage
None

### QA Plan
Repeat the tests performed by the dev (see above)

