### PR TITLE
Logs Encryption failure while sync

### DIFF
--- a/app/src/org/commcare/tasks/DataPullTask.java
+++ b/app/src/org/commcare/tasks/DataPullTask.java
@@ -168,6 +168,7 @@ public abstract class DataPullTask<R>
         byte[] wrappedEncryptionKey = getEncryptionKey();
         if (wrappedEncryptionKey == null) {
             this.publishProgress(PROGRESS_DONE);
+            Logger.exception("Encryption Key Failure", new Exception("Failed to get or generate encryption key for data pull sync"));
             return new ResultAndError<>(PullTaskResult.ENCRYPTION_FAILURE,
                     "Unable to get or generate encryption key");
         }


### PR DESCRIPTION
## Technical Summary

Adding a non-fatal to track occurrences of errors when the encryption key is `null`. Related to the [slack thread here. ](https://dimagi.slack.com/archives/C05UNUNH43X/p1776938718870689)

## Safety Assurance

### Safety story

Log only

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
