### PR TITLE
Run form-entry Next navigation off the main thread

### DIFF
--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -166,6 +166,7 @@ sync.recover.started=Recovering local DB State. Please do not turn off the app!
 form.entry.segfault=There was an unrecoverable error during form entry! If the problem persists, seek CommCare Support
 form.entry.processing=Processing your Form
 form.entry.processing.title=Processing Form
+form.entry.loading.next.question=Loading next question…
 form.entry.complete.save.success=Form successfully completed
 form.entry.incomplete.save.success=Form saved as incomplete
 form.entry.save.error=Sorry, form save failed. Please contact CommCare Support to look into the issue.

--- a/app/res/layout/screen_form_entry.xml
+++ b/app/res/layout/screen_form_entry.xml
@@ -212,6 +212,22 @@
             android:background="@color/transclucent_nearly_solid_grey"
             android:clickable="true"
             android:visibility="gone"/>
+
+        <FrameLayout
+            android:id="@+id/form_entry_loading_overlay"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/transclucent_nearly_solid_grey"
+            android:clickable="true"
+            android:focusable="true"
+            android:visibility="gone">
+
+            <ProgressBar
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:indeterminate="true"/>
+        </FrameLayout>
     </FrameLayout>
 
 

--- a/app/res/layout/screen_form_entry.xml
+++ b/app/res/layout/screen_form_entry.xml
@@ -222,11 +222,24 @@
             android:focusable="true"
             android:visibility="gone">
 
-            <ProgressBar
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:indeterminate="true"/>
+                android:orientation="vertical"
+                android:gravity="center_horizontal">
+
+                <ProgressBar
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:indeterminate="true"/>
+
+                <TextView
+                    android:id="@+id/form_entry_loading_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"/>
+            </LinearLayout>
         </FrameLayout>
     </FrameLayout>
 

--- a/app/src/org/commcare/activities/AsyncFormNavigator.kt
+++ b/app/src/org/commcare/activities/AsyncFormNavigator.kt
@@ -1,0 +1,53 @@
+package org.commcare.activities
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Runs form-navigation stepping on a background thread and delivers the
+ * resulting renderable event back on the main thread.
+ *
+ * Re-entry while a navigation is already in flight is a no-op.
+ */
+class AsyncFormNavigator(
+    private val lifecycleOwner: LifecycleOwner,
+    private val stepWork: StepWork,
+    private val overlayCallback: OverlayCallback
+) {
+
+    fun interface StepWork {
+        fun step(): NavResult
+    }
+
+    fun interface OverlayCallback {
+        fun setVisible(visible: Boolean)
+    }
+
+    fun interface ResultCallback {
+        fun onResult(result: NavResult)
+    }
+
+    private var navigationInFlight = false
+
+    fun isNavigationInFlight(): Boolean = navigationInFlight
+
+    fun navigate(onComplete: ResultCallback) {
+        if (navigationInFlight) {
+            return
+        }
+        navigationInFlight = true
+        overlayCallback.setVisible(true)
+        lifecycleOwner.lifecycleScope.launch {
+            try {
+                val result = withContext(Dispatchers.Default) { stepWork.step() }
+                onComplete.onResult(result)
+            } finally {
+                navigationInFlight = false
+                overlayCallback.setVisible(false)
+            }
+        }
+    }
+}

--- a/app/src/org/commcare/activities/AsyncFormNavigator.kt
+++ b/app/src/org/commcare/activities/AsyncFormNavigator.kt
@@ -3,51 +3,43 @@ package org.commcare.activities
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
  * Runs form-navigation stepping on a background thread and delivers the
  * resulting renderable event back on the main thread.
- *
- * Re-entry while a navigation is already in flight is a no-op.
  */
 class AsyncFormNavigator(
     private val lifecycleOwner: LifecycleOwner,
-    private val stepWork: StepWork,
-    private val overlayCallback: OverlayCallback
+    private val stepWork: StepWork
 ) {
 
     fun interface StepWork {
         fun step(): NavResult
     }
 
-    fun interface OverlayCallback {
-        fun setVisible(visible: Boolean)
+    fun interface StartCallback {
+        fun onStart()
     }
 
     fun interface ResultCallback {
         fun onResult(result: NavResult)
     }
 
-    private var navigationInFlight = false
+    private var job: Job? = null
 
-    fun isNavigationInFlight(): Boolean = navigationInFlight
+    fun navigate(resuming: Boolean, onStart: StartCallback, onResult: ResultCallback) {
+        onStart.onStart()
+        job = lifecycleOwner.lifecycleScope.launch {
+            val result = withContext(Dispatchers.Default) { stepWork.step() }
+            onResult.onResult(result)
+        }
+    }
 
-    fun navigate(onComplete: ResultCallback) {
-        if (navigationInFlight) {
-            return
-        }
-        navigationInFlight = true
-        overlayCallback.setVisible(true)
-        lifecycleOwner.lifecycleScope.launch {
-            try {
-                val result = withContext(Dispatchers.Default) { stepWork.step() }
-                onComplete.onResult(result)
-            } finally {
-                navigationInFlight = false
-                overlayCallback.setVisible(false)
-            }
-        }
+    fun cancel() {
+        job?.cancel()
+        job = null
     }
 }

--- a/app/src/org/commcare/activities/AsyncFormNavigator.kt
+++ b/app/src/org/commcare/activities/AsyncFormNavigator.kt
@@ -29,16 +29,22 @@ class AsyncFormNavigator(
     }
 
     private var job: Job? = null
+    private var currentNavId: Long = 0
 
     fun navigate(resuming: Boolean, onStart: StartCallback, onResult: ResultCallback) {
+        val navId = ++currentNavId
         onStart.onStart()
         job = lifecycleOwner.lifecycleScope.launch {
             val result = withContext(Dispatchers.Default) { stepWork.step() }
+            if (navId != currentNavId) {
+                return@launch
+            }
             onResult.onResult(result)
         }
     }
 
     fun cancel() {
+        currentNavId++
         job?.cancel()
         job = null
     }

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -911,6 +911,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
     protected void onPause() {
         super.onPause();
 
+        uiController.cancelNavigation();
+
         if (!isFinishing() && uiController.questionsView != null && currentPromptIsQuestion()) {
             saveAnswersForCurrentScreen(false);
         }

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -630,6 +630,15 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         return blockingActionsManager.isBlocked() || navigationInFlight;
     }
 
+    protected void cancelNavigation() {
+        if (!navigationInFlight) {
+            return;
+        }
+        asyncFormNavigator.cancel();
+        navigationInFlight = false;
+        formLoadingOverlay.hide();
+    }
+
     protected boolean shouldIgnoreSwipeAction() {
         return isAnimatingSwipe || isDialogShowing;
     }

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -417,71 +417,82 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         // Any info stored about the last changed widget is useless when we move to a new view
         resetLastChangedWidget();
 
-        if (FormEntryActivity.mFormController.getEvent() != FormEntryController.EVENT_END_OF_FORM) {
-            int event;
+        if (FormEntryActivity.mFormController.getEvent() == FormEntryController.EVENT_END_OF_FORM) {
+            return;
+        }
 
-            try {
-                group_skip:
-                do {
-                    event = FormEntryActivity.mFormController.stepToNextEvent(FormEntryController.STEP_OVER_GROUP);
-                    switch (event) {
-                        case FormEntryController.EVENT_QUESTION:
-                            QuestionsView next = createView();
-                            if (!resuming) {
-                                showView(next, LocalePreferences.isLocaleRTL() ? AnimationType.LEFT : AnimationType.RIGHT);
-                            } else {
-                                showView(next, AnimationType.FADE, false);
-                            }
-                            break group_skip;
-                        case FormEntryController.EVENT_END_OF_FORM:
-                            // auto-advance questions might advance past the last form quesion
-                            // In special case when questionsView is null (there is no question),
-                            // to avoid exit dialog without saving option, shown from refreshCurrentView(),
-                            // save and exit method called.
-                            if (questionsView != null) {
-                                refreshCurrentView();
-                            } else {
-                                activity.triggerUserFormComplete();
-                            }
-                            break group_skip;
-                        case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
-                            createRepeatDialog();
-                            break group_skip;
-                        case FormEntryController.EVENT_GROUP:
-                            //We only hit this event if we're at the _opening_ of a field
-                            //list, so it seems totally fine to do it this way, technically
-                            //though this should test whether the index is the field list
-                            //host.
-                            if (FormEntryActivity.mFormController.indexIsInFieldList()
-                                    && FormEntryActivity.mFormController.getQuestionPrompts().length != 0) {
-                                QuestionsView nextGroupView = createView();
-                                if (!resuming) {
-                                    showView(nextGroupView, LocalePreferences.isLocaleRTL() ? AnimationType.LEFT : AnimationType.RIGHT);
-                                } else {
-                                    showView(nextGroupView, AnimationType.FADE, false);
-                                }
-                                break group_skip;
-                            }
-                            // otherwise it's not a field-list group, so just skip it
-                            break;
-                        case FormEntryController.EVENT_REPEAT:
-                            Log.i(TAG, "repeat: " + FormEntryActivity.mFormController.getFormIndex().getReference());
-                            // skip repeats
-                            break;
-                        case FormEntryController.EVENT_REPEAT_JUNCTURE:
-                            Log.i(TAG, "repeat juncture: "
-                                    + FormEntryActivity.mFormController.getFormIndex().getReference());
-                            // skip repeat junctures until we implement them
-                            break;
-                        default:
-                            Log.w(TAG,
-                                    "JavaRosa added a new EVENT type and didn't tell us... shame on them.");
-                            break;
-                    }
-                } while (event != FormEntryController.EVENT_END_OF_FORM);
-            } catch (XPathException e) {
-                new UserfacingErrorHandling<>().logErrorAndShowDialog(activity, e, FormEntryConstants.EXIT);
+        renderNavResult(stepToRenderableEvent(), resuming);
+    }
+
+    /**
+     * Walks the form forward via {@link FormEntryController#stepToNextEvent} until a renderable
+     * event is reached. Pure controller-state access; no view creation or UI side effects.
+     */
+    private NavResult stepToRenderableEvent() {
+        try {
+            while (true) {
+                int event = FormEntryActivity.mFormController.stepToNextEvent(FormEntryController.STEP_OVER_GROUP);
+                switch (event) {
+                    case FormEntryController.EVENT_QUESTION:
+                        return NavResult.Question.INSTANCE;
+                    case FormEntryController.EVENT_END_OF_FORM:
+                        return NavResult.EndOfForm.INSTANCE;
+                    case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
+                        return NavResult.PromptNewRepeat.INSTANCE;
+                    case FormEntryController.EVENT_GROUP:
+                        //We only hit this event if we're at the _opening_ of a field
+                        //list, so it seems totally fine to do it this way, technically
+                        //though this should test whether the index is the field list
+                        //host.
+                        if (FormEntryActivity.mFormController.indexIsInFieldList()
+                                && FormEntryActivity.mFormController.getQuestionPrompts().length != 0) {
+                            return NavResult.FieldListGroup.INSTANCE;
+                        }
+                        // otherwise it's not a field-list group, so just skip it
+                        break;
+                    case FormEntryController.EVENT_REPEAT:
+                        Log.i(TAG, "repeat: " + FormEntryActivity.mFormController.getFormIndex().getReference());
+                        // skip repeats
+                        break;
+                    case FormEntryController.EVENT_REPEAT_JUNCTURE:
+                        Log.i(TAG, "repeat juncture: "
+                                + FormEntryActivity.mFormController.getFormIndex().getReference());
+                        // skip repeat junctures until we implement them
+                        break;
+                    default:
+                        Log.w(TAG,
+                                "JavaRosa added a new EVENT type and didn't tell us... shame on them.");
+                        break;
+                }
             }
+        } catch (XPathException e) {
+            return new NavResult.Error(e);
+        }
+    }
+
+    private void renderNavResult(NavResult result, boolean resuming) {
+        if (result instanceof NavResult.Question || result instanceof NavResult.FieldListGroup) {
+            QuestionsView next = createView();
+            if (!resuming) {
+                showView(next, LocalePreferences.isLocaleRTL() ? AnimationType.LEFT : AnimationType.RIGHT);
+            } else {
+                showView(next, AnimationType.FADE, false);
+            }
+        } else if (result instanceof NavResult.PromptNewRepeat) {
+            createRepeatDialog();
+        } else if (result instanceof NavResult.EndOfForm) {
+            // auto-advance questions might advance past the last form question
+            // In special case when questionsView is null (there is no question),
+            // to avoid exit dialog without saving option, shown from refreshCurrentView(),
+            // save and exit method called.
+            if (questionsView != null) {
+                refreshCurrentView();
+            } else {
+                activity.triggerUserFormComplete();
+            }
+        } else if (result instanceof NavResult.Error) {
+            new UserfacingErrorHandling<>().logErrorAndShowDialog(
+                    activity, ((NavResult.Error)result).getException(), FormEntryConstants.EXIT);
         }
     }
 

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -84,7 +84,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
 
     private static final String KEY_LAST_CHANGED_WIDGET = "index-of-last-changed-widget";
     private TextView finishText;
-    private View loadingOverlay;
+    private FormLoadingOverlay formLoadingOverlay;
     private AsyncFormNavigator asyncFormNavigator;
 
     enum AnimationType {
@@ -146,11 +146,20 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
 
 
         mViewPane = activity.findViewById(R.id.form_entry_pane);
-        loadingOverlay = activity.findViewById(R.id.form_entry_loading_overlay);
+        formLoadingOverlay = new FormLoadingOverlay(
+                activity.findViewById(R.id.form_entry_loading_overlay),
+                activity.findViewById(R.id.form_entry_loading_label),
+                Localization.get("form.entry.loading.next.question"));
         asyncFormNavigator = new AsyncFormNavigator(
                 activity,
                 this::stepToRenderableEvent,
-                visible -> loadingOverlay.setVisibility(visible ? View.VISIBLE : View.GONE));
+                visible -> {
+                    if (visible) {
+                        formLoadingOverlay.show();
+                    } else {
+                        formLoadingOverlay.hide();
+                    }
+                });
 
         activity.requestMajorLayoutUpdates();
 

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -81,6 +81,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
     private BlockingActionsManager blockingActionsManager;
 
     private boolean formRelevanciesUpdateInProgress = false;
+    private boolean navigationInFlight = false;
 
     private static final String KEY_LAST_CHANGED_WIDGET = "index-of-last-changed-widget";
     private TextView finishText;
@@ -152,14 +153,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
                 Localization.get("form.entry.loading.next.question"));
         asyncFormNavigator = new AsyncFormNavigator(
                 activity,
-                this::stepToRenderableEvent,
-                visible -> {
-                    if (visible) {
-                        formLoadingOverlay.show();
-                    } else {
-                        formLoadingOverlay.hide();
-                    }
-                });
+                this::stepToRenderableEvent);
 
         activity.requestMajorLayoutUpdates();
 
@@ -437,7 +431,15 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
             return;
         }
 
-        asyncFormNavigator.navigate(result -> renderNavResult(result, resuming));
+        navigationInFlight = true;
+        asyncFormNavigator.navigate(
+                resuming,
+                formLoadingOverlay::show,
+                result -> {
+                    navigationInFlight = false;
+                    formLoadingOverlay.hide();
+                    renderNavResult(result, resuming);
+                });
     }
 
     /**
@@ -625,8 +627,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
     }
 
     protected boolean shouldIgnoreNavigationAction() {
-        return blockingActionsManager.isBlocked()
-                || (asyncFormNavigator != null && asyncFormNavigator.isNavigationInFlight());
+        return blockingActionsManager.isBlocked() || navigationInFlight;
     }
 
     protected boolean shouldIgnoreSwipeAction() {

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -84,6 +84,8 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
 
     private static final String KEY_LAST_CHANGED_WIDGET = "index-of-last-changed-widget";
     private TextView finishText;
+    private View loadingOverlay;
+    private AsyncFormNavigator asyncFormNavigator;
 
     enum AnimationType {
         LEFT, RIGHT, FADE
@@ -144,6 +146,11 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
 
 
         mViewPane = activity.findViewById(R.id.form_entry_pane);
+        loadingOverlay = activity.findViewById(R.id.form_entry_loading_overlay);
+        asyncFormNavigator = new AsyncFormNavigator(
+                activity,
+                this::stepToRenderableEvent,
+                visible -> loadingOverlay.setVisibility(visible ? View.VISIBLE : View.GONE));
 
         activity.requestMajorLayoutUpdates();
 
@@ -421,7 +428,7 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
             return;
         }
 
-        renderNavResult(stepToRenderableEvent(), resuming);
+        asyncFormNavigator.navigate(result -> renderNavResult(result, resuming));
     }
 
     /**
@@ -609,7 +616,8 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
     }
 
     protected boolean shouldIgnoreNavigationAction() {
-        return blockingActionsManager.isBlocked();
+        return blockingActionsManager.isBlocked()
+                || (asyncFormNavigator != null && asyncFormNavigator.isNavigationInFlight());
     }
 
     protected boolean shouldIgnoreSwipeAction() {

--- a/app/src/org/commcare/activities/FormLoadingOverlay.kt
+++ b/app/src/org/commcare/activities/FormLoadingOverlay.kt
@@ -1,0 +1,40 @@
+package org.commcare.activities
+
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.widget.TextView
+
+/**
+ * Wraps the form-entry loading overlay view. [show] posts a delayed
+ * visibility change so fast navigations don't flash the overlay; [hide]
+ * cancels any pending show and hides the view immediately.
+ */
+class FormLoadingOverlay @JvmOverloads constructor(
+    private val overlayView: View,
+    labelView: TextView,
+    labelText: String,
+    private val showDelayMillis: Long = DEFAULT_SHOW_DELAY_MILLIS
+) {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val showRunnable = Runnable { overlayView.visibility = View.VISIBLE }
+
+    init {
+        labelView.text = labelText
+    }
+
+    fun show() {
+        handler.removeCallbacks(showRunnable)
+        handler.postDelayed(showRunnable, showDelayMillis)
+    }
+
+    fun hide() {
+        handler.removeCallbacks(showRunnable)
+        overlayView.visibility = View.GONE
+    }
+
+    companion object {
+        const val DEFAULT_SHOW_DELAY_MILLIS: Long = 150
+    }
+}

--- a/app/src/org/commcare/activities/NavResult.kt
+++ b/app/src/org/commcare/activities/NavResult.kt
@@ -1,0 +1,14 @@
+package org.commcare.activities
+
+import org.javarosa.xpath.XPathException
+
+/**
+ * Outcome of stepping the form to the next renderable event.
+ */
+sealed class NavResult {
+    object Question : NavResult()
+    object FieldListGroup : NavResult()
+    object PromptNewRepeat : NavResult()
+    object EndOfForm : NavResult()
+    data class Error(val exception: XPathException) : NavResult()
+}


### PR DESCRIPTION
## Product Description

When tapping Next in a form, the CommCare client previously froze the
UI while it walked the form model between renderable events — on forms
with heavy XPath evaluation (complex relevance, calculations, lookups)
this produced noticeable stalls and dropped frames. With this change,
that walk runs on a background dispatcher and a "Loading next question…"
overlay appears after 150 ms on slow steps (invisible on fast ones).
Rapid double-taps now advance a single question instead of double-stepping.

## Technical Summary

No ticket; produced from the off-main-thread form navigation plan.

- `NavResult` (sealed class) models the outcome of a step: `Question`,
  `FieldListGroup`, `PromptNewRepeat`, `EndOfForm`, `Error(XPathException)`.
- `showNextView` split into `stepToRenderableEvent()` (pure controller
  walk, returns `NavResult`) and `renderNavResult()` (view work on Main).
- `AsyncFormNavigator` (new Kotlin) runs the stepper via
  `withContext(Dispatchers.Default)` on `lifecycleScope.launch`, retains
  the launched `Job`, and uses a monotonic `currentNavId` to drop
  results whose navigation was superseded or cancelled.
- `FormLoadingOverlay` (new Kotlin) posts a 150 ms-delayed `VISIBLE`
  so fast navigations don't flash; `hide()` cancels any pending post.
- `navigationInFlight` lives on `FormEntryActivityUIController`;
  `shouldIgnoreNavigationAction()` checks it so Next/Previous/swipe
  are dropped during an in-flight step.
- `FormEntryActivity.onPause()` calls `uiController.cancelNavigation()`
  which cancels the navigator, clears the flag, and hides the overlay —
  prevents a late result firing against a paused UI.
- Locale key `form.entry.loading.next.question` added for the overlay.

Out of scope / deferred:
- `createView()` / `showView()` still run on Main (view inflation must).
- Select-choice prefetch, same pattern on `showPreviousView` /
  `refreshCurrentView`, and a `pendingNavigationAfterRestore` flag
  for config-change mid-nav resumption.

## Safety Assurance

### Safety story

- The nav-id in `AsyncFormNavigator` guarantees late/stale results
  are dropped, including results that resume past a `Job.cancel()`
  due to cooperative cancellation.
- `cancelNavigation()` on `onPause()` prevents a background step from
  delivering a result after the activity is paused.
- `shouldIgnoreNavigationAction()` blocks additional Next/Previous
  during an in-flight step, so the main thread is idle between the
  `showNextView` prologue and the result callback. `FormController` /
  `FormDef` are not internally synchronized; correctness relies on
  this invariant — other main-thread code paths that touch the form
  controller (save-answers, etc.) run either before `navigate()` or
  after the result callback.
- Existing XPath-error behavior preserved: errors from stepping flow
  through `UserfacingErrorHandling` via `NavResult.Error`.
- Blast radius is limited to the forward-navigation path; back-nav,
  refresh-current-view, and repeat-dialog entry are unchanged.

### Automated test coverage

None added in this PR. Follow-up to add Robolectric coverage for:
delayed-overlay visibility, superseded-result drop, cancel-on-pause,
and dropped rapid double-tap. Plus an Espresso test exercising a
relevance-heavy form.

### QA Plan

- Forward-nav through a relevance-heavy form — overlay only on slow
  steps, renders correct next question afterward.
- Rapid double-tap Next — single advance.
- Swipe forward — same result as Next button.
- End-of-form triggers form-complete.
- `EVENT_PROMPT_NEW_REPEAT` opens the add-repeat dialog.
- XPath error during stepping shows the existing error dialog.
- Background the app mid-nav and return — no stale overlay, no crash.
- Rotate mid-nav — no crash; form resumes on the pre-nav question.
  (Mid-step resumption is a known limitation — deferred follow-up.)
- Back / Previous behavior unchanged.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage? If yes,
      RELEASES.md is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating?
      If yes, RELEASES.md is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the
      level of risk of the change