### PR TITLE
Limit Dependabot to major version updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,19 @@ updates:
       interval: daily
     labels:
       - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
   - package-ecosystem: gradle
     directory: "/app"
     schedule:
       interval: daily
     labels:
       - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"


### PR DESCRIPTION
## Product Description

No user-facing changes. Infrastructure configuration update.

## Technical Summary

Configures Dependabot to ignore patch and minor semver updates for GitHub Actions dependencies. Only major version updates will trigger Dependabot PRs going forward, reducing noise from low-risk automated PRs.

- Add `ignore` rules to `.github/dependabot.yml` filtering out `version-update:semver-patch` and `version-update:semver-minor`

## Safety Assurance

### Safety story

This only affects Dependabot's PR creation behavior — no application code is changed. Major version updates (which are more likely to contain breaking changes) will still be reported.

### Automated test coverage

N/A — configuration-only change.

### QA Plan

- Verify Dependabot stops creating PRs for patch/minor bumps
- Verify major version update PRs are still created

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage? If yes, [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating? If yes, [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change