### PR TITLE
Added Receiver to listen location service status

### DIFF
--- a/app/src/org/commcare/activities/GeoPointActivity.java
+++ b/app/src/org/commcare/activities/GeoPointActivity.java
@@ -262,6 +262,11 @@ public class GeoPointActivity extends CommonBaseActivity implements TimerListene
     }
 
     @Override
+    public void onLocationServiceChange(boolean locationServiceEnabled) {
+
+    }
+
+    @Override
     public void onLocationRequestFailure(@NotNull CommCareLocationListener.Failure failure) {
         if (failure instanceof CommCareLocationListener.Failure.ApiException) {
             Exception exception = ((CommCareLocationListener.Failure.ApiException)failure).getException();

--- a/app/src/org/commcare/android/javarosa/PollSensorController.java
+++ b/app/src/org/commcare/android/javarosa/PollSensorController.java
@@ -128,6 +128,11 @@ public enum PollSensorController implements CommCareLocationListener {
         }
     }
 
+    @Override
+    public void onLocationServiceChange(boolean locationServiceEnabled) {
+
+    }
+
     private class PollingTimeoutTask extends TimerTask {
         @Override
         public void run() {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -564,4 +564,13 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
             locationPermissionLauncher.launch(REQUIRED_PERMISSIONS);
         }
     }
+
+    @Override
+    public void onLocationServiceChange(boolean locationServiceEnabled) {
+        if (!locationServiceEnabled) {
+            location = null;
+            setLocationToolTip(location);
+            updateContinueButtonState();
+        }
+    }
 }

--- a/app/src/org/commcare/location/CommCareFusedLocationController.kt
+++ b/app/src/org/commcare/location/CommCareFusedLocationController.kt
@@ -1,33 +1,43 @@
 package org.commcare.location
 
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.location.Location
+import android.location.LocationManager
+import android.os.Build
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.LocationSettingsRequest
+import org.commcare.utils.GeoUtils.locationServicesEnabledGlobally
 
 /**
  * @author $|-|!˅@M
  */
 class CommCareFusedLocationController(
-    private var mContext: Context?, private var mListener: CommCareLocationListener?) : CommCareLocationController {
-
+    private var mContext: Context?,
+    private var mListener: CommCareLocationListener?,
+) : CommCareLocationController {
     private val mFusedLocationClient = LocationServices.getFusedLocationProviderClient(mContext!!)
     private val settingsClient = LocationServices.getSettingsClient(mContext!!)
-    private val mLocationRequest = LocationRequest.create().apply {
-        priority = LocationRequest.PRIORITY_HIGH_ACCURACY
-        interval = LOCATION_UPDATE_INTERVAL
-    }
-    private var mCurrentLocation: Location? = null
-    private val mLocationCallback = object: LocationCallback() {
-        override fun onLocationResult(result: LocationResult) {
-            result ?: return
-            mCurrentLocation = result.lastLocation
-            mListener?.onLocationResult(mCurrentLocation!!)
+    private val mLocationServiceChangeReceiver = LocationChangeReceiverBroadcast()
+    private val mLocationRequest =
+        LocationRequest.create().apply {
+            priority = LocationRequest.PRIORITY_HIGH_ACCURACY
+            interval = LOCATION_UPDATE_INTERVAL
         }
-    }
+    private var mCurrentLocation: Location? = null
+    private val mLocationCallback =
+        object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                result ?: return
+                mCurrentLocation = result.lastLocation
+                mListener?.onLocationResult(mCurrentLocation!!)
+            }
+        }
 
     companion object {
         const val LOCATION_UPDATE_INTERVAL = 5000L
@@ -42,16 +52,19 @@ class CommCareFusedLocationController(
     }
 
     override fun start() {
-        val locationSettingsRequest = LocationSettingsRequest.Builder()
-            .addLocationRequest(mLocationRequest)
-            .setAlwaysShow(true)
-            .build()
-        settingsClient.checkLocationSettings(locationSettingsRequest)
+        val locationSettingsRequest =
+            LocationSettingsRequest
+                .Builder()
+                .addLocationRequest(mLocationRequest)
+                .setAlwaysShow(true)
+                .build()
+        settingsClient
+            .checkLocationSettings(locationSettingsRequest)
             .addOnSuccessListener {
                 mListener?.onLocationRequestStart()
                 requestUpdates()
-            }
-            .addOnFailureListener { exception ->
+                restartLocationServiceChangeReceiver() //  if already started listening, it should be stopped before starting new
+            }.addOnFailureListener { exception ->
                 mListener?.onLocationRequestFailure(CommCareLocationListener.Failure.ApiException(exception))
             }
     }
@@ -60,12 +73,51 @@ class CommCareFusedLocationController(
         mFusedLocationClient.removeLocationUpdates(mLocationCallback)
     }
 
-    override fun getLocation(): Location? {
-        return mCurrentLocation
-    }
+    override fun getLocation(): Location? = mCurrentLocation
 
     override fun destroy() {
+        stopLocationServiceChangeReceiver()
         mContext = null
         mListener = null
+    }
+
+    fun restartLocationServiceChangeReceiver() {
+        stopLocationServiceChangeReceiver()
+        startLocationServiceChangeReceiver()
+    }
+
+    fun startLocationServiceChangeReceiver() {
+        val intentFilter = IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mContext?.registerReceiver(mLocationServiceChangeReceiver, intentFilter, Context.RECEIVER_EXPORTED)
+        } else {
+            mContext?.registerReceiver(mLocationServiceChangeReceiver, intentFilter)
+        }
+    }
+
+    fun stopLocationServiceChangeReceiver() {
+        try {
+            mContext?.unregisterReceiver(mLocationServiceChangeReceiver)
+        } catch (e: IllegalArgumentException) {
+            // This can happen if stop is called multiple times
+        }
+    }
+
+    inner class LocationChangeReceiverBroadcast : BroadcastReceiver() {
+        override fun onReceive(
+            context: Context,
+            intent: Intent,
+        ) {
+            if (LocationManager.PROVIDERS_CHANGED_ACTION == intent.getAction()) {
+                val lm = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+                val locationServiceEnabled = locationServicesEnabledGlobally(lm)
+                if (locationServiceEnabled) {
+                    start()
+                } else {
+                    stop()
+                }
+                mListener?.onLocationServiceChange(locationServiceEnabled)
+            }
+        }
     }
 }

--- a/app/src/org/commcare/location/CommCareLocationListener.kt
+++ b/app/src/org/commcare/location/CommCareLocationListener.kt
@@ -7,7 +7,6 @@ import java.lang.Exception
  * @author $|-|!˅@M
  */
 interface CommCareLocationListener {
-
     // Inform the listener that we've starting listening for location updates, and it can show a
     // progress dialog or something similar in place.
     fun onLocationRequestStart()
@@ -20,8 +19,13 @@ interface CommCareLocationListener {
 
     fun onLocationRequestFailure(failure: Failure)
 
+    fun onLocationServiceChange(locationServiceEnabled: Boolean)
+
     sealed class Failure {
         object NoProvider : Failure()
-        data class ApiException(val exception: Exception) : Failure()
+
+        data class ApiException(
+            val exception: Exception,
+        ) : Failure()
     }
 }

--- a/app/src/org/commcare/utils/GeoUtils.java
+++ b/app/src/org/commcare/utils/GeoUtils.java
@@ -147,7 +147,7 @@ public class GeoUtils {
         context.startActivity(intent);
     }
 
-    private static boolean locationServicesEnabledGlobally(LocationManager lm) {
+    public static boolean locationServicesEnabledGlobally(LocationManager lm) {
         boolean gpsEnabled = false, networkEnabled = false;
         try {
             gpsEnabled = lm.isProviderEnabled(LocationManager.GPS_PROVIDER);


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/QA-8241

Application will listen to location service status and will take necessary action depending upon the status. 

### QA Plan
1. While doing PersonalId sign up and entering the phone number, QA can turn ON / OFF the location service. 
2. Application should show correct location tool tip depending upon the location service status.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
