### PR TITLE
Cleaned up local DB passphrase code

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -12,7 +12,6 @@
     <string name="ota_restore_url" translatable="false">https://staging.commcarehq.org/ota_restore</string>
     <!-- string name="PostURL">https://pact.dimagi.com/receiver/submit/pact</string -->
     <!-- string name="ota_restore_url">https://pact.dimagi.com/provider/caselist</string -->
-    <string name="ConnectFetchDbKeyURL">/users/fetch_db_key</string>
     <string name="ConnectTokenURL">/o/token/</string>
     <string name="ConnectHeartbeatURL">/users/heartbeat</string>
     <!-- region: All strings for multiple apps and app-agnostic properties -->

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -20,7 +20,7 @@ public class ConnectKeyRecord extends Persisted {
     @Deprecated
     @Persisting(2)
     @MetaField(IS_LOCAL)
-    boolean isLocal = true;
+    boolean isLocal;
 
     public ConnectKeyRecord() {
     }

--- a/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
+++ b/app/src/org/commcare/android/database/global/models/ConnectKeyRecord.java
@@ -5,8 +5,6 @@ import org.commcare.models.framework.Persisting;
 import org.commcare.modern.database.Table;
 import org.commcare.modern.models.MetaField;
 
-import kotlin.Metadata;
-
 /**
  * DB model for storing the encrypted/encoded Connect DB passphrase
  *
@@ -19,16 +17,16 @@ public class ConnectKeyRecord extends Persisted {
     @Persisting(1)
     String encryptedPassphrase;
 
+    @Deprecated
     @Persisting(2)
     @MetaField(IS_LOCAL)
-    boolean isLocal;
+    boolean isLocal = true;
 
     public ConnectKeyRecord() {
     }
 
-    public ConnectKeyRecord(String encryptedPassphrase, boolean isLocal) {
+    public ConnectKeyRecord(String encryptedPassphrase) {
         this.encryptedPassphrase = encryptedPassphrase;
-        this.isLocal = isLocal;
     }
 
     public String getEncryptedPassphrase() {
@@ -37,11 +35,8 @@ public class ConnectKeyRecord extends Persisted {
     public void setEncryptedPassphrase(String passphrase) {
         encryptedPassphrase = passphrase;
     }
-    public boolean getIsLocal() {
-        return isLocal;
-    }
 
     public static ConnectKeyRecord fromV6(ConnectKeyRecordV6 oldVersion) {
-        return new ConnectKeyRecord(oldVersion.getEncryptedPassphrase(), true);
+        return new ConnectKeyRecord(oldVersion.getEncryptedPassphrase());
     }
 }

--- a/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
@@ -11,8 +11,6 @@ import org.commcare.utils.EncryptionKeyAndTransform;
 import org.commcare.utils.EncryptionKeyProvider;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Vector;
-
 public class ConnectDatabaseUtils {
     // the value of the key should not be renamed due to backward compatibility
     private static final String SECRET_NAME = "secret";
@@ -41,11 +39,13 @@ public class ConnectDatabaseUtils {
     }
 
     public static ConnectKeyRecord getKeyRecord() {
-        Vector<ConnectKeyRecord> records = CommCareApplication.instance()
-                .getGlobalStorage(ConnectKeyRecord.class)
-                .getRecordsForValue(ConnectKeyRecord.IS_LOCAL, true);
+        Iterable<ConnectKeyRecord> records = CommCareApplication.instance()
+                .getGlobalStorage(ConnectKeyRecord.class);
 
-        return records.size() > 0 ? records.firstElement() : null;
+        if (records.iterator().hasNext()) {
+            return records.iterator().next();
+        }
+        return null;
     }
 
     public static void storeConnectDbPassphrase(Context context, String base64EncodedPassphrase) {

--- a/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
@@ -7,10 +7,8 @@ import org.commcare.android.database.global.models.ConnectKeyRecord;
 import org.commcare.util.Base64;
 import org.commcare.util.Base64DecoderException;
 import org.commcare.util.EncryptionUtils;
-import org.commcare.utils.CrashUtil;
 import org.commcare.utils.EncryptionKeyAndTransform;
 import org.commcare.utils.EncryptionKeyProvider;
-import org.javarosa.core.services.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Vector;
@@ -18,7 +16,7 @@ import java.util.Vector;
 public class ConnectDatabaseUtils {
     // the value of the key should not be renamed due to backward compatibility
     private static final String SECRET_NAME = "secret";
-    public static void storeConnectDbPassphrase(@NotNull Context context, byte[] passphrase, boolean isLocal) {
+    public static void storeConnectDbPassphrase(@NotNull Context context, byte[] passphrase) {
         try {
             if (passphrase == null || passphrase.length == 0) {
                 throw new IllegalArgumentException("Passphrase must not be null or empty");
@@ -29,9 +27,9 @@ public class ConnectDatabaseUtils {
             String encoded = EncryptionUtils.encrypt(passphrase, keyAndTransform.getKey(),
                     keyAndTransform.getTransformation(), true);
 
-            ConnectKeyRecord record = getKeyRecord(isLocal);
+            ConnectKeyRecord record = getKeyRecord();
             if (record == null) {
-                record = new ConnectKeyRecord(encoded, isLocal);
+                record = new ConnectKeyRecord(encoded);
             } else {
                 record.setEncryptedPassphrase(encoded);
             }
@@ -42,39 +40,26 @@ public class ConnectDatabaseUtils {
         }
     }
 
-    public static ConnectKeyRecord getKeyRecord(boolean local) {
+    public static ConnectKeyRecord getKeyRecord() {
         Vector<ConnectKeyRecord> records = CommCareApplication.instance()
                 .getGlobalStorage(ConnectKeyRecord.class)
-                .getRecordsForValue(ConnectKeyRecord.IS_LOCAL, local);
+                .getRecordsForValue(ConnectKeyRecord.IS_LOCAL, true);
 
         return records.size() > 0 ? records.firstElement() : null;
     }
 
-    public static void storeConnectDbPassphrase(Context context, String base64EncodedPassphrase, boolean isLocal) {
+    public static void storeConnectDbPassphrase(Context context, String base64EncodedPassphrase) {
         try {
             byte[] bytes = Base64.decode(base64EncodedPassphrase);
-            storeConnectDbPassphrase(context, bytes, isLocal);
+            storeConnectDbPassphrase(context, bytes);
         } catch (Base64DecoderException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static String getConnectDbEncodedPassphrase(Context context, boolean isLocal) {
+    public static byte[] getConnectDbPassphrase(Context context) {
         try {
-            byte[] passBytes = getConnectDbPassphrase(context, isLocal);
-            if (passBytes != null) {
-                return Base64.encode(passBytes);
-            }
-        } catch (Exception e) {
-            Logger.exception("Getting DB passphrase", e);
-        }
-
-        return null;
-    }
-
-    public static byte[] getConnectDbPassphrase(Context context, boolean isLocal) {
-        try {
-            ConnectKeyRecord record = ConnectDatabaseUtils.getKeyRecord(isLocal);
+            ConnectKeyRecord record = ConnectDatabaseUtils.getKeyRecord();
             if (record == null) {
                 return null;
             }

--- a/app/src/org/commcare/connect/network/ApiPersonalId.java
+++ b/app/src/org/commcare/connect/network/ApiPersonalId.java
@@ -219,15 +219,6 @@ public class ApiPersonalId {
         throw new TokenUnavailableException();
     }
 
-
-    public static void fetchDbPassphrase(Context context, ConnectUserRecord user, IApiCallback callback) {
-        String url = PersonalIdApiClient.BASE_URL + context.getString(R.string.ConnectFetchDbKeyURL);
-        ConnectNetworkHelper.get(context,
-                url,
-                API_VERSION_PERSONAL_ID, new AuthInfo.ProvidedAuth(user.getUserId(), user.getPassword(), false),
-                ArrayListMultimap.create(), true, callback);
-    }
-
     public static void confirmBackupCode(Context context,
             String backupCode, String token, IApiCallback callback) {
 

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -50,7 +50,6 @@ public class CCAnalyticsEvent {
     static final String CCC_PAYMENT_CONFIRMATION_DISPLAY = "ccc_payment_confirmation_display";
     static final String CCC_PAYMENT_CONFIRMATION_INTERACT = "ccc_payment_confirmation_interact";
     static final String CCC_NOTIFICATION_TYPE = "ccc_notification_type";
-    static final String CCC_REKEYED_DB = "ccc_rekeyed_db";
     static final String CCC_BIOMETRIC_INVALIDATED = "ccc_biometric_invalidated";
     static final String PERSONAL_ID_CONFIGURATION_FAILURE = "personal_id_configuration_failure";
     static final String NAV_DRAWER_OPEN = "nav_drawer_open";

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -560,10 +560,6 @@ public class FirebaseAnalyticsUtil {
                 CCAnalyticsParam.NOTIFICATION_TYPE, notificationType);
     }
 
-    public static void reportRekeyedDatabase() {
-        reportEvent(CCAnalyticsEvent.CCC_REKEYED_DB);
-    }
-
     public static void reportBiometricInvalidated() {
         reportEvent(CCAnalyticsEvent.CCC_BIOMETRIC_INVALIDATED);
     }

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -88,16 +88,6 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
         getDbFile().delete();
     }
 
-    public static void rekeyDB(IDatabase db, String newPassphrase) throws Base64DecoderException {
-        if(db != null) {
-            byte[] newBytes = Base64.decode(newPassphrase);
-            String newKeyEncoded = UserSandboxUtils.getSqlCipherEncodedKey(newBytes);
-
-            db.execSQL("PRAGMA rekey = '" + newKeyEncoded + "';");
-            db.close();
-        }
-    }
-
     @Override
     public void onCreate(SQLiteDatabase db) {
         IDatabase database = new EncryptedDatabaseAdapter(db);


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-1574

## Product Description
No user-facing changes

## Technical Summary
This PR cleans up the migration code that was introduced earlier this year when we changed the Connect DB to start using a passphrase managed by PersonalID for encryption, instead of a locally-generated passphrase.

Brief description of the migration flow:
-Added an isLocal flag to ConnectKeyRecord
-All existing passphrases became "local" passphrases (isLocal=true) during the upgrade
-At app startup, we would issue a special API call if we detected the user didn't have the remote passphrase yet (isLocal=false)
-Once the remote passphrase was received, we would:
   -Store it as remote
   -Rekey the database if necessary (local != remote)
   -Store it as local

One additional caveat:
During the change described above we realized Connect was using the wrong overload for the DatabaseConnectOpenHelper constructor, and passing in a byte[] instead of an encoded string. So while supporting the upgrade/migration, we kept the ability for the app to keep accessing the DB via the legacy method until the migration was complete. The code supporting the legacy byte[] method has also been removed in this PR.
-Connect legacy used Base64.encodeToString
-Common CC code uses UserSandboxUtils.getSqlCipherEncodedKey

Changes to the code:
-Removed obsolete code for retrieving remote passphrase and re-keying DB.
-Removed legacy support for DBs using the old passphrase system (with different handling when getting DB handle).
-Deprecated the isLocal flag in ConnectKeyRecord

## Feature Flag
PersonalID

## Safety Assurance

### Safety story
Dev tested:
1. Start with v2.60 and PersonalID configured, then upgrade to the latest and verify things work as expected
2. Restart the app after the above and verify again
3. Install the latest from scratch, then configure PersonalID and verify things work as expected
4. Restart the app after the above and verify again

For all 4 tests, "things work as expected" simply means that PersonalID is functional. This can be tested by:
-Viewing the side nav menu and verifying the PersonalID user info is displayed
-Account does not automatically get de-configured
-No crashes

### Automated test coverage
None

### QA Plan
See the dev tests conducted above with success criteria
