### PR TITLE
Prevent Combobox dropdown list dismissal during text changed event

### DIFF
--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -29,6 +29,7 @@ public class ComboboxWidget extends QuestionWidget {
     private Vector<SelectChoice> choices;
     private Vector<String> choiceTexts;
     private Combobox comboBox;
+    private boolean wasWidgetChangedOnTextChanged = false;
 
     public ComboboxWidget(Context context, FormEntryPrompt prompt, ComboboxFilterRule filterRule) {
         super(context, prompt);
@@ -95,7 +96,12 @@ public class ComboboxWidget extends QuestionWidget {
 
             @Override
             public void afterTextChanged(Editable s) {
-                widgetEntryChanged();
+                try {
+                    wasWidgetChangedOnTextChanged = true;
+                    widgetEntryChanged();
+                } finally {
+                    wasWidgetChangedOnTextChanged = false;
+                }
             }
         });
     }
@@ -115,7 +121,9 @@ public class ComboboxWidget extends QuestionWidget {
     @Override
     public IAnswerData getAnswer() {
         // So that we can see any error message that gets shown as a result of this
-        comboBox.dismissDropDown();
+        if(!wasWidgetChangedOnTextChanged) {
+            comboBox.dismissDropDown();
+        }
 
         comboBox.autoCorrectCapitalization();
         String enteredText = comboBox.getText().toString();


### PR DESCRIPTION
## Product Description
This addresses an issue introduced by #3445. QA reported that when users manually delete the selected item in the ComboboxWidget, the dropdown list is dismissed, preventing users from seeing the filtered items (see video below). 
<table>
<tr>
<td>Dropdown list dismissed on every text change</td><td>Expected behavior</td>
</tr>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/e4384b5d-ed0b-4f35-ac41-8dd23b25ea88" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/d61fdf21-ec3d-4755-bacc-573fe8157989" />
</td>
</tr>
</table>

Ticket: https://dimagi.atlassian.net/browse/QA-8262

## Technical Summary
The issue occurs because widgetEntryChanged() calls getAnswer(), and within the `ComboboxWidget`, this method dismisses the dropdown list. The solution here was to prevent the dismissal when the `widgetEntryChanged()` is called during an `afterTextChanged()` event.

## Safety Assurance

### Safety story
Successfully tested locally.

### QA Plan
QA will retest this fix to confirm that the issue has been resolved.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
