### PR TITLE
Fix app sandbox setup

### DIFF
--- a/app/src/org/commcare/activities/connect/viewmodel/PersonalIdWorkHistoryViewModel.kt
+++ b/app/src/org/commcare/activities/connect/viewmodel/PersonalIdWorkHistoryViewModel.kt
@@ -98,8 +98,8 @@ class PersonalIdWorkHistoryViewModel(
 
     private fun getWorkHistoryForAppRecord(record: ApplicationRecord): Iterable<PersonalIdWorkHistory> {
         val commcareApp = CommCareApp(record)
+        commcareApp.setupSandbox()
         try {
-            commcareApp.setupSandbox()
             val profile = commcareApp.initApplicationProfile()
             return profile.credentials.map { credential ->
                 PersonalIdWorkHistory().apply {


### PR DESCRIPTION
## Product Description

Fixes https://dimagi.atlassian.net/browse/QA-8210

## Technical Summary

We were not restoring the last app sandbox state correctly leading to [this crash](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/51aa7f6f5eb33e037c6fcb406e79cad7?time=12h&versions=2.61%20(477622);2.61%20(484255)&sessionEventKey=6909D11D036E000153B2B4A291C94671_2147282452912389058)

I added more sandbox handling to reset to the initial state and could verify the issue is fixed. 

- I also have put this code behind the pending flags check as this evaluation can be expensive and doesn't need to happen at the momenet when pending tabs are not turned on


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
