### PR TITLE
CCCT-1952 New Firebase Analytics Property

### DIFF
--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
@@ -48,5 +48,5 @@ public class CCAnalyticsParam {
     static final String NOTIFICATION_ID = "notification_id";
     static final String NOTIFICATION_CLICK_METHOD = "click_method";
     static final String IS_PERSONAL_ID_DEMO_USER = "is_personal_id_demo_user";
-    static final String CONNECT_SERVER = "connect_server";
+    static final String APP_FLAVOR = "app_flavor";
 }

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -126,7 +126,7 @@ public class FirebaseAnalyticsUtil {
 
         flagPersonalIDDemoUser(ReportingUtils.getIsPersonalIDDemoUser());
 
-        analyticsInstance.setUserProperty(CCAnalyticsParam.CONNECT_SERVER, BuildConfig.CCC_HOST);
+        analyticsInstance.setUserProperty(CCAnalyticsParam.APP_FLAVOR, BuildConfig.FLAVOR);
     }
 
     private static String getFreeDiskBucket() {


### PR DESCRIPTION
### [CCCT-1952](https://dimagi.atlassian.net/browse/CCCT-1952)

## Technical Summary

I added the connect server to the user properties for all firebase analytics events. Here are the name-value pairs that will now appear for all events:
- `connect_server` -> `connect.dimagi.com`
- `connect_server` -> `connect-staging.dimagi.com`

**_Edit:_** I updated the name-value pairs to the following:
- `app_flavor` -> `commcare`
- `app_flavor` -> `cccStaging`

## Safety Assurance

### Safety story

I went into BigQuery and ran a query to verify that this new user property does show for my test device, and I tested with both a staging and a prod build.
