### PR TITLE
Upgraded Firebase Auth dependency to 23.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ configurations {
 
 dependencies {
     implementation 'androidx.exifinterface:exifinterface:1.3.6'
-    implementation 'com.google.android.play:integrity:1.4.0'
+    implementation 'com.google.android.play:integrity:1.6.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation('org.robolectric:robolectric:4.8.2') {
         exclude(group: 'org.bouncycastle', module: 'bcprov-jdk15on')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -163,7 +163,7 @@ dependencies {
     implementation "androidx.camera:camera-camera2:$cameraX_version"
     implementation "androidx.camera:camera-lifecycle:$cameraX_version"
     implementation 'com.google.android.gms:play-services-mlkit-face-detection:17.1.0'
-    implementation 'com.google.firebase:firebase-auth:22.3.0'
+    implementation 'com.google.firebase:firebase-auth:23.2.0'
     implementation 'org.gavaghan:geodesy:1.1.3'
 }
 def localProperties = new Properties()


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CI-636

## Product Description
No user-facing change

## Technical Summary
Upgraded the Firebase Auth dependency to 23.2.0.
This was done to resolve a deprecated dependency to reCAPTCHA, loaded transitively via the old Firebase Auth.
Starting with this one upgrade to minimize changes while solving the deprecation issue.
Note we also discussed upgrading the Play Integrity dependency but that doesn't seem necessary so I left it out.

Checking the new dependency for recaptcha (Windows PowerShell syntax):
<img width="1177" height="69" alt="image" src="https://github.com/user-attachments/assets/ff941d04-b06b-4661-aa55-b09fd9af0a60" />


## Safety Assurance

### Safety story
I verified I can still recover my PersonalID account after the change.
I also tested with a new demo user who was not pre-invited and got all the way to the backup code page with no issues.
I also searched the dependencies after build and verified that recaptcha will now use v18.6.1 instead of the old 18.1.2
All unit and integration tests still pass with no additional changes.

### Automated test coverage
No new testing added, functionality should be identical to callers.

### QA Plan
Verify that both Connect and non-Connect users can still register and recover their accounts after the change.