### PR TITLE
CCCT-1867 Connect Message Fragment Crash

### DIFF
--- a/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
+++ b/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
@@ -26,7 +26,6 @@ import org.commcare.connect.MessageManager;
 import org.commcare.connect.database.ConnectMessagingDatabaseHelper;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.FragmentConnectMessageBinding;
-
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.utils.FirebaseMessagingUtil;
 
@@ -109,7 +108,14 @@ public class ConnectMessageFragment extends Fragment {
             if (success) {
                 refreshUi();
             } else {
-                Toast.makeText(requireContext(), getString(R.string.connect_messaging_retrieve_messages_fail), Toast.LENGTH_SHORT).show();
+                Context context = getContext();
+                if (context != null) {
+                    Toast.makeText(
+                            context,
+                            getString(R.string.connect_messaging_retrieve_messages_fail),
+                            Toast.LENGTH_SHORT
+                    ).show();
+                }
             }
         });
     }


### PR DESCRIPTION
### [CCCT-1867](https://dimagi.atlassian.net/browse/CCCT-1867)

## Technical Summary

This crash happens when the user goes to the Connect Message Fragment screen, the app begins to asynchronously fetch messages, and then the user goes to another screen (e.g. hitting the back button once or twice) before the asynchronous work is finished (in this case, the work finishes with a failure). This crash happens because the fragment's context is `null` when the fragment detaches from its Activity, and we are attempting to use that `null` context to display a Toast message to the user.

So, to fix the crash I simply added a null check for the fragment's context before we try to show the Toast message.

The reason I chose this solution is because it doesn't make sense to me to show the user a Toast message regarding receiving messages if they're on a different screen entirely, which leads to poor UX.  Whenever the user returns to the Connect Message Fragment Screen, the app will try to fetch the messages again anyways. However, I'd love to hear everyone's thoughts on this.

## Safety Assurance

### Safety story

I verified that the app no longer crashes when following these repro steps:
1. Turn on airplane mode.
2. Open a message channel.
3. **_Immediately_** hit the back button.

Here is a video example of the crash **_before_** my changes:

https://github.com/user-attachments/assets/0d5b8771-dc77-4247-9a1c-4da07db3449f

Here is a video example **_after_** my changes:

https://github.com/user-attachments/assets/adc79c9c-6d0d-4423-90b2-3e07176241db

### QA Plan

For QA, we should verify that if you follow these steps, the app does not crash:

1. Turn on airplane mode.
2. Open a message channel.
3. **_Immediately_** hit the back button.
4. Try steps 1 through 3 a few different times.
