### PR TITLE
Scrolling scroll view to bottom in BasePersonalIdFragment when view r…

### DIFF
--- a/app/src/org/commcare/fragments/personalId/BasePersonalIdFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/BasePersonalIdFragment.kt
@@ -57,7 +57,8 @@ abstract class BasePersonalIdFragment : Fragment() {
     protected fun setupKeyboardScrollListener(scrollView: ScrollView) {
         globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
             val visibleHeight = scrollView.height
-            if (lastVisibleHeight > 0 && visibleHeight < lastVisibleHeight) {
+            if (lastVisibleHeight > 0 && lastVisibleHeight / visibleHeight.toDouble() > 1.1) {
+                //Scroll to end when window shrinks by more than 10%
                 val contentHeight = scrollView.getChildAt(0)?.bottom ?: 0
                 scrollView.smoothScrollTo(0, contentHeight)
             }


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-2197

## Product Description
Fixes a bug with scrolling on in PersonalID configuration
On some devices:
* The title bar becomes too thick
* When displaying the keyboard the main display shrinks too much.
   Note CommCare logo unnecessarily scrolled away in the "before" shot below

Before (showing the error):
<img width="400" height="640" alt="image" src="https://github.com/user-attachments/assets/540a9576-89f5-45b7-b280-5af7dc62aa93" />


After (fixed):
<img width="400" height="640" alt="image" src="https://github.com/user-attachments/assets/e19eac24-4d92-4685-b81a-a5bc065ef49b" />


## Technical Summary
Scrolling scroll view to bottom in BasePersonalIdFragment when view resizes.
Not taking over edge-to-edge and trying to manually handle IME offsets reliably.

The simpler solution to this issue turned out to just be letting the ScrollView resize naturally when the keyboard appears, and then scroll to the bottom to ensure the last element (always the Continue button) is showing.

## Feature Flag
None

## Safety Assurance

### Safety story
I was eventually able to reproduce this on a Google Pixel Tablet
See screenshots above showing before and after views of the fix.

I also verified that the scrolling works as desired on my phone when the keyboard appears and disappears.

### Automated test coverage
None

### QA Plan
Repeat steps described in the Safety Story above.