### PR TITLE
Encrypt androidTest APK artifact in PR workflow

### DIFF
--- a/.github/workflows/commcare-android-pr-workflow.yml
+++ b/.github/workflows/commcare-android-pr-workflow.yml
@@ -91,11 +91,19 @@ jobs:
       - name: Assemble CommCare apk for Instrumentation Testing
         run: ./gradlew assembleCommcareReleaseAndroidTest
         working-directory: commcare-android
+      - name: Encrypt CommCare androidTest apk
+        run: |
+          openssl enc -aes-256-cbc -salt -pbkdf2 \
+            -in commcare-android/app/build/outputs/apk/androidTest/commcare/release/app-commcare-release-androidTest.apk \
+            -out commcare-android/app/build/outputs/apk/androidTest/commcare/release/app-commcare-release-androidTest.apk.enc \
+            -pass pass:"$HQ_API_PASSWORD"
+        env:
+          HQ_API_PASSWORD: ${{ secrets.HQ_API_PASSWORD }}
       - name: Upload CommCare apk for Instrumentation Testing
         uses: actions/upload-artifact@v6
         with:
           name: commcare-release-androidTest-apk
-          path: commcare-android/app/build/outputs/apk/androidTest/commcare/release/app-commcare-release-androidTest.apk
+          path: commcare-android/app/build/outputs/apk/androidTest/commcare/release/app-commcare-release-androidTest.apk.enc
       - name: Generate JaCoCo Report
         run: ./gradlew JacocoTestReport
         working-directory: commcare-android
@@ -129,6 +137,14 @@ jobs:
         with:
           name: commcare-release-androidTest-apk
           path: commcare-release-androidTest-apk
+      - name: Decrypt CommCare androidTest apk
+        run: |
+          openssl enc -aes-256-cbc -d -pbkdf2 \
+            -in commcare-release-androidTest-apk/app-commcare-release-androidTest.apk.enc \
+            -out commcare-release-androidTest-apk/app-commcare-release-androidTest.apk \
+            -pass pass:"$HQ_API_PASSWORD"
+        env:
+          HQ_API_PASSWORD: ${{ secrets.HQ_API_PASSWORD }}
       - name: Run BrowserStack Instrumentation Tests
         run: python commcare-android/scripts/browserstack.py
         env:


### PR DESCRIPTION
## Product Description
No user-facing changes. This is a CI-only change.

## Technical Summary
The androidTest APK artifact contains a mildly sensitive secret. This PR encrypts it with `openssl aes-256-cbc` (keyed by `HQ_API_PASSWORD`) before uploading as a workflow artifact in the `build-test-assemble` job, and decrypts it after downloading in the `browserstack-tests` job.

## Feature Flag
N/A

## Safety Assurance

### Safety story
- Only the CI workflow file is modified; no application code changes
- Encryption/decryption uses the existing `HQ_API_PASSWORD` secret already available in both jobs
- The `browserstack-tests` job's `TEST_APP_LOCATION` env var still points to the same decrypted filename, so downstream usage is unaffected

### Automated test coverage
The PR workflow itself serves as the test — if encryption or decryption fails, the browserstack-tests job will fail.

### QA Plan
- [x] Verify the `build-test-assemble` job completes with the new encrypt step
- [x] Verify the `browserstack-tests` job decrypts and runs instrumentation tests successfully

## Labels and Review

- [x] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [x] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)