### PR TITLE
Updated jacoco paths to find java and kotlin classes

### DIFF
--- a/app/jacoco.gradle
+++ b/app/jacoco.gradle
@@ -23,8 +23,13 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testCommcareDebugUnitTest
                       '**/*Test*.*',
                       'android/**/*.*',
                       '**/data/models/*']
-    def classes = fileTree(dir: "${project.buildDir}/intermediates/javac/commcareDebug/classes/", excludes: fileFilter)
-    getClassDirectories().setFrom(files([classes]))
+    def javaClasses = fileTree(
+            dir: "${project.buildDir}/intermediates/javac/commcareDebug/compileCommcareDebugJavaWithJavac/classes/",
+            excludes: fileFilter)
+    def kotlinClasses = fileTree(
+            dir: "${project.buildDir}/tmp/kotlin-classes/commcareDebug/",
+            excludes: fileFilter)
+    getClassDirectories().setFrom(files([javaClasses, kotlinClasses]))
 
     def sourceFiles = "${project.projectDir}/src/org/commcare"
     getSourceDirectories().setFrom(files([sourceFiles]))


### PR DESCRIPTION
Quick change: Fixing the configured location for jacoco to look for java and kotlin classes. This changed with AGP 8.