### PR TITLE
CCCT-2341 Migrate Job-Specific Shared Prefs

### DIFF
--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -911,7 +911,7 @@ public class ConnectJobRecord extends Persisted implements Serializable {
         }
     }
 
-    private ConnectJobPreferences getJobPreferences() {
+    public ConnectJobPreferences getJobPreferences() {
         if (jobPreferences == null) {
             jobPreferences = new ConnectJobPreferences(jobUUID);
         }

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import androidx.annotation.Nullable;
 
 import org.commcare.android.storage.framework.Persisted;
+import org.commcare.connect.database.ConnectJobUtils;
 import org.commcare.connect.network.connect.models.ParsedConnectTask;
 import org.commcare.dalvik.R;
 import org.commcare.models.framework.Persisting;
@@ -183,8 +184,6 @@ public class ConnectJobRecord extends Persisted implements Serializable {
     static Date startDate = new Date();
 
     private boolean claimed;
-
-    private transient ConnectJobPreferences jobPreferences;
 
     public ConnectJobRecord() {
         lastUpdate = new Date();
@@ -862,11 +861,12 @@ public class ConnectJobRecord extends Persisted implements Serializable {
     }
 
     public boolean isRelearnTaskPending() {
-        return getJobPreferences().isRelearnTaskPending() && status == STATUS_DELIVERING;
+        ConnectJobPreferences jobPrefs = ConnectJobUtils.getJobPreferences(jobUUID);
+        return jobPrefs.isRelearnTaskPending() && status == STATUS_DELIVERING;
     }
 
     public boolean shouldShowRelearnTasksCompletedMessage() {
-        ConnectJobPreferences jobPrefs = getJobPreferences();
+        ConnectJobPreferences jobPrefs = ConnectJobUtils.getJobPreferences(jobUUID);
         long relearnTasksCompletedTimeMs = jobPrefs.getRelearnTasksCompletedTimeMs();
         long timeElapsedSinceTasksCompleted = new Date().getTime() - relearnTasksCompletedTimeMs;
 
@@ -875,7 +875,7 @@ public class ConnectJobRecord extends Persisted implements Serializable {
     }
 
     public void syncRelearnTasksPrefs(List<ParsedConnectTask> tasks) {
-        ConnectJobPreferences jobPrefs = getJobPreferences();
+        ConnectJobPreferences jobPrefs = ConnectJobUtils.getJobPreferences(jobUUID);
 
         if (tasks == null || tasks.isEmpty()) {
             jobPrefs.setRelearnTaskPending(false);
@@ -909,13 +909,5 @@ public class ConnectJobRecord extends Persisted implements Serializable {
             long newTasksCompletedTime = latestModified != null ? latestModified.getTime() : new Date().getTime();
             jobPrefs.setRelearnTasksCompletedTime(newTasksCompletedTime);
         }
-    }
-
-    public ConnectJobPreferences getJobPreferences() {
-        if (jobPreferences == null) {
-            jobPreferences = new ConnectJobPreferences(jobUUID);
-        }
-
-        return jobPreferences;
     }
 }

--- a/app/src/org/commcare/connect/ConnectConstants.java
+++ b/app/src/org/commcare/connect/ConnectConstants.java
@@ -66,6 +66,4 @@ public class ConnectConstants {
     public final static String NOTIFICATION_STATUS = "status";
     public final static String NOTIFICATION_MESSAGE_ID = "message_id";
     public final static String NOTIFICATION_CHANNEL_ID = "channel";
-    public final static String PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME =
-            "payment_confirmation_hidden_since_time";
 }

--- a/app/src/org/commcare/connect/ConnectJobHelper.kt
+++ b/app/src/org/commcare/connect/ConnectJobHelper.kt
@@ -116,7 +116,7 @@ object ConnectJobHelper {
                     if (job.payments.isNotEmpty()) {
                         events.add(PAID_DELIVERY)
                     }
-                    ConnectJobUtils.storePayments(context, job.payments, job.jobUUID, true, job.jobPreferences)
+                    ConnectJobUtils.storePayments(context, job.payments, job.jobUUID, true)
                 }
 
                 job.syncRelearnTasksPrefs(deliveryAppProgressResponseModel.parsedTasks)

--- a/app/src/org/commcare/connect/ConnectJobHelper.kt
+++ b/app/src/org/commcare/connect/ConnectJobHelper.kt
@@ -116,7 +116,7 @@ object ConnectJobHelper {
                     if (job.payments.isNotEmpty()) {
                         events.add(PAID_DELIVERY)
                     }
-                    ConnectJobUtils.storePayments(context, job.payments, job.jobUUID, true)
+                    ConnectJobUtils.storePayments(context, job.payments, job.jobUUID, true, job.jobPreferences)
                 }
 
                 job.syncRelearnTasksPrefs(deliveryAppProgressResponseModel.parsedTasks)

--- a/app/src/org/commcare/connect/database/ConnectJobUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectJobUtils.java
@@ -16,6 +16,7 @@ import org.commcare.connect.PersonalIdManager;
 import org.commcare.core.services.CommCarePreferenceManagerFactory;
 import org.commcare.core.services.ICommCarePreferenceManager;
 import org.commcare.models.database.SqlStorage;
+import org.commcare.preferences.ConnectJobPreferences;
 import org.javarosa.xform.util.CalendarUtils;
 
 import java.util.ArrayList;
@@ -27,8 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
-
-import static org.commcare.connect.ConnectConstants.PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME;
 
 public class ConnectJobUtils {
 
@@ -267,7 +266,8 @@ public class ConnectJobUtils {
             Context context,
             List<ConnectJobPaymentRecord> payments,
             String jobUUID,
-            boolean pruneMissing
+            boolean pruneMissing,
+            ConnectJobPreferences jobPrefs
     ) {
         SqlStorage<ConnectJobPaymentRecord> storage = ConnectDatabaseHelper.getConnectStorage(
                 context,
@@ -311,12 +311,8 @@ public class ConnectJobUtils {
             }
         }
 
-        // Check if there is a brand new payment so that we can reset the timer for the payment
-        // confirmation tile.
         if (newPaymentReceived) {
-            ICommCarePreferenceManager preferenceManager =
-                    CommCarePreferenceManagerFactory.getCommCarePreferenceManager();
-            preferenceManager.putLong(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME, -1);
+            jobPrefs.resetPaymentConfirmationHiddenSinceTime();
         }
     }
 

--- a/app/src/org/commcare/connect/database/ConnectJobUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectJobUtils.java
@@ -13,8 +13,6 @@ import org.commcare.android.database.connect.models.ConnectJobRecord;
 import org.commcare.android.database.connect.models.ConnectLearnModuleSummaryRecord;
 import org.commcare.android.database.connect.models.ConnectPaymentUnitRecord;
 import org.commcare.connect.PersonalIdManager;
-import org.commcare.core.services.CommCarePreferenceManagerFactory;
-import org.commcare.core.services.ICommCarePreferenceManager;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.preferences.ConnectJobPreferences;
 import org.javarosa.xform.util.CalendarUtils;

--- a/app/src/org/commcare/connect/database/ConnectJobUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectJobUtils.java
@@ -35,6 +35,10 @@ public class ConnectJobUtils {
         new JobStoreManager(context).storeJobs(context, list, false);
     }
 
+    public static ConnectJobPreferences getJobPreferences(String jobUUID) {
+        return new ConnectJobPreferences(jobUUID);
+    }
+
     public static ConnectJobRecord getCompositeJob(Context context, String jobUUID) {
         Vector<ConnectJobRecord> jobs = ConnectDatabaseHelper.getConnectStorage(
                 context,
@@ -264,8 +268,7 @@ public class ConnectJobUtils {
             Context context,
             List<ConnectJobPaymentRecord> payments,
             String jobUUID,
-            boolean pruneMissing,
-            ConnectJobPreferences jobPrefs
+            boolean pruneMissing
     ) {
         SqlStorage<ConnectJobPaymentRecord> storage = ConnectDatabaseHelper.getConnectStorage(
                 context,
@@ -310,7 +313,7 @@ public class ConnectJobUtils {
         }
 
         if (newPaymentReceived) {
-            jobPrefs.resetPaymentConfirmationHiddenSinceTime();
+            getJobPreferences(jobUUID).resetPaymentConfirmationHiddenSinceTime();
         }
     }
 

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -35,6 +35,7 @@ import org.commcare.dalvik.databinding.FragmentConnectDeliveryProgressBinding;
 import org.commcare.dalvik.databinding.ViewJobCardBinding;
 import org.commcare.fragments.RefreshableFragment;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
+import org.commcare.preferences.ConnectJobPreferences;
 import org.commcare.utils.ConnectivityStatus;
 import org.commcare.views.connect.ConnectViewUtils;
 import org.javarosa.core.model.utils.DateUtils;
@@ -44,8 +45,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
-import static org.commcare.connect.ConnectConstants.PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME;
 
 public class ConnectDeliveryProgressFragment extends ConnectJobFragment<FragmentConnectDeliveryProgressBinding>
         implements RefreshableFragment {
@@ -161,8 +160,7 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
     private void handlePaymentConfirmationNoClick() {
         updatePaymentConfirmationTile(true);
         FirebaseAnalyticsUtil.reportCccPaymentConfirmationInteraction(false);
-        ICommCarePreferenceManager preferenceManager = CommCarePreferenceManagerFactory.getCommCarePreferenceManager();
-        preferenceManager.putLong(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME, new Date().getTime());
+        job.getJobPreferences().setPaymentConfirmationHiddenSinceTime(new Date().getTime());
     }
 
     private void handlePaymentConfirmYesButtonClick() {
@@ -277,13 +275,13 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
             }
         }
 
-        ICommCarePreferenceManager preferenceManager = CommCarePreferenceManagerFactory.getCommCarePreferenceManager();
-        long hiddenSinceTimeMs = preferenceManager.getLong(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME, -1);
+        ConnectJobPreferences jobPrefs = job.getJobPreferences();
+        long hiddenSinceTimeMs = jobPrefs.getPaymentConfirmationHiddenSinceTime();
         long timeElapsedSinceLastHiddenMs = new Date().getTime() - hiddenSinceTimeMs;
 
         boolean showTile = !paymentsToConfirm.isEmpty()
                 && ConnectivityStatus.isNetworkAvailable(requireContext())
-                && (hiddenSinceTimeMs == -1 || timeElapsedSinceLastHiddenMs > DateUtils.DAY_IN_MS * 7);
+                && (jobPrefs.paymentConfirmationHiddenSinceTimeNotSet() || timeElapsedSinceLastHiddenMs > DateUtils.DAY_IN_MS * 7);
 
         if (showTile) {
             getBinding().connectPaymentConfirmLabel.setText(

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -27,6 +27,7 @@ import org.commcare.connect.ConnectAppUtils;
 import org.commcare.connect.ConnectDateUtils;
 import org.commcare.connect.ConnectJobHelper;
 import org.commcare.connect.PersonalIdManager;
+import org.commcare.connect.database.ConnectJobUtils;
 import org.commcare.connect.network.connect.models.ConnectPaymentConfirmationModel;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.FragmentConnectDeliveryProgressBinding;
@@ -158,7 +159,8 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
     private void handlePaymentConfirmationNoClick() {
         updatePaymentConfirmationTile(true);
         FirebaseAnalyticsUtil.reportCccPaymentConfirmationInteraction(false);
-        job.getJobPreferences().setPaymentConfirmationHiddenSinceTime(new Date().getTime());
+        ConnectJobPreferences jobPrefs = ConnectJobUtils.getJobPreferences(job.getJobUUID());
+        jobPrefs.setPaymentConfirmationHiddenSinceTime(new Date().getTime());
     }
 
     private void handlePaymentConfirmYesButtonClick() {
@@ -273,7 +275,7 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
             }
         }
 
-        ConnectJobPreferences jobPrefs = job.getJobPreferences();
+        ConnectJobPreferences jobPrefs = ConnectJobUtils.getJobPreferences(job.getJobUUID());
         long hiddenSinceTimeMs = jobPrefs.getPaymentConfirmationHiddenSinceTime();
         long timeElapsedSinceLastHiddenMs = new Date().getTime() - hiddenSinceTimeMs;
 

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -28,8 +28,6 @@ import org.commcare.connect.ConnectDateUtils;
 import org.commcare.connect.ConnectJobHelper;
 import org.commcare.connect.PersonalIdManager;
 import org.commcare.connect.network.connect.models.ConnectPaymentConfirmationModel;
-import org.commcare.core.services.CommCarePreferenceManagerFactory;
-import org.commcare.core.services.ICommCarePreferenceManager;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.FragmentConnectDeliveryProgressBinding;
 import org.commcare.dalvik.databinding.ViewJobCardBinding;

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -60,7 +60,11 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
     }
 
     @Override
-    public @NotNull View onCreateView(@NotNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public @NotNull View onCreateView(
+            @NotNull LayoutInflater inflater,
+            @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState
+    ) {
         View view = super.onCreateView(inflater, container, savedInstanceState);
         requireActivity().setTitle(R.string.connect_progress_delivery);
 
@@ -96,17 +100,21 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
             }
         }
 
-        getBinding().connectDeliveryProgressViewPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
-            @Override
-            public void onPageSelected(int position) {
-                if (!isProgrammaticTabChange) {
-                    tabLayout.selectTab(tabLayout.getTabAt(position));
-                    FirebaseAnalyticsUtil.reportConnectTabChange(tabLayout.getTabAt(position).getText().toString());
-                } else {
-                    isProgrammaticTabChange = false;
+        getBinding().connectDeliveryProgressViewPager.registerOnPageChangeCallback(
+                new ViewPager2.OnPageChangeCallback() {
+                    @Override
+                    public void onPageSelected(int position) {
+                        if (!isProgrammaticTabChange) {
+                            tabLayout.selectTab(tabLayout.getTabAt(position));
+                            FirebaseAnalyticsUtil.reportConnectTabChange(
+                                    tabLayout.getTabAt(position).getText().toString()
+                            );
+                        } else {
+                            isProgrammaticTabChange = false;
+                        }
+                    }
                 }
-            }
-        });
+        );
 
         tabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
             @Override
@@ -127,19 +135,25 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
     @Override
     public void refresh() {
         setWaitDialogEnabled(false);
-        ConnectJobHelper.INSTANCE.updateDeliveryProgress(getContext(), job, true, this, (success, error) -> {
-            if (success && isAdded()) {
-                updateLastUpdatedText(new Date());
-                updateCardMessage();
-                updatePaymentConfirmationTile(false);
-                viewPagerAdapter.refresh();
-            }
-        });
+        ConnectJobHelper.INSTANCE.updateDeliveryProgress(
+                getContext(),
+                job,
+                true,
+                this,
+                (success, error) -> {
+                    if (success && isAdded()) {
+                        updateLastUpdatedText(new Date());
+                        updateCardMessage();
+                        updatePaymentConfirmationTile(false);
+                        viewPagerAdapter.refresh();
+                    }
+                }
+        );
     }
 
     private void setWaitDialogEnabled(boolean enabled) {
         Activity activity = getActivity();
-        if(activity instanceof ConnectActivity connectActivity) {
+        if (activity instanceof ConnectActivity connectActivity) {
             connectActivity.setWaitDialogEnabled(enabled);
         }
     }
@@ -165,7 +179,9 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
 
     private void handlePaymentConfirmYesButtonClick() {
         if (paymentsToConfirm.isEmpty()) {
-            throw new IllegalStateException("No payments to confirm but confirmation card was shown.");
+            throw new IllegalStateException(
+                    "No payments to confirm but confirmation card was shown."
+            );
         }
 
         FirebaseAnalyticsUtil.reportCccPaymentConfirmationInteraction(true);
@@ -281,7 +297,8 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
 
         boolean showTile = !paymentsToConfirm.isEmpty()
                 && ConnectivityStatus.isNetworkAvailable(requireContext())
-                && (jobPrefs.paymentConfirmationHiddenSinceTimeNotSet() || timeElapsedSinceLastHiddenMs > DateUtils.DAY_IN_MS * 7);
+                && (jobPrefs.paymentConfirmationHiddenSinceTimeNotSet()
+                || timeElapsedSinceLastHiddenMs > DateUtils.DAY_IN_MS * 7);
 
         if (showTile) {
             getBinding().connectPaymentConfirmLabel.setText(
@@ -301,8 +318,11 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
 
     private void updateLastUpdatedText(Date lastUpdate) {
         getBinding().connectDeliveryLastUpdate.setText(
-                getString(R.string.connect_last_update,
-                        ConnectDateUtils.INSTANCE.formatDateTime(lastUpdate)));
+                getString(
+                        R.string.connect_last_update,
+                        ConnectDateUtils.INSTANCE.formatDateTime(lastUpdate)
+                )
+        );
     }
 
     private void navigateToDeliverAppHome() {
@@ -328,7 +348,10 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
     }
 
     @Override
-    protected @NotNull FragmentConnectDeliveryProgressBinding inflateBinding(@NotNull LayoutInflater inflater, @Nullable ViewGroup container) {
+    protected @NotNull FragmentConnectDeliveryProgressBinding inflateBinding(
+            @NotNull LayoutInflater inflater,
+            @Nullable ViewGroup container
+    ) {
         return FragmentConnectDeliveryProgressBinding.inflate(inflater, container, false);
     }
 

--- a/app/src/org/commcare/preferences/ConnectJobPreferences.kt
+++ b/app/src/org/commcare/preferences/ConnectJobPreferences.kt
@@ -26,10 +26,24 @@ class ConnectJobPreferences(jobUUID: String) {
         setRelearnTasksCompletedTime(RELEARN_TASKS_COMPLETED_TIME_NOT_SET)
     }
 
+    fun getPaymentConfirmationHiddenSinceTime(): Long = prefs.getLong(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME, PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME_NOT_SET)
+
+    fun paymentConfirmationHiddenSinceTimeNotSet(): Boolean = getPaymentConfirmationHiddenSinceTime() == PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME_NOT_SET
+
+    fun setPaymentConfirmationHiddenSinceTime(hiddenSinceTimeMs: Long) {
+        prefs.edit { putLong(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME, hiddenSinceTimeMs) }
+    }
+
+    fun resetPaymentConfirmationHiddenSinceTime() {
+        setPaymentConfirmationHiddenSinceTime(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME_NOT_SET)
+    }
+
     companion object {
         private const val PREF_NAME_PREFIX = "connect_job_prefs_"
         private const val KEY_RELEARN_TASK_PENDING = "relearn_task_pending"
         private const val KEY_RELEARN_TASKS_COMPLETED_TIME_MS = "relearn_tasks_completed_time_ms"
         private const val RELEARN_TASKS_COMPLETED_TIME_NOT_SET = -1L
+        private const val PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME = "payment_confirmation_hidden_since_time"
+        private const val PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME_NOT_SET = -1L
     }
 }

--- a/app/src/org/commcare/preferences/ConnectJobPreferences.kt
+++ b/app/src/org/commcare/preferences/ConnectJobPreferences.kt
@@ -5,7 +5,9 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import org.commcare.CommCareApplication
 
-class ConnectJobPreferences(jobUUID: String) {
+class ConnectJobPreferences(
+    jobUUID: String,
+) {
     private val prefs = CommCareApplication.instance().getSharedPreferences(PREF_NAME_PREFIX + jobUUID, Context.MODE_PRIVATE)
 
     fun isRelearnTaskPending(): Boolean = prefs.getBoolean(KEY_RELEARN_TASK_PENDING, false)
@@ -14,36 +16,35 @@ class ConnectJobPreferences(jobUUID: String) {
         prefs.edit { putBoolean(KEY_RELEARN_TASK_PENDING, relearnTaskPending) }
     }
 
-    fun getRelearnTasksCompletedTimeMs(): Long = prefs.getLong(KEY_RELEARN_TASKS_COMPLETED_TIME_MS, RELEARN_TASKS_COMPLETED_TIME_NOT_SET)
+    fun getRelearnTasksCompletedTimeMs(): Long = prefs.getLong(KEY_RELEARN_TASKS_COMPLETED_TIME_MS, TIMESTAMP_NOT_SET)
 
-    fun relearnTasksCompletedTimeNotSet(): Boolean = getRelearnTasksCompletedTimeMs() == RELEARN_TASKS_COMPLETED_TIME_NOT_SET
+    fun relearnTasksCompletedTimeNotSet(): Boolean = getRelearnTasksCompletedTimeMs() == TIMESTAMP_NOT_SET
 
     fun setRelearnTasksCompletedTime(completedTimeMs: Long) {
         prefs.edit { putLong(KEY_RELEARN_TASKS_COMPLETED_TIME_MS, completedTimeMs) }
     }
 
     fun resetRelearnTasksCompletedTime() {
-        setRelearnTasksCompletedTime(RELEARN_TASKS_COMPLETED_TIME_NOT_SET)
+        setRelearnTasksCompletedTime(TIMESTAMP_NOT_SET)
     }
 
-    fun getPaymentConfirmationHiddenSinceTime(): Long = prefs.getLong(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME, PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME_NOT_SET)
+    fun getPaymentConfirmationHiddenSinceTime(): Long = prefs.getLong(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME, TIMESTAMP_NOT_SET)
 
-    fun paymentConfirmationHiddenSinceTimeNotSet(): Boolean = getPaymentConfirmationHiddenSinceTime() == PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME_NOT_SET
+    fun paymentConfirmationHiddenSinceTimeNotSet(): Boolean = getPaymentConfirmationHiddenSinceTime() == TIMESTAMP_NOT_SET
 
     fun setPaymentConfirmationHiddenSinceTime(hiddenSinceTimeMs: Long) {
         prefs.edit { putLong(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME, hiddenSinceTimeMs) }
     }
 
     fun resetPaymentConfirmationHiddenSinceTime() {
-        setPaymentConfirmationHiddenSinceTime(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME_NOT_SET)
+        setPaymentConfirmationHiddenSinceTime(TIMESTAMP_NOT_SET)
     }
 
     companion object {
         private const val PREF_NAME_PREFIX = "connect_job_prefs_"
         private const val KEY_RELEARN_TASK_PENDING = "relearn_task_pending"
         private const val KEY_RELEARN_TASKS_COMPLETED_TIME_MS = "relearn_tasks_completed_time_ms"
-        private const val RELEARN_TASKS_COMPLETED_TIME_NOT_SET = -1L
         private const val PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME = "payment_confirmation_hidden_since_time"
-        private const val PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME_NOT_SET = -1L
+        private const val TIMESTAMP_NOT_SET = -1L
     }
 }

--- a/app/src/org/commcare/preferences/ConnectJobPreferences.kt
+++ b/app/src/org/commcare/preferences/ConnectJobPreferences.kt
@@ -13,7 +13,8 @@ class ConnectJobPreferences(
             Context.MODE_PRIVATE,
         )
 
-    fun isRelearnTaskPending(): Boolean = prefs.getBoolean(KEY_RELEARN_TASK_PENDING, false)
+    fun isRelearnTaskPending(): Boolean =
+        prefs.getBoolean(KEY_RELEARN_TASK_PENDING, false)
 
     fun setRelearnTaskPending(relearnTaskPending: Boolean) {
         prefs.edit { putBoolean(KEY_RELEARN_TASK_PENDING, relearnTaskPending) }
@@ -25,7 +26,8 @@ class ConnectJobPreferences(
             TIMESTAMP_NOT_SET,
         )
 
-    fun relearnTasksCompletedTimeNotSet(): Boolean = getRelearnTasksCompletedTimeMs() == TIMESTAMP_NOT_SET
+    fun relearnTasksCompletedTimeNotSet(): Boolean =
+        getRelearnTasksCompletedTimeMs() == TIMESTAMP_NOT_SET
 
     fun setRelearnTasksCompletedTime(completedTimeMs: Long) {
         prefs.edit { putLong(KEY_RELEARN_TASKS_COMPLETED_TIME_MS, completedTimeMs) }
@@ -41,7 +43,8 @@ class ConnectJobPreferences(
             TIMESTAMP_NOT_SET,
         )
 
-    fun paymentConfirmationHiddenSinceTimeNotSet(): Boolean = getPaymentConfirmationHiddenSinceTime() == TIMESTAMP_NOT_SET
+    fun paymentConfirmationHiddenSinceTimeNotSet(): Boolean =
+        getPaymentConfirmationHiddenSinceTime() == TIMESTAMP_NOT_SET
 
     fun setPaymentConfirmationHiddenSinceTime(hiddenSinceTimeMs: Long) {
         prefs.edit { putLong(PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME, hiddenSinceTimeMs) }


### PR DESCRIPTION
### [CCCT-2341](https://dimagi.atlassian.net/browse/CCCT-2341)

> **Note for reviewers:** This branch was forked from the branch in https://github.com/dimagi/commcare-android/pull/3677 (CCCT-2294) so that it could reuse the new `ConnectJobPreferences` class introduced there. As a result, every commit from PR #3677 is included here. To keep review focused, **please review only the last four commits on this branch**:
> - `92a43537a` — CCCT-2341 Migrate Job-Specific Shared Prefs
> - `7565f6048` — CCCT-2341 Optimized imports
> - `8e2f9fe9b` — CCCT-2341 Decoupled job prefs from `ConnectJobRecord`
> - `908a3a674` — CCCT-2341 Consolidated "timestamp not set" constants
>
> The earlier commits will land in master via PR #3677 and should not be re-reviewed here.

## Technical Summary

Moves the `payment_confirmation_hidden_since_time` value out of the global `CommCarePreferenceManager` and into the per-job `ConnectJobPreferences` file (`connect_job_prefs_<jobUUID>`).

The previous implementation stored a single global timestamp for "user has hidden the payment confirmation tile". With multiple Connect jobs/opportunities, hiding the tile on one job would silently suppress it on all others. The value is conceptually job-specific, so it now lives in the per-job prefs file alongside the relearn-task prefs introduced in PR #3677.

Changes:
- `ConnectJobPreferences.kt` — adds `getPaymentConfirmationHiddenSinceTime` / `setPaymentConfirmationHiddenSinceTime` / `resetPaymentConfirmationHiddenSinceTime` / `paymentConfirmationHiddenSinceTimeNotSet`. The two per-key "not set" sentinels were collapsed into a single `TIMESTAMP_NOT_SET = -1L`.
- `ConnectJobUtils.getJobPreferences(jobUUID)` — new static accessor so any caller with a `jobUUID` can reach a job's prefs without going through a `ConnectJobRecord` instance. The cached `ConnectJobPreferences` field and `getJobPreferences()` getter on `ConnectJobRecord` were removed; the model's remaining pref-reading methods (`isRelearnTaskPending`, `shouldShowRelearnTasksCompletedMessage`, `syncRelearnTasksPrefs`) call the static helper.
- `ConnectJobUtils.storePayments` — drops the `ConnectJobPreferences` parameter and looks prefs up via the new static accessor when resetting the hidden-since timestamp on new payments.
- `ConnectDeliveryProgressFragment` — read/write paths now go through `ConnectJobUtils.getJobPreferences(job.getJobUUID())`.
- `ConnectConstants.PAYMENT_CONFIRMATION_HIDDEN_SINCE_TIME` constant removed.
- Stale `CommCarePreferenceManagerFactory` / `ICommCarePreferenceManager` imports removed from the two touched files.

### Codebase audit — no other migration candidates

I searched the rest of the codebase for additional job-specific values still living in global shared prefs and found none. Reasoning:

- No `preferenceManager.put*/get*` calls remain anywhere in `org.commcare.connect.*`, `org.commcare.fragments.connect.*`, or `org.commcare.android.database.connect.*`.
- No `HiddenPreferences.put*/get*/set*` calls in connect-related code (the lone reference, `HiddenPreferences.getUserDomain()` in `ApiPersonalId.java`, is user-level and correctly app-global).
- No ad-hoc `getSharedPreferences(...)` calls anywhere in the connect packages.
- `ConnectConstants.java` — every remaining constant is an intent extra, request code, navigation destination, auth token, or notification field. None are persisted shared-prefs keys.
- `NotificationPrefs.kt` is the only other custom prefs file; it stores a single global FCM-notification-read boolean, which is not per-job.
- The only persistent prefs keys with job-flavored names (`relearn_task_pending`, `relearn_tasks_completed_time_ms`, `payment_confirmation_hidden_since_time`) all live in `ConnectJobPreferences`.

## Safety Assurance

### Safety story

- I tested the app locally and confirmed the payment-confirmation tile is still hidden correctly when the user dismisses it in the UI.
- Behavior change for existing users: any previously-stored global `payment_confirmation_hidden_since_time` value is effectively reset on first launch after this change (the new per-job key starts unset), so users will see the tile re-appear once if they had previously dismissed it. If they hide it again, that hide is now correctly scoped to the active job.
- No schema/migration changes; the affected storage is a SharedPreferences file.

### Automated test coverage

No new unit tests added — the change is a straightforward storage-location swap.

### QA Plan

QA should regression-test the payment confirmation tile flow to confirm there are no regressions, in particular:
- The tile appears when there are unconfirmed payments and disappears after the user dismisses ("Ask Later"), then reappears after the documented hidden window.
- With multiple opportunities, dismissing the tile on one opportunity should not suppress it on others.
- A brand-new payment received from the server should clear the hidden state and re-show the tile.

[CCCT-2341]: https://dimagi.atlassian.net/browse/CCCT-2341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ