### PR TITLE
Improved wrong backup code error message

### DIFF
--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -470,7 +470,7 @@
     <string name="personalid_recovery_failed_title">Recuperación fallida</string>
     <string name="personalid_recovery_lockout_title">Cuenta bloqueada</string>
     <string name="personalid_recovery_failed_message">Parece que olvidaste tu código de respaldo, estamos creando una nueva cuenta para ti</string>
-    <string name="personalid_recovery_lockout_message">Ha ingresado el código de respaldo incorrecto demasiadas veces. Su cuenta ha sido bloqueada.</string>
+    <string name="personalid_recovery_lockout_message">Ha ingresado el código de respaldo incorrecto demasiadas veces. Su cuenta ha sido bloqueada. Comuníquese con el soporte para desbloquear su cuenta.</string>
     <string name="personalid_wrong_backup_message">Ha introducido el código de seguridad incorrecto. Inténtelo de nuevo. Su cuenta se bloqueará después de %d intentos incorrectos más.</string>
     <string name="personalid_camera_permission_title">Permiso de cámara</string>
     <string name="personalid_camera_permission_msg">Para tomar una foto, CommCare necesita permiso para usar la cámara de tu dispositivo.</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -474,7 +474,7 @@ License.
     <string name="personalid_recovery_failed_title">La récupération a échoué</string>
     <string name="personalid_recovery_lockout_title">Compte Verrouillé</string>
     <string name="personalid_recovery_failed_message">Il semble que vous ayez oublié votre code de sauvegarde, nous créons un nouveau compte pour vous</string>
-    <string name="personalid_recovery_lockout_message">Vous avez saisi un code de secours incorrect un trop grand nombre de fois. Votre compte a été bloqué.</string>
+    <string name="personalid_recovery_lockout_message">Vous avez saisi un code de secours incorrect un trop grand nombre de fois. Votre compte a été bloqué. Veuillez contacter le support pour débloquer votre compte.</string>
     <string name="personalid_wrong_backup_message">Vous avez saisi un code de sauvegarde incorrect. Veuillez réessayer. Votre compte sera bloqué après %d tentatives incorrectes supplémentaires.</string>
     <string name="personalid_camera_permission_title">Autorisation pour la caméra</string>
     <string name="personalid_camera_permission_msg">Afin de prendre une photo, CommCare a besoin de l\'autorisation d\'utiliser l\'appareil photo de votre appareil.</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -467,7 +467,7 @@ License.
     <string name="personalid_recovery_failed_title">पुनर्प्राप्ति विफल</string>
     <string name="personalid_recovery_lockout_title">खाता बंद</string>
     <string name="personalid_recovery_failed_message">ऐसा लगता है कि आप अपना बैकअप कोड भूल गए हैं, हम आपके लिए एक नया खाता बना रहे हैं</string>
-    <string name="personalid_recovery_lockout_message">आपने बहुत बार गलत बैकअप कोड दर्ज किया है। आपका खाता लॉक कर दिया गया है।</string>
+    <string name="personalid_recovery_lockout_message">आपने बहुत बार गलत बैकअप कोड दर्ज किया है। आपका खाता लॉक कर दिया गया है। अपना अकाउंट अनलॉक करने के लिए कृपया सपोर्ट से संपर्क करें।</string>
     <string name="personalid_wrong_backup_message">आपने गलत बैकअप कोड डाला है। कृपया फिर से कोशिश करें। %d और गलत कोशिशों के बाद आपका अकाउंट लॉक हो जाएगा।</string>
     <string name="personalid_camera_permission_title">कैमरे के लिए अनुमति</string>
     <string name="personalid_camera_permission_msg">तस्वीर लेने के लिए, CommCare को आपके डिवाइस के कैमरे का उपयोग करने की अनुमति चाहिए।</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -120,7 +120,7 @@
     <string name="connect_otp_verified">Suksess! Ditt telefonnummer er blitt bekreftet.</string>
     <string name="personalid_otp_verification_failed_generic">Noe gikk galt under bekreftelsen av ditt telefonnummer. Prøv igjen.</string>
     <string name="personalid_incorrect_otp">Du har tastet inn feil 6-sifret adgangskode. Prøv igjen.</string>
-    <string name="personalid_recovery_lockout_message">Du har tastet inn feil reservekode for mange ganger. Kontoen din er blitt låst.</string>
+    <string name="personalid_recovery_lockout_message">Du har tastet inn feil reservekode for mange ganger. Kontoen din er blitt låst. Kontakt kundestøtte for å låse opp kontoen din.</string>
     <string name="connect_backup_code_mismatch">Reservekodene du taster inn, må stemme overens. Oppbevar den på et trygt sted, da du trenger den for å få tilgang til kontoen din igjen.</string>
     <string name="connect_recovery_success_message">Kontoen din er blitt gjenopprettet! Du kan gjenoppta bruken av PersonalID.</string>
     <string name="connect_register_success_message">Kontoen din er blitt opprettet og er klar til bruk</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -480,7 +480,7 @@
     <string name="personalid_recovery_failed_title">Falha na recuperação</string>
     <string name="personalid_recovery_lockout_title">Conta Bloqueada</string>
     <string name="personalid_recovery_failed_message">Parece que se esqueceu do seu código de backup, estamos a criar uma nova conta para si</string>
-    <string name="personalid_recovery_lockout_message">Você inseriu o código de backup incorreto muitas vezes. A sua conta foi bloqueada.</string>
+    <string name="personalid_recovery_lockout_message">Você inseriu o código de backup incorreto muitas vezes. A sua conta foi bloqueada. Entre em contacto com o suporte para desbloquear a sua conta.</string>
     <string name="personalid_wrong_backup_message">Introduziu o código de segurança incorretamente. Tente novamente. A sua conta será bloqueada após %d tentativas incorretas.</string>
     <string name="personalid_camera_permission_title">Permissão para câmara</string>
     <string name="personalid_camera_permission_msg">Para tirar uma fotografia, o CommCare precisa de permissão para utilizar a câmara do seu dispositivo.</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -481,7 +481,7 @@
     <string name="personalid_recovery_lockout_title">Akaunti Imefungwa</string>
     <string name="personalid_recovery_failed_message">Inaonekana umesahau Nambari yako ya Hifadhi Nambari, tunakuundia akaunti mpya</string>
     <string name="personalid_wrong_backup_message">Umeingiza Nambari ya Kuhifadhi Nakala Isiyo sahihi. Tafadhali jaribu tena. Akaunti yako itafungwa baada ya majaribio %d zaidi yasiyo sahihi.</string>
-    <string name="personalid_recovery_lockout_message">Umeweka msimbo wa akiba usio sahihi mara nyingi sana. Akaunti yako imefungwa.</string>
+    <string name="personalid_recovery_lockout_message">Umeweka msimbo wa akiba usio sahihi mara nyingi sana. Akaunti yako imefungwa. Tafadhali wasiliana na usaidizi ili kufungua akaunti yako.</string>
     <string name="personalid_camera_permission_title">Ruhusa ya kamera</string>
     <string name="personalid_camera_permission_msg">Ili kupiga picha, CommCare inahitaji ruhusa ya kutumia kamera ya kifaa chako.</string>
     <string name="personalid_capture_photo">Piga Picha</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -465,7 +465,7 @@
     <string name="personalid_recovery_failed_title">ምሕዋይ ኣይተዓወተን</string>
     <string name="personalid_recovery_lockout_title">ኣካውንት ተዓጽዩ።</string>
     <string name="personalid_recovery_failed_message">Backup Code ናትካ ዝረሳዕካዮ ይመስል፣ ሓድሽ ኣካውንት ንፈጥር ኣለና።</string>
-    <string name="personalid_recovery_lockout_message">ንስኻ ነቲ ናይ ምትካእ ኮድ ብጌጋ ብዙሕ ግዜ ኣእቲኻዮ። ሕሳብካ ተዓጽዩ ኣሎ።</string>
+    <string name="personalid_recovery_lockout_message">ንስኻ ነቲ ናይ ምትካእ ኮድ ብጌጋ ብዙሕ ግዜ ኣእቲኻዮ። ሕሳብካ ተዓጽዩ ኣሎ። ኣካውንትኩም ንምኽፋት በጃኹም ምስ ደገፍ ተወከሱ።</string>
     <string name="personalid_wrong_backup_message">ጌጋ Backup Code ኣእቲኻ ኣለኻ። በጃኹም ደጊምኩም ፈትኑ። ድሕሪ %d ዝያዳ ጌጋ ፈተነታት ኣካውንትካ ክዕጾ እዩ።</string>
     <string name="personalid_camera_permission_title">ፍቓድ ንካሜራ</string>
     <string name="personalid_camera_permission_msg">ስእሊ ንምውሳድ፡ ኮምኬር ናይ መሳርሒኻ ካሜራ ንኽጥቀም ፍቓድ የድልዮ።</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -631,7 +631,7 @@
     <string name="personalid_recovery_failed_title">Recovery failed</string>
     <string name="personalid_recovery_lockout_title">Account Locked</string>
     <string name="personalid_recovery_failed_message">Looks like you’ve forgotten your Backup Code, we’re creating a new account for you</string>
-    <string name="personalid_recovery_lockout_message">You have entered the wrong Backup Code too many times. Your account has been locked.</string>
+    <string name="personalid_recovery_lockout_message">You have entered the wrong Backup Code too many times. Your account has been locked. Please contact support to unlock your account.</string>
     <string name="personalid_wrong_backup_message">You have entered the wrong Backup Code. Please try again. Your account will be locked after %d more incorrect attempts.</string>
     <string name="personalid_camera_permission_title">Permission for camera</string>
     <string name="personalid_camera_permission_msg">In order to take a picture, CommCare needs permission to use your device camera.</string>


### PR DESCRIPTION
Discovered while working on an interrupt ticket:
https://dimagi.atlassian.net/browse/CI-448

## Product Description
Changed error message after wrong backup code to indicate account will be locked instead of creating a new one.

## Technical Summary
Simple string change

## Feature Flag
None

## Safety Assurance

### Safety story
Simple change, nothing much to test

### Automated test coverage
None

### QA Plan
Verify the new message text appears