### PR TITLE
CCCT-1774 Redirect User To Job Status Page For Completed Opportunity

### DIFF
--- a/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
@@ -125,7 +125,6 @@ public class ConnectJobsListsFragment extends BaseConnectFragment<FragmentConnec
         setActiveJob(job);
 
         String appId = isLearning ? job.getLearnAppInfo().getAppId() : job.getDeliveryAppInfo().getAppId();
-        boolean appInstalled = AppUtils.isAppInstalled(appId);
 
         // We need the composite job because it has the correct number of deliveries.
         ConnectJobRecord compositeJob = ConnectJobUtils.getCompositeJob(requireActivity(), job.getJobId());
@@ -133,7 +132,7 @@ public class ConnectJobsListsFragment extends BaseConnectFragment<FragmentConnec
 
         if (deliveryComplete && !isLearning) {
             navigateToDeliveryProgress();
-        } else if (appInstalled) {
+        } else if (AppUtils.isAppInstalled(appId)) {
             ConnectAppUtils.INSTANCE.launchApp(requireActivity(), isLearning, appId);
         } else {
             int textId = isLearning ? R.string.connect_downloading_learn : R.string.connect_downloading_delivery;


### PR DESCRIPTION
### [CCCT-1774](https://dimagi.atlassian.net/browse/CCCT-1774)

## Product Description

I redirected the user to the job status page whenever an opportunity is completed.

**_Before_** my changes:

https://github.com/user-attachments/assets/78876ca0-d808-421f-b23d-4b4fdc4e26bb

**_After_** my changes:

https://github.com/user-attachments/assets/27d6ea47-b2a3-4407-853d-212bd56a6e1f

**_EDIT_** this is what it looks like after @shubham1g5's suggestion!:

https://github.com/user-attachments/assets/f72a2013-d7f4-4b96-be30-7087f9096a1a

## Technical Summary

At first I wanted to use the `ConnectJobRecord` that was already present inside the `ConnectJobsListsFragment.launchAppForJob()` function to determine if an opportunity is complete, but I ran into a bug where the job did not have the correct number of deliveries set on it and thus the code was incorrectly determining that an opportunity was incomplete when it was actually complete. So that's the reason for me utilizing `ConnectJobUtils` to get the composite job. Let me know if there is a better way to achieve this!

## Safety Assurance

### Safety story

I verified that, completed opportunities, as defined in the ticket, now redirect the user to the job status page instead of the home page. And, all non-complete opportunities are unaffected.

### QA Plan

On the opportunities list page, tap through several different opportunities (both complete and non-complete) and ensure that you are directed to the correct page.
