### PR TITLE
Move incomplete forms count off the main thread

### DIFF
--- a/app/src/org/commcare/activities/HomeButtons.java
+++ b/app/src/org/commcare/activities/HomeButtons.java
@@ -206,23 +206,26 @@ public class HomeButtons {
 
     private static TextSetter getIncompleteButtonTextSetter(final StandardHomeActivity activity) {
         return (cardDisplayData, squareButtonViewHolder, context, notificationText) -> {
-            int numIncompleteForms;
-            try {
-                numIncompleteForms = StorageUtils.getNumIncompleteForms();
-            } catch (SessionUnavailableException e) {
-                // stop button setup, since redirection to login is imminent
-                return;
-            }
+            getIncompleteFormsExecutor().submit(
+                    LifecycleOwnerKt.getLifecycleScope(activity),
+                    StorageUtils::getNumIncompleteForms,
+                    new LatestTaskExecutor.Callback<>() {
+                        @Override
+                        public void onResult(Integer numIncompleteForms) {
+                            if (activity.isFinishing() || activity.isDestroyed()) {
+                                return;
+                            }
+                            updateIncompleteFormsUI(activity, squareButtonViewHolder.textView, numIncompleteForms);
+                        }
 
-            if (numIncompleteForms > 0) {
-                Spannable incompleteIndicator =
-                        (activity.localize("home.forms.incomplete.indicator",
-                                new String[]{String.valueOf(numIncompleteForms),
-                                        Localization.get("home.forms.incomplete")}));
-                squareButtonViewHolder.textView.setText(incompleteIndicator);
-            } else {
-                squareButtonViewHolder.textView.setText(activity.localize("home.forms.incomplete"));
-            }
+                        @Override
+                        public void onError(@NonNull Exception exception) {
+                            if (!(exception instanceof SessionUnavailableException)) {
+                                Logger.exception("Failed to retrieve incomplete forms count ", exception);
+                            }
+                        }
+                    });
+
             squareButtonViewHolder.textView.setTextColor(context.getResources()
                     .getColor(cardDisplayData.textColor));
             squareButtonViewHolder.subTextView.setVisibility(View.GONE);

--- a/app/src/org/commcare/activities/HomeButtons.java
+++ b/app/src/org/commcare/activities/HomeButtons.java
@@ -4,7 +4,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.text.Spannable;
 import android.view.View;
+import android.widget.TextView;
 import android.widget.Toast;
+import androidx.annotation.NonNull;
 
 import org.commcare.adapters.HomeCardDisplayData;
 import org.commcare.adapters.SquareButtonViewHolder;
@@ -12,12 +14,16 @@ import org.commcare.dalvik.R;
 import org.commcare.google.services.analytics.AnalyticsParamValue;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.services.CommCareSessionService;
+import org.commcare.tasks.LatestTaskExecutor;
 import org.commcare.utils.SessionUnavailableException;
 import org.commcare.utils.StorageUtils;
 import org.commcare.utils.SyncDetailCalculations;
+import org.javarosa.core.services.Logger;
 import org.javarosa.core.services.locale.Localization;
 
 import java.util.Vector;
+
+import androidx.lifecycle.LifecycleOwnerKt;
 
 
 /**
@@ -29,6 +35,8 @@ public class HomeButtons {
 
     private final static String[] buttonNames =
             new String[]{"start", "training", "saved", "incomplete", "connect", "sync", "report", "logout"};
+
+    private static LatestTaskExecutor<Integer> incompleteFormsExecutor;
 
     /**
      * Note: The order in which home cards are returned by this method should be consistent with
@@ -171,6 +179,29 @@ public class HomeButtons {
             reportButtonClick(AnalyticsParamValue.INCOMPLETE_FORMS_BUTTON);
             activity.goToFormArchive(true);
         };
+    }
+
+    private static LatestTaskExecutor<Integer> getIncompleteFormsExecutor() {
+        if (incompleteFormsExecutor == null) {
+            incompleteFormsExecutor = new LatestTaskExecutor<>();
+        }
+        return incompleteFormsExecutor;
+    }
+
+    private static void updateIncompleteFormsUI(
+            StandardHomeActivity activity,
+            TextView squareButtonText,
+            Integer numIncompleteForms
+    ) {
+        if (numIncompleteForms > 0) {
+            Spannable incompleteIndicator =
+                    (activity.localize("home.forms.incomplete.indicator",
+                            new String[]{String.valueOf(numIncompleteForms),
+                                    Localization.get("home.forms.incomplete")}));
+            squareButtonText.setText(incompleteIndicator);
+        } else {
+            squareButtonText.setText(activity.localize("home.forms.incomplete"));
+        }
     }
 
     private static TextSetter getIncompleteButtonTextSetter(final StandardHomeActivity activity) {


### PR DESCRIPTION
## Product Description

No user-facing changes. The home screen incomplete forms button now loads its count asynchronously, preventing potential UI jank from the database query.

## Technical Summary

The `StorageUtils.getNumIncompleteForms()` database query in `HomeButtons` was running synchronously on the main thread during home screen button setup. This moves it off the main thread using `LatestTaskExecutor` (coroutine-based) tied to the activity's lifecycle scope.

- Extract `updateIncompleteFormsUI()` helper method for updating the button text
- Add lazy-initialized `LatestTaskExecutor<Integer>` for async execution
- Replace synchronous `getNumIncompleteForms()` call with async `submit()` via `Dispatchers.IO`
- `SessionUnavailableException` is silently ignored in `onError` since it indicates expected session expiry, not a real error

## Safety Assurance

### Safety story
- The coroutine is scoped to the activity's lifecycle via `LifecycleOwnerKt.getLifecycleScope()`, so it's automatically cancelled on activity destruction
- Additional `isFinishing() || isDestroyed()` guard in the callback as a belt-and-suspenders check
- `LatestTaskExecutor` cancels any previous in-flight task on re-submit, preventing stale results
- Button text defaults to the plain "Incomplete Forms" label from `cardDisplayData.text` while the async count loads
- This change was successfully tested locally. Steps taken were:
  - Verified that the incomplete forms button shows the correct count on the home screen
  - Submitted and deleted incomplete forms and returned to home screen, verified that the count updated accordingly
  - Rotated the device on the home screen, and verified that there were no crashes and count still appears

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage? If yes, [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating? If yes, [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change