### PR TITLE
Drawing geo points on entity map when available

### DIFF
--- a/app/src/org/commcare/gis/EntityMapActivity.java
+++ b/app/src/org/commcare/gis/EntityMapActivity.java
@@ -210,11 +210,16 @@ public class EntityMapActivity extends CommCareActivity implements OnMapReadyCal
         if (displayInfo.getPoints() != null) {
             for(int i=0; i<displayInfo.getPoints().size(); i++) {
                 LatLng coordinate = displayInfo.getPoints().get(i);
+                int color = Color.WHITE;
+                if(displayInfo.getPointColorsHex() != null &&
+                        displayInfo.getPointColorsHex().size() > i) {
+                    color = displayInfo.getPointColorsHex().get(i);
+                }
                 CircleOptions options = new CircleOptions()
                         .center(coordinate)
                         .radius(GEO_POINT_RADIUS_METERS)
-                        .strokeColor(displayInfo.getPointColorsHex().get(i))
-                        .fillColor(displayInfo.getPointColorsHex().get(i));
+                        .strokeColor(color)
+                        .fillColor(color);
 
                 mMap.addCircle(options);
                 builder.include(coordinate);


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-1937

Cross-request: https://github.com/dimagi/commcare-core/pull/1513

## Product Description
When geo points are included in the case list, they will be drawn as small circles on the entity map.
Individual colors for the points can be specified, otherwise white will be used as a default.

The geo points and colors can be specified in the case lists using the following new formats:
* geo_points
* geo_points_colors_hex

Screenshot showing some points (see the two small orange circles in the corner of the bottom-left polygon):
<img width="540" height="1170" alt="image" src="https://github.com/user-attachments/assets/68efd44d-f9fd-4df9-b1c3-92950b1fc624" />


## Technical Summary
When geo points were retrieved from the case list, circles are drawn on the map corresponding to each point.
The circles are not clickable.


## Feature Flag
None

## Safety Assurance

### Safety story
Tested the geo point functionality by manually uploading some points and colors to the case data for a sample project, then manually editing a CCZ to include the two new fields in the case list with special new formats.

The screenshot above shows the resulting circles.

### Automated test coverage
None

### QA Plan
This will be easier to test once the associated HQ ticket is complete (for specifying the new formats in the case list).
