### PR TITLE
more robust view inflation checking in test

### DIFF
--- a/app/unit-tests/src/org/commcare/android/tests/formsave/CyclicCasesPurgeTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/formsave/CyclicCasesPurgeTest.java
@@ -28,6 +28,8 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowDialog;
 import org.robolectric.shadows.ShadowLooper;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Test Scenarios related to cyclic case relationships encountered during the case purge process.
  * These tests are only relevant when the case purge process is enabled with property `cc-auto-purge`
@@ -75,6 +77,11 @@ public class CyclicCasesPurgeTest {
             // Run additional looper tasks and wait
             ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
             ShadowLooper.idleMainLooper();
+            try {
+                Thread.sleep(TimeUnit.MILLISECONDS.toMillis(100));
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
         }
 
         // verify that form save results into an error


### PR DESCRIPTION
## Technical Summary

Trying to improve frequent failures on `CyclicCasesPurgeTest` on Jenkins with error -> 

````
java.lang.NullPointerException: Cannot invoke "android.widget.TextView.getText()" because the return value of "android.app.Dialog.findViewById(int)" is null
	at org.commcare.android.tests.formsave.CyclicCasesPurgeTest.testFormSaveResultingIntoCaseCycles_ShouldFail(CyclicCasesPurgeTest.java:80)
````

This happens on and off and think there is somewhere a race condition with Robolectric that is causing the test to assert before view gets inflated. I am not able to repro it locally, but the change should be harmless to make. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
