### PR TITLE
CCCT-2160 - Device info at the end of registration / recovery

### DIFF
--- a/app/src/org/commcare/connect/network/ApiPersonalId.java
+++ b/app/src/org/commcare/connect/network/ApiPersonalId.java
@@ -11,6 +11,7 @@ import org.commcare.core.network.AuthInfo;
 import org.commcare.network.HttpUtils;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.preferences.ServerUrls;
+import org.commcare.utils.DeviceIdentifier;
 import org.commcare.utils.FirebaseMessagingUtil;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.services.Logger;
@@ -124,6 +125,11 @@ public class ApiPersonalId {
         HashMap<String, String> params = new HashMap<>();
         params.put("recovery_pin", backupCode);
 
+        String model = DeviceIdentifier.getDeviceModel();
+        if (model != null) {
+            params.put("device", model);
+        }
+
         AuthInfo authInfo = new AuthInfo.TokenAuth(token);
         String tokenAuth = HttpUtils.getCredential(authInfo);
 
@@ -202,6 +208,11 @@ public class ApiPersonalId {
         params.put("photo", photoAsBase64);
         params.put("name", userName);
         params.put("recovery_pin", backupCode);
+
+        String model = DeviceIdentifier.getDeviceModel();
+        if (model != null) {
+            params.put("device", model);
+        }
 
         ApiService apiService = PersonalIdApiClient.getClientApi();
         Call<ResponseBody> call = apiService.completeProfile(tokenAuth, params);

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -51,7 +51,6 @@ import org.commcare.location.CommCareLocationControllerFactory;
 import org.commcare.location.CommCareLocationListener;
 import org.commcare.location.LocationRequestFailureHandler;
 import org.commcare.util.LogTypes;
-import org.commcare.utils.DeviceIdentifier;
 import org.commcare.utils.GeoUtils;
 import org.commcare.utils.KeyboardHelper;
 import org.commcare.utils.Permissions;
@@ -296,11 +295,6 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
         body.put("application_id", requireContext().getPackageName());
         body.put("gps_location", GeoUtils.locationToString(location));
         body.put("cc_device_id", ReportingUtils.getDeviceId());
-
-        String model = DeviceIdentifier.getDeviceModel();
-        if(model != null) {
-            body.put("device", model);
-        }
 
         integrityTokenApiRequestHelper.withIntegrityToken(body,
                 new IntegrityTokenViewModel.IntegrityTokenCallback() {


### PR DESCRIPTION
## Technical Summary
https://dimagi.atlassian.net/browse/CCCT-2160

Sending device info changed from Personalid start configuration call to end of registration / recovery. 

## Safety Assurance

### Safety story
The start configuration API works without sending device info.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
