### PR TITLE
Visual adjustments to opportunity cards

### DIFF
--- a/app/res/layout/connect_job_list_item.xml
+++ b/app/res/layout/connect_job_list_item.xml
@@ -43,8 +43,8 @@
 
         <ImageView
             android:id="@+id/iv_completed_check"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
             android:contentDescription="@null"
             android:importantForAccessibility="no"
             android:src="@drawable/ic_connect_check_circle"

--- a/app/res/values/colors.xml
+++ b/app/res/values/colors.xml
@@ -233,6 +233,7 @@
     <color name="lunar_mist">#E7E8F8</color>
     <color name="steel_dust">#ABABAB</color>
     <color name="sterling_ash">#959595</color>
+    <color name="burnt_amber">#C67E13</color>
 
     <color name="ic_backup">#14006C</color>
     <color name="icon_tint_dark_gray">#333333</color>

--- a/app/src/org/commcare/adapters/JobListConnectHomeAppsAdapter.java
+++ b/app/src/org/commcare/adapters/JobListConnectHomeAppsAdapter.java
@@ -257,6 +257,7 @@ public class JobListConnectHomeAppsAdapter extends RecyclerView.Adapter<Recycler
     ) {
         int progress = 0;
         int progressColor = 0;
+        boolean showPercentageText = true;
         ConnectLoginJobListModel.JobListEntryType jobType = item.getJobType();
         ConnectJobRecord job = item.getJob();
 
@@ -266,6 +267,11 @@ public class JobListConnectHomeAppsAdapter extends RecyclerView.Adapter<Recycler
         }
 
         switch (jobType) {
+            case NEW_OPPORTUNITY:
+                progress = 100;
+                progressColor = ContextCompat.getColor(context, R.color.burnt_amber);
+                showPercentageText = false;
+                break;
             case LEARNING:
                 if (!job.passedAssessment()) {
                     progress = item.getLearningProgress();
@@ -285,7 +291,7 @@ public class JobListConnectHomeAppsAdapter extends RecyclerView.Adapter<Recycler
         binding.progressBar.setStrokeWidth(20);
         binding.progressBar.setProgress(progress);
         binding.progressBar.setProgressColor(progressColor);
-        binding.tvProgressPercent.setText(progress + " %");
+        binding.tvProgressPercent.setText(showPercentageText ? progress + " %" : "");
     }
 
     private void configureJobType(

--- a/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
@@ -268,10 +268,12 @@ public class ConnectJobsListsFragment extends BaseConnectFragment<FragmentConnec
             }
         }
 
+        sortJobListByLastAccessed(inProgressJobs);
+        sortJobListByLastAccessed(inProgressCompleteJobs);
+
         //Jobs with completed delivery moved to the end
         inProgressJobs.addAll(inProgressCompleteJobs);
 
-        sortJobListByLastAccessed(inProgressJobs);
         sortJobListByLastAccessed(newJobs);
         sortJobListByLastAccessed(finishedJobs);
         initRecyclerView();


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-2199

## Product Description
Small visual adjustments to the opportunity cards in the Connect home page.

New appearance:
<img width="270" height="635" alt="image" src="https://github.com/user-attachments/assets/abee7d0a-fd10-4d5d-8825-6d5446843157" /> <img width="270" height="635" alt="image" src="https://github.com/user-attachments/assets/a6f6605b-a28d-4b1a-ba6f-a6cc79b4602e" />


## Technical Summary
Made "delivery complete" check mark smaller.
Setting progress ring to orange at 100% with no percentage text for "new" opportunities. Fixed a sorting issue (re-sorting In Progress opps after putting delivery-complete opps at the end)

## Feature Flag
None

## Safety Assurance

### Safety story
Changes tested on my phone (see screenshots above showing various job states)

### Automated test coverage
None

### QA Plan
Go to the Connect home page (jobs list) and verify that the cards all appear correctly as shown above and in [this Figma](https://www.figma.com/design/q1YNogvfI52thl7BLhR3KT/Connect-Landing-Redesign?node-id=1485-683&t=gljVCMXI04QmlZT2-4).
