### PR TITLE
QA-8496 Fix False 'Job Ended' Display For Active Jobs

### DIFF
--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -181,7 +181,6 @@ public class ConnectJobRecord extends Persisted implements Serializable {
     private ConnectAppRecord learnAppInfo;
     private ConnectAppRecord deliveryAppInfo;
     private List<ConnectPaymentUnitRecord> paymentUnits;
-    static Date startDate = new Date();
 
     private boolean claimed;
 
@@ -212,9 +211,6 @@ public class ConnectJobRecord extends Persisted implements Serializable {
         job.organization = json.getString(META_ORGANIZATION);
         job.projectEndDate = DateUtils.parseDate(json.getString(META_END_DATE));
         job.projectStartDate = DateUtils.parseDate(json.getString(META_START_DATE));
-        if (job.projectStartDate != null && job.projectStartDate.after(startDate)) {
-            startDate = job.projectStartDate;
-        }
         job.maxVisits = json.getInt(META_MAX_VISITS_PER_USER);
         job.maxDailyVisits = json.getInt(META_MAX_DAILY_VISITS);
         job.budgetPerVisit = json.getInt(META_BUDGET_PER_VISIT);
@@ -488,7 +484,7 @@ public class ConnectJobRecord extends Persisted implements Serializable {
     }
 
     public int getDaysRemaining() {
-        long millis = projectEndDate.getTime() - (startDate).getTime();
+        long millis = projectEndDate.getTime() - new Date().getTime();
         //End date has 00:00 time, but project is valid until midnight
         //So add just under one day to the difference
         millis += 86399999; //one ms less than 24 hours
@@ -867,14 +863,6 @@ public class ConnectJobRecord extends Persisted implements Serializable {
 
     public void setJobUUID(String modelId) {
         this.jobUUID = modelId;
-    }
-
-    public static Date getStartDate() {
-        return startDate;
-    }
-
-    public static void setStartDate(Date startDate) {
-        ConnectJobRecord.startDate = startDate;
     }
 
     public boolean isClaimed() {


### PR DESCRIPTION
### [QA-8496](https://dimagi.atlassian.net/browse/QA-8496)

## Product Description

Active Connect jobs no longer falsely display *"The job has ended"* or *"Task ended on [future date]"* when the user has another job assigned whose start date is later than the active job's end date. Affected jobs previously showed the warning on the StandardHomeActivity tile, in the ConnectLearningProgressFragment, and were grouped under "Completed" in the jobs list, even though the server still had them active and their end date was in the future.

## Technical Summary

`ConnectJobRecord` had a process-static `startDate` field (initialized to `new Date()` at class load) that was mutated as a side-effect of `fromJson(...)` whenever a parsed job's `projectStartDate` was later than the current value. `getDaysRemaining()` used this static as the "today" baseline rather than the actual current time. Once a single future-start job flowed through `fromJson` during a sync, the static was advanced past every other job's `projectEndDate`, so `getDaysRemaining()` returned `0` for those jobs, `isFinished()` returned `true`, and the home screen + learning progress fragment both rendered the "job ended" UI — paradoxically alongside a `Task ended on …` date that was clearly in the future.

The fix:

- `getDaysRemaining()` now compares `projectEndDate` against `new Date()` directly.
- The `fromJson` side-effect that mutated the static is removed (parsing should not have time-dependent side-effects).
- The static field and its unused `getStartDate` / `setStartDate` accessors are removed. Verified across `commcare-android` and `commcare-core` that nothing outside this class referenced them.

This also explains why the bug was inconsistent across devices and intermittent across sessions: the static lived only in process memory, was reset by every process kill, and only got polluted on processes that happened to parse a future-start job during their lifetime.

## Safety Assurance

### Safety story

- I reproduced the bug locally by creating a job whose start date was far into the future (past the end date of other jobs assigned to my user) — that made the other jobs incorrectly appear under the "Completed" section in the jobs list and show the "job ended" message on the CC app home screen. With this change, the bug no longer reproduces.
- I also did a quick smoke test of the app and did not notice any unusual behavior.
- The change is contained to date-math inside a single model class. No persisted state is involved (the buggy field was an in-memory static), so existing job records on disk are unaffected and no migration is needed.

### Automated test coverage

No new automated tests were added in this PR. The bug lived in a date comparison whose previous implementation depended on a process-wide static; covering it with a unit test would require injecting a clock or restructuring more surface than is appropriate to bundle into this fix. Worth a follow-up to add a clock abstraction and a unit test for `getDaysRemaining()` / `isFinished()`.

### QA Plan

- Repro / verification: Assign a test user two jobs — Job A with a start date in the past and an end date in the near future, Job B with a start date far in the future (past Job A's end date). Force-stop CommCare on the device, log in, sync. Without this fix: Job A is shown under "Completed", `Task ended on [Job A's future end date]` appears on the home screen tile, and `The job has ended. You will not earn any progress for additional work.` appears on both the home screen card and ConnectLearningProgressFragment. With this fix: Job A renders normally with `Complete by [end date]` and no warning, and stays in the active jobs section.
- Regression check: Verify users with no future-start jobs see no behavior change on home / learn screens.
- QA ticket: [QA-8496](https://dimagi.atlassian.net/browse/QA-8496)

[QA-8496]: https://dimagi.atlassian.net/browse/QA-8496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-8496]: https://dimagi.atlassian.net/browse/QA-8496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ