### PR TITLE
Changing to full desugaring, and upgrading to latest version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -149,7 +149,7 @@ dependencies {
     implementation 'io.michaelrocks:libphonenumber-android:8.13.11'
     implementation 'com.nulab-inc:zxcvbn:1.7.0'
     // Dependency required for API desugaring
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_minimal:2.1.3'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
     implementation 'com.google.android.gms:play-services-auth:21.3.0'
     implementation "androidx.navigation:navigation-fragment:$nav_version"
     implementation "androidx.navigation:navigation-ui:$nav_version"


### PR DESCRIPTION
This is a draft PR just to test whether the simple act of changing from minimal to full desugaring is enough to break BrowserStack on API 28.

Related to work upgrading Firebase in [this ticket](https://dimagi.atlassian.net/browse/CCCT-2032)