### PR TITLE
Bug solved for retrieve notification API for storing connect messaging

### DIFF
--- a/app/src/org/commcare/connect/network/connectId/parser/RetrieveNotificationsResponseParser.kt
+++ b/app/src/org/commcare/connect/network/connectId/parser/RetrieveNotificationsResponseParser.kt
@@ -63,12 +63,10 @@ class RetrieveNotificationsResponseParser<T>(
             for (notificationJsonIndex in 0 until notificationsJsonArray!!.length()) {
                 val notificationJsonObject =
                     notificationsJsonArray!!.getJSONObject(notificationJsonIndex)
-                if (isNotificationMessageType(notificationJsonObject) &&
-                    notificationJsonObject.getJSONObject("data").has("message_id")
-                ) {
+                if (isNotificationMessageType(notificationJsonObject)) {
                     val message =
                         ConnectMessagingMessageRecord.fromJson(
-                            notificationJsonObject.getJSONObject("data"),
+                            notificationJsonObject,
                             existingChannels,
                         )
                     if (message != null) {
@@ -111,5 +109,5 @@ class RetrieveNotificationsResponseParser<T>(
                 notificationJsonObject.get(
                     "notification_type",
                 ),
-            ) && notificationJsonObject.has("data") && notificationJsonObject.getJSONObject("data") != null
+            )
 }


### PR DESCRIPTION
Connect messages were not getting stored due to recent changes in retrieve notification api. This is solved in this PR.


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
