### PR TITLE
Code Coverage Report in PRs

### DIFF
--- a/.github/workflows/commcare-android-pr-workflow.yml
+++ b/.github/workflows/commcare-android-pr-workflow.yml
@@ -89,6 +89,22 @@ jobs:
       - name: Run Tests
         run: ./gradlew testCommcareDebug
         working-directory: commcare-android
+      - name: Generate JaCoCo Report
+        run: ./gradlew jacocoTestReport
+        working-directory: commcare-android
+      - name: Upload JaCoCo Report
+        uses: actions/upload-artifact@v6
+        with:
+          name: jacoco-report
+          path: commcare-android/app/build/reports/jacoco
+      - name: Comment JaCoCo Coverage on PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: commcare-android/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Code Coverage
+          update-comment: true
       - name: Restore Keystore
         run: echo "$SIGNING_KEY" | base64 -d > ~/.gradle/commcare-odk-keys.keystore
         env:
@@ -155,14 +171,6 @@ jobs:
         with:
           name: commcare-release-androidTest-apk
           path: commcare-android/app/build/outputs/apk/androidTest/commcare/release/app-commcare-release-androidTest.apk.enc
-      - name: Generate JaCoCo Report
-        run: ./gradlew JacocoTestReport
-        working-directory: commcare-android
-      - name: Upload JaCoCo Report
-        uses: actions/upload-artifact@v6
-        with:
-          name: jacoco-report
-          path: commcare-android/app/build/reports
       - name: Report status to commcare-core
         if: ${{ always() && inputs.commcare_core_check_name && inputs.commcare_core_sha }}
         uses: actions/github-script@v7

--- a/.github/workflows/commcare-android-pr-workflow.yml
+++ b/.github/workflows/commcare-android-pr-workflow.yml
@@ -23,6 +23,9 @@ jobs:
   build-test-assemble:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout commcare-android
         uses: actions/checkout@v6
@@ -90,16 +93,19 @@ jobs:
         run: ./gradlew testCommcareDebug
         working-directory: commcare-android
       - name: Generate JaCoCo Report
+        continue-on-error: true
         run: ./gradlew jacocoTestReport
         working-directory: commcare-android
       - name: Upload JaCoCo Report
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: jacoco-report
           path: commcare-android/app/build/reports/jacoco
       - name: Comment JaCoCo Coverage on PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: madrapps/jacoco-report@v1.7.1
+        continue-on-error: true
+        uses: madrapps/jacoco-report@v1.7.2
         with:
           paths: commcare-android/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-2305

## Product Description
No user-facing change

## Technical Summary
Moved the jacoco code coverage report earlier in the build process (so we're more likely to get the report even if a later step fails).
Configured the coverage report to post as a comment on the PR.

## Safety Assurance

### Safety story
These changes do not affect the actual app that gets built, they are just a reporting metric during the build.

### Automated test coverage
None

### QA Plan
None
