### PR TITLE
Improved Connect DB error handling

### DIFF
--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -44,6 +44,7 @@ import org.commcare.util.LogTypes;
 import org.commcare.utils.BiometricsHelper;
 import org.commcare.utils.CrashUtil;
 import org.commcare.utils.EncryptionKeyProvider;
+import org.commcare.utils.GlobalErrors;
 import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.services.Logger;
@@ -124,7 +125,7 @@ public class PersonalIdManager {
                 }
             } else if (ConnectDatabaseHelper.isDbBroken()) {
                 //Corrupt DB, inform user to recover
-                ConnectDatabaseHelper.crashDb();
+                ConnectDatabaseHelper.crashDb(GlobalErrors.PERSONALID_DB_STARTUP_ERROR);
             }
         }
     }

--- a/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
@@ -73,6 +73,9 @@ public class ConnectDatabaseHelper {
                     if (connectDatabase == null || !connectDatabase.isOpen()) {
                         try {
                             byte[] passphrase = ConnectDatabaseUtils.getConnectDbPassphrase(context, true);
+                            if(passphrase == null) {
+                                throw new IllegalStateException("Attempting to access Connect DB without a passphrase");
+                            }
 
                             String remotePassphrase = ConnectDatabaseUtils.getConnectDbEncodedPassphrase(context, false);
                             String localPassphrase = ConnectDatabaseUtils.getConnectDbEncodedPassphrase(context, true);
@@ -83,8 +86,7 @@ public class ConnectDatabaseHelper {
                                         UserSandboxUtils.getSqlCipherEncodedKey(passphrase));
                             } else {
                                 //LEGACY: Used to open the DB using the byte[], not String overload
-                                String encrypted = passphrase != null ? "(encrypted)" : "(unencrypted)";
-                                Logger.exception("Legacy DB Usage", new Exception("Accessing Connect DB via legacy code " + encrypted));
+                                Logger.exception("Legacy DB Usage", new Exception("Accessing Connect DB via legacy code"));
                                 dbConnectOpenHelper = new DatabaseConnectOpenHelper(this.c,
                                         Base64.encodeToString(passphrase, Base64.NO_WRAP));
                             }

--- a/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
@@ -52,7 +52,7 @@ public class ConnectDatabaseHelper {
             //Store the received passphrase as what's in use locally
             ConnectDatabaseUtils.storeConnectDbPassphrase(context, remotePassphrase, true);
         } catch (Exception e) {
-            crashDb(GlobalErrors.PERSONALID_DB_UPGRADE_ERROR);
+            crashDb(GlobalErrors.PERSONALID_DB_UPGRADE_ERROR, e);
         }
     }
 
@@ -93,7 +93,7 @@ public class ConnectDatabaseHelper {
                         } catch (Exception e) {
                             //Flag the DB as broken if we hit an error opening it (usually means corrupted or bad encryption)
                             dbBroken = true;
-                            crashDb(GlobalErrors.PERSONALID_GENERIC_ERROR);
+                            crashDb(GlobalErrors.PERSONALID_GENERIC_ERROR, e);
                         }
                     }
                     return connectDatabase;
@@ -112,8 +112,12 @@ public class ConnectDatabaseHelper {
     }
 
     public static void crashDb(GlobalErrors error) {
+        crashDb(error, null);
+    }
+
+    public static void crashDb(GlobalErrors error, Exception ex) {
         GlobalErrorUtil.addError(new GlobalErrorRecord(new Date(), error.ordinal()));
-        throw new RuntimeException("Connect database crash: " + error.name());
+        throw new RuntimeException("Connect database crash: " + error.name(), ex);
     }
 
     public static void storeHqToken(Context context, String appId, String userId, SsoToken token) {

--- a/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
@@ -52,8 +52,7 @@ public class ConnectDatabaseHelper {
             //Store the received passphrase as what's in use locally
             ConnectDatabaseUtils.storeConnectDbPassphrase(context, remotePassphrase, true);
         } catch (Exception e) {
-            Logger.exception("Handling received DB passphrase", e);
-            crashDb();
+            crashDb(GlobalErrors.PERSONALID_DB_UPGRADE_ERROR);
         }
     }
 
@@ -94,8 +93,7 @@ public class ConnectDatabaseHelper {
                         } catch (Exception e) {
                             //Flag the DB as broken if we hit an error opening it (usually means corrupted or bad encryption)
                             dbBroken = true;
-                            Logger.exception("Corrupt Connect DB", e);
-                            crashDb();
+                            crashDb(GlobalErrors.PERSONALID_GENERIC_ERROR);
                         }
                     }
                     return connectDatabase;
@@ -113,13 +111,9 @@ public class ConnectDatabaseHelper {
         }
     }
 
-    public static void crashDb() {
-        crashDb(GlobalErrors.PERSONALID_GENERIC_ERROR);
-    }
-
     public static void crashDb(GlobalErrors error) {
         GlobalErrorUtil.addError(new GlobalErrorRecord(new Date(), error.ordinal()));
-        throw new RuntimeException("Connect database crash");
+        throw new RuntimeException("Connect database crash: " + error.name());
     }
 
     public static void storeHqToken(Context context, String appId, String userId, SsoToken token) {

--- a/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
@@ -75,17 +75,17 @@ public class ConnectDatabaseUtils {
     public static byte[] getConnectDbPassphrase(Context context, boolean isLocal) {
         try {
             ConnectKeyRecord record = ConnectDatabaseUtils.getKeyRecord(isLocal);
-            if (record != null) {
-                byte[] encrypted = Base64.decode(record.getEncryptedPassphrase());
-
-                EncryptionKeyProvider encryptionKeyProvider = new EncryptionKeyProvider(context, false,
-                        SECRET_NAME);
-                EncryptionKeyAndTransform keyAndTransform = encryptionKeyProvider.getKeyForDecryption();
-                return EncryptionUtils.decrypt(encrypted, keyAndTransform.getKey(), keyAndTransform.getTransformation(), true);
-            } else {
-                CrashUtil.log("We don't find paraphrase in db");
-                throw new RuntimeException("We don't find a record in db to get passphrase");
+            if (record == null) {
+                return null;
             }
+
+            byte[] encrypted = Base64.decode(record.getEncryptedPassphrase());
+
+            EncryptionKeyProvider encryptionKeyProvider = new EncryptionKeyProvider(context, false,
+                    SECRET_NAME);
+            EncryptionKeyAndTransform keyAndTransform = encryptionKeyProvider.getKeyForDecryption();
+            return EncryptionUtils.decrypt(encrypted, keyAndTransform.getKey(),
+                    keyAndTransform.getTransformation(), true);
         } catch (Base64DecoderException | EncryptionUtils.EncryptionException e) {
             throw new RuntimeException(e);
         }

--- a/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
+++ b/app/src/org/commcare/models/database/app/DatabaseAppOpenHelper.java
@@ -10,6 +10,7 @@ import org.commcare.logging.DataChangeLog;
 import org.commcare.logging.DataChangeLogger;
 import org.commcare.models.database.EncryptedDatabaseAdapter;
 import org.commcare.models.database.DbUtil;
+import org.javarosa.core.services.Logger;
 
 import static org.commcare.models.database.app.AppDatabaseSchemaManager.DB_VERSION_APP;
 import static org.commcare.models.database.app.AppDatabaseSchemaManager.getDbName;
@@ -44,6 +45,7 @@ public class DatabaseAppOpenHelper extends SQLiteOpenHelper {
         try {
             return super.getWritableDatabase();
         } catch (SQLiteException sqle) {
+            Logger.exception("Opening database failed", sqle);
             DbUtil.trySqlCipherDbUpdate(key, context, getDbName(mAppId));
             return super.getWritableDatabase();
         }

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -31,6 +31,7 @@ import org.commcare.modern.database.TableBuilder;
 import org.commcare.util.Base64;
 import org.commcare.util.Base64DecoderException;
 import org.commcare.utils.CrashUtil;
+import org.javarosa.core.services.Logger;
 
 import java.io.File;
 
@@ -157,6 +158,7 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
         try {
             return super.getWritableDatabase();
         } catch (SQLiteException sqle) {
+            Logger.exception("Opening database failed", sqle);
             DbUtil.trySqlCipherDbUpdate(key, mContext, CONNECT_DB_LOCATOR);
             try {
                 return super.getWritableDatabase();

--- a/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
+++ b/app/src/org/commcare/models/database/global/DatabaseGlobalOpenHelper.java
@@ -10,6 +10,7 @@ import org.commcare.logging.DataChangeLog;
 import org.commcare.logging.DataChangeLogger;
 import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.EncryptedDatabaseAdapter;
+import org.javarosa.core.services.Logger;
 
 import static org.commcare.models.database.global.GlobalDatabaseSchemaManager.GLOBAL_DB_LOCATOR;
 import static org.commcare.models.database.global.GlobalDatabaseSchemaManager.GLOBAL_DB_VERSION;
@@ -39,6 +40,7 @@ public class DatabaseGlobalOpenHelper extends SQLiteOpenHelper {
         try {
             return super.getWritableDatabase();
         } catch (SQLiteException sqle) {
+            Logger.exception("Opening database failed", sqle);
             DbUtil.trySqlCipherDbUpdate(key, mContext, GLOBAL_DB_LOCATOR);
             return super.getWritableDatabase();
         }

--- a/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
+++ b/app/src/org/commcare/models/database/user/DatabaseUserOpenHelper.java
@@ -11,6 +11,7 @@ import org.commcare.logging.DataChangeLog;
 import org.commcare.logging.DataChangeLogger;
 import org.commcare.models.database.EncryptedDatabaseAdapter;
 import org.commcare.models.database.DbUtil;
+import org.javarosa.core.services.Logger;
 
 import static org.commcare.models.database.user.UserDatabaseSchemaManager.USER_DB_VERSION;
 import static org.commcare.models.database.user.UserDatabaseSchemaManager.getDbName;
@@ -48,6 +49,7 @@ public class DatabaseUserOpenHelper extends SQLiteOpenHelper {
         try {
             return super.getWritableDatabase();
         } catch (SQLiteException sqle) {
+            Logger.exception("Opening database failed", sqle);
             DbUtil.trySqlCipherDbUpdate(key, context, getDbName(mUserId));
             return super.getWritableDatabase();
         }

--- a/app/src/org/commcare/utils/GlobalErrors.java
+++ b/app/src/org/commcare/utils/GlobalErrors.java
@@ -4,9 +4,9 @@ import org.commcare.dalvik.R;
 
 public enum GlobalErrors {
     PERSONALID_GENERIC_ERROR(R.string.personalid_generic_error),
+    PERSONALID_LOST_CONFIGURATION_ERROR(R.string.recovery_network_token_request_rejected),
     PERSONALID_DB_STARTUP_ERROR(R.string.personalid_generic_error),
-    PERSONALID_DB_UPGRADE_ERROR(R.string.personalid_generic_error),
-    PERSONALID_LOST_CONFIGURATION_ERROR(R.string.recovery_network_token_request_rejected);
+    PERSONALID_DB_UPGRADE_ERROR(R.string.personalid_generic_error);
 
     final int messageId;
 

--- a/app/src/org/commcare/utils/GlobalErrors.java
+++ b/app/src/org/commcare/utils/GlobalErrors.java
@@ -4,6 +4,8 @@ import org.commcare.dalvik.R;
 
 public enum GlobalErrors {
     PERSONALID_GENERIC_ERROR(R.string.personalid_generic_error),
+    PERSONALID_DB_STARTUP_ERROR(R.string.personalid_generic_error),
+    PERSONALID_DB_UPGRADE_ERROR(R.string.personalid_generic_error),
     PERSONALID_LOST_CONFIGURATION_ERROR(R.string.recovery_network_token_request_rejected);
 
     final int messageId;


### PR DESCRIPTION
## Product Description
No visible user changes

## Technical Summary
Removed ambiguous logging about not finding DB passphrase (often false-alarms)
Removed redundant non-fatal exceptions just before DB crashes (which cause fatal exceptions)
Added a new check and crash to prevent unencrypted Connect DB
Added non-fatal exception when error encountered opening any DB (before trySqlCipherDbUpdate)
Improved exception logging when crashing Connect DB to indicate source

## Feature Flag
PersonalID

## Safety Assurance

### Safety story
Should be no noticeable changes to user, but simply reduced/improved logging when errors occur.
The new crash before opening an unencrypted DB is the biggest risk and could cause users to crash on upgrade.
If so, they would simply be prompted to reconfigure PersonalID when restarting the app.

### Automated test coverage
None

### QA Plan
Basic regression testing around PersonalID configuration and de-configuration, ensure no errors
