### PR TITLE
CCCT-2078 Extract Personal ID Unlock Logic Into PersonalIdUnlocker

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -58,6 +58,15 @@ we would like to communicate to QA as part of the release testing
   - In order to achieve this functionality, DB migrations are done to accommodate the new email address field. QA should start testing with the previous version of the app, having PersonalID login already, and then upgrade to this new version. The app should work without crashing.
   - QA should also test with a fresh installation of this new version, going through PersonalID signup/recovery.
 
+
+- Verify that biometric/PIN unlock still triggers correctly in all existing entry points:
+  - Login screen auto-unlock (`LoginActivity`)
+  - Connect messaging notification tap (`ConnectMessagingActivity`)
+  - Connect nav helper flows (`ConnectNavHelper`)
+  - Connect unlock fragment (`ConnectUnlockFragment`)
+  - App-linking dialogs (`PersonalIdManager`)
+
+
 ## CommCare 2.63
 
 ### Release Notes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -59,12 +59,7 @@ we would like to communicate to QA as part of the release testing
   - QA should also test with a fresh installation of this new version, going through PersonalID signup/recovery.
 
 
-- Verify that biometric/PIN unlock still triggers correctly in all existing entry points:
-  - Login screen auto-unlock (`LoginActivity`)
-  - Connect messaging notification tap (`ConnectMessagingActivity`)
-  - Connect nav helper flows (`ConnectNavHelper`)
-  - Connect unlock fragment (`ConnectUnlockFragment`)
-  - App-linking dialogs (`PersonalIdManager`)
+- Verify that biometric/PIN unlock still triggers correctly in all existing entry points
 
 
 ## CommCare 2.63

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -40,6 +40,7 @@ import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.perf.FirebasePerformance;
 
 import org.commcare.activities.LoginActivity;
+import org.commcare.personalId.PersonalIdUnlocker;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
 import org.commcare.android.database.global.models.ApplicationRecord;
@@ -219,6 +220,7 @@ public class CommCareApplication extends Application implements LifecycleEventOb
     @Override
     public void onCreate() {
         super.onCreate();
+        PersonalIdUnlocker.INSTANCE.resetSession();
 
         ConnectSyncPreferences.Companion.getInstance(this).markSessionStart();
 

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -26,6 +26,8 @@ import org.commcare.connect.ConnectConstants;
 import org.commcare.connect.ConnectJobHelper;
 import org.commcare.connect.ConnectNavHelper;
 import org.commcare.connect.PersonalIdManager;
+import org.commcare.personalId.PersonalIdUnlocker;
+import org.commcare.personalId.UnlockPolicy;
 import org.commcare.connect.database.ConnectJobUtils;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
@@ -238,7 +240,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
             doLogin(loginMode, restoreSession, "AUTO");
         } else if (loginManagedByPersonalId()) {
             //Unlock and then auto login
-            personalIdManager.unlockConnect(this, success -> {
+            PersonalIdUnlocker.INSTANCE.unlock(this, UnlockPolicy.ALWAYS, success -> {
                 if (success) {
                     String username = uiController.getEnteredUsername();
                     String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();

--- a/app/src/org/commcare/activities/connect/ConnectMessagingActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectMessagingActivity.java
@@ -14,6 +14,8 @@ import org.commcare.android.database.connect.models.ConnectMessagingChannelRecor
 import org.commcare.android.database.connect.models.ConnectMessagingMessageRecord;
 import org.commcare.connect.MessageManager;
 import org.commcare.connect.PersonalIdManager;
+import org.commcare.personalId.PersonalIdUnlocker;
+import org.commcare.personalId.UnlockPolicy;
 import org.commcare.connect.database.ConnectMessagingDatabaseHelper;
 import org.commcare.connect.database.NotificationRecordDatabaseHelper;
 import org.commcare.dalvik.R;
@@ -133,7 +135,7 @@ public class ConnectMessagingActivity extends NavigationHostCommCareActivity<Con
                     getNotificationActionFromIntent(getIntent()),
                     getIntent().getStringExtra(NOTIFICATION_ID)
             );
-            PersonalIdManager.getInstance().unlockConnect(this, success -> {
+            PersonalIdUnlocker.INSTANCE.unlock(this, UnlockPolicy.ALWAYS, success -> {
                 if (success) {
                     String channelId = getIntent().getStringExtra(
                             ConnectMessagingMessageRecord.META_MESSAGE_CHANNEL_ID);

--- a/app/src/org/commcare/connect/ConnectNavHelper.kt
+++ b/app/src/org/commcare/connect/ConnectNavHelper.kt
@@ -21,7 +21,6 @@ object ConnectNavHelper {
         listener: ConnectActivityCompleteListener,
         navigationAction: (Context) -> Unit,
     ) {
-        PersonalIdManager.getInstance().init(activity)
         PersonalIdUnlocker.unlock(activity, UnlockPolicy.ALWAYS) { success ->
             if (success) {
                 navigationAction(activity)

--- a/app/src/org/commcare/connect/ConnectNavHelper.kt
+++ b/app/src/org/commcare/connect/ConnectNavHelper.kt
@@ -12,6 +12,8 @@ import org.commcare.connect.ConnectConstants.GO_TO_JOB_STATUS
 import org.commcare.connect.ConnectConstants.OPPORTUNITY_UUID
 import org.commcare.connect.ConnectConstants.SHOW_LAUNCH_BUTTON
 import org.commcare.connect.database.ConnectUserDatabaseUtil
+import org.commcare.personalId.PersonalIdUnlocker
+import org.commcare.personalId.UnlockPolicy
 
 object ConnectNavHelper {
     private fun unlockAndGoTo(
@@ -19,11 +21,8 @@ object ConnectNavHelper {
         listener: ConnectActivityCompleteListener,
         navigationAction: (Context) -> Unit,
     ) {
-        val personalIdManager: PersonalIdManager = PersonalIdManager.getInstance()
-        personalIdManager.init(activity)
-        personalIdManager.unlockConnect(
-            activity,
-        ) { success: Boolean ->
+        PersonalIdManager.getInstance().init(activity)
+        PersonalIdUnlocker.unlock(activity, UnlockPolicy.ALWAYS) { success ->
             if (success) {
                 navigationAction(activity)
             }

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -7,6 +7,7 @@ import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
 import org.commcare.personalId.PersonalIdUnlocker;
+import org.commcare.personalId.UnlockPolicy;
 import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.connect.PersonalIdActivity;
 import org.commcare.android.database.connect.models.ConnectAppRecord;
@@ -369,7 +370,7 @@ public class PersonalIdManager {
 
     private void unlockAndLinkConnect(CommCareActivity<?> activity, ConnectLinkedAppRecord linkedApp,
                                       String username, String password, ConnectActivityCompleteListener callback) {
-        unlockConnect(activity, success -> {
+        PersonalIdUnlocker.INSTANCE.unlock(activity, UnlockPolicy.ALWAYS, success -> {
             if (!success) {
                 callback.connectActivityComplete(false);
                 FirebaseAnalyticsUtil.reportPersonalIDLinking(linkedApp.getAppId(), FAILURE_UNLOCK_FAILED);
@@ -414,7 +415,7 @@ public class PersonalIdManager {
 
         dialog.setPositiveButton(activity.getString(R.string.personalid_link_app_yes), (d, w) -> {
             activity.dismissAlertDialog();
-            unlockConnect(activity, success -> {
+            PersonalIdUnlocker.INSTANCE.unlock(activity, UnlockPolicy.ALWAYS, success -> {
                 if (success) {
                     ConnectLinkedAppRecord linkedApp = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(activity,
                             appId, username);

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
+import org.commcare.personalId.PersonalIdUnlocker;
 import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.connect.PersonalIdActivity;
 import org.commcare.android.database.connect.models.ConnectAppRecord;
@@ -241,6 +242,7 @@ public class PersonalIdManager {
         NotificationPrefs.INSTANCE.removeNotificationReadPref(CommCareApplication.instance());
 
         ConnectReleaseTogglesWorker.Companion.cancelPeriodicFetch(CommCareApplication.instance());
+        PersonalIdUnlocker.INSTANCE.resetSession();
     }
 
     public AuthInfo.TokenAuth getConnectToken() {

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -3,7 +3,6 @@ package org.commcare.connect;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.widget.Toast;
 
 import org.commcare.CommCareApplication;
 import org.commcare.personalId.PersonalIdUnlocker;
@@ -13,8 +12,6 @@ import org.commcare.activities.connect.PersonalIdActivity;
 import org.commcare.android.database.connect.models.ConnectAppRecord;
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
-import org.commcare.android.database.connect.models.PersonalIdSessionData;
-import org.commcare.android.security.AndroidKeyStore;
 import org.commcare.connect.database.ConnectAppDatabaseUtil;
 import org.commcare.connect.database.ConnectDatabaseHelper;
 import org.commcare.connect.database.ConnectJobUtils;
@@ -32,9 +29,7 @@ import org.commcare.navdrawer.BaseDrawerActivity;
 import org.commcare.pn.workermanager.NotificationsSyncWorkerManager;
 import org.commcare.preferences.NotificationPrefs;
 import org.commcare.util.LogTypes;
-import org.commcare.utils.BiometricsHelper;
 import org.commcare.utils.CrashUtil;
-import org.commcare.utils.EncryptionKeyProvider;
 import org.commcare.utils.GlobalErrorUtil;
 import org.commcare.utils.GlobalErrors;
 import org.commcare.views.dialogs.StandardAlertDialog;
@@ -47,7 +42,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.biometric.BiometricManager;
-import androidx.biometric.BiometricPrompt;
 import androidx.fragment.app.FragmentActivity;
 import androidx.work.BackoffPolicy;
 import androidx.work.Constraints;
@@ -146,66 +140,6 @@ public class PersonalIdManager {
     public boolean isloggedIn() {
         return personalIdSatus == PersonalIdStatus.LoggedIn;
     }
-
-    public void unlockConnect(CommCareActivity<?> activity, ConnectActivityCompleteListener callback) {
-        if (BuildConfig.IS_QA_AUTOMATION) {
-            userUnlockedPersonalId();
-            callback.connectActivityComplete(true);
-            return;
-        }
-        logBiometricInvalidations();
-
-        BiometricPrompt.AuthenticationCallback callbacks = new BiometricPrompt.AuthenticationCallback() {
-            @Override
-            public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
-                callback.connectActivityComplete(false);
-            }
-
-            @Override
-            public void onAuthenticationSucceeded(@NonNull BiometricPrompt.AuthenticationResult result) {
-                userUnlockedPersonalId();
-                callback.connectActivityComplete(true);
-            }
-
-            @Override
-            public void onAuthenticationFailed() {
-                callback.connectActivityComplete(false);
-            }
-        };
-
-
-        BiometricManager bioManager = getBiometricManager(activity);
-        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(activity);
-        if (BiometricsHelper.isFingerprintConfigured(activity, bioManager)) {
-            boolean allowOtherOptions = BiometricsHelper.isPinConfigured(activity, bioManager)
-                    && PersonalIdSessionData.PIN.equals(user.getRequiredLock());
-            BiometricsHelper.authenticateFingerprint(activity, bioManager, callbacks, allowOtherOptions);
-        } else if (BiometricsHelper.isPinConfigured(activity, bioManager) && PersonalIdSessionData.PIN.equals(
-                user.getRequiredLock())) {
-            BiometricsHelper.authenticatePin(activity, bioManager, callbacks);
-        } else {
-            callback.connectActivityComplete(false);
-            Logger.exception("No unlock method available when trying to unlock PersonalId",
-                    new Exception("No unlock option"));
-            Toast.makeText(activity, activity.getString(R.string.connect_unlock_unavailable),
-                    Toast.LENGTH_SHORT).show();
-        }
-    }
-
-    private void logBiometricInvalidations() {
-        if (AndroidKeyStore.INSTANCE.doesKeyExist(BIOMETRIC_INVALIDATION_KEY)) {
-            EncryptionKeyProvider encryptionKeyProvider = new EncryptionKeyProvider(parentActivity, true,
-                    BIOMETRIC_INVALIDATION_KEY);
-            if (!encryptionKeyProvider.isKeyValid()) {
-                FirebaseAnalyticsUtil.reportBiometricInvalidated();
-
-                // reset key
-                encryptionKeyProvider.deleteKey();
-                encryptionKeyProvider.getKeyForEncryption();
-            }
-        }
-    }
-
 
     public void completeSignin() {
         personalIdSatus = PersonalIdStatus.LoggedIn;

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -60,7 +60,6 @@ import static org.commcare.google.services.analytics.AnalyticsParamValue.SYNC_SU
  * @author dviggiano
  */
 public class PersonalIdManager {
-    public static final String BIOMETRIC_INVALIDATION_KEY = "biometric-invalidation-key";
     private static final long DAYS_TO_SECOND_OFFER = 30;
 
     /**

--- a/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
@@ -20,11 +20,12 @@ import org.commcare.activities.CommCareActivity;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
 import org.commcare.connect.ConnectConstants;
-import org.commcare.connect.PersonalIdManager;
 import org.commcare.connect.database.ConnectUserDatabaseUtil;
 import org.commcare.connect.network.connect.ConnectApiHandler;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.FragmentConnectUnlockBinding;
+import org.commcare.personalId.PersonalIdUnlocker;
+import org.commcare.personalId.UnlockPolicy;
 import org.javarosa.core.services.Logger;
 
 import java.util.List;
@@ -62,7 +63,7 @@ public class ConnectUnlockFragment extends Fragment {
     private final Runnable unlockRunnable = new Runnable() {
         @Override
         public void run() {
-            PersonalIdManager.getInstance().unlockConnect((CommCareActivity<?>) requireActivity(), success -> {
+            PersonalIdUnlocker.INSTANCE.unlock((CommCareActivity<?>) requireActivity(), UnlockPolicy.ALWAYS, success -> {
                 if (success) {
                     retrieveOpportunities();
                 } else {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBiometricConfigFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBiometricConfigFragment.java
@@ -2,7 +2,7 @@ package org.commcare.fragments.personalId;
 
 import static org.commcare.android.database.connect.models.PersonalIdSessionData.BIOMETRIC_TYPE;
 import static org.commcare.android.database.connect.models.PersonalIdSessionData.PIN;
-import static org.commcare.connect.PersonalIdManager.BIOMETRIC_INVALIDATION_KEY;
+import static org.commcare.personalId.PersonalIdUnlockerKt.BIOMETRIC_INVALIDATION_KEY;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.CONTINUE_WITH_FINGERPRINT;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.CONTINUE_WITH_PIN;
 import static org.commcare.utils.BiometricsHelper.isAnyBiometricConfigured;

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -16,8 +16,9 @@ import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.BiometricsHelper
 import org.commcare.utils.EncryptionKeyProvider
 import org.javarosa.core.services.Logger
+import kotlin.time.Duration.Companion.minutes
 
-private const val SESSION_UNLOCK_THRESHOLD_MS = 10 * 60 * 1000L // 10 minutes
+private val SESSION_UNLOCK_THRESHOLD_MS = 10.minutes.inWholeMilliseconds
 internal const val BIOMETRIC_INVALIDATION_KEY = "biometric-invalidation-key"
 
 /** Middleware to manage Personal ID unlock prompts with session-based bypass logic. */
@@ -58,16 +59,15 @@ object PersonalIdUnlocker {
         activity: CommCareActivity<*>,
         callback: PersonalIdManager.ConnectActivityCompleteListener,
     ) {
+        val personalIdManager = PersonalIdManager.getInstance()
         if (BuildConfig.IS_QA_AUTOMATION) {
             lastUnlockTime = SystemClock.elapsedRealtime()
-            PersonalIdManager.getInstance().userUnlockedPersonalId()
+            personalIdManager.userUnlockedPersonalId()
             callback.connectActivityComplete(true)
             return
         }
 
         logBiometricInvalidations(activity)
-
-        val personalIdManager = PersonalIdManager.getInstance()
         val bioManager = personalIdManager.getBiometricManager(activity)
         val user = ConnectUserDatabaseUtil.getUser(activity)
 
@@ -119,7 +119,7 @@ object PersonalIdUnlocker {
     private fun logBiometricInvalidations(activity: Context) {
         if (!AndroidKeyStore.doesKeyExist(BIOMETRIC_INVALIDATION_KEY)) return
         val provider = EncryptionKeyProvider(activity, true, BIOMETRIC_INVALIDATION_KEY)
-        if (!provider.isKeyValid()) {
+        if (!provider.isKeyValid) {
             FirebaseAnalyticsUtil.reportBiometricInvalidated()
             provider.deleteKey()
             provider.getKeyForEncryption()

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -6,6 +6,7 @@ import org.commcare.connect.PersonalIdManager
 
 private const val SESSION_UNLOCK_THRESHOLD_MS = 10 * 60 * 1000L // 10 minutes
 
+/** Middleware to manage Personal ID unlock prompts with session-based bypass logic. */
 object PersonalIdUnlocker {
     @VisibleForTesting
     internal var lastUnlockTime: Long? = null
@@ -40,7 +41,9 @@ object PersonalIdUnlocker {
         activity: CommCareActivity<*>,
         callback: PersonalIdManager.ConnectActivityCompleteListener,
     ) {
-        PersonalIdManager.getInstance().unlockConnect(activity) { success ->
+        val personalIdManager = PersonalIdManager.getInstance()
+        personalIdManager.init(activity)
+        personalIdManager.unlockConnect(activity) { success ->
             if (success) lastUnlockTime = System.currentTimeMillis()
             callback.connectActivityComplete(success)
         }

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -17,7 +17,6 @@ import org.commcare.utils.EncryptionKeyProvider
 import org.javarosa.core.services.Logger
 
 private const val SESSION_UNLOCK_THRESHOLD_MS = 10 * 60 * 1000L // 10 minutes
-private const val BIOMETRIC_INVALIDATION_KEY = "biometric-invalidation-key"
 
 /** Middleware to manage Personal ID unlock prompts with session-based bypass logic. */
 object PersonalIdUnlocker {
@@ -115,8 +114,8 @@ object PersonalIdUnlocker {
     }
 
     private fun logBiometricInvalidations(activity: Context) {
-        if (!AndroidKeyStore.doesKeyExist(BIOMETRIC_INVALIDATION_KEY)) return
-        val provider = EncryptionKeyProvider(activity, true, BIOMETRIC_INVALIDATION_KEY)
+        if (!AndroidKeyStore.doesKeyExist(PersonalIdManager.BIOMETRIC_INVALIDATION_KEY)) return
+        val provider = EncryptionKeyProvider(activity, true, PersonalIdManager.BIOMETRIC_INVALIDATION_KEY)
         if (!provider.isKeyValid()) {
             FirebaseAnalyticsUtil.reportBiometricInvalidated()
             provider.deleteKey()

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -17,6 +17,7 @@ import org.commcare.utils.EncryptionKeyProvider
 import org.javarosa.core.services.Logger
 
 private const val SESSION_UNLOCK_THRESHOLD_MS = 10 * 60 * 1000L // 10 minutes
+internal const val BIOMETRIC_INVALIDATION_KEY = "biometric-invalidation-key"
 
 /** Middleware to manage Personal ID unlock prompts with session-based bypass logic. */
 object PersonalIdUnlocker {
@@ -115,8 +116,8 @@ object PersonalIdUnlocker {
     }
 
     private fun logBiometricInvalidations(activity: Context) {
-        if (!AndroidKeyStore.doesKeyExist(PersonalIdManager.BIOMETRIC_INVALIDATION_KEY)) return
-        val provider = EncryptionKeyProvider(activity, true, PersonalIdManager.BIOMETRIC_INVALIDATION_KEY)
+        if (!AndroidKeyStore.doesKeyExist(BIOMETRIC_INVALIDATION_KEY)) return
+        val provider = EncryptionKeyProvider(activity, true, BIOMETRIC_INVALIDATION_KEY)
         if (!provider.isKeyValid()) {
             FirebaseAnalyticsUtil.reportBiometricInvalidated()
             provider.deleteKey()

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -60,6 +60,7 @@ object PersonalIdUnlocker {
         callback: PersonalIdManager.ConnectActivityCompleteListener,
     ) {
         val personalIdManager = PersonalIdManager.getInstance()
+        personalIdManager.init(activity)
         if (BuildConfig.IS_QA_AUTOMATION) {
             lastUnlockTime = SystemClock.elapsedRealtime()
             personalIdManager.userUnlockedPersonalId()

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -57,6 +57,7 @@ object PersonalIdUnlocker {
         callback: PersonalIdManager.ConnectActivityCompleteListener,
     ) {
         if (BuildConfig.IS_QA_AUTOMATION) {
+            lastUnlockTime = System.currentTimeMillis()
             PersonalIdManager.getInstance().userUnlockedPersonalId()
             callback.connectActivityComplete(true)
             return

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -1,6 +1,7 @@
 package org.commcare.personalId
 
 import android.content.Context
+import android.os.SystemClock
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
 import androidx.biometric.BiometricPrompt
@@ -58,7 +59,7 @@ object PersonalIdUnlocker {
         callback: PersonalIdManager.ConnectActivityCompleteListener,
     ) {
         if (BuildConfig.IS_QA_AUTOMATION) {
-            lastUnlockTime = System.currentTimeMillis()
+            lastUnlockTime = SystemClock.elapsedRealtime()
             PersonalIdManager.getInstance().userUnlockedPersonalId()
             callback.connectActivityComplete(true)
             return
@@ -78,7 +79,7 @@ object PersonalIdUnlocker {
                 ) = callback.connectActivityComplete(false)
 
                 override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-                    lastUnlockTime = System.currentTimeMillis()
+                    lastUnlockTime = SystemClock.elapsedRealtime()
                     personalIdManager.userUnlockedPersonalId()
                     callback.connectActivityComplete(true)
                 }
@@ -128,7 +129,7 @@ object PersonalIdUnlocker {
     @VisibleForTesting
     internal fun requiresUnlockForSession(): Boolean {
         val last = lastUnlockTime ?: return true
-        return System.currentTimeMillis() - last > SESSION_UNLOCK_THRESHOLD_MS
+        return SystemClock.elapsedRealtime() - last >= SESSION_UNLOCK_THRESHOLD_MS
     }
 
     /**

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -1,0 +1,73 @@
+package org.commcare.personalId
+
+import androidx.annotation.VisibleForTesting
+import org.commcare.activities.CommCareActivity
+import org.commcare.connect.PersonalIdManager
+
+private const val SESSION_UNLOCK_THRESHOLD_MS = 10 * 60 * 1000L // 10 minutes
+
+object PersonalIdUnlocker {
+    @VisibleForTesting
+    internal var lastUnlockTime: Long? = null
+
+    /**
+     * Attempts a Personal ID biometric/PIN unlock, applying [policy] to decide
+     * whether the prompt is actually shown. Always invokes [callback] with the result.
+     *
+     * [UnlockPolicy.ALWAYS] — always prompts (existing behaviour, no session bypass).
+     * [UnlockPolicy.SESSION_WITH_TIME_THRESHOLD] — skips prompt if unlocked within
+     *     the last 10 minutes; caller is responsible for first checking that the app
+     *     is Personal ID managed before calling this.
+     */
+    fun unlock(
+        activity: CommCareActivity<*>,
+        policy: UnlockPolicy,
+        callback: PersonalIdManager.ConnectActivityCompleteListener,
+    ) {
+        when (policy) {
+            UnlockPolicy.ALWAYS -> performUnlock(activity, callback)
+            UnlockPolicy.SESSION_WITH_TIME_THRESHOLD -> {
+                if (requiresUnlockForSession()) {
+                    performUnlock(activity, callback)
+                } else {
+                    callback.connectActivityComplete(true)
+                }
+            }
+        }
+    }
+
+    private fun performUnlock(
+        activity: CommCareActivity<*>,
+        callback: PersonalIdManager.ConnectActivityCompleteListener,
+    ) {
+        PersonalIdManager.getInstance().unlockConnect(activity) { success ->
+            if (success) lastUnlockTime = System.currentTimeMillis()
+            callback.connectActivityComplete(success)
+        }
+    }
+
+    @VisibleForTesting
+    internal fun requiresUnlockForSession(): Boolean {
+        val last = lastUnlockTime ?: return true
+        return System.currentTimeMillis() - last > SESSION_UNLOCK_THRESHOLD_MS
+    }
+
+    /**
+     * Resets session unlock state. Call on every app process start and on
+     * Personal ID logout so stale unlock timestamps are never inherited.
+     */
+    fun resetSession() {
+        lastUnlockTime = null
+    }
+}
+
+enum class UnlockPolicy {
+    /** Always prompts for biometric/PIN regardless of prior unlock in this session. */
+    ALWAYS,
+
+    /**
+     * Skips the prompt if the user unlocked within [SESSION_UNLOCK_THRESHOLD_MS].
+     * The caller must first verify the app is Personal ID managed before using this policy.
+     */
+    SESSION_WITH_TIME_THRESHOLD,
+}

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -1,10 +1,23 @@
 package org.commcare.personalId
 
+import android.content.Context
+import android.widget.Toast
 import androidx.annotation.VisibleForTesting
+import androidx.biometric.BiometricPrompt
 import org.commcare.activities.CommCareActivity
+import org.commcare.android.database.connect.models.PersonalIdSessionData
+import org.commcare.android.security.AndroidKeyStore
 import org.commcare.connect.PersonalIdManager
+import org.commcare.connect.database.ConnectUserDatabaseUtil
+import org.commcare.dalvik.BuildConfig
+import org.commcare.dalvik.R
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
+import org.commcare.utils.BiometricsHelper
+import org.commcare.utils.EncryptionKeyProvider
+import org.javarosa.core.services.Logger
 
 private const val SESSION_UNLOCK_THRESHOLD_MS = 10 * 60 * 1000L // 10 minutes
+private const val BIOMETRIC_INVALIDATION_KEY = "biometric-invalidation-key"
 
 /** Middleware to manage Personal ID unlock prompts with session-based bypass logic. */
 object PersonalIdUnlocker {
@@ -26,7 +39,10 @@ object PersonalIdUnlocker {
         callback: PersonalIdManager.ConnectActivityCompleteListener,
     ) {
         when (policy) {
-            UnlockPolicy.ALWAYS -> performUnlock(activity, callback)
+            UnlockPolicy.ALWAYS -> {
+                performUnlock(activity, callback)
+            }
+
             UnlockPolicy.SESSION_WITH_TIME_THRESHOLD -> {
                 if (requiresUnlockForSession()) {
                     performUnlock(activity, callback)
@@ -41,11 +57,70 @@ object PersonalIdUnlocker {
         activity: CommCareActivity<*>,
         callback: PersonalIdManager.ConnectActivityCompleteListener,
     ) {
+        if (BuildConfig.IS_QA_AUTOMATION) {
+            PersonalIdManager.getInstance().userUnlockedPersonalId()
+            callback.connectActivityComplete(true)
+            return
+        }
+
+        logBiometricInvalidations(activity)
+
         val personalIdManager = PersonalIdManager.getInstance()
-        personalIdManager.init(activity)
-        personalIdManager.unlockConnect(activity) { success ->
-            if (success) lastUnlockTime = System.currentTimeMillis()
-            callback.connectActivityComplete(success)
+        val bioManager = personalIdManager.getBiometricManager(activity)
+        val user = ConnectUserDatabaseUtil.getUser(activity)
+
+        val callbacks =
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationError(
+                    errorCode: Int,
+                    errString: CharSequence,
+                ) = callback.connectActivityComplete(false)
+
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    lastUnlockTime = System.currentTimeMillis()
+                    personalIdManager.userUnlockedPersonalId()
+                    callback.connectActivityComplete(true)
+                }
+
+                override fun onAuthenticationFailed() = callback.connectActivityComplete(false)
+            }
+
+        when {
+            BiometricsHelper.isFingerprintConfigured(activity, bioManager) -> {
+                val allowOtherOptions =
+                    BiometricsHelper.isPinConfigured(activity, bioManager) &&
+                        PersonalIdSessionData.PIN == user.requiredLock
+                BiometricsHelper.authenticateFingerprint(activity, bioManager, callbacks, allowOtherOptions)
+            }
+
+            BiometricsHelper.isPinConfigured(activity, bioManager) &&
+                PersonalIdSessionData.PIN == user.requiredLock -> {
+                BiometricsHelper.authenticatePin(activity, bioManager, callbacks)
+            }
+
+            else -> {
+                callback.connectActivityComplete(false)
+                Logger.exception(
+                    "No unlock method available when trying to unlock PersonalId",
+                    Exception("No unlock option"),
+                )
+                Toast
+                    .makeText(
+                        activity,
+                        activity.getString(R.string.connect_unlock_unavailable),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+            }
+        }
+    }
+
+    private fun logBiometricInvalidations(activity: Context) {
+        if (!AndroidKeyStore.doesKeyExist(BIOMETRIC_INVALIDATION_KEY)) return
+        val provider = EncryptionKeyProvider(activity, true, BIOMETRIC_INVALIDATION_KEY)
+        if (!provider.isKeyValid()) {
+            FirebaseAnalyticsUtil.reportBiometricInvalidated()
+            provider.deleteKey()
+            provider.getKeyForEncryption()
         }
     }
 

--- a/app/unit-tests/src/org/commcare/personalId/PersonalIdUnlockerTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/PersonalIdUnlockerTest.kt
@@ -9,6 +9,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = CommCareTestApplication::class)
@@ -31,21 +33,21 @@ class PersonalIdUnlockerTest {
 
     @Test
     fun `SESSION_WITH_TIME_THRESHOLD requires unlock when last unlock at exactly the threshold`() {
-        val tenMinutesAgo = SystemClock.elapsedRealtime() - (10 * 60 * 1000L)
+        val tenMinutesAgo = SystemClock.elapsedRealtime() - 10.minutes.inWholeMilliseconds
         PersonalIdUnlocker.lastUnlockTime = tenMinutesAgo
         assertTrue(PersonalIdUnlocker.requiresUnlockForSession())
     }
 
     @Test
     fun `SESSION_WITH_TIME_THRESHOLD requires unlock when last unlock exceeded threshold`() {
-        val elevenMinutesAgo = SystemClock.elapsedRealtime() - (11 * 60 * 1000L)
+        val elevenMinutesAgo = SystemClock.elapsedRealtime() - 11.minutes.inWholeMilliseconds
         PersonalIdUnlocker.lastUnlockTime = elevenMinutesAgo
         assertTrue(PersonalIdUnlocker.requiresUnlockForSession())
     }
 
     @Test
     fun `SESSION_WITH_TIME_THRESHOLD bypasses unlock when last unlock is just within threshold boundary`() {
-        val nineMinutesAgo = SystemClock.elapsedRealtime() - (10 * 60 * 1000L - 1)
+        val nineMinutesAgo = SystemClock.elapsedRealtime() - 10.minutes.inWholeMilliseconds + 1
         PersonalIdUnlocker.lastUnlockTime = nineMinutesAgo
         assertFalse(PersonalIdUnlocker.requiresUnlockForSession())
     }

--- a/app/unit-tests/src/org/commcare/personalId/PersonalIdUnlockerTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/PersonalIdUnlockerTest.kt
@@ -1,0 +1,45 @@
+package org.commcare.personalId
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PersonalIdUnlockerTest {
+    @Before
+    fun setUp() {
+        PersonalIdUnlocker.resetSession()
+    }
+
+    @Test
+    fun `SESSION_WITH_TIME_THRESHOLD requires unlock when session has never been unlocked`() {
+        assertTrue(PersonalIdUnlocker.requiresUnlockForSession())
+    }
+
+    @Test
+    fun `SESSION_WITH_TIME_THRESHOLD bypasses unlock when unlocked within threshold`() {
+        PersonalIdUnlocker.lastUnlockTime = System.currentTimeMillis()
+        assertFalse(PersonalIdUnlocker.requiresUnlockForSession())
+    }
+
+    @Test
+    fun `SESSION_WITH_TIME_THRESHOLD requires unlock when last unlock exceeded threshold`() {
+        val elevenMinutesAgo = System.currentTimeMillis() - (11 * 60 * 1000L)
+        PersonalIdUnlocker.lastUnlockTime = elevenMinutesAgo
+        assertTrue(PersonalIdUnlocker.requiresUnlockForSession())
+    }
+
+    @Test
+    fun `SESSION_WITH_TIME_THRESHOLD bypasses unlock when last unlock is within threshold boundary`() {
+        val nineMinutesAgo = System.currentTimeMillis() - (9 * 60 * 1000L)
+        PersonalIdUnlocker.lastUnlockTime = nineMinutesAgo
+        assertFalse(PersonalIdUnlocker.requiresUnlockForSession())
+    }
+
+    @Test
+    fun `resetSession clears lastUnlockTime`() {
+        PersonalIdUnlocker.lastUnlockTime = System.currentTimeMillis()
+        PersonalIdUnlocker.resetSession()
+        assertTrue(PersonalIdUnlocker.requiresUnlockForSession())
+    }
+}

--- a/app/unit-tests/src/org/commcare/personalId/PersonalIdUnlockerTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/PersonalIdUnlockerTest.kt
@@ -1,10 +1,17 @@
 package org.commcare.personalId
 
+import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.commcare.CommCareTestApplication
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
+@RunWith(AndroidJUnit4::class)
+@Config(application = CommCareTestApplication::class)
 class PersonalIdUnlockerTest {
     @Before
     fun setUp() {
@@ -18,27 +25,34 @@ class PersonalIdUnlockerTest {
 
     @Test
     fun `SESSION_WITH_TIME_THRESHOLD bypasses unlock when unlocked within threshold`() {
-        PersonalIdUnlocker.lastUnlockTime = System.currentTimeMillis()
+        PersonalIdUnlocker.lastUnlockTime = SystemClock.elapsedRealtime()
         assertFalse(PersonalIdUnlocker.requiresUnlockForSession())
     }
 
     @Test
+    fun `SESSION_WITH_TIME_THRESHOLD requires unlock when last unlock at exactly the threshold`() {
+        val tenMinutesAgo = SystemClock.elapsedRealtime() - (10 * 60 * 1000L)
+        PersonalIdUnlocker.lastUnlockTime = tenMinutesAgo
+        assertTrue(PersonalIdUnlocker.requiresUnlockForSession())
+    }
+
+    @Test
     fun `SESSION_WITH_TIME_THRESHOLD requires unlock when last unlock exceeded threshold`() {
-        val elevenMinutesAgo = System.currentTimeMillis() - (11 * 60 * 1000L)
+        val elevenMinutesAgo = SystemClock.elapsedRealtime() - (11 * 60 * 1000L)
         PersonalIdUnlocker.lastUnlockTime = elevenMinutesAgo
         assertTrue(PersonalIdUnlocker.requiresUnlockForSession())
     }
 
     @Test
-    fun `SESSION_WITH_TIME_THRESHOLD bypasses unlock when last unlock is within threshold boundary`() {
-        val nineMinutesAgo = System.currentTimeMillis() - (9 * 60 * 1000L)
+    fun `SESSION_WITH_TIME_THRESHOLD bypasses unlock when last unlock is just within threshold boundary`() {
+        val nineMinutesAgo = SystemClock.elapsedRealtime() - (10 * 60 * 1000L - 1)
         PersonalIdUnlocker.lastUnlockTime = nineMinutesAgo
         assertFalse(PersonalIdUnlocker.requiresUnlockForSession())
     }
 
     @Test
     fun `resetSession clears lastUnlockTime`() {
-        PersonalIdUnlocker.lastUnlockTime = System.currentTimeMillis()
+        PersonalIdUnlocker.lastUnlockTime = SystemClock.elapsedRealtime()
         PersonalIdUnlocker.resetSession()
         assertTrue(PersonalIdUnlocker.requiresUnlockForSession())
     }


### PR DESCRIPTION
### Product Description

Early No-Op refactor for [CCCT-2078](https://dimagi.atlassian.net/browse/CCCT-2078) without making any user visible changes yet.  

## Technical Summary

- Extracts biometric/PIN unlock logic from `PersonalIdManager.unlockConnect()` into a new `PersonalIdUnlocker` Kotlin singleton.
- Introduces an `UnlockPolicy` enum with two values:
  - `ALWAYS` — always prompts (preserves existing behaviour); used by all current callers.
  - `SESSION_WITH_TIME_THRESHOLD` — skips the prompt if the user unlocked within the last 10 minutes (groundwork for future use).
- Migrates all callers (`LoginActivity`, `ConnectMessagingActivity`, `ConnectNavHelper`, `ConnectUnlockFragment`, `PersonalIdManager` internals) to `PersonalIdUnlocker.unlock()`.
- Adds `resetSession()`, called on app start and Personal ID logout, so stale unlock timestamps are never inherited across sessions.

## Safety Assurance

### Safety story

This is a pure refactor — no user-visible behaviour changes. All existing callers are migrated to `UnlockPolicy.ALWAYS`, which replicates the previous unconditional-prompt logic exactly. The new `SESSION_WITH_TIME_THRESHOLD` policy is introduced but not yet invoked in any production path. `resetSession()` is called at app start and on logout to ensure unlock state is never stale.

### Automated test coverage

`PersonalIdUnlockerTest` covers all branches of the session-bypass logic:
- No prior unlock → requires unlock
- Unlocked within threshold → bypasses prompt
- Unlocked beyond threshold (11 min) → requires unlock
- Unlocked at boundary (9 min) → bypasses prompt
- After `resetSession()` → requires unlock

[CCCT-2078]: https://dimagi.atlassian.net/browse/CCCT-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ