### PR TITLE
Center Icons In Personal ID Account Registration Flow.

### DIFF
--- a/app/res/layout/fragment_recovery_code.xml
+++ b/app/res/layout/fragment_recovery_code.xml
@@ -86,7 +86,8 @@
                 android:layout_width="42dp"
                 android:layout_height="42dp"
                 android:background="@drawable/connect_side_icon_bg"
-                android:gravity="center">
+                android:gravity="center"
+                android:layout_gravity="center">
 
                 <ImageView
                     android:layout_width="wrap_content"
@@ -131,7 +132,8 @@
                 android:layout_width="42dp"
                 android:layout_height="42dp"
                 android:background="@drawable/connect_side_icon_bg"
-                android:gravity="center">
+                android:gravity="center"
+                android:layout_gravity="center">
 
                 <ImageView
                     android:layout_width="wrap_content"

--- a/app/res/layout/screen_personalid_name.xml
+++ b/app/res/layout/screen_personalid_name.xml
@@ -52,7 +52,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:background="@drawable/connect_side_icon_bg"
-                        android:gravity="center">
+                        android:gravity="center"
+                        android:layout_gravity="center">
 
                         <ImageView
                             android:layout_width="42dp"

--- a/app/res/layout/screen_personalid_phone_verify.xml
+++ b/app/res/layout/screen_personalid_phone_verify.xml
@@ -66,7 +66,8 @@
                 android:layout_width="42dp"
                 android:layout_height="42dp"
                 android:background="@drawable/connect_side_icon_bg"
-                android:gravity="center">
+                android:gravity="center"
+                android:layout_gravity="center">
 
                 <ImageView
                     android:layout_width="wrap_content"

--- a/app/res/layout/screen_personalid_phoneno.xml
+++ b/app/res/layout/screen_personalid_phoneno.xml
@@ -60,7 +60,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:background="@drawable/connect_side_icon_bg"
-                    android:gravity="center">
+                    android:gravity="center"
+                    android:layout_gravity="center">
 
                     <ImageView
                         android:layout_width="42dp"


### PR DESCRIPTION
Something I noticed when using the app for myself is that there are a few icons in the Personal ID sign in/register flow that are not centered. The changes needed to center the icons is very trivial and straightforward, so I figured I would raise a quick PR for this. There is no JIRA ticket for this that I'm aware of.

<img width="300" alt="Screenshot 2025-11-03 at 1 12 29 PM" src="https://github.com/user-attachments/assets/507f26c5-89b4-4825-ad40-101b54434e96" />
<img width="300" alt="Screenshot 2025-11-03 at 1 13 29 PM" src="https://github.com/user-attachments/assets/a5ac5a9d-259c-4cb7-88ea-3b9d2b610931" />
<img width="300" alt="Screenshot 2025-11-03 at 1 13 57 PM" src="https://github.com/user-attachments/assets/1bc7f48e-e841-4ec9-b20a-23cc823636a4" />
<img width="300" alt="Screenshot 2025-11-03 at 1 14 32 PM" src="https://github.com/user-attachments/assets/f4670990-378a-4564-8124-66ffb7f3894d" />
