### PR TITLE
Remove generic errors from non-recoverable list for Firebase OTP

### DIFF
--- a/app/src/org/commcare/utils/OtpErrorType.java
+++ b/app/src/org/commcare/utils/OtpErrorType.java
@@ -8,8 +8,6 @@ public enum OtpErrorType {
     VERIFICATION_FAILED;
 
     public boolean isNonRecoverable() {
-        return this == OtpErrorType.MISSING_ACTIVITY ||
-                this == OtpErrorType.VERIFICATION_FAILED ||
-                this == OtpErrorType.GENERIC_ERROR;
+        return this == OtpErrorType.VERIFICATION_FAILED;
     }
 }


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CI-596

## Technical Summary

This aims to make fallback to Twilio more easily accessible for Firebase errors, we have seen firebase errors happening without much reasoning behind why they happen and it seems like we can't really trust generic error codes from Firebase to make this decision. Therefore, I have decided to keep only the "VERIFICATION_FAILED" (user typing the wrong code) as a valid reason for us to not auto fallback to twilio. 


## Safety Assurance

### Safety story

Fallback mechanism is already used by users and we are only changing the trigger to that mechanism. 


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
