### PR TITLE
Make trace nullable when stopping tracing

### DIFF
--- a/app/src/org/commcare/google/services/analytics/CCPerfMonitoring.kt
+++ b/app/src/org/commcare/google/services/analytics/CCPerfMonitoring.kt
@@ -47,7 +47,7 @@ object CCPerfMonitoring {
             attrs?.forEach { (key, value) -> trace?.putAttribute(key, value) }
             trace?.stop()
         } catch (exception: Exception) {
-            Logger.exception("Error stopping perf trace: ${trace?.name}", exception)
+            Logger.exception("Error stopping perf trace: ${trace?.name?: "Unknown trace"}", exception)
         }
     }
 
@@ -58,7 +58,7 @@ object CCPerfMonitoring {
             attrs[ATTR_FILE_TYPE] = FilenameUtils.getExtension(fileName)
             stopTracing(trace, attrs)
         } catch (e: java.lang.Exception) {
-            Logger.exception("Failed to stop tracing: ${trace?.name}", e)
+            Logger.exception("Failed to stop tracing: $TRACE_FILE_ENCRYPTION_TIME", e)
         }
     }
 


### PR DESCRIPTION
## Product Description
Minor improvement to make stopping tracing `null-safe`.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
