### PR TITLE
Added analytics event for PersonalID account lockout (on Backup Code …

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
@@ -258,6 +258,7 @@ public class PersonalIdBackupCodeFragment extends BasePersonalIdFragment {
 
     private void handleAccountLockout() {
         logRecoveryResult(false);
+        FirebaseAnalyticsUtil.reportPersonalIdConfigurationFailure(AnalyticsParamValue.START_CONFIGURATION_LOCKED_ACCOUNT_FAILURE);
         clearBackupCodeFields();
         navigateWithMessage(getString(R.string.personalid_recovery_lockout_title),
                 getString(R.string.personalid_recovery_lockout_message),


### PR DESCRIPTION
Added an analytics event when the user is informed that their PersonalID account has been locked on the Backup Code page.