### PR TITLE
Hide "this is not me" Button

### DIFF
--- a/app/res/layout/fragment_recovery_code.xml
+++ b/app/res/layout/fragment_recovery_code.xml
@@ -194,6 +194,7 @@
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintEnd_toStartOf="@id/connect_backup_code_button"
                     app:layout_constraintBottom_toBottomOf="parent"
+                    android:visibility="gone"
                     android:textStyle="bold"/>
 
                 <com.google.android.material.button.MaterialButton

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
@@ -78,13 +78,11 @@ public class PersonalIdBackupCodeFragment extends BasePersonalIdFragment {
             binding.backupCodeSubtitle.setText(R.string.connect_backup_code_message);
             binding.backupCodeLayout.setVisibility(View.VISIBLE);
             binding.confirmCodeLayout.setVisibility(View.GONE);
-            binding.notMeButton.setVisibility(View.VISIBLE);
             setUserNameAndPhoto();
         } else {
             titleId = R.string.connect_backup_code_title_set;
             binding.backupCodeLayout.setVisibility(View.VISIBLE);
             binding.confirmCodeLayout.setVisibility(View.VISIBLE);
-            binding.notMeButton.setVisibility(View.GONE);
             binding.welcomeBackLayout.setVisibility(View.GONE);
         }
     }


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/CCCT-1731

## Labels and Review

- [x] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [x] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


Release/QA Note: Remove "This is Not me" button from Personal ID sign up flow