### PR TITLE
QA-8501 Hide Breadcrumb Bar On Push Notification Screen

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -58,6 +58,7 @@ we would like to communicate to QA as part of the release testing
 
 - Test the new offline status indicator at the top of refreshable Connect pages (Connect Home, Learning Progress, Delivery Progress). Verify that the error message appears when entering these pages while offline, and that it disappears once the device comes back online.
 - Verify that the combobox widget is working as expected when selecting an item that is used to filter another combobox widget and also determines the visibility of some other unrelated question whose relevance condition depends on the selection.
+- Open the Connect notification history screen (the list of push notifications) and verify the screen title reads "Notifications" (or the localized PersonalID notification title) and that no secondary breadcrumb/title strip is shown above or below it. Confirm the back arrow and the cloud-sync menu action both still work, and that opening a notification still routes correctly.
 
 ## CommCare 2.62
 

--- a/app/src/org/commcare/activities/PushNotificationActivity.kt
+++ b/app/src/org/commcare/activities/PushNotificationActivity.kt
@@ -62,6 +62,8 @@ class PushNotificationActivity : CommCareActivity<PushNotificationActivity>() {
         }
     }
 
+    override fun shouldShowBreadcrumbBar(): Boolean = false
+
     override fun onPostCreate(savedInstanceState: Bundle?) {
         super.onPostCreate(savedInstanceState)
         supportActionBar?.title = getString(R.string.personalid_notification)
@@ -112,7 +114,9 @@ class PushNotificationActivity : CommCareActivity<PushNotificationActivity>() {
                 true
             }
 
-            else -> super.onOptionsItemSelected(item)
+            else -> {
+                super.onOptionsItemSelected(item)
+            }
         }
 
     fun registerForNewNotification() {


### PR DESCRIPTION
### [QA-8501](https://dimagi.atlassian.net/browse/QA-8501)

## Product Description
On the push notification history screen (the in-app "Notifications" list accessed from the Connect/PersonalID notification entry point) the screen title was rendering both the action bar title and the generic breadcrumb bar, which obscured/duplicated the screen title. After this change only the action bar title (`personalid_notification`) is shown, matching the intended design.

## Technical Summary
- [QA-8501](https://dimagi.atlassian.net/browse/QA-8501)
- `PushNotificationActivity` extends `CommCareActivity`, which by default renders a breadcrumb bar in addition to the action bar. The activity already sets `supportActionBar?.title` in `onPostCreate`, so the breadcrumb bar was redundant and visually conflicting with the title.
- Override `shouldShowBreadcrumbBar()` to return `false` for this activity so only the action bar title is displayed.
- No behavior changes to the notification list, the cloud-sync menu action, the back arrow, or any other code path on this screen.

## Safety Assurance

### Safety story

**What gives confidence:**
- I ran the app on a device, opened the push notification history screen, and confirmed the screen title displays correctly and the breadcrumb bar no longer appears.
- `shouldShowBreadcrumbBar()` is the documented extension point in `CommCareActivity` for exactly this case; other activities already override it the same way, so the pattern is well-established.
- The change is scoped to a single activity, so other screens in the app are unaffected.

### Automated test coverage
No new automated tests. The change is a single-line UI chrome override; there is no existing automated coverage for the breadcrumb bar on this activity, and adding UI test infrastructure for it is out of scope. Manual QA covers the visible regression.

### QA Plan
QA steps are documented in `[RELEASES.md](http://releases.md/)` under the `CommCare 2.63`  QA Notes section. Summary: Open the Connect notification history screen and verify the title displays correctly, and that the back arrow and cloud-sync menu action still work and notifications still route correctly when tapped. Upon navigating back to the notification screen, the title (Notifications) is correctly displayed.

[QA-8501]: https://dimagi.atlassian.net/browse/QA-8501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-8501]: https://dimagi.atlassian.net/browse/QA-8501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ