### PR TITLE
Earned and Transfer amount on the payment tab issue solved

### DIFF
--- a/app/src/org/commcare/fragments/connect/ConnectResultsSummaryListFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectResultsSummaryListFragment.java
@@ -43,6 +43,7 @@ public class ConnectResultsSummaryListFragment extends ConnectJobFragment<Fragme
     public @NotNull View onCreateView(@NotNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = super.onCreateView(inflater, container, savedInstanceState);
         setupRecyclerView();
+        updateSummaryView();
         return view;
     }
 


### PR DESCRIPTION
## Product Description
When user navigates to the payment tab on the delivery progress screen, the amount under Earned and Transferred boxes is not displayed and only appears when user clicks on the sync button. 
Issue was that app was not calling view to display its value whenever landing on this screen.

## Technical Summary
https://dimagi.atlassian.net/browse/QA-8251

### QA Plan
QA should be able to view the earned and transferred amount right after landing on this screen

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
