### PR TITLE
Fix and modernize PR CI workflow

### DIFF
--- a/.github/workflows/commcare-android-pr-workflow.yml
+++ b/.github/workflows/commcare-android-pr-workflow.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Generate Gradle properties
         run: |
           mkdir -p ~/.gradle
-          cat > ~/.gradle/gradle.properties <<EOF
+          cat > ~/.gradle/gradle.properties <<'EOF'
           org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
           org.gradle.parallel=false
           TEST_BUILD_TYPE=release
-          RELEASE_STORE_FILE=$HOME/.gradle/commcare-odk-keys.keystore
+          RELEASE_STORE_FILE=/home/runner/.gradle/commcare-odk-keys.keystore
           RELEASE_STORE_PASSWORD=${{ secrets.KEY_STORE_PASSWORD }}
           RELEASE_KEY_ALIAS=${{ secrets.ALIAS }}
           RELEASE_KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}


### PR DESCRIPTION
## Summary

This PR replaces the broken/dormant GitHub Actions PR workflow with one that matches the current Jenkins CI configuration, so we can eventually retire Jenkins.

The old GHA workflow that I started with here had some issues that prevented it from running at all (unicode tildes in paths, missing secret mappings, deprecated Actions, wrong trigger types). This PR rebuilds the workflow to match what Jenkins actually does today.

## Key decisions

- **Ubuntu runner instead of macOS** — Avoids 3 macOS-specific test failures. Jenkins also uses Linux.
- **Python pinned to 3.9** — The `github3.py` dependency (used by the cross-request script) uses `collections.Callable`, which was removed in Python 3.10.
- **gradle.properties generated from individual secrets** — Rather than passing all the secrets in to gradle with `-P`, I opted to generate something like the gradle.properties file used on Jenkins from github secrets.
- **BrowserStack tests run in a separate job** — This lets us restart just the one job in case of a failure (infrastructure or flaky tests), saving about 20m. The job downloads the APK artifacts from the build job rather than building again.

## What's NOT in this PR

- Removing Jenkins — that's a follow-up after this is validated
- Fixing the pre-existing BrowserStack test failures (likely caused by #3540, being investigated separately in #3558)

## Feature Flag
N/A

## Safety Assurance

### Safety story
CI-only changes — no application code modified.

### Automated test coverage
The workflow itself is the test. Build + unit tests + lint + BrowserStack all run on every push to this PR.

### QA Plan
N/A — CI workflow configuration.