### PR TITLE
Adds hausa translations for Connect and Personal ID

### DIFF
--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -64,7 +64,7 @@
     <string name="permission_external_action_description">Permite que esta aplicación active operaciones como iniciar sesión, cerrar sesión y sincronizar en CommCare</string>
     <string name="permission_commcare_logout_label">Permitir el cierre de sesión automático de CommCare</string>
     <string name="permission_commcare_logout_description">Permite que esta aplicación cierre la sesión de un usuario de la aplicación CommCare</string>
-    <string name="title_activity_report_problem">Informar de un problema de actividad</string>
+    <string name="title_activity_report_problem">Informar problema</string>
     <string name="panes">uno</string>
     <string name="restore_session_prompt">Restaurar la sesión guardada al iniciar sesión</string>
     <string name="managed_configuration_username">Nombre de usuario del trabajador móvil</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -64,7 +64,7 @@ License.
     <string name="permission_external_action_description">Permet à cette application de déclencher des opérations telles que la connexion, la déconnexion et la synchronisation dans CommCare</string>
     <string name="permission_commcare_logout_label">Autoriser la déconnexion automatique de CommCare</string>
     <string name="permission_commcare_logout_description">Permet à cette application de déconnecter un utilisateur de l\'application CommmCare</string>
-    <string name="title_activity_report_problem">Signaler un problème d\'activité</string>
+    <string name="title_activity_report_problem">Signaler un problème</string>
     <string name="panes">un</string>
     <string name="restore_session_prompt">Restaurer la session enregistrée lors de la connexion</string>
     <string name="managed_configuration_username">Nom d\'utilisateur du travailleur mobile</string>

--- a/app/res/values-ha/strings.xml
+++ b/app/res/values-ha/strings.xml
@@ -64,7 +64,7 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="permission_external_action_description">Yana bawa wannan app damar fara ayyukan kamar shiga, fita da daidaitawa a cikin CommCare</string>
     <string name="permission_commcare_logout_label">Bada izinin Fita daga Kamfanin Sadarwa ta atomatik</string>
     <string name="permission_commcare_logout_description">Yana bawa wannan manhajar damar fita daga mai amfani daga Manhajar CommmCare</string>
-    <string name="title_activity_report_problem">RahotonMatsalaAyyukan</string>
+    <string name="title_activity_report_problem">Bayar da Rahoto</string>
     <string name="panes">ɗaya</string>
     <string name="restore_session_prompt">Mayar da zaman da aka adana bayan shiga</string>
     <string name="managed_configuration_username">Sunan mai amfani na Ma\'aikacin Wayar hannu</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -64,7 +64,7 @@ License.
     <string name="permission_external_action_description">इस एप्लिकेशन को CommCare में लॉग इन, लॉग आउट और सिंक जैसे ऑपरेशन ट्रिगर करने की अनुमति देता है</string>
     <string name="permission_commcare_logout_label">CommCare से स्वचालित लॉगआउट की अनुमति दें</string>
     <string name="permission_commcare_logout_description">इस एप्लिकेशन को CommmCare एप्लिकेशन से किसी उपयोगकर्ता को लॉग आउट करने की अनुमति देता है</string>
-    <string name="title_activity_report_problem">गतिविधि समस्या की रिपोर्ट करें</string>
+    <string name="title_activity_report_problem">समस्या की रिपोर्ट करें</string>
     <string name="panes">एक</string>
     <string name="restore_session_prompt">लॉग इन करते समय सहेजा गया सत्र पुनर्स्थापित करें</string>
     <string name="managed_configuration_username">मोबाइल कार्यकर्ता उपयोगकर्ता नाम</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -65,7 +65,7 @@
     <string name="permission_external_action_description">Permite que este aplicativo acione operações como login, logout e sincronização no CommCare</string>
     <string name="permission_commcare_logout_label">Permitir logout automático do CommCare</string>
     <string name="permission_commcare_logout_description">Permite que este aplicativo desconecte um usuário do aplicativo CommmCare</string>
-    <string name="title_activity_report_problem">ReportProblemActivity</string>
+    <string name="title_activity_report_problem">Informar problema</string>
     <string name="panes">um</string>
     <string name="restore_session_prompt">Restaurar sessão salva no login</string>
     <string name="managed_configuration_username">Nome de usuário do trabalhador móvel</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -65,7 +65,7 @@
     <string name="permission_external_action_description">Inaruhusu programu hii kuanzisha shughuli kama vile kuingia, kuondoka na kusawazisha katika CommCare</string>
     <string name="permission_commcare_logout_label">Ruhusu Kuondoka kwa Auto CommCare</string>
     <string name="permission_commcare_logout_description">Inaruhusu programu hii kumtoa mtumiaji kutoka kwa Programu ya CommmCare</string>
-    <string name="title_activity_report_problem">RipotiProblemActivity</string>
+    <string name="title_activity_report_problem">Ripoti Tatizo</string>
     <string name="panes">moja</string>
     <string name="restore_session_prompt">Rejesha kipindi kilichohifadhiwa unapoingia</string>
     <string name="managed_configuration_username">Jina la mtumiaji la Mfanyakazi wa Simu</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -53,7 +53,7 @@
     <string name="permission_external_action_description">እዚ ኣፕ ኣብ ኮምኬር ከም ምእታው፣ ምውጻእን ምትእስሳርን ዝኣመሰሉ ስርሓት ክጅምር ይፍቀዱ</string>
     <string name="permission_commcare_logout_label">ናይ ዓርሰ ምዉፃእ ንCommCare ፈቃድ ይሃብዎ</string>
     <string name="permission_commcare_logout_description">እዚ ኣፕ ንሓደ ተጠቃሚ ካብ CommmCare App ንኽወጽእ የኽእሎ</string>
-    <string name="title_activity_report_problem">ኣብ ናይ ንጥፈታት ፀገም እንተሃሊዩ የፍልጡ</string>
+    <string name="title_activity_report_problem">ጸገም ጸብጻብ</string>
     <string name="panes">ሓደ</string>
     <string name="restore_session_prompt">ኣብ እዋን ምእታው ዝተዓቀበ ክፍለ ግዜ ምምላስ</string>
     <string name="managed_configuration_username">ሞባይል ሰራሕተኛ ስም ተጠቃሚ</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -84,7 +84,7 @@
 
     <string name="permission_group_internal_action_label">Permission group for CommCare Internal Actions</string>
 
-    <string name="title_activity_report_problem">ReportProblemActivity</string>
+    <string name="title_activity_report_problem">Report Problem</string>
     <string name="panes">one</string>
 
     <string name="restore_session_prompt">Restore saved session upon login</string>


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/CCCT-2060

## Technical Summary

Added translations from the [excel](https://docs.google.com/spreadsheets/d/10qWIGF9pbkLk6TF45mKq923RzENTJQ4tIpVnzFq_jRQ/edit?gid=607391226#gid=607391226), plus also made sure that any new translations not present in the excel are added with. a machine translation. 


## Safety Assurance

Skipping as translations only.

### QA Plan

No QA planned but we might get some feedback from field testing later on. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
