### PR TITLE
Fixes crash on clicking View Job Status

### DIFF
--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -81,9 +81,9 @@ public class ConnectActivity extends NavigationHostCommCareActivity<ConnectActiv
 
     private void initStateFromExtras() {
         redirectionAction = getIntent().getStringExtra(REDIRECT_ACTION);
-        String opportunityId = getIntent().getStringExtra(ConnectConstants.OPPORTUNITY_ID);
-        if(!TextUtils.isEmpty(opportunityId)){
-            job = ConnectJobUtils.getCompositeJob(this, Integer.parseInt(opportunityId));
+        int opportunityId = getIntent().getIntExtra(ConnectConstants.OPPORTUNITY_ID, -1);
+        if(opportunityId != -1) {
+            job = ConnectJobUtils.getCompositeJob(this, opportunityId);
         }
     }
 

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -24,6 +24,7 @@ import androidx.navigation.fragment.NavHostFragment;
 
 import com.google.common.base.Strings;
 
+import org.apache.commons.lang3.StringUtils;
 import org.commcare.activities.NavigationHostCommCareActivity;
 import org.commcare.activities.PushNotificationActivity;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
@@ -82,6 +83,12 @@ public class ConnectActivity extends NavigationHostCommCareActivity<ConnectActiv
     private void initStateFromExtras() {
         redirectionAction = getIntent().getStringExtra(REDIRECT_ACTION);
         int opportunityId = getIntent().getIntExtra(ConnectConstants.OPPORTUNITY_ID, -1);
+        if (opportunityId == -1) {
+            String opportunityIdStr = getIntent().getStringExtra(ConnectConstants.OPPORTUNITY_ID);
+            if (!StringUtils.isEmpty(opportunityIdStr)) {
+                opportunityId = Integer.parseInt(opportunityIdStr);
+            }
+        }
         if(opportunityId != -1) {
             job = ConnectJobUtils.getCompositeJob(this, opportunityId);
         }


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/QA-8141

[crash](https://console.firebase.google.com/u/1/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/2453761d848f4bb7f52a49ae1554ea26?time=60m&sessionEventKey=68E4E50E033C000132D6FCAEBF1E4D76_2136864156345115017)


## Technical Summary

We were using incorrect data type for opportunity id which was resulting in the job to be set as null for `connectActivity` 

[This is where](https://github.com/dimagi/commcare-android/blob/master/app/src/org/commcare/connect/ConnectNavHelper.kt#L76) we add opportunity id to the extras as Integer


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
