### PR TITLE
Locking ConnectActivity to portrait screen orientation

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -182,7 +182,8 @@
         <activity android:name="org.commcare.activities.MenuActivity" />
         <activity
             android:name="org.commcare.activities.connect.ConnectActivity"
-            android:exported="false"/>
+            android:exported="false"
+            android:screenOrientation="portrait"/>
         <service android:name="com.google.android.gms.metadata.ModuleDependencies"
             android:enabled="false"
             android:exported="false"


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CI-197
https://dimagi.atlassian.net/browse/CCCT-1659

## Product Description
All Connect screens will only be shown in portrait mode.

## Technical Summary
Simple change to manifest, to avoid state issues when the screen downloads.
This was causing a crash when downloading a learn/deliver app if the user rotated the screen.
The job being passed via the intent got lost, and the ConnectJobFragment would crash.
This error could technically happen with any job-depended fragment.

## Feature Flag
Connect

## Safety Assurance

### Safety story
Easy to test, screen no longer adjusts to landscape when rotated.

### Automated test coverage
None

### QA Plan
Verify the device will not display any Connect pages in landscape mode.
