### PR TITLE
Open keyboard with focus on name input on opening up name page

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdNameFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdNameFragment.java
@@ -21,6 +21,7 @@ import org.commcare.connect.network.PersonalIdOrConnectApiErrorHandler;
 import org.commcare.connect.network.connectId.PersonalIdApiHandler;
 import org.commcare.dalvik.databinding.ScreenPersonalidNameBinding;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
+import org.commcare.utils.KeyboardHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,6 +44,14 @@ public class PersonalIdNameFragment extends BasePersonalIdFragment {
         enableContinueButton(false);
         binding.nameTextValue.addTextChangedListener(createNameWatcher());
         return binding.getRoot();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if( binding.nameTextValue.requestFocus()){
+            KeyboardHelper.showKeyboardOnInput(activity, binding.nameTextValue);
+        }
     }
 
     private TextWatcher createNameWatcher() {


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CCCT-2103

https://github.com/user-attachments/assets/7180fd2f-db38-44ea-88d9-d307ed112a48



## Technical Summary

I tried the similar things listed in https://github.com/dimagi/commcare-android/pull/3532 to make the keyboard open without a delay but it didn't do the trick, so I ended up using the current approach to open the keyboard as well here that opens the keyboard after a 250 ms delay. 



## Safety Assurance

Verified locally


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
