### PR TITLE
CCCT-2334 - Hide the pending filter in the payment unit detail screen if there are no pending visits for that payment unit

### DIFF
--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryListFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryListFragment.java
@@ -85,7 +85,26 @@ public class ConnectDeliveryListFragment extends ConnectJobFragment<FragmentConn
             filterCards[i].setOnClickListener(v -> onFilterSelected(filter, filterCards, filterLabels));
         }
 
+        updatePendingFilterVisibility();
         setFilterHighlight(filterCards[0], filterLabels[0], true);
+    }
+
+    private void updatePendingFilterVisibility() {
+        boolean hasPending = hasPendingDeliveries();
+        getBinding().pendingFilterButton.setVisibility(hasPending ? View.VISIBLE : View.GONE);
+        if (!hasPending && PENDING_IDENTIFIER.equals(currentFilter)) {
+            getBinding().allFilterButton.performClick();
+        }
+    }
+
+    private boolean hasPendingDeliveries() {
+        for (ConnectJobDeliveryRecord delivery : job.getDeliveries()) {
+            if (delivery.getUnitName().equalsIgnoreCase(unitName)
+                    && PENDING_IDENTIFIER.equalsIgnoreCase(delivery.getStatus())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void onFilterSelected(String selectedFilter, CardView[] filterCards, TextView[] filterLabels) {
@@ -126,6 +145,7 @@ public class ConnectDeliveryListFragment extends ConnectJobFragment<FragmentConn
     private void refreshData() {
         ConnectJobHelper.INSTANCE.updateDeliveryProgress(getContext(), job, true, this, (success,error) -> {
             if (success) {
+                updatePendingFilterVisibility();
                 adapter.updateDeliveries(getFilteredDeliveries());
             }
         });

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryListFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryListFragment.java
@@ -99,8 +99,7 @@ public class ConnectDeliveryListFragment extends ConnectJobFragment<FragmentConn
 
     private boolean hasPendingDeliveries() {
         for (ConnectJobDeliveryRecord delivery : job.getDeliveries()) {
-            if (delivery.getUnitName().equalsIgnoreCase(unitName)
-                    && PENDING_IDENTIFIER.equalsIgnoreCase(delivery.getStatus())) {
+            if (matchesFilter(delivery, PENDING_IDENTIFIER)) {
                 return true;
             }
         }
@@ -162,15 +161,18 @@ public class ConnectDeliveryListFragment extends ConnectJobFragment<FragmentConn
 
     private List<ConnectJobDeliveryRecord> getFilteredDeliveries() {
         List<ConnectJobDeliveryRecord> filteredList = new ArrayList<>();
-
         for (ConnectJobDeliveryRecord delivery : job.getDeliveries()) {
-            boolean matchesUnit = delivery.getUnitName().equalsIgnoreCase(unitName);
-            boolean matchesFilter = currentFilter.equals(ALL_IDENTIFIER) || delivery.getStatus().equalsIgnoreCase(currentFilter);
-            if (matchesUnit && matchesFilter) {
+            if (matchesFilter(delivery, currentFilter)) {
                 filteredList.add(delivery);
             }
         }
         return filteredList;
+    }
+
+    private boolean matchesFilter(ConnectJobDeliveryRecord delivery, String filter) {
+        boolean matchesUnit = delivery.getUnitName().equalsIgnoreCase(unitName);
+        boolean matchesStatus = filter.equals(ALL_IDENTIFIER) || delivery.getStatus().equalsIgnoreCase(filter);
+        return matchesUnit && matchesStatus;
     }
 
     @Override


### PR DESCRIPTION
## Product Description
It has visible changes; it will hide the pending filter in the payment unit detail screen if there are no pending visits for that payment unit.

## Technical Summary
### [CCCT-2334](https://dimagi.atlassian.net/browse/CCCT-2334) ###

The application is checking for the pending visits in the payment unit detail screen. If there are no pending visits for that payment unit, it will hide the pending filter else will keep it visible.

The check is done at two places, while loading initial data and after data refresh.

<img width="200" height="445" alt="Screenshot_20260428_100544" src="https://github.com/user-attachments/assets/194ba494-2c6d-4023-8a73-700a83967631" />

Note: I have applied a temporarily patch in the code to get a screenshot to show that buttons are aligned uniformly after removing the pending button.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


[CCCT-2334]: https://dimagi.atlassian.net/browse/CCCT-2334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ