### PR TITLE
Removed showing messaging in notification history list

### DIFF
--- a/app/src/org/commcare/utils/PushNotificationApiHelper.kt
+++ b/app/src/org/commcare/utils/PushNotificationApiHelper.kt
@@ -89,7 +89,6 @@ object PushNotificationApiHelper {
                         }
                         continuation.resume(Result.success(newResultWithoutMessaging))
                     }
-
                 }
 
                 override fun onFailure(


### PR DESCRIPTION
## Product Description
Notification history will not show messaging 

## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-1897

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
