### PR TITLE
Emit widget changed event on manual ComboboxWidget item deletion

### DIFF
--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -95,10 +95,7 @@ public class ComboboxWidget extends QuestionWidget {
 
             @Override
             public void afterTextChanged(Editable s) {
-                if (s != null && s.toString().isEmpty()) {
-                    widgetEntryChanged();
-                }
-                clearWarningMessage();
+                widgetEntryChanged();
             }
         });
     }


### PR DESCRIPTION
## Product Description
This PR attempts to fix the `parameter must be a descendant of this view` crashes reported in Crashlytics, [link](https://console.firebase.google.com/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/1ceae08e29560910c0e182b24852e881?time=90d&types=crash&sessionEventKey=6929D62E030A0001286A6D9C8ABD185B_2156270093216382305).
It seems that the issue is caused by two factors:
- Manually deleting a `ComboboxWidget` selected item doesn’t fire the `widgetEntryChanged()` event, causing dependent questions and possibly UI updates to be delayed until the next screen refresh;
- `Notification labels` in CommCare whose content depends on other questions may change dimensions when those dependent values get updated. This can trigger a layout pass in the parent view;

In terms of the sequence of events:
- When a user manually deletes the selected option in `ComboboxWidget A`, no updates are triggered for its dependent questions, so the `Notification label`'s text and `ComboboxWidget B`'s visibility remain unchanged;
- if the user then taps `ComboboxWidget B`, which should not be visible by now, it causes `ComboboxWidget A` to lose focus. This triggers the `widgetEntryChanged()` event, and as a consequence, the UI update that should have happened immediately after the deletion;
- During the update, the notification label gets refreshed and its dimensions recalculated, leading to a layout pass. However, the UI is being updated and the focus is on a view that shouldn’t be visible and therefore is no longer part of the label’s parent view hierarchy, and this leads to an `java.lang.IllegalArgumentException - parameter must be a descendant of this view being thrown`

Ticket: https://dimagi.atlassian.net/browse/MOB-158

## Technical Summary
The solution applied to this is basically to trigger the `widgetEntryChanged()` event, when the user manually deletes its selected item.

## Safety Assurance

### Safety story
Successfully tested locally. 

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
