### PR TITLE
Add Claude-powered Dependabot PR review workflow

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -1,0 +1,147 @@
+# Claude Dependabot PR Review Workflow
+#
+# This workflow automatically runs Claude analysis on Dependabot PRs to:
+# - Identify dependency changes and their versions
+# - Look up changelogs for updated packages
+# - Assess breaking changes and security impacts
+# - Provide actionable recommendations for the development team
+#
+# Triggered on: Dependabot PRs (opened, synchronize)
+# Requirements: ANTHROPIC_API_KEY secret must be configured
+
+name: Claude Dependabot PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to analyze'
+        required: true
+        type: string
+
+jobs:
+  dependabot-review:
+    # Only run on Dependabot PRs, or manual dispatch for testing
+    if: github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+
+    steps:
+      - name: Resolve PR ref
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ inputs.pr_number || github.event.pull_request.number }}"
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          REF=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.ref }}
+          fetch-depth: 2
+
+      - name: Checkout commcare-core
+        uses: actions/checkout@v4
+        with:
+          repository: dimagi/commcare-core
+          ref: master
+          path: commcare-core
+
+      - name: Run Claude Dependabot Analysis
+        id: claude_review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "dependabot[bot]"
+          claude_args: |
+            --allowedTools "Grep,Bash(git:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,WebFetch"
+          prompt: |
+            You are reviewing PR #${{ steps.pr.outputs.pr_number }}.
+
+            You are Claude, an AI assistant specialized in reviewing Dependabot dependency update PRs
+            for CommCare Android — a mixed Java/Kotlin Android application built with Android Gradle
+            Plugin (AGP). Dependencies are declared in the root build.gradle, in app/build.gradle and 
+            submodule build.gradle files, and are managed via Gradle. 
+            The project uses SQLCipher, Retrofit/OkHttp, Firebase, AndroidX, and two submodules: 
+            commcare-core which lives in a root sibling folder and commcare-support-library which lives 
+            in a subfolder /commcare-support-library/ 
+
+            Your primary tasks are:
+            1. **Analyze the dependency changes** in this Dependabot PR
+            2. **Look up changelogs** for all updated dependencies to understand what changed
+            3. **Identify breaking changes** and assess potential impact on the CommCare android codebase
+            4. **Provide actionable recommendations** for the development team
+
+            ## Analysis Process:
+
+            1. **Identify Changed Dependencies**:
+               - Use `gh pr diff` to see what dependencies were updated
+               - Parse build.gradle files for dependency changes
+               - List all package versions: old → new
+
+            2. **Changelog Research**:
+               - For each updated dependency, look up its changelog/release notes in:
+                  - AndroidX: https://developer.android.com/jetpack/androidx/releases/{artifact-group}
+                  - Firebase: https://firebase.google.com/support/release-notes/android
+                  - Play Services: https://developers.google.com/android/guides/releases
+                  - For other libraries, check GitHub releases at the repo URL
+               - Focus on versions between the old and new versions
+               - Identify: breaking changes, deprecations, security fixes, new features
+
+            3. **Breaking Change Assessment**:
+               - Categorize changes: BREAKING, MAJOR, MINOR, PATCH, SECURITY
+               - Assess impact on CommCare Android's usage patterns
+               - Check if CommCare Android uses affected APIs/features
+               - Look for migration guides or upgrade instructions
+
+            4. **Codebase Impact Analysis**:
+               - Search the codebase for usage of changed APIs
+               - Check usage of updated packages in the codebase
+               - Identify any tests that might be affected by the changes
+               - Identify files that might be affected by breaking changes
+
+            ## Output Format:
+
+            Post a PR comment with a comprehensive review for MAJOR bumps. For MINOR and PATCH 
+            bumps, use a condensed format with only a summary, risk level and merge recommendation.  
+            Structure your comment with the following sections:
+
+            ### 🔍 Dependency Analysis Summary
+            - List of updated packages with version changes
+            - Overall risk assessment (LOW/MEDIUM/HIGH)
+
+            ### 📋 Detailed Changelog Review
+            For each updated dependency:
+            - **Package**: name (old_version → new_version)
+            - **Changes**: Summary of key changes
+            - **Breaking Changes**: List any breaking changes
+            - **Security Fixes**: Note security improvements
+            - **Migration Notes**: Any upgrade steps needed
+
+            ### ⚠️ Impact Assessment
+            - **Breaking Changes Found**: Yes/No with details
+            - **Affected Files**: List CommCare files that may need updates
+            - **Test Impact**: Any tests that may need updating
+            - **Configuration Changes**: Required config updates
+
+            ### 🛠️ Recommendations
+            - **Action Required**: What the team should do
+            - **Testing Focus**: Areas to test thoroughly
+            - **Follow-up Tasks**: Any additional work needed
+            - **Merge Recommendation**: APPROVE / REVIEW_NEEDED / HOLD
+
+            ### 📚 Useful Links
+            - Links to relevant changelogs, migration guides, documentation
+
+            Be thorough but concise. Focus on actionable insights that help the development
+            team make informed decisions about the dependency updates.

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -72,9 +72,10 @@ jobs:
             for CommCare Android — a mixed Java/Kotlin Android application built with Android Gradle
             Plugin (AGP). Dependencies are declared in the root build.gradle, in app/build.gradle and 
             submodule build.gradle files, and are managed via Gradle. 
-            The project uses SQLCipher, Retrofit/OkHttp, Firebase, AndroidX, and two submodules: 
-            commcare-core which lives in a root sibling folder and commcare-support-library which lives 
-            in a subfolder /commcare-support-library/ 
+            The project uses SQLCipher, Retrofit/OkHttp, Firebase, and AndroidX, and includes two
+            Gradle subprojects (each with its own build.gradle): `commcare-core` — XForm engine and
+            core business logic — located in a sibling directory (`../commcare-core`), and
+            `commcare-support-library` — shared components — located at `/commcare-support-library/`.
 
             Your primary tasks are:
             1. **Analyze the dependency changes** in this Dependabot PR
@@ -86,7 +87,8 @@ jobs:
 
             1. **Identify Changed Dependencies**:
                - Use `gh pr diff` to see what dependencies were updated
-               - Parse build.gradle files for dependency changes
+               - Parse `build.gradle`, `app/build.gradle` and `commcare-support-libraries/build.gradle` files 
+                 for dependency changes
                - List all package versions: old → new
 
             2. **Changelog Research**:


### PR DESCRIPTION
## Product Description

No user-facing changes. This adds a CI workflow that runs automatically on Dependabot PRs.

## Technical Summary

Adds a GitHub Actions workflow (`.github/workflows/claude-dependabot.yml`) that uses [Claude Code Action](https://github.com/anthropics/claude-code-action) to automatically review Dependabot dependency update PRs.

**What it does:**
- Triggers on Dependabot PRs (opened/synchronize) and via manual `workflow_dispatch`
- Checks out the PR branch and commcare-core master for codebase search
- Uses Claude to analyze the dependency diff, fetch changelogs from AndroidX/Firebase/Play Services/GitHub releases, assess breaking changes, search the codebase for affected usage, and post a structured review comment on the PR

**Key design decisions:**
- Read-only toolset: `Grep`, `Read`, `WebFetch`, `git`, `gh pr comment/diff/view` — Claude cannot modify code
- No JDK/Gradle on the runner — analysis relies on `gh pr diff` and file reads, not compilation
- Condensed output format for minor/patch bumps, full analysis for major bumps
- 30-minute timeout to bound API costs

**Requires:** `ANTHROPIC_API_KEY` repository secret to be configured.

## Safety Assurance

### Safety story
- The workflow only has `contents: read` and `pull-requests: write` permissions — it cannot push code or modify the repository
- Claude's allowed tools are explicitly scoped — no `Edit`, no `Write`, no arbitrary `Bash`
- The `if:` condition restricts the job to `dependabot[bot]` actor or manual dispatch only
- Tested the prompt structure iteratively in local Claude Code sessions

### Automated test coverage
N/A — this is a CI workflow file, not application code.

### QA Plan
- Trigger manually via `workflow_dispatch` on a known Dependabot PR to verify the review comment is posted correctly
- Verify the workflow does not trigger on non-Dependabot PRs

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change