### PR TITLE
Remove linters step from PR workflow

### DIFF
--- a/.github/workflows/commcare-android-pr-workflow.yml
+++ b/.github/workflows/commcare-android-pr-workflow.yml
@@ -54,9 +54,6 @@ jobs:
           java-version: '17'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Run Linters
-        run: ./gradlew lintCommcareRelease
-        working-directory: commcare-android
       - name: Run Tests
         run: ./gradlew testCommcareDebug
         working-directory: commcare-android


### PR DESCRIPTION
Removed the step to run linters in the workflow.

## Technical Summary

Think this was a new step that got added in comparison to Jenkins workflow and our code base doesn't seem ready to handle all lint errors produced by this command. I am removing this for now as it's blocking some time sensitive merges and we might decide to get back to this if we feel a need, Think most of the lints should also get surfaced by super linter workflow on the PRs - https://github.com/dimagi/commcare-android/blob/master/.github/workflows/linter.yml


## Safety Assurance

Build only

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, the "QA Note" label is set correctly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, the "Release Note" label is set and a "Release Note" is specified in PR description.
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
