### PR TITLE
Prevent Combobox dropdown list dismissal during text changed event

### DIFF
--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -29,7 +29,7 @@ public class ComboboxWidget extends QuestionWidget {
     private Vector<SelectChoice> choices;
     private Vector<String> choiceTexts;
     private Combobox comboBox;
-    private boolean isEntryChangedEventFiredDuringOnTextChanged = false;
+    private boolean wasWidgetChangedOnTextChanged = false;
 
     public ComboboxWidget(Context context, FormEntryPrompt prompt, ComboboxFilterRule filterRule) {
         super(context, prompt);
@@ -97,10 +97,10 @@ public class ComboboxWidget extends QuestionWidget {
             @Override
             public void afterTextChanged(Editable s) {
                 try {
-                    isEntryChangedEventFiredDuringOnTextChanged = true;
+                    wasWidgetChangedOnTextChanged = true;
                     widgetEntryChanged();
                 } finally {
-                    isEntryChangedEventFiredDuringOnTextChanged = false;
+                    wasWidgetChangedOnTextChanged = false;
                 }
             }
         });
@@ -121,7 +121,7 @@ public class ComboboxWidget extends QuestionWidget {
     @Override
     public IAnswerData getAnswer() {
         // So that we can see any error message that gets shown as a result of this
-        if(!isEntryChangedEventFiredDuringOnTextChanged) {
+        if(!wasWidgetChangedOnTextChanged) {
             comboBox.dismissDropDown();
         }
 


### PR DESCRIPTION
## Product Description
This addresses an issue introduced by this PR. QA reported that when users manually delete the selected item in the ComboboxWidget, the dropdown list is dismissed, preventing users from seeing the filtered items (see video below). This occurs because `widgetEntryChanged()` calls `getAnswer()`, and within the `CommboboxWidget`, this method dismisses the dropdown list. 

## Technical Summary
The solution here was to prevent the dismissal when the `widgetEntryChanged()` is called during an `afterTextChanged()` event.


## Safety Assurance

### Safety story
Successfully tested locally.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
