### PR TITLE
Preserving local job status when updating list from API call.

### DIFF
--- a/app/src/org/commcare/connect/database/JobStoreManager.java
+++ b/app/src/org/commcare/connect/database/JobStoreManager.java
@@ -101,6 +101,7 @@ public class JobStoreManager {
         for (ConnectJobRecord existingJob : existingJobs) {
             if (existingJob.getJobId() == job.getJobId()) {
                 job.setID(existingJob.getID());  // Set ID for updating
+                job.setStatus(existingJob.getStatus());
                 isExisting = true;
                 break;
             }


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-1713

## Product Description
Job status is preserved when performing updates from the server (learning won't reset to available).

## Technical Summary
Keeping the local status when updating storage from the list that was received from the API.
The server doesn't send storage, so we try to calculate it.
But if we knew the status before making the API call, that should be treated as the latest value.

## Feature Flag
Connect

## Safety Assurance

### Safety story
Small change, only affects job status
Dev tested, dev approved

### Automated test coverage
None

### QA Plan
Invite user to a new job, begin learning, but don't complete and learning modules. Return to the jobs list, and after refreshing the job should still show "learning" status (should not go back to "available" status).
