### PR TITLE
CCCT-1910 Locked Account 401 Error Handling

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
@@ -197,9 +197,6 @@ public class PersonalIdBackupCodeFragment extends BasePersonalIdFragment {
             public void onSuccess(PersonalIdSessionData sessionData) {
                 if (sessionData.getDbKey() != null) {
                     handleSuccessfulRecovery();
-                } else if (sessionData.getSessionFailureCode() != null &&
-                                sessionData.getSessionFailureCode().equalsIgnoreCase("LOCKED_ACCOUNT")) {
-                    handleAccountLockout();
                 } else if (sessionData.getAttemptsLeft() != null && sessionData.getAttemptsLeft() > 0) {
                     handleFailedBackupCodeAttempt();
                 }
@@ -248,15 +245,6 @@ public class PersonalIdBackupCodeFragment extends BasePersonalIdFragment {
         navigateWithMessage(getString(R.string.connect_backup_fail_title),
                 getString(R.string.personalid_wrong_backup_message, personalIdSessionData.getAttemptsLeft()),
                 ConnectConstants.PERSONALID_RECOVERY_WRONG_BACKUPCODE);
-    }
-
-    private void handleAccountLockout() {
-        logRecoveryResult(false);
-        FirebaseAnalyticsUtil.reportPersonalIdConfigurationFailure(AnalyticsParamValue.START_CONFIGURATION_LOCKED_ACCOUNT_FAILURE);
-        clearBackupCodeFields();
-        navigateWithMessage(getString(R.string.personalid_recovery_lockout_title),
-                getString(R.string.personalid_recovery_lockout_message),
-                ConnectConstants.PERSONALID_RECOVERY_ACCOUNT_LOCKED);
     }
 
     private void logRecoveryResult(boolean success) {


### PR DESCRIPTION
### [CCCT-1910](https://dimagi.atlassian.net/browse/CCCT-1910)

## Technical Summary

I removed unnecessary error handling. These changes have no impact on the user.

Note that I removed the `handleAccountLockout()` function as it is no longer needed because we are already handling account lockout [here](https://github.com/dimagi/commcare-android/blob/a81e3a55883f80c4877f17f9fae3c0658b49ff8e/app/src/org/commcare/fragments/personalId/BasePersonalIdFragment.kt#L29), which is called [here](https://github.com/dimagi/commcare-android/blob/a81e3a55883f80c4877f17f9fae3c0658b49ff8e/app/src/org/commcare/fragments/personalId/BasePersonalIdFragment.kt#L17).

## Safety Assurance

### Safety story

I verified that these changes have no impact on the user by intentionally locking a couple of test accounts. The code that I removed is currently never used or ran.

### QA Plan

It may be worth it for QA to intentionally lock an account by entering the incorrect backup code too many times to ensure that the behavior stays the same, especially the error message shown.
