### PR TITLE
Solved PersonalIdPhoneFragment api failure crash

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -478,6 +478,10 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
     }
 
     private void navigateFailure(PersonalIdApiHandler.PersonalIdOrConnectApiErrorCodes failureCode, Throwable t) {
+        if (!isAdded() || getView() == null || binding == null) {
+            return;
+        }
+
         showError(PersonalIdApiErrorHandler.handle(requireActivity(), failureCode, t));
         if (failureCode.shouldAllowRetry()) {
             enableContinueButton(true);
@@ -490,9 +494,6 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
     }
 
     private void showError(String error) {
-        if (binding == null || !isAdded()) {
-            return;
-        }
         binding.personalidPhoneError.setVisibility(View.VISIBLE);
         binding.personalidPhoneError.setText(error);
     }
@@ -503,7 +504,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
 
     @Override
     protected void navigateToMessageDisplay(String title, String message,  boolean isCancellable, int phase,
-            int buttonText) {
+                                            int buttonText) {
         NavDirections navDirections =
                 PersonalIdPhoneFragmentDirections.actionPersonalidPhoneFragmentToPersonalidMessageDisplay(
                         title, message, phase, getString(buttonText), null).setIsCancellable(isCancellable);


### PR DESCRIPTION
## Crash Description
Ticket -> https://dimagi.atlassian.net/browse/CCCT-1621

          Fatal Exception: java.lang.NullPointerException: Attempt to read from field 'android.widget.TextView org.commcare.dalvik.databinding.ScreenPersonalidPhonenoBinding.personalidPhoneError' on a null object reference in method 'void org.commcare.fragments.personalId.PersonalIdPhoneFragment.showError(java.lang.String)'
       at org.commcare.fragments.personalId.PersonalIdPhoneFragment.showError(PersonalIdPhoneFragment.java:487)
       at org.commcare.fragments.personalId.PersonalIdPhoneFragment.navigateFailure(PersonalIdPhoneFragment.java:475)
       at org.commcare.fragments.personalId.PersonalIdPhoneFragment$4.onFailure(PersonalIdPhoneFragment.java:424)
       at org.commcare.connect.network.base.BaseApiCallback.processFailure(BaseApiCallback.kt:38)
       at org.commcare.connect.network.connectId.PersonalIdApiHandler$1.processFailure(PersonalIdApiHandler.java:55)
       at org.commcare.connect.network.ApiPersonalId$1.onResponse(ApiPersonalId.java:240)
       at retrofit2.DefaultCallAdapterFactory$ExecutorCallbackCall$1.lambda$onResponse$0(DefaultCallAdapterFactory.java:89)
       at android.os.Handler.handleCallback(Handler.java:942)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:8061)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:703)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)
        

## RCA
Crash happens when network callbacks try to update UI after the fragment’s view is destroyed, leaving `binding` null

## Solution
Adding a null check ensures we only update the error view when the fragment is still active and not null, preventing the crash

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
