### PR TITLE
Suppressing map error on empty polygon string

### DIFF
--- a/app/src/org/commcare/gis/EntityMapUtils.kt
+++ b/app/src/org/commcare/gis/EntityMapUtils.kt
@@ -74,7 +74,9 @@ object EntityMapUtils {
     ): List<LatLng>? {
         if (TEMPLATE_FORM_GEO_BOUNDARY == detail.templateForms[fieldIndex]) {
             val boundaryString = entity.getFieldString(fieldIndex).trim { it <= ' ' }
-            return parseBoundaryFromString(boundaryString)
+            if(boundaryString.isNotEmpty()) {
+                return parseBoundaryFromString(boundaryString)
+            }
         }
         return null
     }
@@ -87,8 +89,9 @@ object EntityMapUtils {
     ): Int? {
         if (TEMPLATE_FORM_GEO_BOUNDARY_COLOR == detail.templateForms[fieldIndex]) {
             val colorString = entity.getFieldString(fieldIndex).trim { it <= ' ' }
-            check(colorString.isNotEmpty())
-            return parseHexColor(colorString)
+            if(colorString.isNotEmpty()) {
+                return parseHexColor(colorString)
+            }
         }
         return null
     }


### PR DESCRIPTION
Related to this ticket:
https://dimagi.atlassian.net/browse/QA-8309

## Product Description
Not reporting an error when some cases have boundary polygons and others don't.

## Technical Summary
Checking for empty strings for both the boundary polygon and polygon color case fields.
When the strings are empty we just skip them (before an error was reported to the user).

## Feature Flag
None

## Safety Assurance

### Safety story
Dev tested with the same test app and login that was used in the QA ticket.
The demo video shows the error appearing on the UI when the user goes to the map.
Dev verified that the error message no longer appears.

### Automated test coverage
None

### QA Plan
The test app and login in the QA ticket can be used to verify the fix.
Navigate to the map and verify that no error message is displayed when some cases have boundary polygons but others don't.
