### PR TITLE
CCCT-2052 Track OTP Request/Verify Outcome And Method

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneVerificationFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneVerificationFragment.java
@@ -31,9 +31,11 @@ import org.commcare.connect.network.base.BaseApiHandler;
 import org.commcare.connect.network.PersonalIdOrConnectApiErrorHandler;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.ScreenPersonalidPhoneVerifyBinding;
+import org.commcare.google.services.analytics.AnalyticsParamValue;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.KeyboardHelper;
+import org.commcare.utils.OtpAnalyticsMapper;
 import org.commcare.utils.OtpErrorType;
 import org.commcare.utils.OtpManager;
 import org.commcare.utils.OtpVerificationCallback;
@@ -60,6 +62,9 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
     private SMSBroadcastReceiver smsBroadcastReceiver;
     private ScreenPersonalidPhoneVerifyBinding binding;
     private final Handler resendTimerHandler = new Handler();
+    /** Which OTP call is currently in flight, used to attribute the next callback. */
+    private enum OtpOp { REQUEST, VERIFY }
+    private OtpOp currentOtpOp;
     private OtpManager otpManager;
     private PersonalIdSessionData personalIdSessionData;
     OtpVerificationCallback otpCallback;
@@ -97,23 +102,34 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
             @Override
             public void onCodeSent(String verificationId) {
                 if (otpCallback == null) return;
+                emitOtpAnalytics(AnalyticsParamValue.OTP_OUTCOME_SUCCESS, /* reason= */ null);
                 Toast.makeText(requireContext(), getString(R.string.connect_otp_sent), Toast.LENGTH_SHORT).show();
             }
 
             @Override
             public void onCodeVerified(String code) {
                 if (otpCallback == null) return;
+                // No analytics emission here: this is Firebase's local auto-verification step.
+                // Verify success is recorded from the server-confirmed onSuccess callback so
+                // we don't double-count, and verify failure is recorded from onFailure /
+                // onPersonalIdApiFailure.
                 Toast.makeText(requireContext(), getString(R.string.connect_otp_verified), Toast.LENGTH_SHORT).show();
             }
 
             @Override
             public void onSuccess() {
+                if (otpCallback == null) return;
+                emitOtpAnalytics(AnalyticsParamValue.OTP_OUTCOME_SUCCESS, /* reason= */ null);
                 navigateToNameEntry();
             }
 
             @Override
             public void onFailure(OtpErrorType errorType, @Nullable String errorMessage) {
                 if (otpCallback == null) return;
+
+                emitOtpAnalytics(
+                        AnalyticsParamValue.OTP_OUTCOME_FAILURE,
+                        OtpAnalyticsMapper.reasonFrom(errorType));
 
                 // Auto-switch from Firebase to PersonalId for non-recoverable errors
                 if (shouldAutoSwitchToPersonalIdAuth(errorType)) {
@@ -140,6 +156,12 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
                     @NonNull BaseApiHandler.PersonalIdOrConnectApiErrorCodes failureCode,
                     Throwable t
             ) {
+                if (otpCallback == null) return;
+
+                emitOtpAnalytics(
+                        AnalyticsParamValue.OTP_OUTCOME_FAILURE,
+                        OtpAnalyticsMapper.reasonFrom(failureCode));
+
                 if (handleCommonSignupFailures(failureCode)) {
                     return;
                 }
@@ -329,12 +351,32 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
         }
     }
 
+    private void emitOtpAnalytics(String outcome, @Nullable String reason) {
+        if (currentOtpOp == null) {
+            // Defensive — a callback fired without a tracked op. Don't emit.
+            return;
+        }
+        String eventType = currentOtpOp == OtpOp.REQUEST
+                ? AnalyticsParamValue.OTP_EVENT_TYPE_REQUEST
+                : AnalyticsParamValue.OTP_EVENT_TYPE_VERIFY;
+        // Use lastOtpMethod (the active manager's method) rather than
+        // personalIdSessionData.getSmsMethod(), which is the server-assigned
+        // value and does not reflect setupOtpManager's fallback/auto-switch logic.
+        String method = OtpAnalyticsMapper.methodFromSmsMethod(lastOtpMethod);
+        FirebaseAnalyticsUtil.reportOtpEvent(
+                eventType,
+                outcome,
+                method,
+                reason,
+                personalIdSessionData.getOtpAttempts());
+    }
+
     private void requestOtp() {
         clearOtpError();
         otpRequestTime = new DateTime();
+        currentOtpOp = OtpOp.REQUEST;
         otpManager.requestOtp(primaryPhone);
         personalIdSessionData.setOtpAttempts(personalIdSessionData.getOtpAttempts() + 1);
-        FirebaseAnalyticsUtil.reportOtpRequested(personalIdSessionData.getOtpAttempts());
     }
 
     private void verifyOtp() {
@@ -345,6 +387,7 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
         if (otpCode.length() != 6) {
             Toast.makeText(requireContext(), getString(R.string.connect_enter_otp), Toast.LENGTH_SHORT).show();
         } else {
+            currentOtpOp = OtpOp.VERIFY;
             otpManager.verifyOtp(otpCode);
         }
     }

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneVerificationFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneVerificationFragment.java
@@ -46,6 +46,7 @@ import org.joda.time.DateTime;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.commcare.utils.OtpAnalyticsMapper.getEventType;
 import static org.commcare.utils.OtpManager.SMS_METHOD_FIREBASE;
 import static org.commcare.utils.OtpManager.SMS_METHOD_PERSONAL_ID;
 
@@ -62,9 +63,7 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
     private SMSBroadcastReceiver smsBroadcastReceiver;
     private ScreenPersonalidPhoneVerifyBinding binding;
     private final Handler resendTimerHandler = new Handler();
-    /** Which OTP call is currently in flight, used to attribute the next callback. */
-    private enum OtpOp { REQUEST, VERIFY }
-    private OtpOp currentOtpOp;
+    private OtpAnalyticsMapper.OtpOp currentOtpOp;
     private OtpManager otpManager;
     private PersonalIdSessionData personalIdSessionData;
     OtpVerificationCallback otpCallback;
@@ -102,7 +101,7 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
             @Override
             public void onCodeSent(String verificationId) {
                 if (otpCallback == null) return;
-                emitOtpAnalytics(AnalyticsParamValue.OTP_OUTCOME_SUCCESS, /* reason= */ null);
+                reportOtpAnalytics(AnalyticsParamValue.OTP_OUTCOME_SUCCESS, null);
                 Toast.makeText(requireContext(), getString(R.string.connect_otp_sent), Toast.LENGTH_SHORT).show();
             }
 
@@ -119,17 +118,17 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
             @Override
             public void onSuccess() {
                 if (otpCallback == null) return;
-                emitOtpAnalytics(AnalyticsParamValue.OTP_OUTCOME_SUCCESS, /* reason= */ null);
+                reportOtpAnalytics(AnalyticsParamValue.OTP_OUTCOME_SUCCESS, null);
                 navigateToNameEntry();
             }
 
             @Override
             public void onFailure(OtpErrorType errorType, @Nullable String errorMessage) {
-                if (otpCallback == null) return;
-
-                emitOtpAnalytics(
+                reportOtpAnalytics(
                         AnalyticsParamValue.OTP_OUTCOME_FAILURE,
                         OtpAnalyticsMapper.reasonFrom(errorType));
+
+                if (otpCallback == null) return;
 
                 // Auto-switch from Firebase to PersonalId for non-recoverable errors
                 if (shouldAutoSwitchToPersonalIdAuth(errorType)) {
@@ -158,7 +157,7 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
             ) {
                 if (otpCallback == null) return;
 
-                emitOtpAnalytics(
+                reportOtpAnalytics(
                         AnalyticsParamValue.OTP_OUTCOME_FAILURE,
                         OtpAnalyticsMapper.reasonFrom(failureCode));
 
@@ -351,14 +350,11 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
         }
     }
 
-    private void emitOtpAnalytics(String outcome, @Nullable String reason) {
-        if (currentOtpOp == null) {
-            // Defensive — a callback fired without a tracked op. Don't emit.
-            return;
-        }
-        String eventType = currentOtpOp == OtpOp.REQUEST
-                ? AnalyticsParamValue.OTP_EVENT_TYPE_REQUEST
-                : AnalyticsParamValue.OTP_EVENT_TYPE_VERIFY;
+    private void reportOtpAnalytics(String outcome, @Nullable String reason) {
+
+        String eventType = getEventType(currentOtpOp);
+        if (eventType == null) return;
+
         // Use lastOtpMethod (the active manager's method) rather than
         // personalIdSessionData.getSmsMethod(), which is the server-assigned
         // value and does not reflect setupOtpManager's fallback/auto-switch logic.
@@ -374,7 +370,7 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
     private void requestOtp() {
         clearOtpError();
         otpRequestTime = new DateTime();
-        currentOtpOp = OtpOp.REQUEST;
+        currentOtpOp = OtpAnalyticsMapper.OtpOp.REQUEST;
         otpManager.requestOtp(primaryPhone);
         personalIdSessionData.setOtpAttempts(personalIdSessionData.getOtpAttempts() + 1);
     }
@@ -387,7 +383,7 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
         if (otpCode.length() != 6) {
             Toast.makeText(requireContext(), getString(R.string.connect_enter_otp), Toast.LENGTH_SHORT).show();
         } else {
-            currentOtpOp = OtpOp.VERIFY;
+            currentOtpOp = OtpAnalyticsMapper.OtpOp.VERIFY;
             otpManager.verifyOtp(otpCode);
         }
     }

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneVerificationFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneVerificationFragment.java
@@ -351,13 +351,8 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
     }
 
     private void reportOtpAnalytics(String outcome, @Nullable String reason) {
-
-        String eventType = getEventType(currentOtpOp);
+      String eventType = getEventType(currentOtpOp);
         if (eventType == null) return;
-
-        // Use lastOtpMethod (the active manager's method) rather than
-        // personalIdSessionData.getSmsMethod(), which is the server-assigned
-        // value and does not reflect setupOtpManager's fallback/auto-switch logic.
         String method = OtpAnalyticsMapper.methodFromSmsMethod(lastOtpMethod);
         FirebaseAnalyticsUtil.reportOtpEvent(
                 eventType,

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -211,4 +211,12 @@ public class AnalyticsParamValue {
             "click_resubscribed_confirm";
     public final static String CCC_MESSAGING_EVENT_TYPE_CONSENT_API_RESULT =
             "consent_api_success_result";
+
+    // Param values for OTP analytics (CCCT-2052)
+    public static final String OTP_METHOD_FIREBASE = "firebase";
+    public static final String OTP_METHOD_PERSONAL_ID = "personal_id";
+    public static final String OTP_OUTCOME_SUCCESS = "success";
+    public static final String OTP_OUTCOME_FAILURE = "failure";
+    public static final String OTP_EVENT_TYPE_REQUEST = "request";
+    public static final String OTP_EVENT_TYPE_VERIFY = "verify";
 }

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -212,7 +212,7 @@ public class AnalyticsParamValue {
     public final static String CCC_MESSAGING_EVENT_TYPE_CONSENT_API_RESULT =
             "consent_api_success_result";
 
-    // Param values for OTP analytics (CCCT-2052)
+    // Param values for OTP analytics
     public static final String OTP_METHOD_FIREBASE = "firebase";
     public static final String OTP_METHOD_PERSONAL_ID = "personal_id";
     public static final String OTP_OUTCOME_SUCCESS = "success";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
@@ -50,7 +50,7 @@ public class CCAnalyticsParam {
     static final String CCC_MESSAGING_CONSENT_API_RESULT = "consent_api_success";
     static final String CCC_MESSAGING_DESIRED_CONSENT_STATUS = "consent_api_desired_consent_status";
 
-    // Param keys for OTP analytics (CCCT-2052)
+    // Param keys for OTP analytics
     public static final String OTP_OUTCOME = "outcome";
     public static final String OTP_EVENT_TYPE = "event_type";
     public static final String OTP_METHOD = "method";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
@@ -21,7 +21,7 @@ public class CCAnalyticsParam {
     static final String DIRECTION = "direction";
     static final String TIME_IN_MINUTES = "time_in_minutes";
     static final String MODE = "mode";
-    static final String REASON = "reason";
+    public static final String REASON = "reason";
     static final String RESULT = "result";
     static final String UI_STATE = "uite_state";
     public static final String USERNAME = "username";
@@ -49,4 +49,9 @@ public class CCAnalyticsParam {
     static final String CCC_MESSAGING_CHANNEL_ID = "channel_id";
     static final String CCC_MESSAGING_CONSENT_API_RESULT = "consent_api_success";
     static final String CCC_MESSAGING_DESIRED_CONSENT_STATUS = "consent_api_desired_consent_status";
+
+    // Param keys for OTP analytics (CCCT-2052)
+    public static final String OTP_OUTCOME = "outcome";
+    public static final String OTP_EVENT_TYPE = "event_type";
+    public static final String OTP_METHOD = "method";
 }

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -737,9 +737,37 @@ public class FirebaseAnalyticsUtil {
         );
     }
 
-    public static void reportOtpRequested(int numberOfAttempts) {
+    /**
+     * Reports the otp_requested event with the outcome and reason of an OTP request
+     * or verify call (CCCT-2052).
+     *
+     * @param eventType    one of {@link AnalyticsParamValue#OTP_EVENT_TYPE_REQUEST} /
+     *                     {@link AnalyticsParamValue#OTP_EVENT_TYPE_VERIFY}.
+     * @param outcome      one of {@link AnalyticsParamValue#OTP_OUTCOME_SUCCESS} /
+     *                     {@link AnalyticsParamValue#OTP_OUTCOME_FAILURE}.
+     * @param method       one of {@link AnalyticsParamValue#OTP_METHOD_FIREBASE} /
+     *                     {@link AnalyticsParamValue#OTP_METHOD_PERSONAL_ID}.
+     * @param reason       failure reason from {@link org.commcare.utils.OtpAnalyticsMapper};
+     *                     pass null for success events. Null reasons are omitted from the
+     *                     bundle (Firebase does not accept null string params). Logged under
+     *                     {@link CCAnalyticsParam#REASON}.
+     * @param attempts     attempt counter from PersonalIdSessionData. Logged to
+     *                     {@link FirebaseAnalytics.Param#VALUE} for backwards compatibility
+     *                     with the original event signature.
+     */
+    public static void reportOtpEvent(String eventType,
+                                      String outcome,
+                                      String method,
+                                      @Nullable String reason,
+                                      int attempts) {
         Bundle bundle = new Bundle();
-        bundle.putLong(FirebaseAnalytics.Param.VALUE, numberOfAttempts);
+        bundle.putString(CCAnalyticsParam.OTP_EVENT_TYPE, eventType);
+        bundle.putString(CCAnalyticsParam.OTP_OUTCOME, outcome);
+        bundle.putString(CCAnalyticsParam.OTP_METHOD, method);
+        if (reason != null) {
+            bundle.putString(CCAnalyticsParam.REASON, reason);
+        }
+        bundle.putLong(FirebaseAnalytics.Param.VALUE, attempts);
         reportEvent(CCAnalyticsEvent.OTP_REQUESTED, bundle);
     }
 

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -739,7 +739,7 @@ public class FirebaseAnalyticsUtil {
 
     /**
      * Reports the otp_requested event with the outcome and reason of an OTP request
-     * or verify call (CCCT-2052).
+     * or verify call.
      *
      * @param eventType    one of {@link AnalyticsParamValue#OTP_EVENT_TYPE_REQUEST} /
      *                     {@link AnalyticsParamValue#OTP_EVENT_TYPE_VERIFY}.

--- a/app/src/org/commcare/utils/OtpAnalyticsMapper.kt
+++ b/app/src/org/commcare/utils/OtpAnalyticsMapper.kt
@@ -2,28 +2,31 @@ package org.commcare.utils
 
 import org.commcare.connect.network.base.BaseApiHandler.PersonalIdOrConnectApiErrorCodes
 import org.commcare.google.services.analytics.AnalyticsParamValue
+import org.commcare.util.LogTypes
+import org.javarosa.core.services.Logger
 
 /**
  * Normalizes Firebase {@link OtpErrorType}, {@link PersonalIdOrConnectApiErrorCodes},
  * and the OtpManager SMS-method string into the stable analytics strings emitted with
- * the {@code otp_requested} event (CCCT-2052).
+ * the {@code otp_requested} event.
  */
 object OtpAnalyticsMapper {
     /**
-     * Maps the OtpManager SMS method string ({@link OtpManager#SMS_METHOD_FIREBASE} /
-     * {@link OtpManager#SMS_METHOD_PERSONAL_ID}) to the analytics method constant.
-     * Falls back to {@link AnalyticsParamValue#OTP_METHOD_FIREBASE} when the input is
-     * null or unrecognized so events always carry a method value.
+     * Maps the OtpManager SMS method string ([OtpManager.SMS_METHOD_FIREBASE] /
+     * [OtpManager.SMS_METHOD_PERSONAL_ID]) to the analytics method constant.
+     * Returns [AnalyticsParamValue.OTP_METHOD_FIREBASE] when the input is null
+     * (Firebase is the default flow), and `"UNKNOWN-<input>"` for any other value
+     * so unexpected SMS methods stay visible in BI.
      */
     @JvmStatic
-    fun methodFromSmsMethod(smsMethod: String?): String =
+    fun methodFromSmsMethod(smsMethod: String?): String? =
         when {
             smsMethod == null -> AnalyticsParamValue.OTP_METHOD_FIREBASE
             smsMethod.equals(OtpManager.SMS_METHOD_PERSONAL_ID, ignoreCase = true) ->
                 AnalyticsParamValue.OTP_METHOD_PERSONAL_ID
             smsMethod.equals(OtpManager.SMS_METHOD_FIREBASE, ignoreCase = true) ->
                 AnalyticsParamValue.OTP_METHOD_FIREBASE
-            else -> AnalyticsParamValue.OTP_METHOD_FIREBASE
+            else -> "UNKNOWN-$smsMethod"
         }
 
     /**
@@ -39,4 +42,26 @@ object OtpAnalyticsMapper {
      */
     @JvmStatic
     fun reasonFrom(errorCode: PersonalIdOrConnectApiErrorCodes?): String? = errorCode?.name?.lowercase()
+
+    /** Which OTP call is currently in flight, used to attribute the next callback. */
+    enum class OtpOp {
+        REQUEST,
+        VERIFY,
+    }
+
+    @JvmStatic
+    fun getEventType(currentOtpOp: OtpOp?): String? =
+        when {
+            OtpOp.REQUEST == currentOtpOp -> AnalyticsParamValue.OTP_EVENT_TYPE_REQUEST
+
+            OtpOp.VERIFY == currentOtpOp -> AnalyticsParamValue.OTP_EVENT_TYPE_VERIFY
+
+            else -> {
+                Logger.log(
+                    LogTypes.TYPE_ERROR_DESIGN,
+                    "reportOtpAnalytics called with null OtpOp",
+                )
+                null
+            }
+        }
 }

--- a/app/src/org/commcare/utils/OtpAnalyticsMapper.kt
+++ b/app/src/org/commcare/utils/OtpAnalyticsMapper.kt
@@ -1,0 +1,42 @@
+package org.commcare.utils
+
+import org.commcare.connect.network.base.BaseApiHandler.PersonalIdOrConnectApiErrorCodes
+import org.commcare.google.services.analytics.AnalyticsParamValue
+
+/**
+ * Normalizes Firebase {@link OtpErrorType}, {@link PersonalIdOrConnectApiErrorCodes},
+ * and the OtpManager SMS-method string into the stable analytics strings emitted with
+ * the {@code otp_requested} event (CCCT-2052).
+ */
+object OtpAnalyticsMapper {
+    /**
+     * Maps the OtpManager SMS method string ({@link OtpManager#SMS_METHOD_FIREBASE} /
+     * {@link OtpManager#SMS_METHOD_PERSONAL_ID}) to the analytics method constant.
+     * Falls back to {@link AnalyticsParamValue#OTP_METHOD_FIREBASE} when the input is
+     * null or unrecognized so events always carry a method value.
+     */
+    @JvmStatic
+    fun methodFromSmsMethod(smsMethod: String?): String =
+        when {
+            smsMethod == null -> AnalyticsParamValue.OTP_METHOD_FIREBASE
+            smsMethod.equals(OtpManager.SMS_METHOD_PERSONAL_ID, ignoreCase = true) ->
+                AnalyticsParamValue.OTP_METHOD_PERSONAL_ID
+            smsMethod.equals(OtpManager.SMS_METHOD_FIREBASE, ignoreCase = true) ->
+                AnalyticsParamValue.OTP_METHOD_FIREBASE
+            else -> AnalyticsParamValue.OTP_METHOD_FIREBASE
+        }
+
+    /**
+     * Maps a Firebase {@link OtpErrorType} to a stable lowercase reason string suitable
+     * for analytics. Returns null when the input is null.
+     */
+    @JvmStatic
+    fun reasonFrom(errorType: OtpErrorType?): String? = errorType?.name?.lowercase()
+
+    /**
+     * Maps a PersonalID/Connect API error code to a stable lowercase reason string
+     * suitable for analytics. Returns null when the input is null.
+     */
+    @JvmStatic
+    fun reasonFrom(errorCode: PersonalIdOrConnectApiErrorCodes?): String? = errorCode?.name?.lowercase()
+}

--- a/app/src/org/commcare/utils/OtpAnalyticsMapper.kt
+++ b/app/src/org/commcare/utils/OtpAnalyticsMapper.kt
@@ -19,14 +19,14 @@ object OtpAnalyticsMapper {
      * so unexpected SMS methods stay visible in BI.
      */
     @JvmStatic
-    fun methodFromSmsMethod(smsMethod: String?): String? =
+    fun methodFromSmsMethod(otpMethod: String?): String? =
         when {
-            smsMethod == null -> AnalyticsParamValue.OTP_METHOD_FIREBASE
-            smsMethod.equals(OtpManager.SMS_METHOD_PERSONAL_ID, ignoreCase = true) ->
+            otpMethod == null -> AnalyticsParamValue.OTP_METHOD_FIREBASE
+            otpMethod.equals(OtpManager.SMS_METHOD_PERSONAL_ID, ignoreCase = true) ->
                 AnalyticsParamValue.OTP_METHOD_PERSONAL_ID
-            smsMethod.equals(OtpManager.SMS_METHOD_FIREBASE, ignoreCase = true) ->
+            otpMethod.equals(OtpManager.SMS_METHOD_FIREBASE, ignoreCase = true) ->
                 AnalyticsParamValue.OTP_METHOD_FIREBASE
-            else -> "UNKNOWN-$smsMethod"
+            else -> "UNKNOWN-$otpMethod"
         }
 
     /**

--- a/app/unit-tests/src/org/commcare/utils/OtpAnalyticsMapperTest.kt
+++ b/app/unit-tests/src/org/commcare/utils/OtpAnalyticsMapperTest.kt
@@ -1,0 +1,157 @@
+package org.commcare.utils
+
+import org.commcare.connect.network.base.BaseApiHandler.PersonalIdOrConnectApiErrorCodes
+import org.commcare.google.services.analytics.AnalyticsParamValue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OtpAnalyticsMapperTest {
+    // --- methodFromSmsMethod ---
+
+    @Test
+    fun `methodFromSmsMethod returns firebase for SMS_METHOD_FIREBASE`() {
+        assertEquals(
+            AnalyticsParamValue.OTP_METHOD_FIREBASE,
+            OtpAnalyticsMapper.methodFromSmsMethod(OtpManager.SMS_METHOD_FIREBASE),
+        )
+    }
+
+    @Test
+    fun `methodFromSmsMethod returns personal_id for SMS_METHOD_PERSONAL_ID`() {
+        assertEquals(
+            AnalyticsParamValue.OTP_METHOD_PERSONAL_ID,
+            OtpAnalyticsMapper.methodFromSmsMethod(OtpManager.SMS_METHOD_PERSONAL_ID),
+        )
+    }
+
+    @Test
+    fun `methodFromSmsMethod ignores case`() {
+        assertEquals(
+            AnalyticsParamValue.OTP_METHOD_PERSONAL_ID,
+            OtpAnalyticsMapper.methodFromSmsMethod("Personal_ID"),
+        )
+        assertEquals(
+            AnalyticsParamValue.OTP_METHOD_FIREBASE,
+            OtpAnalyticsMapper.methodFromSmsMethod("FIREBASE"),
+        )
+    }
+
+    @Test
+    fun `methodFromSmsMethod defaults to firebase when null`() {
+        assertEquals(
+            AnalyticsParamValue.OTP_METHOD_FIREBASE,
+            OtpAnalyticsMapper.methodFromSmsMethod(null),
+        )
+    }
+
+    @Test
+    fun `methodFromSmsMethod defaults to firebase when unrecognized`() {
+        assertEquals(
+            AnalyticsParamValue.OTP_METHOD_FIREBASE,
+            OtpAnalyticsMapper.methodFromSmsMethod("twilio"),
+        )
+    }
+
+    // --- reasonFrom(OtpErrorType) ---
+
+    @Test
+    fun `reasonFrom OtpErrorType maps INVALID_CREDENTIAL`() {
+        assertEquals(
+            "invalid_credential",
+            OtpAnalyticsMapper.reasonFrom(OtpErrorType.INVALID_CREDENTIAL),
+        )
+    }
+
+    @Test
+    fun `reasonFrom OtpErrorType maps TOO_MANY_REQUESTS`() {
+        assertEquals(
+            "too_many_requests",
+            OtpAnalyticsMapper.reasonFrom(OtpErrorType.TOO_MANY_REQUESTS),
+        )
+    }
+
+    @Test
+    fun `reasonFrom OtpErrorType maps MISSING_ACTIVITY`() {
+        assertEquals(
+            "missing_activity",
+            OtpAnalyticsMapper.reasonFrom(OtpErrorType.MISSING_ACTIVITY),
+        )
+    }
+
+    @Test
+    fun `reasonFrom OtpErrorType maps GENERIC_ERROR`() {
+        assertEquals(
+            "generic_error",
+            OtpAnalyticsMapper.reasonFrom(OtpErrorType.GENERIC_ERROR),
+        )
+    }
+
+    @Test
+    fun `reasonFrom OtpErrorType maps VERIFICATION_FAILED`() {
+        assertEquals(
+            "verification_failed",
+            OtpAnalyticsMapper.reasonFrom(OtpErrorType.VERIFICATION_FAILED),
+        )
+    }
+
+    @Test
+    fun `reasonFrom OtpErrorType returns null for null input`() {
+        assertNull(OtpAnalyticsMapper.reasonFrom(null as OtpErrorType?))
+    }
+
+    // --- reasonFrom(PersonalIdOrConnectApiErrorCodes) ---
+
+    @Test
+    fun `reasonFrom api code maps INCORRECT_OTP_ERROR`() {
+        assertEquals(
+            "incorrect_otp_error",
+            OtpAnalyticsMapper.reasonFrom(PersonalIdOrConnectApiErrorCodes.INCORRECT_OTP_ERROR),
+        )
+    }
+
+    @Test
+    fun `reasonFrom api code maps NETWORK_ERROR`() {
+        assertEquals(
+            "network_error",
+            OtpAnalyticsMapper.reasonFrom(PersonalIdOrConnectApiErrorCodes.NETWORK_ERROR),
+        )
+    }
+
+    @Test
+    fun `reasonFrom api code maps RATE_LIMIT_EXCEEDED_ERROR`() {
+        assertEquals(
+            "rate_limit_exceeded_error",
+            OtpAnalyticsMapper.reasonFrom(PersonalIdOrConnectApiErrorCodes.RATE_LIMIT_EXCEEDED_ERROR),
+        )
+    }
+
+    @Test
+    fun `reasonFrom api code maps FORBIDDEN_ERROR`() {
+        assertEquals(
+            "forbidden_error",
+            OtpAnalyticsMapper.reasonFrom(PersonalIdOrConnectApiErrorCodes.FORBIDDEN_ERROR),
+        )
+    }
+
+    @Test
+    fun `reasonFrom api code maps UNKNOWN_ERROR`() {
+        assertEquals(
+            "unknown_error",
+            OtpAnalyticsMapper.reasonFrom(PersonalIdOrConnectApiErrorCodes.UNKNOWN_ERROR),
+        )
+    }
+
+    @Test
+    fun `reasonFrom api code maps FAILED_AUTH_ERROR`() {
+        assertEquals(
+            "failed_auth_error",
+            OtpAnalyticsMapper.reasonFrom(PersonalIdOrConnectApiErrorCodes.FAILED_AUTH_ERROR),
+        )
+    }
+
+    @Test
+    fun `reasonFrom api code returns null for null input`() {
+        assertNull(OtpAnalyticsMapper.reasonFrom(null as PersonalIdOrConnectApiErrorCodes?))
+    }
+}

--- a/app/unit-tests/src/org/commcare/utils/OtpAnalyticsMapperTest.kt
+++ b/app/unit-tests/src/org/commcare/utils/OtpAnalyticsMapperTest.kt
@@ -46,9 +46,9 @@ class OtpAnalyticsMapperTest {
     }
 
     @Test
-    fun `methodFromSmsMethod defaults to firebase when unrecognized`() {
+    fun `methodFromSmsMethod prefixes UNKNOWN for unrecognized values`() {
         assertEquals(
-            AnalyticsParamValue.OTP_METHOD_FIREBASE,
+            "UNKNOWN-twilio",
             OtpAnalyticsMapper.methodFromSmsMethod("twilio"),
         )
     }
@@ -153,5 +153,28 @@ class OtpAnalyticsMapperTest {
     @Test
     fun `reasonFrom api code returns null for null input`() {
         assertNull(OtpAnalyticsMapper.reasonFrom(null as PersonalIdOrConnectApiErrorCodes?))
+    }
+
+    // --- getEventType ---
+
+    @Test
+    fun `getEventType returns request for REQUEST`() {
+        assertEquals(
+            AnalyticsParamValue.OTP_EVENT_TYPE_REQUEST,
+            OtpAnalyticsMapper.getEventType(OtpAnalyticsMapper.OtpOp.REQUEST),
+        )
+    }
+
+    @Test
+    fun `getEventType returns verify for VERIFY`() {
+        assertEquals(
+            AnalyticsParamValue.OTP_EVENT_TYPE_VERIFY,
+            OtpAnalyticsMapper.getEventType(OtpAnalyticsMapper.OtpOp.VERIFY),
+        )
+    }
+
+    @Test
+    fun `getEventType returns null for null input`() {
+        assertNull(OtpAnalyticsMapper.getEventType(null))
     }
 }


### PR DESCRIPTION
### [CCCT-2052](https://dimagi.atlassian.net/browse/CCCT-2052)

## Technical Summary

Extends the existing `otp_requested` Firebase Analytics event with four new
parameters — `event_type`, `outcome`, `method`, and `reason` — so OTP
success/failure rates can be broken down by request vs verify and by Firebase
vs PersonalID. The Firebase event name and the existing `value` (attempts)
parameter are preserved for dashboard backwards compatibility.

Key changes:

- `AnalyticsParamValue.java` — adds `OTP_EVENT_TYPE_REQUEST/VERIFY`,
  `OTP_OUTCOME_SUCCESS/FAILURE`, `OTP_METHOD_FIREBASE/PERSONAL_ID` value
  constants.
- `CCAnalyticsParam.java` — adds `OTP_EVENT_TYPE`, `OTP_OUTCOME`, `OTP_METHOD`
  param-key constants. Widens the existing `REASON` constant from
  package-private to `public` so it can be referenced from the fragment.
- `FirebaseAnalyticsUtil.java` — replaces `reportOtpRequested(int)` with
  `reportOtpEvent(eventType, outcome, method, reason, attempts)`. Null
  `reason` is omitted from the bundle (Firebase rejects null string params).
- `OtpAnalyticsMapper.kt` (new) — normalizes the `OtpManager` SMS-method
  string (`firebase` / `personal_id`, case-insensitive, defaults to
  `firebase`) and the `OtpErrorType` / `PersonalIdOrConnectApiErrorCodes`
  enums into stable lowercase analytics strings (e.g. `INVALID_CREDENTIAL` →
  `invalid_credential`).
- `PersonalIdPhoneVerificationFragment.java` — adds an `OtpOp { REQUEST,
  VERIFY }` enum + `currentOtpOp` field, set immediately before each kick-off,
  so the next `OtpVerificationCallback` terminal can attribute itself
  correctly. Emission moves out of the kick-off (`requestOtp`) and into the
  four terminals (`onCodeSent`, `onSuccess`, `onFailure`,
  `onPersonalIdApiFailure`). The Firebase auto-verify `onCodeVerified` path is
  intentionally silent — the server-confirmed `onSuccess` is the authoritative
  verify-success terminal, and emitting on both would double-count.

Design rationale: the helper uses `lastOtpMethod` (the active manager's
method) rather than `personalIdSessionData.getSmsMethod()` (the server-
assigned value), because `setupOtpManager` may fall back or auto-switch
between Firebase and PersonalID independently of the server-assigned value.
In the auto-switch path inside `onFailure`, the original-method failure is
emitted before `setupOtpManager(true)` flips `lastOtpMethod`, and the
follow-up request emits its own event under the new method.

## Safety Assurance

### Safety story

The change is additive and back-compat-preserving from a Firebase Analytics
perspective:

- The event NAME (`otp_requested`) is unchanged. Existing dashboards keyed on
  the event name continue to fire.
- The existing `value` parameter (attempts count) is still emitted with the
  same semantics. Dashboards keyed only on `value` continue to work.
- New breakdowns become available via the four added params; consumers must
  opt in.

The four new fragment callback emissions all early-return when `otpCallback`
is null (cleared in `onDestroyView`), preventing post-destroy NPEs from
late-arriving callbacks. The mapper defaults to `firebase` for null/unknown
method strings so events always carry a method value.

### Automated test coverage

`OtpAnalyticsMapperTest.kt` covers the mapper with 18 JUnit 4 tests across
`methodFromSmsMethod`, `reasonFrom(OtpErrorType)`, and
`reasonFrom(PersonalIdOrConnectApiErrorCodes)` — including null inputs,
case-insensitivity, and the unrecognized-method fallback. The fragment-level
emission wiring is not covered by an automated test (no test exists for this
fragment today); regression coverage relies on manual verification.

[CCCT-2052]: https://dimagi.atlassian.net/browse/CCCT-2052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ