### PR TITLE
Solved crash FragmentManager is already executing transactions

### DIFF
--- a/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
@@ -55,15 +55,19 @@ public class ConnectUnlockFragment extends Fragment {
         binding = FragmentConnectUnlockBinding.inflate(inflater, container, false);
         binding.getRoot().setBackgroundColor(getResources().getColor(R.color.white));
 
-        PersonalIdManager.getInstance().unlockConnect((CommCareActivity<?>)requireActivity(), success -> {
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        PersonalIdManager.getInstance().unlockConnect((CommCareActivity<?>) requireActivity(), success -> {
             if (success) {
                 retrieveOpportunities();
             } else {
                 requireActivity().finish();
             }
         });
-
-        return binding.getRoot();
     }
 
     private void retrieveOpportunities() {


### PR DESCRIPTION
## Crash Description
 Ticket -> https://dimagi.atlassian.net/browse/CCCT-1620
 
          Fatal Exception: java.lang.IllegalStateException: FragmentManager is already executing transactions
       at androidx.fragment.app.FragmentManager.ensureExecReady(FragmentManager.java:1717)
       at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1776)
       at androidx.fragment.app.FragmentManager.executePendingTransactions(FragmentManager.java:641)
       at androidx.biometric.BiometricPrompt.findOrAddBiometricFragment(BiometricPrompt.java:1082)
       at androidx.biometric.BiometricPrompt.authenticateInternal(BiometricPrompt.java:992)
       at androidx.biometric.BiometricPrompt.authenticate(BiometricPrompt.java:972)
       at org.commcare.utils.BiometricsHelper.authenticatePinOrBiometric(BiometricsHelper.java:149)
       at org.commcare.utils.BiometricsHelper.authenticatePin(BiometricsHelper.java:127)
       at org.commcare.connect.PersonalIdManager.unlockConnect(PersonalIdManager.java:192)
       at org.commcare.fragments.connect.ConnectUnlockFragment.onCreateView(ConnectUnlockFragment.java:71)
       at androidx.fragment.app.Fragment.performCreateView(Fragment.java:3114)
       at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:557)
       at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:272)
       at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:1943)
       at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1845)
       at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1782)
       at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3042)
       at androidx.fragment.app.FragmentManager.dispatchViewCreated(FragmentManager.java:2945)
       at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3148)
       at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:588)
       at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:272)
       at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:114)
       at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1455)
       at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3034)
       at androidx.fragment.app.FragmentManager.dispatchActivityCreated(FragmentManager.java:2952)
       at androidx.fragment.app.FragmentController.dispatchActivityCreated(FragmentController.java:263)
       at androidx.fragment.app.FragmentActivity.onStart(FragmentActivity.java:350)
       at androidx.appcompat.app.AppCompatActivity.onStart(AppCompatActivity.java:210)
       at org.commcare.activities.CommCareActivity.onStart(CommCareActivity.java:290)
       at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1455)
       at android.app.Activity.performStart(Activity.java:8085)
       at android.app.ActivityThread.handleStartActivity(ActivityThread.java:3708)
       at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:222)
       at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:202)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:174)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:98)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2252)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:7941)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:553)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
        

## RCA
The crash was caused because `BiometricPrompt.authenticate()` adds an internal fragment to FragmentManager. We were calling it inside `onCreateView()`, while FragmentManager was still inflating ConnectUnlockFragment, leading to:
`IllegalStateException: FragmentManager is already executing transactions`. the issue was timing of the call

## Solution
By moving the call into `onViewCreated()`, we ensure the fragment’s view is fully created and FragmentManager is idle before biometric is triggered. This avoids transaction conflicts.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
