### PR TITLE
Login: App switching fix

### DIFF
--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -760,6 +760,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         // Retrieve the app record corresponding to the app selected
         selectedAppIndex = position;
         String appId = appIdDropdownList.get(selectedAppIndex);
+        presetAppId = appId;
         seatAppIfNeeded(appId);
     }
 
@@ -1033,6 +1034,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
                 if (!appIdDropdownList.isEmpty()) {
                     selectedAppIndex = appIdDropdownList.indexOf(recordId);
                 }
+                presetAppId = recordId;
                 seatAppIfNeeded(recordId);
                 closeDrawer();
             }


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CI-370

## Product Description
Fixes a bug that could prevent a user from switching to a different app on the login page.

## Technical Summary
Once the login page was launched with a presetAppId, it would no longer be possible to seat a different app.
If the user attempted to do so, the app would seat the new app and then immediately seat the preset app again.
When the user selects a new app, the code now updates the presetAppId to match the user's new selection (the original selection that brught us to the page no longer matters).

## Feature Flag
None

## Safety Assurance

### Safety story
I tested before and after the fix and verified that the UX is as desired.
 
### Automated test coverage
None

### QA Plan
-Login to an app
-Use the side drawer to select a different app from the menu
-On the login page, choose a different app rather than logging into the previously selected app
-Observe that the new app is seated correctly and the code doesn't re-seat the previous app.