### PR TITLE
Solved small size issue when capturing photo during personalID sign up

### DIFF
--- a/app/res/layout/screen_personalid_photo_capture.xml
+++ b/app/res/layout/screen_personalid_photo_capture.xml
@@ -49,22 +49,31 @@
             android:contentDescription="@null"
             android:src="@drawable/baseline_person_24" />
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_horizontal"
+            android:layout_marginEnd="20dp"
+            android:layout_marginStart="20dp"
+            >
         <com.google.android.material.button.MaterialButton
             android:id="@+id/take_photo_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_margin="@dimen/activity_horizontal_margin"
+            android:layout_weight="1"
+            android:layout_marginEnd="5dp"
             android:text="@string/personalid_photo_capture_take_photo_button" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/save_photo_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
+            android:layout_weight="1"
             android:enabled="false"
+            android:layout_marginStart="5dp"
             android:text="@string/personalid_photo_capture_save_photo_button" />
-
+        </LinearLayout>
         <TextView
             android:id="@+id/errorTextView"
             tools:text="Error uploading photo"


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/CI-391

As per the ticket, user is having small screen phone so not able to view the `SAVE PHOTO` button after taking the photo. In this current changes, I have made both button on same line equi distance from center as showing in below screen shot


<img width="1220" height="2712" alt="Screenshot_20251118_163551" src="https://github.com/user-attachments/assets/8e95aaa7-5210-4e29-a440-1ab7494e32e2" />


## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance


### QA Plan
Test upload photo

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
