### PR TITLE
CCCT-1992 Tweak Delivery Completion Banner (Part 2)

### DIFF
--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -6,6 +6,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
@@ -185,15 +186,23 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
         String messageText = job.getCardMessageText(requireContext());
 
         if (messageText != null) {
+            @ColorRes int textColorRes;
+            @ColorRes int backgroundColorRes;
+
             if (job.deliveryComplete()) {
-                getBinding().tvConnectMessage.setTextColor(
-                        ContextCompat.getColor(requireActivity(), R.color.connect_blue_color)
-                );
-                getBinding().cvConnectMessage.setCardBackgroundColor(
-                        ContextCompat.getColor(requireActivity(), R.color.porcelain_grey)
-                );
+                textColorRes = R.color.connect_blue_color;
+                backgroundColorRes = R.color.porcelain_grey;
+            } else {
+                textColorRes = R.color.connect_warning_color;
+                backgroundColorRes = R.color.connect_light_orange_color;
             }
 
+            getBinding().tvConnectMessage.setTextColor(
+                    ContextCompat.getColor(requireActivity(), textColorRes)
+            );
+            getBinding().cvConnectMessage.setCardBackgroundColor(
+                    ContextCompat.getColor(requireActivity(), backgroundColorRes)
+            );
             getBinding().tvConnectMessage.setText(messageText);
             getBinding().cvConnectMessage.setVisibility(View.VISIBLE);
         } else {


### PR DESCRIPTION
### [CCCT-1992](https://dimagi.atlassian.net/browse/CCCT-1992)

## Product Description

I was a bit too quick to merge in #3467 😅. Turns out we are using a different message card in the `ConnectDeliveryProgressFragment`, so there is a second place to update the colors.

So, in #3467 I updated the colors in the app home screen. In this PR I updated the colors in the delivery screen.

See #3467 for more context.

https://github.com/user-attachments/assets/b84ab242-8953-418e-bf25-d329317b2119

## Safety Assurance

### Safety story

I verified that the color schemes changed for the correct messages (**_on the delivery screen and not just the app home screen!_**).

### QA Plan

Test that we are able to see the updated color scheme for the two messages (**_on both the CommCare app home screen and the delivery screen_**):

- Finished/expired opportunity:
  - "The job has ended. You will not earn any progress for additional work."
- Maxed out visits/deliveries for an opportunity:
  - "You have completed the maximum number of visits. You will not earn any progress for additional work."
