### PR TITLE
Fix user info missing in Crashlytics reports (Hotfix)

### DIFF
--- a/app/src/org/commcare/android/logging/ReportingUtils.java
+++ b/app/src/org/commcare/android/logging/ReportingUtils.java
@@ -144,8 +144,8 @@ public class ReportingUtils {
             if (user.isEmpty()) {
                 return getPersonalID();
             }
-        } catch (Exception ignored) {
-        }
+            return user;
+        } catch (Exception ignored) {}
         return null;
     }
 


### PR DESCRIPTION
## Product Description
This PR addresses an issue causing Crashlytics reports to not include username information, only Connect PersonalID is showing up in reports since version `2.58`.

Original PR: #3474

## Safety Assurance

### Safety story
Successfully tested locally. Here's the Crashlytics report: https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/eb1732035c3483ae925619824fd819a2

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
