### PR TITLE
fix FNF by ensuring the parent folder exists

### DIFF
--- a/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
+++ b/app/src/org/commcare/android/resource/installers/FileSystemInstaller.java
@@ -149,6 +149,7 @@ abstract class FileSystemInstaller implements ResourceInstaller<AndroidCommCareP
 
     private File writeToTempFile(InputStream inputFileStream) throws LocalStorageUnavailableException, IOException {
         File tempFile = new File(CommCareApplication.instance().getTempFilePath());
+        FileUtil.ensureFilePathExists(tempFile);
         try {
             OutputStream outputFileStream = new FileOutputStream(tempFile);
             StreamsUtil.writeFromInputToOutputNew(inputFileStream, outputFileStream);

--- a/app/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.kt
+++ b/app/unit-tests/src/org/commcare/android/tests/application/AppUpdateTest.kt
@@ -94,9 +94,9 @@ class AppUpdateTest {
         Assert.assertTrue(dir.delete())
         val profileRef = UpdateUtils.buildResourceRef(REF_BASE_DIR, "valid_update", "profile.ccpr")
         UpdateUtils.installUpdate(profileRef,
-                AppInstallStatus.NoLocalStorage,
-                AppInstallStatus.UnknownFailure)
-        checkUpdateComplete(6, false, false)
+                AppInstallStatus.UpdateStaged,
+                AppInstallStatus.Installed)
+        checkUpdateComplete(9, true, true)
     }
 
     @Test

--- a/app/unit-tests/src/org/commcare/update/UpdateWorkerTest.kt
+++ b/app/unit-tests/src/org/commcare/update/UpdateWorkerTest.kt
@@ -58,7 +58,7 @@ class UpdateWorkerTest {
         assertTrue(dir.delete())
 
         val profileRef = UpdateUtils.buildResourceRef(REF_BASE_DIR, "valid_update", "profile.ccpr")
-        runAndTestUpdateWorker(profileRef, ListenableWorker.Result.failure())
+        runAndTestUpdateWorker(profileRef, ListenableWorker.Result.success())
     }
 
     @Test


### PR DESCRIPTION
## Product Description

Potential Fix for https://dimagi.atlassian.net/browse/CCCT-1595

[Crashlytics](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/2e54aefeb20fd192ea86ee2a42f5324d?time=last-ninety-days&sessionEventKey=6891DC700155000161FCDC7344BCFF82_2113493200062635819&sessionTab=data&userInfoQuery=IO7T02HPCDQFBPQTMDJO)


## Technical Summary

My theory is that somehow device ends up in a state where the `temp` file directory is no longer there and results in the crash below.  This PR makes sure that temp file path is created on the device before accessing it. 

````
  Non-fatal Exception: org.commcare.engine.resource.installers.LocalStorageUnavailableException: Couldn't create temp file for file system installation
       at org.commcare.android.resource.installers.FileSystemInstaller.writeToTempFile(FileSystemInstaller.java:157)
       at org.commcare.android.resource.installers.FileSystemInstaller.install(FileSystemInstaller.java:109)
       at org.commcare.android.resource.installers.ProfileAndroidInstaller.install(ProfileAndroidInstaller.java:88)
       at org.commcare.android.resource.installers.ProfileAndroidInstaller.install(ProfileAndroidInstaller.java:44)
````


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
