### PR TITLE
Add perf monitoring trace for form loading time

### DIFF
--- a/app/src/org/commcare/google/services/analytics/CCPerfMonitoring.kt
+++ b/app/src/org/commcare/google/services/analytics/CCPerfMonitoring.kt
@@ -10,11 +10,13 @@ object CCPerfMonitoring {
     // Measures the duration of synchronous case list loading
     const val TRACE_SYNC_ENTITY_LIST_LOADING = "sync_case_list_loading"
     const val TRACE_CASE_SEARCH_TIME = "case_search_time"
+    const val TRACE_FORM_LOADING_TIME = "form_loading_time"
 
     // Attributes
     const val ATTR_NUM_CASES_LOADED = "number_of_cases_loaded"
     const val ATTR_RESULTS_COUNT: String = "case_search_results_count"
     const val ATTR_SEARCH_QUERY_LENGTH: String = "case_search_query_length"
+    const val ATTR_FORM_NAME = "form_name"
 
     fun startTracing(traceName: String): Trace? {
         try {

--- a/app/src/org/commcare/google/services/analytics/CCPerfMonitoring.kt
+++ b/app/src/org/commcare/google/services/analytics/CCPerfMonitoring.kt
@@ -17,6 +17,7 @@ object CCPerfMonitoring {
     const val ATTR_RESULTS_COUNT: String = "case_search_results_count"
     const val ATTR_SEARCH_QUERY_LENGTH: String = "case_search_query_length"
     const val ATTR_FORM_NAME = "form_name"
+    const val ATTR_FORM_XMLNS = "form_xmlns"
 
     fun startTracing(traceName: String): Trace? {
         try {

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -149,6 +149,7 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Integer, String, Fo
 
         if (trace != null) {
             trace.putAttribute(CCPerfMonitoring.ATTR_FORM_NAME, fd.getName());
+            trace.putAttribute(CCPerfMonitoring.ATTR_FORM_XMLNS, fd.getMainInstance().schema);
             CCPerfMonitoring.INSTANCE.stopTracing(trace);
         }
         return data;

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -149,12 +149,12 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Integer, String, Fo
 
         data = new FECWrapper(formController);
 
-        if (trace != null) {
+        try {
             Map<String, String> attrs = new HashMap<>();
             attrs.put(CCPerfMonitoring.ATTR_FORM_NAME, fd.getName());
             attrs.put(CCPerfMonitoring.ATTR_FORM_XMLNS, fd.getMainInstance().schema);
             CCPerfMonitoring.INSTANCE.stopTracing(trace, attrs);
-        }
+        } catch (Exception ignored) {}
         return data;
     }
 

--- a/app/src/org/commcare/tasks/FormLoaderTask.java
+++ b/app/src/org/commcare/tasks/FormLoaderTask.java
@@ -54,6 +54,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.crypto.spec.SecretKeySpec;
 
@@ -148,9 +150,10 @@ public abstract class FormLoaderTask<R> extends CommCareTask<Integer, String, Fo
         data = new FECWrapper(formController);
 
         if (trace != null) {
-            trace.putAttribute(CCPerfMonitoring.ATTR_FORM_NAME, fd.getName());
-            trace.putAttribute(CCPerfMonitoring.ATTR_FORM_XMLNS, fd.getMainInstance().schema);
-            CCPerfMonitoring.INSTANCE.stopTracing(trace);
+            Map<String, String> attrs = new HashMap<>();
+            attrs.put(CCPerfMonitoring.ATTR_FORM_NAME, fd.getName());
+            attrs.put(CCPerfMonitoring.ATTR_FORM_XMLNS, fd.getMainInstance().schema);
+            CCPerfMonitoring.INSTANCE.stopTracing(trace, attrs);
         }
         return data;
     }


### PR DESCRIPTION
## Product Description
This PR implements a performance custom trace to measure form loading times. This is part of an effort to collect performance data related key events in CommCare.

Ticket: https://dimagi.atlassian.net/browse/SAAS-18091

## Safety Assurance

### Safety story
This is supposed to be a lightweight, null-safe operation that has no impact on the user experience.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change