### PR TITLE
Grant id-token: write permission to Claude Dependabot workflow

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -32,6 +32,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
+      id-token: write
 
     steps:
       - name: Resolve PR ref


### PR DESCRIPTION
## Technical Summary

The `Claude Dependabot PR Review` workflow was failing with:

```
Action failed with error: Could not fetch an OIDC token.
```

`anthropics/claude-code-action@v1` calls `core.getIDToken()` internally, which requires the workflow to have been granted the `id-token: write` permission so that the runner exposes `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` to the action.

This PR adds `id-token: write` to the job's `permissions:` block.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage? — No
- [ ] Does the PR introduce any major changes worth communicating? — No
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk