### PR TITLE
PersonalID phone page focus/keyboard improvements

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -54,6 +54,7 @@ import org.commcare.location.LocationRequestFailureHandler;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.DeviceIdentifier;
 import org.commcare.utils.GeoUtils;
+import org.commcare.utils.KeyboardHelper;
 import org.commcare.utils.Permissions;
 import org.commcare.utils.PhoneNumberHelper;
 import org.javarosa.core.services.Logger;
@@ -221,8 +222,10 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                             Toast.makeText(getContext(), R.string.error_occured, Toast.LENGTH_SHORT).show();
                         }
                     } else {
-                        binding.connectPrimaryPhoneInput.post(
-                                () -> binding.connectPrimaryPhoneInput.requestFocus());
+                        View focusView = activity.getCurrentFocus();
+                        if (focusView != null) {
+                            KeyboardHelper.showKeyboardOnInput(activity, focusView);
+                        }
                     }
                 }
         );


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-2102

## Product Description
When phone number dialog (that offers to auto-populate the UI from the device phone number) is dismissed without choosing to auto-populate, the active UI input returns to what was selected before the dialog appeared and the keyboard reappears.

Demo video [here](https://drive.google.com/file/d/1gYOWr2qeJ_YmLuSCuAGb9JFJEVBqKSr2/view?usp=drive_link)

## Technical Summary
Two small changes required for this:
1. Grab the UI element with active focus (instead of always using connectPrimaryPhoneInput)
2. Call KeyboardHelper.showKeyboardOnInput instead of requestFocus directly.

Note the KeyboardHelper method has been required in other places in the workflow in order to get the keyboard to consistently appear as desired. It's a slightly hacky method that requestsFocus and then calls showSoftInput 250ms later, but without it the keyboard doesn't always appear.
Alternatives tried:
* Current code: requestFocus on phone number input (keyboard doesn't appear regardless of previous focus)
* requestFocus on text field that currently has focus (country code or phone number)
* clearFocus and requestFocus on text field that currently has focus
* inputMethodManager.showSoftInput(focusView, InputMethodManager.SHOW_IMPLICIT)
* inputMethodManager.showSoftInput(focusView, InputMethodManager.SHOW_FORCED)
* inputMethodManager.showSoftInput(focusView, 0)
* Moved code to end of onResume and tried requestFocus(focusView)
* Moved code to end of onResume and tried showSoftInput(focusView, InputMethodManager.SHOW_IMPLICIT)

## Feature Flag
None

## Safety Assurance

### Safety story
I tested this on two devices with configured phone numbers and verified the input would return to either the country cod or primary phone input (depending on which I selected in order to bring up the dialog). I also verified the keyboard appears when the dialog is dismissed.

### Automated test coverage
None

### QA Plan
Follow the tests described above to verify the desired behavior when the phone number dialog is dismissed.
