### PR TITLE
Fix NullPointerException in ComboboxWidget item-click handler

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,6 +17,7 @@ These are published publically on Playstore, Github Releases and CommCare Forums
 - [6-box Backup Codes] Using 6-box numeric inputs to collect backup codes from the user
 
 #### Important Bug Fixes
+- Fixed a crash triggered during combobox item selection when the dropdown list had already been dismissed
 
 #### Internal Release Notes
 
@@ -43,6 +44,7 @@ we would like to communicate to QA as part of the release testing
   - Text cursor functionality (i.e. backspacing, clicking an earlier box to jump back)
 
 - Test the new offline status indicator at the top of refreshable Connect pages (Connect Home, Learning Progress, Delivery Progress). Verify that the error message appears when entering these pages while offline, and that it disappears once the device comes back online.
+- Verify that the combobox widget is working as expected when selecting an item that is used to filter another combobox widget and also determines the visibility of some other unrelated question whose relevance condition depends on the selection.
 
 ## CommCare 2.62
 

--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -81,9 +81,9 @@ public class ComboboxWidget extends QuestionWidget {
 
     private void addListeners() {
         comboBox.setOnItemClickListener((parent, view, position, id) -> {
-            selectedComboItem = (ComboItem) parent.getItemAtPosition(position);
-            widgetEntryChanged();}
-        );
+            selectedComboItem = (ComboItem) comboBox.getAdapter().getItem(position);
+            widgetEntryChanged();
+        });
 
         // Note that Combobox has an OnFocusChangeListener defined in its own class, so when
         // re-setting it here we have to make sure to do all of the same things that the original

--- a/app/src/org/commcare/views/widgets/ComboboxWidget.java
+++ b/app/src/org/commcare/views/widgets/ComboboxWidget.java
@@ -14,6 +14,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.InvalidData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
+import org.javarosa.core.services.Logger;
 import org.javarosa.form.api.FormEntryPrompt;
 
 import java.util.Vector;
@@ -82,6 +83,12 @@ public class ComboboxWidget extends QuestionWidget {
     private void addListeners() {
         comboBox.setOnItemClickListener((parent, view, position, id) -> {
             selectedComboItem = (ComboItem) comboBox.getAdapter().getItem(position);
+            if (parent == null) {
+                Logger.exception("ComboBox "+getComboboxQuestionID()+" OnItemClickListener was triggered " +
+                                "with a null parent, position: "+position+" and id: "+id,
+                        new IllegalStateException("Parent was null in Combobox OnItemClickListener")
+                );
+            }
             widgetEntryChanged();
         });
 
@@ -116,6 +123,10 @@ public class ComboboxWidget extends QuestionWidget {
                 }
             }
         });
+    }
+
+    private String getComboboxQuestionID() {
+        return mPrompt.getQuestion() != null ? mPrompt.getQuestion().getTextID() : "null";
     }
 
     private void fillInPreviousAnswer(FormEntryPrompt prompt) {


### PR DESCRIPTION
## Technical Summary
Crashlytics is reporting a `NullPointerException` from `ComboboxWidget.lambda$addListeners$0`:
```
java.lang.NullPointerException: Attempt to invoke virtual method
'java.lang.Object android.widget.AdapterView.getItemAtPosition(int)'
on a null object reference
  at ComboboxWidget.lambda$addListeners$0(ComboboxWidget.java:84)
  at AutoCompleteTextView.performCompletion(AutoCompleteTextView.java:1086)
  at AutoCompleteTextView$DropDownItemClickListener.onItemClick(...)
```
It seems that a race condition causes the dropdown list to be dismissed between when the user selects an item and when the onClick event is processed. This change retrieves the selected from the adapter instead.


Crashlytics report [Link](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/2fdea36c5289476e677c8f301f5a1d53?time=30d&versions=2.62.0%20(486560)&types=crash,ANR&sessionEventKey=69EEFEBE0242000172A2FF27CB470392_2211768961625711250)

## Safety Assurance

### Safety story
- New code preserves existing semantics: `parent.getItemAtPosition(position)` delegates to `adapter.getItem(position)` internally, so a successful click still produces the same `ComboItem`.
- The previous code crashed in the null-`parent` scenario; the new code returns the correct item even if the dropdown list has been dismissed.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage? — No
- [ ] Does the PR introduce any major changes worth communicating? — No
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk