### PR TITLE
Corrects Personal id api Versioning

### DIFF
--- a/app/src/org/commcare/connect/network/ApiPersonalId.java
+++ b/app/src/org/commcare/connect/network/ApiPersonalId.java
@@ -51,7 +51,6 @@ import retrofit2.Response;
 
 public class ApiPersonalId {
     private static final String API_VERSION_NONE = null;
-    public static final String API_VERSION_PERSONAL_ID = "2.0";
     private static final String CONNECT_CLIENT_ID = "zqFUtAAMrxmjnC1Ji74KAa6ZpY1mZly0J0PlalIa";
 
 
@@ -68,7 +67,7 @@ public class ApiPersonalId {
 
                 String tokenAuth = HttpUtils.getCredential(token);
                 HashMap<String, String> headers = new HashMap<>();
-                RequestBody requestBody = ConnectNetworkHelper.buildPostFormHeaders(params, true, API_VERSION_PERSONAL_ID, headers);
+                RequestBody requestBody = ConnectNetworkHelper.buildPostFormHeaders(params, true, PersonalIdApiClient.API_VERSION, headers);
                 ApiService apiService = PersonalIdApiClient.getClientApi();
                 Call<ResponseBody> call = apiService.connectHeartbeat(tokenAuth,headers, requestBody);
                 BaseApi.Companion.callApi(context, call, callback, ApiEndPoints.connectHeartbeatURL);
@@ -98,7 +97,7 @@ public class ApiPersonalId {
         params.put("password", user.getPassword());
 
         HashMap<String, String> headers = new HashMap<>();
-        RequestBody requestBody = ConnectNetworkHelper.buildPostFormHeaders(params, true, API_VERSION_PERSONAL_ID, headers);
+        RequestBody requestBody = ConnectNetworkHelper.buildPostFormHeaders(params, true, PersonalIdApiClient.API_VERSION, headers);
         ApiService apiService = PersonalIdApiClient.getClientApi();
         Call<ResponseBody> call = apiService.connectToken(headers,requestBody);
         BaseApi.Companion.callApi(context, call, callback,ApiEndPoints.connectTokenURL);
@@ -115,7 +114,7 @@ public class ApiPersonalId {
         String url = PersonalIdApiClient.BASE_URL + context.getString(R.string.ConnectTokenURL);
 
         ConnectNetworkHelper.PostResult postResult = ConnectNetworkHelper.postSync(context, url,
-                API_VERSION_PERSONAL_ID, new AuthInfo.NoAuth(), params, true, false);
+                PersonalIdApiClient.API_VERSION, new AuthInfo.NoAuth(), params, true, false);
         Logger.log(LogTypes.TYPE_MAINTENANCE, "Connect Token Post Result " + postResult.responseCode);
         if (postResult.responseCode >= 200 && postResult.responseCode < 300) {
             try {
@@ -346,7 +345,7 @@ public class ApiPersonalId {
         Multimap<String, String> params = ArrayListMultimap.create();
         ConnectNetworkHelper.get(context,
                 context.getString(R.string.ConnectMessageRetrieveMessagesURL),
-                API_VERSION_PERSONAL_ID, authInfo, params, true, callback);
+                PersonalIdApiClient.API_VERSION, authInfo, params, true, callback);
     }
 
     public static boolean updateChannelConsent(Context context, String username, String password,
@@ -360,7 +359,7 @@ public class ApiPersonalId {
 
         return ConnectNetworkHelper.post(context,
                 context.getString(R.string.ConnectMessageChannelConsentURL),
-                API_VERSION_PERSONAL_ID, authInfo, params, false, false, callback);
+                PersonalIdApiClient.API_VERSION, authInfo, params, false, false, callback);
     }
 
     private static void handleApiError(Response<?> response) {
@@ -432,7 +431,7 @@ public class ApiPersonalId {
 
         ConnectNetworkHelper.post(context,
                 context.getString(R.string.ConnectMessageConfirmURL),
-                API_VERSION_PERSONAL_ID, authInfo, params, false, true, callback);
+                PersonalIdApiClient.API_VERSION, authInfo, params, false, true, callback);
     }
 
     public static void sendMessagingMessage(Context context, String username, String password,
@@ -458,8 +457,6 @@ public class ApiPersonalId {
 
         ConnectNetworkHelper.post(context,
                 context.getString(R.string.ConnectMessageSendURL),
-                API_VERSION_PERSONAL_ID, authInfo, params, false, true, callback);
+                PersonalIdApiClient.API_VERSION, authInfo, params, false, true, callback);
     }
-
-
 }

--- a/app/src/org/commcare/connect/network/connectId/PersonalIdApiClient.java
+++ b/app/src/org/commcare/connect/network/connectId/PersonalIdApiClient.java
@@ -9,7 +9,7 @@ import org.commcare.connect.network.base.BaseApiClient;
  */
 public class PersonalIdApiClient {
     public static final String BASE_URL = "https://connectid.dimagi.com";
-    private static final String API_VERSION = "1.0";
+    public static final String API_VERSION = "2.0";
     private static volatile ApiService apiService;
 
     private PersonalIdApiClient() {


### PR DESCRIPTION
## Product Description

We were using 2 different personal ID api versions in sign up (1.0) and post sign up flow (2.0), api version should instead be a singular field per server. This PR corrects that by bumping the version for all calls to `2.0` 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


FYI @calellowitz @Charl1996 
