### PR TITLE
Update Comment In app/build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -163,9 +163,9 @@ dependencies {
 }
 
 ext {
-    // Obtained from ~/.gradle/gradle.properties on build server (mobile agent), or your local
-    // Obtained from ~/.gradle/gradle.properties on build server (mobile agent), or your local
-    // ~/.gradle/gradle.properties file, or loads default empty strings if neither is present
+    // Obtained from ~/.gradle/gradle.properties on build server (mobile agent), or your global
+    // user-level ~/.gradle/gradle.properties file, or loads default empty strings if neither is
+    // present
     MAPBOX_SDK_API_KEY = project.properties['MAPBOX_SDK_API_KEY'] ?: ''
     ANALYTICS_TRACKING_ID_DEV = project.properties['ANALYTICS_TRACKING_ID_DEV'] ?: ''
     ANALYTICS_TRACKING_ID_LIVE = project.properties['ANALYTICS_TRACKING_ID_LIVE'] ?: ''


### PR DESCRIPTION
Based on our mobile team standup meeting this morning, I thought it would be a good idea to quickly update this comment because during my onboarding I personally mistook it for saying that devs should put secrets in the project-level `gradle.properties` file, not the global user-level, which lead me to constantly git stashing and popping the secrets whenever I needed to test something.

I think that making this comment more clear will make it harder for devs in the future to also mistake this and accidentally push secrets to GitHub in the future.

Also, this comment had a duplicate line that should be removed anyways.