### PR TITLE
CCCT-2217 Session Endpoint Navigation From Connect Notifications

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -28,7 +28,7 @@ These notes are only published internally in [CommCare Change log wiki](https://
 along with the public release notes above
 -->
 
-- - Session endpoint navigation from Connect notifications: clicking a notification with a `session_endpoint_id` now navigates the user directly to the specified CommCare session endpoint (after a sync if required), instead of opening the Connect activity.
+- Session endpoint navigation from Connect notifications: clicking a notification with a `session_endpoint_id` now navigates the user directly to the specified CommCare session endpoint (after a sync if required), instead of opening the Connect activity.
 
 
 ### QA Notes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -42,7 +42,7 @@ we would like to communicate to QA as part of the release testing
     - On clicking, Notification should take user to the relevant CommCare App Home page and auto-login and auto-syncs the user with a blocking dialog. 
     - Click the notification while logged out
     - Click the notification while the app is backgrounded
-    - Cancel login normally (back button, no notification) → app should still close as expected.
+    - Verify that notifications redirect work as expected from various places in the app - Opp Screen, App Home, Login Screen, Form Entry etc and back navigation works correctly after the notification redirect
     - Verify no regression on existing Connect notification types (payments, messaging, delivery/learn progress).
 
 - Verify that the existing opportunity card UI is unchanged when there are no relearn tasks.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,8 @@ These are published publically on Playstore, Github Releases and CommCare Forums
 - Offline status shown on refreshable Connect pages when applicable
 
 - [Relearn Tasking] Added relearn task notification UI to Connect opportunity cards
+- [Relearn Tasking] Implements a new notification when a relearn task is assigned to a user
+- [Work Area Assignment] Implements a new notification when a new work area is assigned to a user
 - [6-box Backup Codes] Using 6-box numeric inputs to collect backup codes from the user
 
 #### Important Bug Fixes
@@ -26,6 +28,8 @@ These notes are only published internally in [CommCare Change log wiki](https://
 along with the public release notes above
 -->
 
+- - Session endpoint navigation from Connect notifications: clicking a notification with a `session_endpoint_id` now navigates the user directly to the specified CommCare session endpoint (after a sync if required), instead of opening the Connect activity.
+
 
 ### QA Notes
 
@@ -33,6 +37,13 @@ along with the public release notes above
 These are for internal use and for us to keep track of important notes that
 we would like to communicate to QA as part of the release testing
 -->
+
+- **Task and Work Area Assignment Notifications (Connect):**
+    - On clicking, Notification should take user to the relevant CommCare App Home page and auto-login and auto-syncs the user with a blocking dialog. 
+    - Click the notification while logged out
+    - Click the notification while the app is backgrounded
+    - Cancel login normally (back button, no notification) → app should still close as expected.
+    - Verify no regression on existing Connect notification types (payments, messaging, delivery/learn progress).
 
 - Verify that the existing opportunity card UI is unchanged when there are no relearn tasks.
 - Verify that the opportunity card updates as expected when there are either pending relearn tasks or completed relearn tasks.

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -171,7 +171,6 @@ public class DispatchActivity extends AppCompatActivity {
 
         Intent pnIntent = checkIfAnyPNIntentPresent();
         if (pnIntent != null) {
-            String actionType = pnIntent.getStringExtra(REDIRECT_ACTION);
             FirebaseAnalyticsUtil.reportNotificationEvent(
                     AnalyticsParamValue.NOTIFICATION_EVENT_TYPE_CLICK,
                     AnalyticsParamValue.REPORT_NOTIFICATION_CLICK_NOTIFICATION_TRAY,

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -55,6 +55,7 @@ public class DispatchActivity extends AppCompatActivity {
     // Args to session endpoints can be passed as a name to value bundle or more loosely as a list
     public static final String SESSION_ENDPOINT_ARGUMENTS_BUNDLE = "ccodk_session_endpoint_arguments_bundle";
     public static final String SESSION_ENDPOINT_ARGUMENTS_LIST = "ccodk_session_endpoint_arguments_list";
+    public static final String CC_LAUNCH_REQUIRE_SYNC = "ccodk_require_sync";
     public static final String WAS_EXTERNAL = "launch_from_external";
     public static final String EXIT_AFTER_FORM_SUBMISSION = "ccodk_exit_after_form_submission";
     public static final Boolean EXIT_AFTER_FORM_SUBMISSION_DEFAULT = true;
@@ -441,6 +442,8 @@ public class DispatchActivity extends AppCompatActivity {
                         i.putExtra(SESSION_ENDPOINT_ID, sessionEndpointId);
                         i.putExtra(SESSION_ENDPOINT_ARGUMENTS_BUNDLE, args);
                         i.putStringArrayListExtra(SESSION_ENDPOINT_ARGUMENTS_LIST, argsList);
+                        i.putExtra(CC_LAUNCH_REQUIRE_SYNC,
+                                getIntent().getBooleanExtra(CC_LAUNCH_REQUIRE_SYNC, false));
 
                         // Session Endpoint extra is no longer needed. If not removed, it triggers
                         // the external launch logic in subsequent logins

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -12,8 +12,6 @@ import static org.commcare.utils.FirebaseMessagingUtil.getNotificationActionFrom
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import android.util.Log;
@@ -141,29 +139,11 @@ public class DispatchActivity extends AppCompatActivity {
         return false;
     }
 
-
-    @Override
-    protected void onNewIntent(@NonNull Intent intent) {
-        super.onNewIntent(intent);
-        setIntent(intent);
-        if (shouldFinish) {
-            // onResume already ran and posted a finish();
-            // but a new intent has arrived so cancel that decision and dispatch instead.
-            shouldFinish = false;
-            dispatch();
-        }
-    }
-
     @Override
     protected void onResume() {
         super.onResume();
         if (shouldFinish) {
-            // Post finish() so that onNewIntent() — which Android may deliver synchronously
-            // after onResume() in the same Looper transaction — can cancel it by resetting
-            // shouldFinish before the posted runnable executes.
-            new Handler(Looper.getMainLooper()).post(() -> {
-                if (shouldFinish) finish();
-            });
+            finish();
         } else {
             dispatch();
         }

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -12,6 +12,10 @@ import static org.commcare.utils.FirebaseMessagingUtil.getNotificationActionFrom
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.annotation.NonNull;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -139,10 +143,27 @@ public class DispatchActivity extends AppCompatActivity {
 
 
     @Override
+    protected void onNewIntent(@NonNull Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        if (shouldFinish) {
+            // onResume already ran and posted a finish();
+            // but a new intent has arrived so cancel that decision and dispatch instead.
+            shouldFinish = false;
+            dispatch();
+        }
+    }
+
+    @Override
     protected void onResume() {
         super.onResume();
         if (shouldFinish) {
-            finish();
+            // Post finish() so that onNewIntent() — which Android may deliver synchronously
+            // after onResume() in the same Looper transaction — can cancel it by resetting
+            // shouldFinish before the posted runnable executes.
+            new Handler(Looper.getMainLooper()).post(() -> {
+                if (shouldFinish) finish();
+            });
         } else {
             dispatch();
         }

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -465,6 +465,8 @@ public class DispatchActivity extends AppCompatActivity {
                         i.putStringArrayListExtra(SESSION_ENDPOINT_ARGUMENTS_LIST, argsList);
                         i.putExtra(CC_LAUNCH_REQUIRE_SYNC,
                                 getIntent().getBooleanExtra(CC_LAUNCH_REQUIRE_SYNC, false));
+                        i.putExtra(IS_LAUNCH_FROM_CONNECT,
+                                getIntent().getBooleanExtra(IS_LAUNCH_FROM_CONNECT, false));
 
                         // Session Endpoint extra is no longer needed. If not removed, it triggers
                         // the external launch logic in subsequent logins

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -445,8 +445,6 @@ public class DispatchActivity extends AppCompatActivity {
                         i.putStringArrayListExtra(SESSION_ENDPOINT_ARGUMENTS_LIST, argsList);
                         i.putExtra(CC_LAUNCH_REQUIRE_SYNC,
                                 getIntent().getBooleanExtra(CC_LAUNCH_REQUIRE_SYNC, false));
-                        i.putExtra(IS_LAUNCH_FROM_CONNECT,
-                                getIntent().getBooleanExtra(IS_LAUNCH_FROM_CONNECT, false));
 
                         // Session Endpoint extra is no longer needed. If not removed, it triggers
                         // the external launch logic in subsequent logins

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -182,6 +182,9 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     private FirebaseMessagingDataSyncer dataSyncer;
     private boolean isVisible;
 
+    // Set when a session endpoint launch requires a blocking sync before navigating to the endpoint
+    private boolean pendingEndpointNavigationAfterSync = false;
+
     {
         dataSyncer = new FirebaseMessagingDataSyncer(this);
 
@@ -226,8 +229,15 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     private void processFromExternalLaunch(Bundle savedInstanceState) {
         if (savedInstanceState == null && getIntent().hasExtra(DispatchActivity.WAS_EXTERNAL)) {
             wasExternal = true;
-            if (processSessionEndpoint()) {
-                sessionNavigator.startNextSessionStep();
+            if (getIntent().getBooleanExtra(DispatchActivity.CC_LAUNCH_REQUIRE_SYNC, false)) {
+                getIntent().removeExtra(DispatchActivity.CC_LAUNCH_REQUIRE_SYNC);
+                pendingEndpointNavigationAfterSync = true;
+                redirectedInOnCreate = true;
+                triggerSync(false);
+            } else {
+                if (processSessionEndpoint()) {
+                    sessionNavigator.startNextSessionStep();
+                }
             }
         }
     }
@@ -1322,6 +1332,14 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
     @Override
     public void onResumeSessionSafe() {
+        if (pendingEndpointNavigationAfterSync) {
+            pendingEndpointNavigationAfterSync = false;
+            if (processSessionEndpoint()) {
+                sessionNavigator.startNextSessionStep();
+            }
+            return;
+        }
+
         if (!redirectedInOnCreate && !sessionNavigationProceedingAfterOnResume) {
             refreshActionBar();
             attemptDispatchHomeScreen();

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -147,6 +147,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
      * invalidated in the calling activity and that the current session should be resynced
      */
     public static final int RESULT_RESTART = 3;
+    private static final String CC_APP_HOME_ENDPOINT = "cc_app_home";
 
     private int mDeveloperModeClicks = 0;
 
@@ -232,13 +233,15 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     }
 
     /**
-     * @return If we are launched with a session endpoint, returns whether the endpoint was
-     * successfully processed without errors. If this was not an external launch using session
-     * endpoint, returns true
+     * @return Whether we should proceed with next step in session navigation after processing the session endpoint
      */
     private boolean processSessionEndpoint() {
         if (getIntent().hasExtra(SESSION_ENDPOINT_ID)) {
-            Endpoint endpoint = validateIntentForSessionEndpoint(getIntent());
+            String sessionEndpointId = getIntent().getStringExtra(SESSION_ENDPOINT_ID);
+            if (sessionEndpointId == CC_APP_HOME_ENDPOINT) {
+                return false;
+            }
+            Endpoint endpoint = validateIntentForSessionEndpoint(sessionEndpointId);
             if (endpoint != null) {
                 Bundle intentArgumentsAsBundle = getIntent().getBundleExtra(
                         SESSION_ENDPOINT_ARGUMENTS_BUNDLE);
@@ -278,8 +281,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
         return true;
     }
 
-    private Endpoint validateIntentForSessionEndpoint(Intent intent) {
-        String sessionEndpointId = intent.getStringExtra(SESSION_ENDPOINT_ID);
+    private Endpoint validateIntentForSessionEndpoint(String sessionEndpointId) {
         Endpoint endpoint = CommCareApplication.instance().getCommCarePlatform().getEndpoint(
                 sessionEndpointId);
         if (endpoint == null) {

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -184,6 +184,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
     // Set when a session endpoint launch requires a blocking sync before navigating to the endpoint
     private boolean pendingEndpointNavigationAfterSync = false;
+    private static final String KEY_PENDING_ENDPOINT_NAV_AFTER_SYNC = "pending_endpoint_nav_after_sync";
 
     {
         dataSyncer = new FirebaseMessagingDataSyncer(this);
@@ -220,6 +221,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
         if (savedInstanceState != null) {
             loginExtraWasConsumed = savedInstanceState.getBoolean(EXTRA_CONSUMED_KEY);
             wasExternal = savedInstanceState.getBoolean(WAS_EXTERNAL_KEY);
+            pendingEndpointNavigationAfterSync = savedInstanceState.getBoolean(KEY_PENDING_ENDPOINT_NAV_AFTER_SYNC);
         }
     }
 
@@ -601,6 +603,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
         super.onSaveInstanceState(outState);
         outState.putBoolean(WAS_EXTERNAL_KEY, wasExternal);
         outState.putBoolean(EXTRA_CONSUMED_KEY, loginExtraWasConsumed);
+        outState.putBoolean(KEY_PENDING_ENDPOINT_NAV_AFTER_SYNC, pendingEndpointNavigationAfterSync);
     }
 
     @Override

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -997,10 +997,13 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     }
 
     private boolean exitFromExternalLaunch() {
-        return wasExternal && getIntent() != null &&
-                !getIntent().getBooleanExtra(IS_LAUNCH_FROM_CONNECT, false) &&
-                getIntent().getBooleanExtra(EXIT_AFTER_FORM_SUBMISSION,
-                        EXIT_AFTER_FORM_SUBMISSION_DEFAULT);
+        Intent intent = getIntent();
+        boolean exitAfterFormSubmission = intent != null && intent.getBooleanExtra(EXIT_AFTER_FORM_SUBMISSION,
+                EXIT_AFTER_FORM_SUBMISSION_DEFAULT);
+        if (intent != null) {
+            intent.removeExtra(EXIT_AFTER_FORM_SUBMISSION);
+        }
+        return wasExternal && exitAfterFormSubmission;
     }
 
     private void clearSessionAndExit(AndroidSessionWrapper currentState, boolean shouldWarnUser) {

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -264,14 +264,8 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                 CommCareApplication.instance().getCurrentSessionWrapper().reset();
 
                 try {
-                    if (intentArgumentsAsBundle != null) {
-                        CommCareApplication.instance().getCurrentSessionWrapper()
-                                .executeEndpointStack(endpoint,
-                                        AndroidUtil.bundleAsMap(intentArgumentsAsBundle));
-                    } else if (intentArgumentsAsList != null) {
-                        CommCareApplication.instance().getCurrentSessionWrapper()
-                                .executeEndpointStack(endpoint, intentArgumentsAsList);
-                    }
+                    CommCareApplication.instance().getCurrentSessionWrapper()
+                            .executeEndpointStack(endpoint, intentArgumentsAsBundle, intentArgumentsAsList);
                     return true;
                 } catch (Endpoint.InvalidEndpointArgumentsException e) {
                     String invalidEndpointArgsError =

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -248,7 +248,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     private boolean processSessionEndpoint() {
         if (getIntent().hasExtra(SESSION_ENDPOINT_ID)) {
             String sessionEndpointId = getIntent().getStringExtra(SESSION_ENDPOINT_ID);
-            if (sessionEndpointId == CC_APP_HOME_ENDPOINT) {
+            if (CC_APP_HOME_ENDPOINT.equals(sessionEndpointId)) {
                 return false;
             }
             Endpoint endpoint = validateIntentForSessionEndpoint(sessionEndpointId);

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -1,6 +1,7 @@
 package org.commcare.activities;
 
 import static org.commcare.activities.DispatchActivity.EXIT_AFTER_FORM_SUBMISSION;
+import static org.commcare.connect.ConnectAppUtils.IS_LAUNCH_FROM_CONNECT;
 import static org.commcare.activities.DispatchActivity.EXIT_AFTER_FORM_SUBMISSION_DEFAULT;
 import static org.commcare.activities.DispatchActivity.REDIRECT_TO_CONNECT_OPPORTUNITY_INFO;
 import static org.commcare.activities.DispatchActivity.SESSION_ENDPOINT_ARGUMENTS_BUNDLE;
@@ -1005,6 +1006,7 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
     private boolean exitFromExternalLaunch() {
         return wasExternal && getIntent() != null &&
+                !getIntent().getBooleanExtra(IS_LAUNCH_FROM_CONNECT, false) &&
                 getIntent().getBooleanExtra(EXIT_AFTER_FORM_SUBMISSION,
                         EXIT_AFTER_FORM_SUBMISSION_DEFAULT);
     }

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -1335,12 +1335,6 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
     @Override
     public void onResumeSessionSafe() {
-        if (pendingEndpointNavigationAfterSync && processSessionEndpoint()) {
-            sessionNavigator.startNextSessionStep();
-            resetNavigationFlags();
-            return;
-        }
-
         if (!redirectedInOnCreate && !sessionNavigationProceedingAfterOnResume) {
             refreshActionBar();
             attemptDispatchHomeScreen();
@@ -1359,7 +1353,6 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
         redirectedInOnCreate = false;
         sessionNavigationProceedingAfterOnResume = false;
         shouldTriggerBackgroundSync = true;
-        pendingEndpointNavigationAfterSync = false;
     }
 
     @Override
@@ -1425,7 +1418,10 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                                      boolean userTriggeredSync, boolean formsToSend, boolean usingRemoteKeyManagement) {
         super.handlePullTaskResult(resultAndError, userTriggeredSync, formsToSend,
                 usingRemoteKeyManagement);
-        if (UpdateActivity.sBlockedUpdateWorkflowInProgress) {
+        if (pendingEndpointNavigationAfterSync && processSessionEndpoint()) {
+            sessionNavigator.startNextSessionStep();
+            pendingEndpointNavigationAfterSync = false;
+        } else if (UpdateActivity.sBlockedUpdateWorkflowInProgress) {
             Intent i = new Intent(getApplicationContext(), UpdateActivity.class);
             i.putExtra(UpdateActivity.KEY_PROCEED_AUTOMATICALLY, true);
 

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -237,10 +237,8 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
                 pendingEndpointNavigationAfterSync = true;
                 redirectedInOnCreate = true;
                 triggerSync(false);
-            } else {
-                if (processSessionEndpoint()) {
-                    sessionNavigator.startNextSessionStep();
-                }
+            } else if (processSessionEndpoint()) {
+                sessionNavigator.startNextSessionStep();
             }
         }
     }
@@ -1337,12 +1335,10 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
 
     @Override
     public void onResumeSessionSafe() {
-        if (pendingEndpointNavigationAfterSync) {
-            if (processSessionEndpoint()) {
-                sessionNavigator.startNextSessionStep();
-                resetNavigationFlags();
-                return;
-            }
+        if (pendingEndpointNavigationAfterSync && processSessionEndpoint()) {
+            sessionNavigator.startNextSessionStep();
+            resetNavigationFlags();
+            return;
         }
 
         if (!redirectedInOnCreate && !sessionNavigationProceedingAfterOnResume) {

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -1336,11 +1336,11 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
     @Override
     public void onResumeSessionSafe() {
         if (pendingEndpointNavigationAfterSync) {
-            pendingEndpointNavigationAfterSync = false;
             if (processSessionEndpoint()) {
                 sessionNavigator.startNextSessionStep();
+                resetNavigationFlags();
+                return;
             }
-            return;
         }
 
         if (!redirectedInOnCreate && !sessionNavigationProceedingAfterOnResume) {
@@ -1354,10 +1354,14 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
             dataSyncer.syncData(HiddenPreferences.getPendingSyncRequest(username));
         }
 
-        // reset these
+        resetNavigationFlags();
+    }
+
+    private void resetNavigationFlags() {
         redirectedInOnCreate = false;
         sessionNavigationProceedingAfterOnResume = false;
         shouldTriggerBackgroundSync = true;
+        pendingEndpointNavigationAfterSync = false;
     }
 
     @Override

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -232,17 +232,16 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
      */
     protected void initiateLoginAttempt(boolean restoreSession) {
         LoginMode loginMode = uiController.getLoginMode();
-        //See whether login is managed by PersonalId
-        String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
-        String username = uiController.getEnteredUsername();
-
         if (appLaunchedFromConnect) {
+            connectLaunchPerformed = true;
             //Auto login
             doLogin(loginMode, restoreSession, "AUTO");
         } else if (loginManagedByPersonalId()) {
             //Unlock and then auto login
             personalIdManager.unlockConnect(this, success -> {
                 if (success) {
+                    String username = uiController.getEnteredUsername();
+                    String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
                     String pass = personalIdManager.getStoredPasswordForApp(seatedAppId, username);
                     doLogin(loginMode, restoreSession, pass);
                 }
@@ -329,9 +328,10 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         uiController.refreshView();
 
         // if the app is already seated, we can login immediately
-        if(shouldDoConnectLogin() && isAppSeated(presetAppId)) {
-            connectLaunchPerformed = true;
-            initiateLoginAttempt(uiController.isRestoreSessionChecked());
+        if (isAppSeated(presetAppId)) {
+            if (shouldDoConnectLogin() || loginManagedByPersonalId()) {
+                initiateLoginAttempt(uiController.isRestoreSessionChecked());
+            }
         }
     }
 
@@ -975,7 +975,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
     }
 
     private boolean isAppSeated(String appId) {
-        return appId.equals(CommCareApplication.instance().getCurrentApp().getUniqueId());
+        return appId != null && appId.equals(CommCareApplication.instance().getCurrentApp().getUniqueId());
     }
 
     protected void evaluateConnectAppState() {

--- a/app/src/org/commcare/android/database/connect/models/PushNotificationRecord.kt
+++ b/app/src/org/commcare/android/database/connect/models/PushNotificationRecord.kt
@@ -96,6 +96,10 @@ class PushNotificationRecord :
     @OpportunityStatusType
     var opportunityStatus: String = ""
 
+    @Persisting(18)
+    @MetaField(META_SESSION_ENDPOINT_ID)
+    var sessionEndpointId: String = ""
+
     fun getNotificationActionFromRecord() =
         if (CCC_GENERIC_OPPORTUNITY.equals(action) &&
             !TextUtils.isEmpty(key)
@@ -130,6 +134,7 @@ class PushNotificationRecord :
         const val META_PAYMENT_UUID = "payment_uuid"
         const val META_KEY = "key"
         const val META_OPPORTUNITY_STATUS = "opportunity_status"
+        const val META_SESSION_ENDPOINT_ID = "session_endpoint_id"
 
         fun fromJson(obj: JSONObject): PushNotificationRecord =
             PushNotificationRecord().apply {
@@ -150,27 +155,29 @@ class PushNotificationRecord :
                 paymentUUID = obj.optString(META_PAYMENT_UUID, "")
                 key = obj.optString(META_KEY, "")
                 opportunityStatus = obj.optString(META_OPPORTUNITY_STATUS, "")
+                sessionEndpointId = obj.optString(META_SESSION_ENDPOINT_ID, "")
             }
 
-        fun fromV23(pushNotificationRecordV23: PushNotificationRecordV23): PushNotificationRecord =
+        fun fromV24(v24: PushNotificationRecordV24): PushNotificationRecord =
             PushNotificationRecord().apply {
-                notificationId = pushNotificationRecordV23.notificationId
-                title = pushNotificationRecordV23.title
-                body = pushNotificationRecordV23.body
-                notificationType = pushNotificationRecordV23.notificationType
-                confirmationStatus = pushNotificationRecordV23.confirmationStatus
-                paymentId = pushNotificationRecordV23.paymentId
-                readStatus = pushNotificationRecordV23.readStatus
-                createdDate = pushNotificationRecordV23.createdDate
-                connectMessageId = pushNotificationRecordV23.connectMessageId
-                channel = pushNotificationRecordV23.channel
-                action = pushNotificationRecordV23.action
-                acknowledged = pushNotificationRecordV23.acknowledged
-                opportunityId = pushNotificationRecordV23.opportunityId
-                opportunityUUID = pushNotificationRecordV23.opportunityUUID
-                paymentUUID = pushNotificationRecordV23.paymentUUID
-                key = ""
-                opportunityStatus = ""
+                notificationId = v24.notificationId
+                title = v24.title
+                body = v24.body
+                notificationType = v24.notificationType
+                confirmationStatus = v24.confirmationStatus
+                paymentId = v24.paymentId
+                readStatus = v24.readStatus
+                createdDate = v24.createdDate
+                connectMessageId = v24.connectMessageId
+                channel = v24.channel
+                action = v24.action
+                acknowledged = v24.acknowledged
+                opportunityId = v24.opportunityId
+                opportunityUUID = v24.opportunityUUID
+                paymentUUID = v24.paymentUUID
+                key = v24.key
+                opportunityStatus = v24.opportunityStatus
+                sessionEndpointId = ""
             }
     }
 }

--- a/app/src/org/commcare/android/database/connect/models/PushNotificationRecord.kt
+++ b/app/src/org/commcare/android/database/connect/models/PushNotificationRecord.kt
@@ -100,6 +100,11 @@ class PushNotificationRecord :
     @MetaField(META_SESSION_ENDPOINT_ID)
     var sessionEndpointId: String = ""
 
+    // if we do need to do an app sync, only matters when a session endpoint id is present.
+    @Persisting(19)
+    @MetaField(META_REQUIRE_APP_SYNC)
+    var requireAppSync: Boolean = true
+
     fun getNotificationActionFromRecord() =
         if (CCC_GENERIC_OPPORTUNITY.equals(action) &&
             !TextUtils.isEmpty(key)
@@ -135,6 +140,7 @@ class PushNotificationRecord :
         const val META_KEY = "key"
         const val META_OPPORTUNITY_STATUS = "opportunity_status"
         const val META_SESSION_ENDPOINT_ID = "session_endpoint_id"
+        const val META_REQUIRE_APP_SYNC = "require_app_sync"
 
         fun fromJson(obj: JSONObject): PushNotificationRecord =
             PushNotificationRecord().apply {
@@ -156,6 +162,7 @@ class PushNotificationRecord :
                 key = obj.optString(META_KEY, "")
                 opportunityStatus = obj.optString(META_OPPORTUNITY_STATUS, "")
                 sessionEndpointId = obj.optString(META_SESSION_ENDPOINT_ID, "")
+                requireAppSync = obj.optBoolean(META_REQUIRE_APP_SYNC, true)
             }
 
         fun fromV24(v24: PushNotificationRecordV24): PushNotificationRecord =
@@ -178,6 +185,7 @@ class PushNotificationRecord :
                 key = v24.key
                 opportunityStatus = v24.opportunityStatus
                 sessionEndpointId = ""
+                requireAppSync = true
             }
     }
 }

--- a/app/src/org/commcare/android/database/connect/models/PushNotificationRecordV24.kt
+++ b/app/src/org/commcare/android/database/connect/models/PushNotificationRecordV24.kt
@@ -1,0 +1,123 @@
+package org.commcare.android.database.connect.models
+
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_ACKNOWLEDGED
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_ACTION
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_BODY
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_CHANNEL
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_CONFIRMATION_STATUS
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_CREATED_DATE
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_KEY
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_MESSAGE_ID
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_NOTIFICATION_ID
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_NOTIFICATION_TYPE
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_OPPORTUNITY_ID
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_OPPORTUNITY_STATUS
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_OPPORTUNITY_UUID
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_PAYMENT_ID
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_PAYMENT_UUID
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_READ_STATUS
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_TITLE
+import org.commcare.android.storage.framework.Persisted
+import org.commcare.models.framework.Persisting
+import org.commcare.modern.database.Table
+import org.commcare.modern.models.MetaField
+import java.io.Serializable
+import java.util.Date
+
+@Table(PushNotificationRecordV24.STORAGE_KEY)
+class PushNotificationRecordV24 :
+    Persisted(),
+    Serializable {
+    @Persisting(1)
+    @MetaField(META_NOTIFICATION_ID)
+    var notificationId: String = ""
+
+    @Persisting(2)
+    @MetaField(META_NOTIFICATION_TYPE)
+    var notificationType: String = ""
+
+    @Persisting(3)
+    @MetaField(META_ACTION)
+    var action: String = ""
+
+    @Persisting(4)
+    @MetaField(META_TITLE)
+    var title: String = ""
+
+    @Persisting(5)
+    @MetaField(META_BODY)
+    var body: String = ""
+
+    @Persisting(6)
+    @MetaField(META_CREATED_DATE)
+    var createdDate: Date = Date()
+
+    @Persisting(7)
+    @MetaField(META_CONFIRMATION_STATUS)
+    var confirmationStatus: String = ""
+
+    @Persisting(8)
+    @MetaField(META_OPPORTUNITY_ID)
+    var opportunityId: String = ""
+
+    @Persisting(9)
+    @MetaField(META_MESSAGE_ID)
+    var connectMessageId: String = ""
+
+    @Persisting(10)
+    @MetaField(META_CHANNEL)
+    var channel: String = ""
+
+    @Persisting(11)
+    @MetaField(META_PAYMENT_ID)
+    var paymentId: String = ""
+
+    @Persisting(12)
+    @MetaField(META_READ_STATUS)
+    var readStatus: Boolean = false
+
+    @Persisting(13)
+    @MetaField(META_ACKNOWLEDGED)
+    var acknowledged: Boolean = false
+
+    @Persisting(14)
+    @MetaField(META_PAYMENT_UUID)
+    var paymentUUID: String = ""
+
+    @Persisting(15)
+    @MetaField(META_OPPORTUNITY_UUID)
+    var opportunityUUID: String = ""
+
+    @Persisting(16)
+    @MetaField(META_KEY)
+    var key: String = ""
+
+    @Persisting(17)
+    @MetaField(META_OPPORTUNITY_STATUS)
+    var opportunityStatus: String = ""
+
+    companion object {
+        const val STORAGE_KEY = PushNotificationRecord.STORAGE_KEY
+
+        fun fromV23(pushNotificationRecordV23: PushNotificationRecordV23): PushNotificationRecord =
+            PushNotificationRecord().apply {
+                notificationId = pushNotificationRecordV23.notificationId
+                title = pushNotificationRecordV23.title
+                body = pushNotificationRecordV23.body
+                notificationType = pushNotificationRecordV23.notificationType
+                confirmationStatus = pushNotificationRecordV23.confirmationStatus
+                paymentId = pushNotificationRecordV23.paymentId
+                readStatus = pushNotificationRecordV23.readStatus
+                createdDate = pushNotificationRecordV23.createdDate
+                connectMessageId = pushNotificationRecordV23.connectMessageId
+                channel = pushNotificationRecordV23.channel
+                action = pushNotificationRecordV23.action
+                acknowledged = pushNotificationRecordV23.acknowledged
+                opportunityId = pushNotificationRecordV23.opportunityId
+                opportunityUUID = pushNotificationRecordV23.opportunityUUID
+                paymentUUID = pushNotificationRecordV23.paymentUUID
+                key = ""
+                opportunityStatus = ""
+            }
+    }
+}

--- a/app/src/org/commcare/android/database/connect/models/PushNotificationRecordV24.kt
+++ b/app/src/org/commcare/android/database/connect/models/PushNotificationRecordV24.kt
@@ -99,8 +99,8 @@ class PushNotificationRecordV24 :
     companion object {
         const val STORAGE_KEY = PushNotificationRecord.STORAGE_KEY
 
-        fun fromV23(pushNotificationRecordV23: PushNotificationRecordV23): PushNotificationRecord =
-            PushNotificationRecord().apply {
+        fun fromV23(pushNotificationRecordV23: PushNotificationRecordV23): PushNotificationRecordV24 =
+            PushNotificationRecordV24().apply {
                 notificationId = pushNotificationRecordV23.notificationId
                 title = pushNotificationRecordV23.title
                 body = pushNotificationRecordV23.body

--- a/app/src/org/commcare/connect/database/ConnectJobUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectJobUtils.java
@@ -551,7 +551,7 @@ public class ConnectJobUtils {
         ConnectAppRecord appInfo = isLearning
                 ? job.getLearnAppInfo()
                 : job.getDeliveryAppInfo();
-        return appInfo.getAppId()
+        return appInfo.getAppId();
     }
 
     public static List<ConnectJobPaymentRecord> getPaymentsSortedByDate(ConnectJobRecord job) {

--- a/app/src/org/commcare/connect/database/ConnectJobUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectJobUtils.java
@@ -1,7 +1,10 @@
 package org.commcare.connect.database;
 
+import static org.commcare.connect.ConnectConstants.OPPORTUNITY_STATUS_LEARN;
+
 import android.content.Context;
 import android.os.Build;
+import android.text.TextUtils;
 
 import org.commcare.android.database.connect.models.ConnectAppRecord;
 import org.commcare.android.database.connect.models.ConnectJobAssessmentRecord;
@@ -527,6 +530,28 @@ public class ConnectJobUtils {
             return records.isEmpty() ? null : records.firstElement();
         }
         return null;
+    }
+
+    /**
+     * Returns the CommCare appId for the given opportunity. Will return the learn appId if the opportunity
+     * status is "learn" and delivery appId otherwise.
+     */
+    public static String getAppIdForOpportunity(
+            Context context,
+            String opportunityID,
+            String opportunityStatus) {
+        if (TextUtils.isEmpty(opportunityID)) {
+            throw new IllegalArgumentException("opportunityID can't be empty");
+        }
+        ConnectJobRecord job = getCompositeJob(context, opportunityID);
+        if (job == null) {
+            throw new IllegalArgumentException("No Opportunity found for given opportunityID " + opportunityID);
+        }
+        boolean isLearning = OPPORTUNITY_STATUS_LEARN.equals(opportunityStatus);
+        ConnectAppRecord appInfo = isLearning
+                ? job.getLearnAppInfo()
+                : job.getDeliveryAppInfo();
+        return appInfo.getAppId()
     }
 
     public static List<ConnectJobPaymentRecord> getPaymentsSortedByDate(ConnectJobRecord job) {

--- a/app/src/org/commcare/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/models/AndroidSessionWrapper.java
@@ -1,5 +1,6 @@
 package org.commcare.models;
 
+import android.os.Bundle;
 import android.util.Log;
 
 import org.commcare.CommCareApplication;
@@ -24,6 +25,7 @@ import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackOperation;
 import org.commcare.util.CommCarePlatform;
 import org.commcare.utils.AndroidInstanceInitializer;
+import org.commcare.utils.AndroidUtil;
 import org.commcare.utils.CommCareUtil;
 import org.commcare.utils.CrashUtil;
 import org.javarosa.core.model.FormIndex;
@@ -383,15 +385,27 @@ public class AndroidSessionWrapper implements SessionWrapperInterface {
         cleanVolatiles();
     }
 
-    public void executeEndpointStack(Endpoint endpoint, ArrayList<String> args) {
+    private void executeEndpointStack(Endpoint endpoint, ArrayList<String> args) {
         EvaluationContext evaluationContext = getEvaluationContext();
         Endpoint.populateEndpointArgumentsToEvaluationContext(endpoint, args, evaluationContext);
         executeStackActions(endpoint.getStackOperations(), evaluationContext);
     }
 
-    public void executeEndpointStack(Endpoint endpoint, HashMap args) {
+    private void executeEndpointStack(Endpoint endpoint, HashMap args) {
         EvaluationContext evaluationContext = getEvaluationContext();
         Endpoint.populateEndpointArgumentsToEvaluationContext(endpoint, args, evaluationContext);
         executeStackActions(endpoint.getStackOperations(), evaluationContext);
+    }
+
+    public void executeEndpointStack(Endpoint endpoint, Bundle intentArgumentsAsBundle,
+            ArrayList<String> intentArgumentsAsList) {
+        if (intentArgumentsAsBundle != null) {
+            CommCareApplication.instance().getCurrentSessionWrapper()
+                    .executeEndpointStack(endpoint,
+                            AndroidUtil.bundleAsMap(intentArgumentsAsBundle));
+        } else if (intentArgumentsAsList != null) {
+            CommCareApplication.instance().getCurrentSessionWrapper()
+                    .executeEndpointStack(endpoint, intentArgumentsAsList);
+        }
     }
 }

--- a/app/src/org/commcare/models/AndroidSessionWrapper.java
+++ b/app/src/org/commcare/models/AndroidSessionWrapper.java
@@ -406,6 +406,8 @@ public class AndroidSessionWrapper implements SessionWrapperInterface {
         } else if (intentArgumentsAsList != null) {
             CommCareApplication.instance().getCurrentSessionWrapper()
                     .executeEndpointStack(endpoint, intentArgumentsAsList);
+        } else if (endpoint.getArguments().isEmpty()) {
+            executeStackActions(endpoint.getStackOperations(), getEvaluationContext());
         }
     }
 }

--- a/app/src/org/commcare/models/database/connect/ConnectDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/connect/ConnectDatabaseUpgrader.java
@@ -42,6 +42,7 @@ import org.commcare.android.database.connect.models.PersonalIdWorkHistory;
 import org.commcare.android.database.connect.models.PushNotificationRecord;
 import org.commcare.android.database.connect.models.PushNotificationRecordV21;
 import org.commcare.android.database.connect.models.PushNotificationRecordV23;
+import org.commcare.android.database.connect.models.PushNotificationRecordV24;
 import org.commcare.models.database.ConcreteAndroidDbHelper;
 import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.IDatabase;
@@ -170,6 +171,11 @@ public class ConnectDatabaseUpgrader {
 
         if (oldVersion == 23) {
             upgradeTwentyThreeTwentyFour(db);
+            oldVersion = 24;
+        }
+
+        if (oldVersion == 24) {
+            upgradeTwentyFourTwentyFive(db);
         }
     }
 
@@ -1012,12 +1018,42 @@ public class ConnectDatabaseUpgrader {
 
             SqlStorage<Persistable> newStorage = new SqlStorage<>(
                     PushNotificationRecord.STORAGE_KEY,
-                    PushNotificationRecord.class,
+                    PushNotificationRecordV24.class,
                     new ConcreteAndroidDbHelper(c, db));
 
             for (Persistable r : oldStorage) {
                 PushNotificationRecordV23 oldRecord = (PushNotificationRecordV23)r;
-                PushNotificationRecord newRecord = PushNotificationRecord.Companion.fromV23(oldRecord);
+                PushNotificationRecord newRecord = PushNotificationRecordV24.Companion.fromV23(oldRecord);
+                newRecord.setID(oldRecord.getID());
+                newStorage.write(newRecord);
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+    }
+
+    private void upgradeTwentyFourTwentyFive(IDatabase db) {
+        db.beginTransaction();
+        try {
+            db.execSQL(DbUtil.addColumnToTable(
+                    PushNotificationRecord.STORAGE_KEY,
+                    PushNotificationRecord.META_SESSION_ENDPOINT_ID,
+                    "TEXT"));
+
+            SqlStorage<Persistable> oldStorage = new SqlStorage<>(
+                    PushNotificationRecordV24.STORAGE_KEY,
+                    PushNotificationRecordV24.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            SqlStorage<Persistable> newStorage = new SqlStorage<>(
+                    PushNotificationRecord.STORAGE_KEY,
+                    PushNotificationRecord.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            for (Persistable r : oldStorage) {
+                PushNotificationRecordV24 oldRecord = (PushNotificationRecordV24)r;
+                PushNotificationRecord newRecord = PushNotificationRecord.Companion.fromV24(oldRecord);
                 newRecord.setID(oldRecord.getID());
                 newStorage.write(newRecord);
             }

--- a/app/src/org/commcare/models/database/connect/ConnectDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/connect/ConnectDatabaseUpgrader.java
@@ -1023,7 +1023,7 @@ public class ConnectDatabaseUpgrader {
 
             for (Persistable r : oldStorage) {
                 PushNotificationRecordV23 oldRecord = (PushNotificationRecordV23)r;
-                PushNotificationRecord newRecord = PushNotificationRecordV24.Companion.fromV23(oldRecord);
+                PushNotificationRecordV24 newRecord = PushNotificationRecordV24.Companion.fromV23(oldRecord);
                 newRecord.setID(oldRecord.getID());
                 newStorage.write(newRecord);
             }
@@ -1039,6 +1039,11 @@ public class ConnectDatabaseUpgrader {
             db.execSQL(DbUtil.addColumnToTable(
                     PushNotificationRecord.STORAGE_KEY,
                     PushNotificationRecord.META_SESSION_ENDPOINT_ID,
+                    "TEXT"));
+
+            db.execSQL(DbUtil.addColumnToTable(
+                    PushNotificationRecord.STORAGE_KEY,
+                    PushNotificationRecord.META_REQUIRE_APP_SYNC,
                     "TEXT"));
 
             SqlStorage<Persistable> oldStorage = new SqlStorage<>(

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -66,7 +66,7 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
      *          ConnectJobAssessmentRecord, ConnectPaymentUnitRecord, ConnectJobRecord, ConnectJobPaymentRecord and PushNotificationRecord
      * V.23 - Added a field slugUUID (reference to payment unit uuid) in ConnectJobDeliveryRecord
      * V.24 - Added key (kind of action for ccc_generic_opportunity) and opportunityStatus (values will be learn/delivery)) in PushNotificationRecord record
-     * V.25 - Added sessionEndpointId in PushNotificationRecord
+     * V.25 - Added sessionEndpointId and requireAppSync in PushNotificationRecord
      */
     private static final int CONNECT_DB_VERSION = 25;
 

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -66,8 +66,9 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
      *          ConnectJobAssessmentRecord, ConnectPaymentUnitRecord, ConnectJobRecord, ConnectJobPaymentRecord and PushNotificationRecord
      * V.23 - Added a field slugUUID (reference to payment unit uuid) in ConnectJobDeliveryRecord
      * V.24 - Added key (kind of action for ccc_generic_opportunity) and opportunityStatus (values will be learn/delivery)) in PushNotificationRecord record
+     * V.25 - Added sessionEndpointId in PushNotificationRecord
      */
-    private static final int CONNECT_DB_VERSION = 24;
+    private static final int CONNECT_DB_VERSION = 25;
 
     private static final String CONNECT_DB_LOCATOR = "database_connect";
 

--- a/app/src/org/commcare/notifications_readme.md
+++ b/app/src/org/commcare/notifications_readme.md
@@ -190,7 +190,9 @@ Example 1: Generic Opportunity Push Notification
       "opportunity_uuid": "abcde-328-32mkj-43",
       "payment_uuid": "42309-fdfjl4-4343",
       "opportunity_status" : "delivery",  //  The notification will be shown only if this and ConnectJobRecord status match, thus avoiding unnecessary FCM to users if they have moved ahead already.
-      "key" : "payment_rollback" // For logging real action in Firebase for this type of generic opportunity notification.
+      "key" : "payment_rollback", // For logging real action in Firebase for this type of generic opportunity notification.
+      "session_endpoint_id": "my_endpoint", // Optional. If present, clicking the notification navigates the user directly to this session endpoint in the CommCare app instead of the Connect activity. Use "cc_app_home" to land on the app home screen.
+      "require_app_sync": "true" // Optional, defaults to true. When true, a blocking app sync is performed before navigating to the session endpoint.
     }
   ],
   "channels": []

--- a/app/src/org/commcare/utils/FirebaseMessagingUtil.java
+++ b/app/src/org/commcare/utils/FirebaseMessagingUtil.java
@@ -36,6 +36,7 @@ import org.commcare.android.database.connect.models.PushNotificationRecord;
 import org.commcare.connect.ConnectConstants;
 import org.commcare.connect.MessageManager;
 import org.commcare.connect.PersonalIdManager;
+import org.commcare.connect.database.ConnectJobUtils;
 import org.commcare.connect.database.ConnectUserDatabaseUtil;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
@@ -52,6 +53,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static android.content.Context.NOTIFICATION_SERVICE;
+import static org.commcare.activities.DispatchActivity.SESSION_ENDPOINT_ID;
+import static org.commcare.commcaresupportlibrary.CommCareLauncher.SESSION_ENDPOINT_APP_ID;
+import static org.commcare.connect.ConnectAppUtils.IS_LAUNCH_FROM_CONNECT;
 import static org.commcare.connect.ConnectConstants.CCC_DEST_DELIVERY_PROGRESS;
 import static org.commcare.connect.ConnectConstants.CCC_DEST_LEARN_PROGRESS;
 import static org.commcare.connect.ConnectConstants.CCC_DEST_OPPORTUNITY_SUMMARY_PAGE;
@@ -350,11 +354,48 @@ public class FirebaseMessagingUtil {
         return null;
     }
 
-    private static Intent handleCccGenericOpportunityNotifcation(Context context, FCMMessageData fcmMessageData, boolean showNotification) {
-        Intent intent = getConnectActivityNotification(context, fcmMessageData);
+    private static Intent handleCccGenericOpportunityNotifcation(
+            Context context, FCMMessageData fcmMessageData, boolean showNotification) {
+        String sessionEndpointId = fcmMessageData.getPayloadData()
+                .get(PushNotificationRecord.META_SESSION_ENDPOINT_ID);
+        Intent intent;
+        if (!TextUtils.isEmpty(sessionEndpointId)) {
+            intent =  handleSessionEndpointNotification(context, fcmMessageData, showNotification, sessionEndpointId);
+            if (intent != null) {
+                return intent;
+            }
+        }
+        intent = getConnectActivityNotification(context, fcmMessageData);
         if (showNotification)
-            showNotification(context, buildNotification(context, intent, fcmMessageData),
-                    fcmMessageData);
+            showNotification(context, buildNotification(context, intent, fcmMessageData), fcmMessageData);
+        return intent;
+    }
+
+    private static Intent handleSessionEndpointNotification(
+            Context context, FCMMessageData fcmMessageData, boolean showNotification,
+            String sessionEndpointId) {
+        String opportunityID = fcmMessageData.getPayloadData().get(OPPORTUNITY_UUID);
+        String opportunityStatus = fcmMessageData.getPayloadData().get(OPPORTUNITY_STATUS);
+        String appId = null;
+        try {
+            appId = ConnectJobUtils.getAppIdForOpportunity(context, opportunityID, opportunityStatus);
+        } catch (IllegalArgumentException e) {
+            Logger.exception("Could not resolve appId for opportunity", e);
+        }
+
+        if (appId == null) {
+            // we can't launch the session endpoint,
+            // so exit and handle as a normal notification without session endpoint details
+            return null;
+        }
+
+        Intent intent = new Intent(context, DispatchActivity.class);
+        intent.putExtra(SESSION_ENDPOINT_ID, sessionEndpointId);
+        intent.putExtra(SESSION_ENDPOINT_APP_ID, appId);
+        intent.putExtra(IS_LAUNCH_FROM_CONNECT, true);
+        if (showNotification) {
+            showNotification(context, buildNotification(context, intent, fcmMessageData), fcmMessageData);
+        }
         return intent;
     }
 

--- a/app/src/org/commcare/utils/FirebaseMessagingUtil.java
+++ b/app/src/org/commcare/utils/FirebaseMessagingUtil.java
@@ -375,8 +375,9 @@ public class FirebaseMessagingUtil {
     private static Intent handleSessionEndpointNotification(
             Context context, FCMMessageData fcmMessageData, boolean showNotification,
             String sessionEndpointId) {
-        String opportunityID = fcmMessageData.getPayloadData().get(OPPORTUNITY_UUID);
-        String opportunityStatus = fcmMessageData.getPayloadData().get(OPPORTUNITY_STATUS);
+        Map<String, String> payloadData = fcmMessageData.getPayloadData();
+        String opportunityID = payloadData.get(OPPORTUNITY_UUID);
+        String opportunityStatus = payloadData.get(OPPORTUNITY_STATUS);
         String appId = null;
         try {
             appId = ConnectJobUtils.getAppIdForOpportunity(context, opportunityID, opportunityStatus);
@@ -394,7 +395,10 @@ public class FirebaseMessagingUtil {
         intent.putExtra(SESSION_ENDPOINT_ID, sessionEndpointId);
         intent.putExtra(SESSION_ENDPOINT_APP_ID, appId);
         intent.putExtra(IS_LAUNCH_FROM_CONNECT, true);
-        intent.putExtra(CC_LAUNCH_REQUIRE_SYNC, true);
+        // Default to true when the field is absent — older server payloads always require sync
+        String requireAppSyncStr = payloadData.get(PushNotificationRecord.META_REQUIRE_APP_SYNC);
+        boolean requireSync = requireAppSyncStr == null || Boolean.parseBoolean(requireAppSyncStr);
+        intent.putExtra(CC_LAUNCH_REQUIRE_SYNC, requireSync);
         if (showNotification) {
             showNotification(context, buildNotification(context, intent, fcmMessageData), fcmMessageData);
         }

--- a/app/src/org/commcare/utils/FirebaseMessagingUtil.java
+++ b/app/src/org/commcare/utils/FirebaseMessagingUtil.java
@@ -53,6 +53,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static android.content.Context.NOTIFICATION_SERVICE;
+import static org.commcare.activities.DispatchActivity.CC_LAUNCH_REQUIRE_SYNC;
 import static org.commcare.activities.DispatchActivity.SESSION_ENDPOINT_ID;
 import static org.commcare.commcaresupportlibrary.CommCareLauncher.SESSION_ENDPOINT_APP_ID;
 import static org.commcare.connect.ConnectAppUtils.IS_LAUNCH_FROM_CONNECT;
@@ -393,6 +394,7 @@ public class FirebaseMessagingUtil {
         intent.putExtra(SESSION_ENDPOINT_ID, sessionEndpointId);
         intent.putExtra(SESSION_ENDPOINT_APP_ID, appId);
         intent.putExtra(IS_LAUNCH_FROM_CONNECT, true);
+        intent.putExtra(CC_LAUNCH_REQUIRE_SYNC, true);
         if (showNotification) {
             showNotification(context, buildNotification(context, intent, fcmMessageData), fcmMessageData);
         }

--- a/app/src/org/commcare/utils/FirebaseMessagingUtil.java
+++ b/app/src/org/commcare/utils/FirebaseMessagingUtil.java
@@ -555,8 +555,7 @@ public class FirebaseMessagingUtil {
      * @return NotificationCompat.Builder
      */
     private static NotificationCompat.Builder buildNotification(Context context, Intent intent, FCMMessageData fcmMessageData) {
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP |
-                Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
 
         int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
                 ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE

--- a/app/src/org/commcare/utils/FirebaseMessagingUtil.java
+++ b/app/src/org/commcare/utils/FirebaseMessagingUtil.java
@@ -359,14 +359,13 @@ public class FirebaseMessagingUtil {
             Context context, FCMMessageData fcmMessageData, boolean showNotification) {
         String sessionEndpointId = fcmMessageData.getPayloadData()
                 .get(PushNotificationRecord.META_SESSION_ENDPOINT_ID);
-        Intent intent;
+        Intent intent = null;
         if (!TextUtils.isEmpty(sessionEndpointId)) {
             intent =  handleSessionEndpointNotification(context, fcmMessageData, showNotification, sessionEndpointId);
-            if (intent != null) {
-                return intent;
-            }
         }
-        intent = getConnectActivityNotification(context, fcmMessageData);
+        if (intent == null) {
+            intent = getConnectActivityNotification(context, fcmMessageData);
+        }
         if (showNotification)
             showNotification(context, buildNotification(context, intent, fcmMessageData), fcmMessageData);
         return intent;
@@ -383,11 +382,6 @@ public class FirebaseMessagingUtil {
             appId = ConnectJobUtils.getAppIdForOpportunity(context, opportunityID, opportunityStatus);
         } catch (IllegalArgumentException e) {
             Logger.exception("Could not resolve appId for opportunity", e);
-        }
-
-        if (appId == null) {
-            // we can't launch the session endpoint,
-            // so exit and handle as a normal notification without session endpoint details
             return null;
         }
 
@@ -398,9 +392,6 @@ public class FirebaseMessagingUtil {
         String requireAppSyncStr = payloadData.get(PushNotificationRecord.META_REQUIRE_APP_SYNC);
         boolean requireSync = requireAppSyncStr == null || Boolean.parseBoolean(requireAppSyncStr);
         intent.putExtra(CC_LAUNCH_REQUIRE_SYNC, requireSync);
-        if (showNotification) {
-            showNotification(context, buildNotification(context, intent, fcmMessageData), fcmMessageData);
-        }
         return intent;
     }
 

--- a/app/src/org/commcare/utils/FirebaseMessagingUtil.java
+++ b/app/src/org/commcare/utils/FirebaseMessagingUtil.java
@@ -394,7 +394,6 @@ public class FirebaseMessagingUtil {
         Intent intent = new Intent(context, DispatchActivity.class);
         intent.putExtra(SESSION_ENDPOINT_ID, sessionEndpointId);
         intent.putExtra(SESSION_ENDPOINT_APP_ID, appId);
-        intent.putExtra(IS_LAUNCH_FROM_CONNECT, true);
         // Default to true when the field is absent — older server payloads always require sync
         String requireAppSyncStr = payloadData.get(PushNotificationRecord.META_REQUIRE_APP_SYNC);
         boolean requireSync = requireAppSyncStr == null || Boolean.parseBoolean(requireAppSyncStr);

--- a/app/src/org/commcare/utils/FirebaseMessagingUtil.java
+++ b/app/src/org/commcare/utils/FirebaseMessagingUtil.java
@@ -54,6 +54,7 @@ import java.util.Map;
 
 import static android.content.Context.NOTIFICATION_SERVICE;
 import static org.commcare.activities.DispatchActivity.CC_LAUNCH_REQUIRE_SYNC;
+import static org.commcare.activities.DispatchActivity.EXIT_AFTER_FORM_SUBMISSION;
 import static org.commcare.activities.DispatchActivity.SESSION_ENDPOINT_ID;
 import static org.commcare.commcaresupportlibrary.CommCareLauncher.SESSION_ENDPOINT_APP_ID;
 import static org.commcare.connect.ConnectAppUtils.IS_LAUNCH_FROM_CONNECT;
@@ -388,6 +389,7 @@ public class FirebaseMessagingUtil {
         Intent intent = new Intent(context, DispatchActivity.class);
         intent.putExtra(SESSION_ENDPOINT_ID, sessionEndpointId);
         intent.putExtra(SESSION_ENDPOINT_APP_ID, appId);
+        intent.putExtra(EXIT_AFTER_FORM_SUBMISSION, false);
         // Default to true when the field is absent — older server payloads always require sync
         String requireAppSyncStr = payloadData.get(PushNotificationRecord.META_REQUIRE_APP_SYNC);
         boolean requireSync = requireAppSyncStr == null || Boolean.parseBoolean(requireAppSyncStr);

--- a/app/src/org/commcare/utils/PushNotificationApiHelper.kt
+++ b/app/src/org/commcare/utils/PushNotificationApiHelper.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.commcare.android.database.connect.models.PushNotificationRecord
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_REQUIRE_APP_SYNC
+import org.commcare.android.database.connect.models.PushNotificationRecord.Companion.META_SESSION_ENDPOINT_ID
 import org.commcare.connect.ConnectActivityCompleteListener
 import org.commcare.connect.ConnectConstants.NOTIFICATION_BODY
 import org.commcare.connect.ConnectConstants.NOTIFICATION_CHANNEL_ID
@@ -206,7 +208,8 @@ object PushNotificationApiHelper {
         pn.put(PAYMENT_ID, "" + pnRecord.paymentId)
         pn.put(NOTIFICATION_KEY, pnRecord.key)
         pn.put(OPPORTUNITY_STATUS, pnRecord.opportunityStatus)
-        pn.put(PushNotificationRecord.META_SESSION_ENDPOINT_ID, pnRecord.sessionEndpointId)
+        pn.put(META_SESSION_ENDPOINT_ID, pnRecord.sessionEndpointId)
+        pn.put(META_REQUIRE_APP_SYNC, pnRecord.requireAppSync.toString())
         return pn
     }
 

--- a/app/src/org/commcare/utils/PushNotificationApiHelper.kt
+++ b/app/src/org/commcare/utils/PushNotificationApiHelper.kt
@@ -206,6 +206,7 @@ object PushNotificationApiHelper {
         pn.put(PAYMENT_ID, "" + pnRecord.paymentId)
         pn.put(NOTIFICATION_KEY, pnRecord.key)
         pn.put(OPPORTUNITY_STATUS, pnRecord.opportunityStatus)
+        pn.put(PushNotificationRecord.META_SESSION_ENDPOINT_ID, pnRecord.sessionEndpointId)
         return pn
     }
 

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -416,7 +416,10 @@ public class FormStorageTest {
             "org.commcare.android.database.connect.models.ConnectPaymentUnitRecordV21",
             "org.commcare.android.database.connect.models.PushNotificationRecordV21",
             "org.commcare.android.database.connect.models.ConnectJobDeliveryRecordV22",
-            "org.commcare.android.database.connect.models.PushNotificationRecordV23"
+            "org.commcare.android.database.connect.models.PushNotificationRecordV23",
+
+            // Added in 2.63
+            "org.commcare.android.database.connect.models.PushNotificationRecordV24"
 
     );
 

--- a/app/unit-tests/src/org/commcare/utils/SessionEndpointNotificationTest.kt
+++ b/app/unit-tests/src/org/commcare/utils/SessionEndpointNotificationTest.kt
@@ -1,0 +1,168 @@
+package org.commcare.utils
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.commcare.CommCareTestApplication
+import org.commcare.activities.DispatchActivity
+import org.commcare.activities.connect.ConnectActivity
+import org.commcare.android.database.connect.models.PushNotificationRecord
+import org.commcare.commcaresupportlibrary.CommCareLauncher
+import org.commcare.connect.ConnectAppUtils
+import org.commcare.connect.ConnectConstants
+import org.commcare.connect.PersonalIdManager
+import org.commcare.connect.database.ConnectJobUtils
+import org.commcare.utils.FirebaseMessagingUtil.handleNotification
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.robolectric.annotation.Config
+
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class SessionEndpointNotificationTest {
+    private val context: Context = CommCareTestApplication.instance()
+
+    private val learnAppId = "learn-app"
+    private val deliveryAppId = "delivery-app"
+    private val opportunityUuidValue = "opp-1"
+    private val endpointIdValue = "ep-1"
+
+    private lateinit var connectJobUtilsMock: MockedStatic<ConnectJobUtils>
+    private lateinit var savedStatus: PersonalIdManager.PersonalIdStatus
+
+    @Before
+    fun setUp() {
+        // Set PersonalIdManager status to LoggedIn directly to satisfy cccCheckPassed().
+        // init() only touches the DB when status == NotIntroduced; once LoggedIn it's a no-op.
+        val manager = PersonalIdManager.getInstance()
+        savedStatus = manager.getStatus()
+        manager.setStatus(PersonalIdManager.PersonalIdStatus.LoggedIn)
+
+        connectJobUtilsMock = Mockito.mockStatic(ConnectJobUtils::class.java)
+        connectJobUtilsMock
+            .`when`<String> {
+                ConnectJobUtils.getAppIdForOpportunity(
+                    Mockito.any(),
+                    Mockito.eq(opportunityUuidValue),
+                    Mockito.eq(ConnectConstants.OPPORTUNITY_STATUS_LEARN),
+                )
+            }.thenReturn(learnAppId)
+        connectJobUtilsMock
+            .`when`<String> {
+                ConnectJobUtils.getAppIdForOpportunity(
+                    Mockito.any(),
+                    Mockito.eq(opportunityUuidValue),
+                    Mockito.eq(ConnectConstants.OPPORTUNITY_STATUS_DELIVERY),
+                )
+            }.thenReturn(deliveryAppId)
+    }
+
+    @After
+    fun tearDown() {
+        connectJobUtilsMock.close()
+        PersonalIdManager.getInstance().setStatus(savedStatus)
+    }
+
+    private fun buildPayload(
+        action: String = "ccc_generic_opportunity",
+        sessionEndpointId: String? = endpointIdValue,
+        opportunityUuid: String? = opportunityUuidValue,
+        opportunityStatus: String? = ConnectConstants.OPPORTUNITY_STATUS_LEARN,
+    ): Map<String, String> {
+        val map =
+            mutableMapOf(
+                "action" to action,
+                "title" to "Test",
+                "body" to "Test body",
+            )
+        if (sessionEndpointId != null) {
+            map[PushNotificationRecord.META_SESSION_ENDPOINT_ID] = sessionEndpointId
+        }
+        if (opportunityUuid != null) {
+            map["opportunity_uuid"] = opportunityUuid
+        }
+        if (opportunityStatus != null) {
+            map["opportunity_status"] = opportunityStatus
+        }
+        return map
+    }
+
+    @Test
+    fun `ccc_generic_opportunity with session_endpoint_id routes to DispatchActivity`() {
+        val payload = buildPayload()
+        val intent = handleNotification(context, payload, null, false)
+        assertEquals(
+            DispatchActivity::class.java.name,
+            intent!!.component!!.className,
+        )
+        assertEquals(endpointIdValue, intent.getStringExtra(DispatchActivity.SESSION_ENDPOINT_ID))
+        assertTrue(intent!!.getBooleanExtra(ConnectAppUtils.IS_LAUNCH_FROM_CONNECT, false))
+    }
+
+    @Test
+    fun `SESSION_ENDPOINT_APP_ID uses learn appId for learn status`() {
+        val payload = buildPayload(opportunityStatus = ConnectConstants.OPPORTUNITY_STATUS_LEARN)
+        val intent = handleNotification(context, payload, null, false)
+        assertEquals(learnAppId, intent!!.getStringExtra(CommCareLauncher.SESSION_ENDPOINT_APP_ID))
+    }
+
+    @Test
+    fun `SESSION_ENDPOINT_APP_ID uses delivery appId for delivery status`() {
+        val payload = buildPayload(opportunityStatus = ConnectConstants.OPPORTUNITY_STATUS_DELIVERY)
+        val intent = handleNotification(context, payload, null, false)
+        assertEquals(deliveryAppId, intent!!.getStringExtra(CommCareLauncher.SESSION_ENDPOINT_APP_ID))
+    }
+
+    @Test
+    fun `ccc_generic_opportunity without session_endpoint_id routes to ConnectActivity`() {
+        val payload = buildPayload(sessionEndpointId = null)
+        val intent = handleNotification(context, payload, null, false)
+        assertEquals(
+            ConnectActivity::class.java.name,
+            intent!!.component!!.className,
+        )
+    }
+
+    @Test
+    fun `missing opportunityUUID falls back to ConnectActivity`() {
+        connectJobUtilsMock
+            .`when`<String> {
+                ConnectJobUtils.getAppIdForOpportunity(
+                    Mockito.any(),
+                    Mockito.isNull(),
+                    Mockito.any(),
+                )
+            }.thenReturn(null)
+
+        val payload = buildPayload(opportunityUuid = null)
+        val intent = handleNotification(context, payload, null, false)
+        assertEquals(
+            ConnectActivity::class.java.name,
+            intent!!.component!!.className,
+        )
+    }
+
+    @Test
+    fun `job not found falls back to ConnectActivity`() {
+        connectJobUtilsMock
+            .`when`<String> {
+                ConnectJobUtils.getAppIdForOpportunity(
+                    Mockito.any(),
+                    Mockito.eq(opportunityUuidValue),
+                    Mockito.any(),
+                )
+            }.thenReturn(null)
+
+        val payload = buildPayload()
+        val intent = handleNotification(context, payload, null, false)
+        assertEquals(
+            ConnectActivity::class.java.name,
+            intent!!.component!!.className,
+        )
+    }
+}

--- a/app/unit-tests/src/org/commcare/utils/SessionEndpointNotificationTest.kt
+++ b/app/unit-tests/src/org/commcare/utils/SessionEndpointNotificationTest.kt
@@ -25,7 +25,7 @@ import org.robolectric.annotation.Config
 @Config(application = CommCareTestApplication::class)
 @RunWith(AndroidJUnit4::class)
 class SessionEndpointNotificationTest {
-    private val context: Context = CommCareTestApplication.instance()
+    private val context = CommCareTestApplication.instance()
 
     private val learnAppId = "learn-app"
     private val deliveryAppId = "delivery-app"
@@ -40,8 +40,8 @@ class SessionEndpointNotificationTest {
         // Set PersonalIdManager status to LoggedIn directly to satisfy cccCheckPassed().
         // init() only touches the DB when status == NotIntroduced; once LoggedIn it's a no-op.
         val manager = PersonalIdManager.getInstance()
-        savedStatus = manager.getStatus()
-        manager.setStatus(PersonalIdManager.PersonalIdStatus.LoggedIn)
+        savedStatus = manager.status
+        manager.status = PersonalIdManager.PersonalIdStatus.LoggedIn
 
         connectJobUtilsMock = Mockito.mockStatic(ConnectJobUtils::class.java)
         connectJobUtilsMock
@@ -65,7 +65,7 @@ class SessionEndpointNotificationTest {
     @After
     fun tearDown() {
         connectJobUtilsMock.close()
-        PersonalIdManager.getInstance().setStatus(savedStatus)
+        PersonalIdManager.getInstance().status = savedStatus
     }
 
     private fun buildPayload(
@@ -101,7 +101,6 @@ class SessionEndpointNotificationTest {
             intent!!.component!!.className,
         )
         assertEquals(endpointIdValue, intent.getStringExtra(DispatchActivity.SESSION_ENDPOINT_ID))
-        assertTrue(intent!!.getBooleanExtra(ConnectAppUtils.IS_LAUNCH_FROM_CONNECT, false))
     }
 
     @Test

--- a/app/unit-tests/src/org/commcare/utils/SessionEndpointNotificationTest.kt
+++ b/app/unit-tests/src/org/commcare/utils/SessionEndpointNotificationTest.kt
@@ -128,25 +128,6 @@ class SessionEndpointNotificationTest {
     }
 
     @Test
-    fun `missing opportunityUUID falls back to ConnectActivity`() {
-        connectJobUtilsMock
-            .`when`<String> {
-                ConnectJobUtils.getAppIdForOpportunity(
-                    Mockito.any(),
-                    Mockito.isNull(),
-                    Mockito.any(),
-                )
-            }.thenReturn(null)
-
-        val payload = buildPayload(opportunityUuid = null)
-        val intent = handleNotification(context, payload, null, false)
-        assertEquals(
-            ConnectActivity::class.java.name,
-            intent!!.component!!.className,
-        )
-    }
-
-    @Test
     fun `job not found falls back to ConnectActivity`() {
         connectJobUtilsMock
             .`when`<String> {
@@ -155,7 +136,7 @@ class SessionEndpointNotificationTest {
                     Mockito.eq(opportunityUuidValue),
                     Mockito.any(),
                 )
-            }.thenReturn(null)
+            }.thenThrow(IllegalArgumentException("Opportunity not found"))
 
         val payload = buildPayload()
         val intent = handleNotification(context, payload, null, false)


### PR DESCRIPTION
### [CCCT-2217](https://dimagi.atlassian.net/browse/CCCT-2217) · [CCCT-2329](https://dimagi.atlassian.net/browse/CCCT-2329)

## Product Description

When a Connect push notification with a `session_endpoint_id` is clicked, the user is now navigated directly to the relevant session endpoint in their CommCare app (optionally after a blocking sync), rather than landing on the Connect activity. A special `cc_app_home` endpoint is also supported, which simply leaves the user on the app home screen.

Video showing redirect based on user state - 


https://github.com/user-attachments/assets/faaf758a-52b9-45c1-adb4-279379dd6f45


Video showing app switching from notification redirect- 




https://github.com/user-attachments/assets/73be0468-ab93-4bca-a639-2a7fbc899288


Video showing notification redirect directly into a form - 


https://github.com/user-attachments/assets/0e311888-c298-4b55-836a-2e3b95d0005f




## Technical Summary

This PR wires up session endpoint navigation from Connect push notifications end-to-end:

- **`PushNotificationRecord` (DB v24 → v25):** Added `sessionEndpointId` and `requireAppSync` fields. `requireAppSync` defaults to `true` so older server payloads always trigger a sync. Includes a versioned snapshot class (`PushNotificationRecordV24`) and an additive migration that adds the new columns.
- **`ConnectJobUtils`:** New `getAppIdForOpportunity()` helper that resolves the CommCare app ID from an opportunity UUID and status (learn vs. delivery).
- **`FirebaseMessagingUtil`:** `ccc_generic_opportunity` notifications that carry a `session_endpoint_id` are now routed to `DispatchActivity` (with the endpoint ID, app ID, and `requireSync` flag) instead of `ConnectActivity`. Falls back to `ConnectActivity` routing if the opportunity or app ID cannot be resolved.
- **`HomeScreenBaseActivity`:** Handles the `CC_LAUNCH_REQUIRE_SYNC` flag — when set, triggers a blocking sync before navigating to the session endpoint. Adds support for the `cc_app_home` endpoint, which no-ops navigation and leaves the user on the home screen.
- **`DispatchActivity`:** Propagates `CC_LAUNCH_REQUIRE_SYNC` to `HomeScreenBaseActivity`. Fixes a lifecycle race condition: when a session endpoint notification is clicked while the login screen is showing, `FLAG_ACTIVITY_CLEAR_TOP` causes `LoginActivity` to send `RESULT_CANCELED` to `DispatchActivity`, which was calling `finish()` in `onResume` before `onNewIntent` could deliver the new notification intent. The fix posts `finish()` via `Handler.post()` so `onNewIntent` (delivered synchronously in the same Looper transaction) can cancel it and dispatch instead.

## Safety Assurance

### Safety story

- DB migration is purely additive — two new columns with safe defaults (`""` and `true`). Existing records are migrated with those defaults applied.
- Notification routing falls back to the existing `ConnectActivity` path if the opportunity ID is missing or the app ID cannot be resolved, so no regression for malformed payloads.
- The `DispatchActivity` lifecycle fix is guarded by a re-check of `shouldFinish` inside the posted lambda, so the normal "user pressed back from login → close app" flow is unaffected.
- Local Testing:
-  notification click from login screen, notification click while app is backgrounded, and normal login-cancel flow. 
- Test the behaviour from different screens on top of activity stack when user clicks on notification
- Update Testing for Notifications Migration
- Tests session endpoints other than App home

### Automated test coverage

`SessionEndpointNotificationTest` covers:
- `ccc_generic_opportunity` with `session_endpoint_id` routes to `DispatchActivity` with correct extras


[CCCT-2217]: https://dimagi.atlassian.net/browse/CCCT-2217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCCT-2329]: https://dimagi.atlassian.net/browse/CCCT-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ