### PR TITLE
Extract shared dependency versions to root build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     testImplementation 'org.json:json:20250517'
     testImplementation 'org.mockito:mockito-core:5.5.0'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.11.0'
+    testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp_version"
     testImplementation "androidx.navigation:navigation-testing:$nav_version"
     testImplementation project(path: ':commcare-core', configuration: 'testsAsJar')
 
@@ -94,7 +94,7 @@ dependencies {
     implementation 'androidx.sqlite:sqlite:2.2.0'
     implementation 'com.google.android.gms:play-services-auth-api-phone:18.1.0'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.11.0'
+    implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.google.android.gms:play-services-identity:18.1.0'
     implementation 'com.google.android.gms:play-services-base:18.5.0'
@@ -136,7 +136,7 @@ dependencies {
     implementation 'android.arch.lifecycle:common-java8:1.1.1'
 
 
-    implementation('com.squareup.okhttp3:okhttp-tls:4.11.0') {
+    implementation("com.squareup.okhttp3:okhttp-tls:$okhttp_version") {
         exclude(group: 'org.bouncycastle', module: 'bcprov-jdk15on')
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,9 +93,9 @@ dependencies {
     implementation 'net.zetetic:sqlcipher-android:4.9.0@aar'
     implementation 'androidx.sqlite:sqlite:2.2.0'
     implementation 'com.google.android.gms:play-services-auth-api-phone:18.1.0'
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
-    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
     implementation 'com.google.android.gms:play-services-identity:18.1.0'
     implementation 'com.google.android.gms:play-services-base:18.5.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,8 +83,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
+    implementation "androidx.legacy:legacy-support-v4:$legacy_support_version"
+    implementation "androidx.legacy:legacy-preference-v14:$legacy_support_version"
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation 'org.bouncycastle:bcprov-jdk15to18:1.72'
     implementation 'com.google.android.gms:play-services-maps:19.2.0'
@@ -115,7 +115,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-perf:21.0.1'
     implementation 'com.google.firebase:firebase-crashlytics:18.3.7'
     
-    implementation 'androidx.legacy:legacy-support-core-ui:1.0.0'
+    implementation "androidx.legacy:legacy-support-core-ui:$legacy_support_version"
     implementation('com.github.bumptech.glide:glide:4.9.0') {
         exclude group: 'com.android.support'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.6.1'
     testImplementation 'androidx.test:runner:1.6.2'
     testImplementation 'androidx.test.ext:junit:1.2.1'
-    testImplementation 'androidx.work:work-testing:2.7.1'
+    testImplementation "androidx.work:work-testing:$work_version"
     testImplementation "androidx.test.espresso:espresso-core:$espresso_version"
     testImplementation "androidx.test.espresso:espresso-intents:$espresso_version"
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     testImplementation 'androidx.test:runner:1.6.2'
     testImplementation 'androidx.test.ext:junit:1.2.1'
     testImplementation 'androidx.work:work-testing:2.7.1'
-    testImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    testImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
+    testImplementation "androidx.test.espresso:espresso-core:$espresso_version"
+    testImplementation "androidx.test.espresso:espresso-intents:$espresso_version"
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
     testImplementation 'io.mockk:mockk:1.12.7'
     testImplementation 'org.json:json:20250517'
@@ -55,12 +55,12 @@ dependencies {
     testImplementation project(path: ':commcare-core', configuration: 'testsAsJar')
 
     androidTestImplementation 'androidx.test:runner:1.6.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.ext:truth:1.6.0'
     androidTestImplementation 'androidx.test:rules:1.6.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
-    androidTestImplementation ('androidx.test.espresso:espresso-contrib:3.6.1') {
+    androidTestImplementation "androidx.test.espresso:espresso-intents:$espresso_version"
+    androidTestImplementation ("androidx.test.espresso:espresso-contrib:$espresso_version") {
         exclude(group: 'com.google.protobuf', module: 'protobuf-lite')
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,8 +130,8 @@ dependencies {
     implementation "io.noties.markwon:ext-tables:$markwon_version"
     implementation "io.noties.markwon:ext-strikethrough:$markwon_version"
     
-    implementation 'androidx.work:work-runtime:2.10.3'
-    implementation 'androidx.work:work-runtime-ktx:2.10.3'
+    implementation "androidx.work:work-runtime:$work_version"
+    implementation "androidx.work:work-runtime-ktx:$work_version"
     implementation 'com.google.android.play:app-update:2.1.0'
     implementation 'android.arch.lifecycle:common-java8:1.1.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,4 +35,5 @@ ext {
     lifecycle_version = '2.5.1'
     cameraX_version = '1.4.0'
     okhttp_version = '4.11.0'
+    retrofit_version = '2.9.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,4 +36,5 @@ ext {
     cameraX_version = '1.4.0'
     okhttp_version = '4.11.0'
     retrofit_version = '2.9.0'
+    espresso_version = '3.6.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -38,4 +38,5 @@ ext {
     retrofit_version = '2.9.0'
     espresso_version = '3.6.1'
     work_version = '2.10.3'
+    legacy_support_version = '1.0.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,4 +34,5 @@ ext {
     markwon_version = '4.6.2'
     lifecycle_version = '2.5.1'
     cameraX_version = '1.4.0'
+    okhttp_version = '4.11.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,4 +37,5 @@ ext {
     okhttp_version = '4.11.0'
     retrofit_version = '2.9.0'
     espresso_version = '3.6.1'
+    work_version = '2.10.3'
 }


### PR DESCRIPTION
## Technical Summary

Dependencies that are version-aligned are now supposed to share a single `ext` variable in the global `build.gradle` instead of repeating the hardcoded version string in `app/build.gradle`. Keeps co-released dependencies locked in step and cuts down on places an upgrade can miss.

New variables:

| Variable | Value | Artifacts |
| --- | --- | --- |
| `okhttp_version` | `4.11.0` | `mockwebserver`, `logging-interceptor`, `okhttp-tls` |
| `retrofit_version` | `2.9.0` | `retrofit`, `converter-gson` |
| `espresso_version` | `3.6.1` | `espresso-core`, `espresso-intents`, `espresso-contrib` (5 call sites across test + androidTest) |
| `work_version` | `2.10.3` | `work-runtime`, `work-runtime-ktx`, `work-testing` |
| `legacy_support_version` | `1.0.0` | `legacy-support-v4`, `legacy-preference-v14`, `legacy-support-core-ui` |

**Side effect:** the final commit bumps `androidx.work:work-testing` from `2.7.1` to `2.10.3` so it lines up with the rest of the Work family. It had drifted to `2.7.1` while runtime was on `2.10.3` — mismatched Work artifacts across runtime/testing can hide real bugs from Robolectric tests.

**Not included (deliberate):**

- Firebase and Play Services — each artifact has its own version, so a single variable does not help. Better handled by a BOM; Firebase BoM is already in flight on #3510.
- `androidx.test` / `androidx.test.ext:junit` / `androidx.test:runner` at their current pins — left as-is.

## Safety Assurance

### Safety story
Covered by existing tests

## Labels and Review

- [x] No manual QA enhancement needed — dependency-refactor only
- [x] No change worth calling out in RELEASES.md
- [ ] Risk label: low (build-script refactor with one contained test-dep bump)
- [ ] Pinging someone familiar with the Work-based test suite is enough

🤖 Generated with [Claude Code](https://claude.com/claude-code)