### PR TITLE
Read build properties from local.properties before user-level gradle.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ git clone https://github.com/dimagi/commcare-core.git
 - Wait while Android Studio spins its wheels
 - Download any build dependencies that the SDK Manager tells you you need.
 
-Note: If you are using any functionality that depends on the Google Cloud Project (like
+Note: 
+- Android Secrets should be placed in the `local.properties` -> global or project-level `gradle.properties`, 
+in that order of priority. Failing to do so may result in build or runtime errors.
+- If you are using any functionality that depends on the Google Cloud Project (like
 [Google Integrity APIs](https://developer.android.com/google/play/integrity/standard)), you will need to
-define `GOOGLE_CLOUD_PROJECT_NUMBER` in your local `gradle.properties` file otherwise relevant parts of the
+define `GOOGLE_CLOUD_PROJECT_NUMBER` in your Android secrets otherwise relevant parts of the
 application will crash for you with
 `Caused by: java.lang.IllegalArgumentException: Google Cloud Project Number is not defined`.
 
@@ -100,7 +103,7 @@ You may also run individual unit tests, via auto-configured Gradle tasks, by cli
 ## Instrumentation Tests
 
 The commcare-android repository uses [Espresso](https://developer.android.com/training/testing/espresso/) to write UI tests.
-You need to have two keys in your `gradle.properties` before being able to run any instrumentation tests. **But make sure you never commit these keys to GitHub.**
+You need to have two keys in your Android secrets before being able to run any instrumentation tests. **But make sure you never commit these keys to GitHub.**
 ```properties
 HQ_API_USERNAME=<ASK_ANOTHER_DEV_FOR_KEY>
 HQ_API_PASSWORD=<ASK_ANOTHER_DEV_FOR_KEY>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,9 +176,9 @@ def loadProp = { String key, def defaultValue = '' ->
 }
 
 ext {
-    // Obtained from local.properties (project root) -> ~/.gradle/gradle.properties (user-level) -> default value
-    // On build server, it's supposed to load from the user-level ~/.gradle/gradle.properties since
-    // local.properties is not supposed to be checked in with secrets
+    // Obtained from local.properties (project root) -> gradle.properties (global and project-level) -> default value
+    // On build server, it's supposed to load from the gradle.properties since local.properties is not supposed
+    // to be checked in with secrets
     MAPBOX_SDK_API_KEY = loadProp('MAPBOX_SDK_API_KEY', '')
     ANALYTICS_TRACKING_ID_DEV = loadProp('ANALYTICS_TRACKING_ID_DEV', '')
     ANALYTICS_TRACKING_ID_LIVE = loadProp('ANALYTICS_TRACKING_ID_LIVE', '')


### PR DESCRIPTION
## Product Description
This stemmed from a retro following an android secret was accidentally leaked in a PR. During the retro, it was noted that developers, particularly new team members, sometimes get confused about where secrets should be stored, so it was suggested to read from the 'local.properties' first. Since`local.properties` is gitignored by default in Android projects, so it is safe for per-developer overrides without risk of committing secrets. Build server behaviour is unchanged since build servers do not have a `local.properties` file.

## Technical Summary
Previously, all build properties (API keys, signing config, test credentials) were read exclusively from `project.properties`, which resolves user-level `~/.gradle/gradle.properties` with higher priority than the project-level file. This made it inconvenient to override properties locally without touching the shared `gradle.properties`.

## Safety Assurance

### Safety story
Built successfully locally.

## Labels and Review

- [X] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [X] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change