### PR TITLE
Solved Android 15 edge to edge issue + added loading blocking UI 

### DIFF
--- a/app/res/layout/activity_push_notification.xml
+++ b/app/res/layout/activity_push_notification.xml
@@ -12,13 +12,11 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:orientation="vertical"
-        android:paddingTop="?attr/actionBarSize"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:layout_marginBottom="10dp"
         tools:listitem="@layout/item_push_notification" />
 
     <androidx.appcompat.widget.AppCompatTextView

--- a/app/src/org/commcare/activities/PushNotificationActivity.kt
+++ b/app/src/org/commcare/activities/PushNotificationActivity.kt
@@ -5,7 +5,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import org.commcare.activities.connect.viewmodel.PushNotificationViewModel
 import org.commcare.adapters.PushNotificationAdapter
@@ -13,13 +12,13 @@ import org.commcare.android.database.connect.models.PushNotificationRecord
 import org.commcare.dalvik.R
 import org.commcare.dalvik.databinding.ActivityPushNotificationBinding
 import org.commcare.google.services.analytics.AnalyticsParamValue
-import org.commcare.google.services.analytics.CCAnalyticsParam
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.pn.helper.NotificationBroadcastHelper
 import org.commcare.preferences.NotificationPrefs
 import org.commcare.utils.FirebaseMessagingUtil.getIntentForPNClick
+import org.commcare.views.dialogs.CustomProgressDialog
 
-class PushNotificationActivity : AppCompatActivity() {
+class PushNotificationActivity : CommCareActivity<PushNotificationActivity>() {
     private val binding: ActivityPushNotificationBinding by lazy {
         ActivityPushNotificationBinding.inflate(layoutInflater)
     }
@@ -32,7 +31,7 @@ class PushNotificationActivity : AppCompatActivity() {
         initViews()
         observeRetrieveNotificationApi()
         registerForNewNotification()
-        pushNotificationViewModel.loadNotifications(isRefreshed = false)
+        pushNotificationViewModel.loadNotifications(isRefreshed = false, this)
     }
 
     private fun observeRetrieveNotificationApi() {
@@ -109,7 +108,7 @@ class PushNotificationActivity : AppCompatActivity() {
             }
 
             R.id.notification_cloud_sync -> {
-                pushNotificationViewModel.loadNotifications(isRefreshed = true)
+                pushNotificationViewModel.loadNotifications(isRefreshed = true, this)
                 true
             }
 
@@ -121,7 +120,10 @@ class PushNotificationActivity : AppCompatActivity() {
             // Whenever new notification is received, signalling is calling retrieve_notifications api
             // so whenever this broadcast is received, new notification is already stored in local DB
             // that's the reason that isRefreshed = false is required
-            pushNotificationViewModel.loadNotifications(false)
+            pushNotificationViewModel.loadNotifications(false, this)
         }
     }
+
+    override fun generateProgressDialog(taskId: Int): CustomProgressDialog =
+        CustomProgressDialog.newInstance(null, getString(R.string.please_wait), taskId)
 }

--- a/app/src/org/commcare/pn/helper/NotificationBroadcastHelper.kt
+++ b/app/src/org/commcare/pn/helper/NotificationBroadcastHelper.kt
@@ -7,32 +7,38 @@ import android.content.IntentFilter
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+
 object NotificationBroadcastHelper {
     const val ACTION_NEW_NOTIFICATIONS = "org.commcare.dalvik.action.NEW_NOTIFICATION"
 
     fun registerForNotifications(
         context: Context,
         owner: LifecycleOwner,
-        onNewNotification: () -> Unit
+        onNewNotification: () -> Unit,
     ) {
-        val receiver = object : BroadcastReceiver() {
-            override fun onReceive(c: Context?, i: Intent?) {
-                onNewNotification()
+        val receiver =
+            object : BroadcastReceiver() {
+                override fun onReceive(
+                    c: Context?,
+                    i: Intent?,
+                ) {
+                    onNewNotification()
+                }
             }
-        }
 
         val manager = LocalBroadcastManager.getInstance(context)
 
-        owner.lifecycle.addObserver(object : DefaultLifecycleObserver {
-            override fun onResume(owner: LifecycleOwner) {
-                manager.registerReceiver(receiver, IntentFilter(ACTION_NEW_NOTIFICATIONS))
-                onNewNotification()
-            }
+        owner.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onResume(owner: LifecycleOwner) {
+                    manager.registerReceiver(receiver, IntentFilter(ACTION_NEW_NOTIFICATIONS))
+                }
 
-            override fun onPause(owner: LifecycleOwner) {
-                manager.unregisterReceiver(receiver)
-            }
-        })
+                override fun onPause(owner: LifecycleOwner) {
+                    manager.unregisterReceiver(receiver)
+                }
+            },
+        )
     }
 
     fun sendNewNotificationBroadcast(context: Context) {


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/QA-8230

CommCareActivity has handling for edge to edge issue, which might arise between Android versions greater and less than 15.  PushNotificationActivity was showing correctly for Android 15+ but having this issue for <Android 15. So now PushNotificationActivity is extended from CommCareActivity. As PushNotification is extended from CommCareActivity, changes have been made to show the blocking loading await popup also whenever API is being called. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
