### PR TITLE
Added performance monitor tracing for entity map loading

### DIFF
--- a/app/src/org/commcare/google/services/analytics/CCPerfMonitoring.kt
+++ b/app/src/org/commcare/google/services/analytics/CCPerfMonitoring.kt
@@ -12,7 +12,8 @@ object CCPerfMonitoring {
     const val TRACE_APP_SYNC_DURATION = "app_sync_duration"
     const val TRACE_CASE_SEARCH_TIME = "case_search_time"
     const val TRACE_FORM_LOADING_TIME = "form_loading_time"
-    const val TRACE_ENTITY_MAP_LOADING_TIME = "entity_map_loading_time"
+    const val TRACE_ENTITY_MAP_READY_TIME = "entity_map_ready_time"
+    const val TRACE_ENTITY_MAP_LOADED_TIME = "entity_map_loaded_time"
 
     // Attributes
     const val ATTR_NUM_CASES_LOADED = "number_of_cases_loaded"


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-1949

## Product Description
No visible user-facing changes

## Technical Summary
Added performance monitoring trace to track how long it takes the map to load.
When there is additional data to show (markers, polygons, etc.), the trace ends when the map finishes zooming/scrolling to the desired area (or user cancels the zoom/scroll by taking control).

When there is no additional data to display the trace ends sooner, as no zoom is performed. I'm guessing this should never happen since the map is only accessible if address data is included, but since the performance trace includes counts of the additional entities we can treat the 0/0/0 case separately.

## Feature Flag
None

## Safety Assurance

### Safety story
Tested the changes manually and verified that the trace gets logged.
The code is pretty minimal and safe, not much that could cause an issue here.

### Automated test coverage
None

### QA Plan
Test accessing the entity map page with any additional display info (like centroid markers).
Nothing visible should be different from before this change.