### PR TITLE
Minor bug found for generic opportunity push notification

### DIFF
--- a/app/src/org/commcare/android/database/connect/models/PushNotificationRecord.kt
+++ b/app/src/org/commcare/android/database/connect/models/PushNotificationRecord.kt
@@ -148,6 +148,8 @@ class PushNotificationRecord :
                 opportunityId = obj.optString(META_OPPORTUNITY_ID, "")
                 opportunityUUID = obj.optString(META_OPPORTUNITY_UUID, "")
                 paymentUUID = obj.optString(META_PAYMENT_UUID, "")
+                key = obj.optString(META_KEY, "")
+                opportunityStatus = obj.optString(META_OPPORTUNITY_STATUS, "")
             }
 
         fun fromV23(pushNotificationRecordV23: PushNotificationRecordV23): PushNotificationRecord =


### PR DESCRIPTION
## Technical Summary
Minor bug found for generic opportunity push notification. PushNotificationRecords was not parsing the value of `key` and `opportunity_status` due to which these values were always blank. This issue is solved in this PR.


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
