### PR TITLE
Selecting entity when user clicks info marker label from boundary polygon

### DIFF
--- a/app/src/org/commcare/gis/EntityMapActivity.java
+++ b/app/src/org/commcare/gis/EntityMapActivity.java
@@ -458,8 +458,7 @@ public class EntityMapActivity extends CommCareActivity implements OnMapReadyCal
         TreeReference ref;
         if (marker.equals(polygonInfoMarker)) {
             ref = polygonInfoMarkerReference;
-        }
-        else {
+        } else {
             ref = markerReferences.get(marker);
         }
         SerializationUtil.serializeToIntent(i, EntityDetailActivity.CONTEXT_REFERENCE, ref);


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/QA-8310

## Product Description
Supporting click on info marker label from boundary polygon to select a case.
Previously the app might crash when the user clicked the label from the info marker.
If not a crash, the click would be ignored instead.

## Technical Summary
Storing the entity related to each polygon with the polygon reference (instead of just label strings).
Holding the tree reference related to a polygon when the polygon is clicked and info marker is shown.
Selecting the relevant entity when the user presses the label of the info marker for the boundary polygon.

The actual crash was an NPE caused when trying to serialize a null entity to the intent (for launching the case detail). The null entity was because no tree reference value could be found for the Marker (key in a hashmap). That lookup should have been skipped (exit function early) when the marker was seen to be equal to the special "info marker" that we display when the user presses the polygon, but the == wasn't identifying the equality correctly ("equals" function works properly).

Stack trace from the crash:
````
java.lang.NullPointerException: Attempt to invoke interface method 'void org.javarosa.core.util.externalizable.Externalizable.writeExternal(java.io.DataOutputStream)' on a null object reference
at org.commcare.utils.SerializationUtil.serialize(SerializationUtil.java:24)
at org.commcare.utils.SerializationUtil.serializeToIntent(SerializationUtil.java:46)
at org.commcare.gis.EntityMapActivity.onInfoWindowClick(EntityMapActivity.java:461)
at com.google.android.gms.maps.zzc.zzb(com.google.android.gms:play-services-maps@@19.2.0:1)
at com.google.android.gms.maps.internal.zzac.zza(com.google.android.gms:play-services-maps@@19.2.0:3)
at com.google.android.gms.internal.maps.zzb.onTransact(com.google.android.gms:play-services-maps@@19.2.0:3)
at android.os.Binder.transact(Binder.java:1325)
at m140.ayh.c(:com.google.android.gms.policy_maps_core_dynamite@254515607@254515602025.843324832.843324832:8)
at com.google.maps.api.android.lib6.impl.fa.d(:com.google.android.gms.policy_maps_core_dynamite@254515607@254515602025.843324832.843324832:35)
at com.google.maps.api.android.lib6.phoenix.am.a(:com.google.android.gms.policy_maps_core_dynamite@254515607@254515602025.843324832.843324832:75)
at m140.azl.run(:com.google.android.gms.policy_maps_core_dynamite@254515607@254515602025.843324832.843324832:16)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:520)
at m140.bnt$a.run(:com.google.android.gms.policy_maps_core_dynamite@254515607@254515602025.843324832.843324832:14)
at android.os.Handler.handleCallback(Handler.java:1070)
at android.os.Handler.dispatchMessage(Handler.java:125)
at android.os.Looper.dispatchMessage(Looper.java:333)
at android.os.Looper.loopOnce(Looper.java:263)
at android.os.Looper.loop(Looper.java:367)
at android.app.ActivityThread.main(ActivityThread.java:9287)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
````

## Feature Flag
None

## Safety Assurance

### Safety story
Dev tested and verified that pressing the label now selects the relevant case (screen navigates to case details).

### Automated test coverage
None

### QA Plan
Verify that navigation works correctly (to case details) when user presses a boundary polygon and then the label of the marker that appears in the center of the polygon.