### PR TITLE
Test Improver Workflow improvements

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -1,0 +1,14 @@
+{
+  "entries": {
+    "actions/github-script@v8": {
+      "repo": "actions/github-script",
+      "version": "v8",
+      "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
+    },
+    "github/gh-aw/actions/setup@v0.57.2": {
+      "repo": "github/gh-aw/actions/setup",
+      "version": "v0.57.2",
+      "sha": "32b3a711a9ee97d38e3989c90af0385aff0066a7"
+    }
+  }
+}

--- a/.github/workflows/pr-comment-handler.lock.yml
+++ b/.github/workflows/pr-comment-handler.lock.yml
@@ -30,7 +30,7 @@
 # - Skips ambiguous or contested comments rather than guessing
 # Always transparent, never merges PRs, defers to human judgement on contested changes.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"ef11af9f93cfc3ac0d7ff8e6f4688f0562f9a9167594bbf948cd8c67b8ea7660","compiler_version":"v0.57.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8d2433b41cad2962ad79c96ad6461d068bfe47d86619f866447e78f84212f310","compiler_version":"v0.57.2","strict":true}
 
 name: "PR Comment Handler"
 "on":
@@ -1279,7 +1279,7 @@ jobs:
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
-          GH_AW_NOOP_REPORT_AS_ISSUE: "true"
+          GH_AW_NOOP_REPORT_AS_ISSUE: "false"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-comment-handler.md
+++ b/.github/workflows/pr-comment-handler.md
@@ -25,6 +25,8 @@ network:
   - java
 
 safe-outputs:
+  noop:
+    report-as-issue: false
   add-comment:
     max: 10
     target: "*"
@@ -89,14 +91,39 @@ Always be:
      - Check if it has already been addressed (a bot reply, or the thread is resolved). Skip if so.
      - Note the file, line, and reviewer's text.
    - Fetch any general (non-line) review body comments.
-4. If no PR has unresolved actionable comments, exit silently (do not post any comment).
-5. If all unresolved comments were already addressed by previous workflow runs, exit silently without posting any comment on PR or Issue.
+4. For each such PR, also check if it has merge conflicts (mergeable state is `CONFLICTING`).
+5. If no PR has unresolved actionable comments and no PR has merge conflicts, exit silently (do not post any comment).
 
-### Step 3: Process Each PR
+### Step 3: Resolve Merge Conflicts
+
+For each `[Test Improver]` PR that has merge conflicts:
+
+1. Check out the PR's head branch locally.
+2. Fetch the base branch (usually `master` or `main`) and rebase the PR branch onto it:
+   - Prefer rebase over merge to keep a clean history.
+   - If rebase is not safe (e.g., the branch has been force-pushed by a human), skip and post a comment asking for human assistance.
+3. Resolve any conflicts by favouring the intent of the PR's changes:
+   - Read the conflicting files carefully before resolving.
+   - If a conflict is in a test file added by Test Improver, keep the test changes and integrate with whatever changed on the base branch.
+   - If a conflict is ambiguous or risky (e.g., both sides changed the same logic significantly), do not guess — post a comment describing the conflict and ask for human help.
+4. After resolving, run the relevant tests to confirm nothing is broken.
+5. Commit with:
+   ```
+   Resolve merge conflicts with base branch
+
+   🤖 PR Comment Handler
+   ```
+6. Push to the PR branch.
+7. Post a brief comment on the PR:
+   ```
+   🤖 *PR Comment Handler here — I've rebased this branch onto the latest base branch to resolve merge conflicts. Please re-review if the conflict resolution affected your area of interest.*
+   ```
+
+### Step 4: Process Each PR
 
 For each PR that has unresolved actionable comments:
 
-#### 3a. Classify Comments
+#### 4a. Classify Comments
 
 For each unresolved comment, classify it:
 
@@ -105,7 +132,7 @@ For each unresolved comment, classify it:
 - **Opinion / discussion**: The reviewer is sharing a view without a clear action item, or the PR author has already pushed back. → Skip; do not take sides.
 - **Out of scope**: The reviewer asks for changes well beyond this PR's purpose. → Note in summary, suggest a follow-up issue.
 
-#### 3b. Implement Clear Changes
+#### 4b. Implement Clear Changes
 
 For comments classified as **Clear code change**:
 
@@ -125,7 +152,7 @@ For comments classified as **Clear code change**:
    ```
 7. Push to the PR branch.
 
-#### 3c. Post Summary Comment
+#### 4c. Post Summary Comment
 
 After processing all comments on a PR, post a single summary comment:
 
@@ -148,7 +175,7 @@ Please re-review the latest commit. Happy to make further adjustments.
 
 If nothing was implemented (only clarifications needed), say so clearly.
 
-### Step 4: Update Memory
+### Step 5: Update Memory
 
 Update repo memory with:
 - Any new build/test/lint commands discovered


### PR DESCRIPTION
## Technical Summary

Make 2 changes in the test improver workflow - 
1.  Stop posting[ no-op comments](https://github.com/dimagi/commcare-android/issues/3649)
2.  Add directions for automated conflict resolution

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
