### PR TITLE
Null-check when logging integrity analytics event

### DIFF
--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -18,7 +18,8 @@ import org.commcare.utils.FormUploadResult;
 import org.javarosa.core.services.Logger;
 
 import java.util.Date;
-import java.util.Objects;
+
+import javax.annotation.Nullable;
 
 import androidx.navigation.NavController;
 import androidx.navigation.NavDestination;
@@ -34,8 +35,6 @@ import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_U
 import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_USAGE_MOST;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_USAGE_OTHER;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_USAGE_PARTIAL;
-
-import javax.annotation.Nullable;
 
 /**
  * Created by amstone326 on 10/13/17.


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-1808

## Product Description
No user-facing change

## Technical Summary
Logging a non-fatal exception when trying to send integrity analytics event with a null (or "null") responseCode.

### Safety story
Simple change to log a non-fatal exception, not user-facing.

### Automated test coverage
None
