### PR TITLE
Ignore errors in handling colors for the case list map

### DIFF
--- a/app/src/org/commcare/gis/EntityMapUtils.kt
+++ b/app/src/org/commcare/gis/EntityMapUtils.kt
@@ -87,7 +87,7 @@ object EntityMapUtils {
     ): Int? {
         if (TEMPLATE_FORM_GEO_BOUNDARY_COLOR == detail.templateForms[fieldIndex]) {
             val colorString = entity.getFieldString(fieldIndex).trim { it <= ' ' }
-            check(!colorString.isEmpty())
+            check(colorString.isNotEmpty())
             return parseHexColor(colorString)
         }
         return null


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/QA-8306
[Crash](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/1bd0c0fd7eb8f86808dbc5ad9cbbc810)

## Technical Summary

We currently treat colors as optional given we have a default color implementation in the code when a color is not specified by the HQ app. Given that, I don't think we want to crash in case of any errors in the code evalauting the color string for the map screen, but more convey the user that an error occured evaluating map options. 

## Safety Assurance

### Safety story

More resilient (fail-safe) exception handling. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
