### PR TITLE
Improve logging during resizing in QuestionsView 

### DIFF
--- a/app/src/org/commcare/views/QuestionsView.java
+++ b/app/src/org/commcare/views/QuestionsView.java
@@ -353,10 +353,8 @@ public class QuestionsView extends ScrollView
         try {
             super.onSizeChanged(w, h, oldw, oldh);
         } catch (IllegalArgumentException e) {
-            Logger.log(LogTypes.SOFT_ASSERT,
-                    "Resizing from " + oldw + "X" + oldh + " to " + w + "X" + h + " failed with focus on: " + getFocusedViewClassName());
-            Logger.log(LogTypes.SOFT_ASSERT,
-                    "Parent view of the focused view during the resizing: " + getFocusedViewParentView());
+            Logger.log(LogTypes.SOFT_ASSERT, "Resizing from " + oldw + "X" + oldh + " to " + w + "X" + h +
+                    " failed with focus on: " + getFocusedViewClassName() + "/" + getFocusedViewParentView());
             throw e;
         }
     }


### PR DESCRIPTION
## Product Description
Additional logging around the QuestionsView.onSizeChanged() callback method to get more insight into [these](https://console.firebase.google.com/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/1ceae08e29560910c0e182b24852e881?time=30d&types=crash&sessionEventKey=68F1FC52035D000159E86D9473069443_2140605356365267502) crashes. The initial set allowed us to identify the widget involved in the crashes, but replication hasn't yet been successful.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
