### PR TITLE
CCCT-1992 Tweak Delivery Completion Banner

### DIFF
--- a/app/res/values/colors.xml
+++ b/app/res/values/colors.xml
@@ -8,6 +8,7 @@
     <color name="grey">#A3A3A3</color>
     <color name="grey_light">#D3D3D3</color>
     <color name="grey_lighter">#EBEBEB</color>
+    <color name="porcelain_grey">#F1F1F1</color>
     <color name="white">#FFFFFF</color>
     <color name="translucent_grey_dark">#20959699</color>
     <color name="translucent_grey">#80D3D3D3</color>

--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -119,6 +119,9 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
             if (job.readyToTransitionToDelivery()) {
                 textColorRes = R.color.connect_green;
                 backgroundColorRes = R.color.connect_light_green;
+            } else if (job.deliveryComplete()) {
+                textColorRes = R.color.connect_blue_color;
+                backgroundColorRes = R.color.porcelain_grey;
             } else {
                 textColorRes = R.color.connect_warning_color;
                 backgroundColorRes = R.color.connect_light_orange_color;

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -708,4 +708,8 @@ public class ConnectJobRecord extends Persisted implements Serializable {
 
         return newRecord;
     }
+
+    public boolean deliveryComplete() {
+        return isFinished() || getDeliveries().size() >= getMaxVisits();
+    }
 }


### PR DESCRIPTION
### [CCCT-1992](https://dimagi.atlassian.net/browse/CCCT-1992)

## Product Description

I tweaked the color schemes for two messages indicating a complete delivery.

https://github.com/user-attachments/assets/9f3168f9-f095-4cc8-b3c2-e54a0670f287

## Technical Summary

Nothing much to say here. This one is pretty straightforward. 

## Safety Assurance

### Safety story

I verified that the color schemes changed for the correct messages.

### QA Plan

Test that we are able to see the updated color scheme for the two messages:

- Finished/expired opportunity:
  - "The job has ended. You will not earn any progress for additional work."
- Maxed out visits/deliveries for an opportunity:
  - "You have completed the maximum number of visits. You will not earn any progress for additional work."
