### PR TITLE
Corrects layout for work history list

### DIFF
--- a/app/res/layout/fragment_work_history_earned.xml
+++ b/app/res/layout/fragment_work_history_earned.xml
@@ -24,8 +24,8 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvEarnedWorkHistory"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_marginTop="10dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/QA-8193

## Technical Summary

Seems like a mistake that the layout width and heights were set to `0` 


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
