### PR TITLE
Crash solved while moving back and forth in connect message screen

### DIFF
--- a/app/src/org/commcare/fragments/connect/ConnectJobDetailBottomSheetDialogFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobDetailBottomSheetDialogFragment.java
@@ -82,10 +82,4 @@ public class ConnectJobDetailBottomSheetDialogFragment extends BottomSheetDialog
         }
         return paymentTextBuilder.toString();
     }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        binding = null;
-    }
 }

--- a/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
@@ -80,13 +80,6 @@ public class ConnectUnlockFragment extends Fragment {
         new Handler().post(unlockRunnable);
     }
 
-
-    @Override
-    public void onDestroyView() {
-        binding = null;
-        super.onDestroyView();
-    }
-
     private void retrieveOpportunities() {
         ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(getContext());
         new ConnectApiHandler<ConnectOpportunitiesResponseModel>() {

--- a/app/src/org/commcare/fragments/connectMessaging/ConnectMessageChannelListFragment.java
+++ b/app/src/org/commcare/fragments/connectMessaging/ConnectMessageChannelListFragment.java
@@ -127,11 +127,6 @@ public class ConnectMessageChannelListFragment extends Fragment {
                         channel.getChannelName());
     }
 
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-    }
-
     public void refreshUi() {
         Context context = getContext();
         if (context != null) {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
@@ -64,12 +64,6 @@ public class PersonalIdBackupCodeFragment extends BasePersonalIdFragment {
         return binding.getRoot();
     }
 
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        binding = null;
-    }
-
     private void configureUiByMode() {
         isRecovery = personalIdSessionData.getAccountExists();
         if (isRecovery) {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBiometricConfigFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBiometricConfigFragment.java
@@ -88,12 +88,6 @@ public class PersonalIdBiometricConfigFragment extends BasePersonalIdFragment {
         updateUiBasedOnMinSecurityRequired();
     }
 
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        binding = null;
-    }
-
     private BiometricPrompt.AuthenticationCallback setupBiometricCallback() {
         Context context = requireActivity();
         return new BiometricPrompt.AuthenticationCallback() {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdMessageFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdMessageFragment.java
@@ -99,12 +99,6 @@ public class PersonalIdMessageFragment extends BottomSheetDialogFragment {
         }
     }
 
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        binding = null;
-    }
-
     private void setButton2Text(String buttonText) {
         boolean show = buttonText != null;
         binding.connectMessageButton2.setVisibility(show ? View.VISIBLE : View.GONE);

--- a/app/src/org/commcare/fragments/personalId/PersonalIdNameFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdNameFragment.java
@@ -63,12 +63,6 @@ public class PersonalIdNameFragment extends BasePersonalIdFragment {
         };
     }
 
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        binding = null;
-    }
-
     private void setListeners() {
         binding.personalidNameContinueButton.setOnClickListener(v -> verifyOrAddName());
     }

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -149,7 +149,6 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
     public void onDestroyView() {
         super.onDestroyView();
         locationController.destroy();
-        binding = null;
     }
 
     private void checkGooglePlayServices() {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneVerificationFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneVerificationFragment.java
@@ -268,7 +268,6 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        binding = null;
         otpCallback = null;
     }
 

--- a/app/src/org/commcare/fragments/personalId/WorkHistoryEarnedFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/WorkHistoryEarnedFragment.kt
@@ -69,9 +69,4 @@ class WorkHistoryEarnedFragment : Fragment() {
             return fragment
         }
     }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        binding = null
-    }
 }

--- a/app/src/org/commcare/fragments/personalId/WorkHistoryPendingFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/WorkHistoryPendingFragment.kt
@@ -65,9 +65,4 @@ class WorkHistoryPendingFragment : Fragment() {
             return fragment
         }
     }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        binding = null
-    }
 }


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/QA-8252

This crash was happening if user is navigating too fast between connect message and channel list screen. 
Firebase [log](https://console.firebase.google.com/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/6b09c99ccb1c190d3dd1627b3b2ef603?time=7d&types=crash&sessionEventKey=6927015800F400013CA914A0CED5EE18_2155472008000216394)

There was a condition where binding getting null due to destroyed view and app's main thread was [here](https://github.com/dimagi/commcare-android/blob/9a0eca84d3b46a8d35d5cf613c1b09c3a1880aad/app/src/org/commcare/fragments/connectMessaging/ConnectMessageChannelListFragment.java#L140) updating the UI. This crash will not happen if network gets completed, updated UI and than fragment is destroyed. 

### QA Plan
QA should navigate between connect message and channel list screen and app should not crash

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
