### PR TITLE
Disable markdown and natural language linters

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -41,6 +41,8 @@ jobs:
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_TRIVY: false
           VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_MARKDOWN: false
+          VALIDATE_NATURAL_LANGUAGE: false
           VALIDATE_YAML_PRETTIER: false
           VALIDATE_GOOGLE_JAVA_FORMAT: false
 


### PR DESCRIPTION
Don't think we really care about these linters and I am disabling these for now in order to make the complete lint check blocking on PRs without it flagging any unwanted changes. 


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
