### PR TITLE
Job Status Fix

### DIFF
--- a/app/src/org/commcare/connect/database/JobStoreManager.java
+++ b/app/src/org/commcare/connect/database/JobStoreManager.java
@@ -101,7 +101,10 @@ public class JobStoreManager {
         for (ConnectJobRecord existingJob : existingJobs) {
             if (existingJob.getJobId() == job.getJobId()) {
                 job.setID(existingJob.getID());  // Set ID for updating
-                job.setStatus(existingJob.getStatus());
+                if(existingJob.getStatus() > job.getStatus()) {
+                    //Status should never go backwards
+                    job.setStatus(existingJob.getStatus());
+                }
                 isExisting = true;
                 break;
             }


### PR DESCRIPTION
Only overriding job status from existing if the existing value is later in the workflow.

## Product Description
Job status will properly proceed from Learning to Delivery when user claims the job.

## Technical Summary
Preserving the later status when overwriting existing job from DB with updated version.
Status never goes backwards.

## Feature Flag
Connect

## Safety Assurance

### Safety story
Fixed after bug exposed by QA.
Existing testing will verify the fix.

### Automated test coverage
None