### PR TITLE
Improved form entry cleanup

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1252,7 +1252,9 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             }
         }
 
-        mFormController = null;
+        if (!isChangingConfigurations()) {
+            mFormController = null;
+        }
 
         TextToSpeechConverter.INSTANCE.shutDown();
         super.onDestroy();


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-2025

## Product Description
No user visible change.

## Technical Summary
Nulling out mFormController when FormEntryActivity shuts down (so other code knows when form entry is in progress).
This work is being done as part of a ticket to better handle kicking the user out when their PersonalID configuration is invalidated. But if the user is in the middle of form entry, we want to let them finish before interrupting their experience. This change will support that work.

## Feature Flag
None

## Safety Assurance

### Safety story
Tested entering a form and backing out, then entering again. No issues encountered

### Automated test coverage
Existing tests should cover this part of the code well (exiting form entry in various ways).

### QA Plan
Test the functionality around exiting form entry (backing out or completing the form)
Test that form entry with phone rotation is saved and submitted successfully to the server 
