### PR TITLE
Fix for Intermittent Cyclic Test Failures

### DIFF
--- a/app/unit-tests/src/org/commcare/android/tests/formsave/CyclicCasesPurgeTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formsave/CyclicCasesPurgeTest.java
@@ -56,11 +56,24 @@ public class CyclicCasesPurgeTest {
         FormEntryActivity formEntryActivity = ActivityLaunchUtils.launchFormEntry();
         View finishButton = formEntryActivity.findViewById(R.id.nav_btn_finish);
         finishButton.performClick();
+        
+        // Wait for async form save task to complete and dialog to be created
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
         ShadowLooper.idleMainLooper();
+        
+        // Retry mechanism to handle async timing issues
+        Dialog latestDialog = null;
+        for (int attempt = 0; attempt < 5; attempt++) {
+            latestDialog = ShadowDialog.getLatestDialog();
+            if (latestDialog != null) {
+                break;
+            }
+            // Run additional looper tasks and wait
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
+            ShadowLooper.idleMainLooper();
+        }
 
         // verify that form save results into an error
-        Dialog latestDialog = ShadowDialog.getLatestDialog();
         assertNotNull(latestDialog);
         assertTrue(latestDialog.isShowing());
 


### PR DESCRIPTION
## Product Description

Potential test fix, unable to repro locally but Jenkins often fails with this issue. 
Adds a retry mechanism for async task to succeed before we check for error dialog. 

More contex in https://github.com/dimagi/commcare-android/pull/3015

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
