### PR TITLE
Shift PR comment handler to run once a day

### DIFF
--- a/.github/workflows/pr-comment-handler.lock.yml
+++ b/.github/workflows/pr-comment-handler.lock.yml
@@ -30,7 +30,7 @@
 # - Skips ambiguous or contested comments rather than guessing
 # Always transparent, never merges PRs, defers to human judgement on contested changes.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"8d2433b41cad2962ad79c96ad6461d068bfe47d86619f866447e78f84212f310","compiler_version":"v0.57.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"35c55c40c2c020afd7b8edc2dde05cbb3203d8f4d392a0deb1b9e848c50b2fd5","compiler_version":"v0.57.2","strict":true}
 
 name: "PR Comment Handler"
 "on":
@@ -61,7 +61,7 @@ name: "PR Comment Handler"
     - created
     - edited
   schedule:
-  - cron: "0 */4 * * *"
+  - cron: "12 15 * * *"
   workflow_dispatch: null
 
 permissions: {}

--- a/.github/workflows/pr-comment-handler.lock.yml
+++ b/.github/workflows/pr-comment-handler.lock.yml
@@ -30,7 +30,7 @@
 # - Skips ambiguous or contested comments rather than guessing
 # Always transparent, never merges PRs, defers to human judgement on contested changes.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"35c55c40c2c020afd7b8edc2dde05cbb3203d8f4d392a0deb1b9e848c50b2fd5","compiler_version":"v0.57.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"2012c3aaed166d13f7be06c9d13f12f55b781b0bd86c055e53bef7c26c380826","compiler_version":"v0.57.2","strict":true}
 
 name: "PR Comment Handler"
 "on":
@@ -789,7 +789,7 @@ jobs:
                   "GITHUB_LOCKDOWN_MODE": "$GITHUB_MCP_LOCKDOWN",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_MCP_SERVER_TOKEN",
                   "GITHUB_READ_ONLY": "1",
-                  "GITHUB_TOOLSETS": "all"
+                  "GITHUB_TOOLSETS": "pull_requests,repos,context"
                 }
               },
               "safeoutputs": {

--- a/.github/workflows/pr-comment-handler.md
+++ b/.github/workflows/pr-comment-handler.md
@@ -10,7 +10,7 @@ description: |
   Always transparent, never merges PRs, defers to human judgement on contested changes.
 
 on:
-  schedule: "0 */4 * * *"
+  schedule: daily
   workflow_dispatch:
   slash_command:
     name: pr-assist

--- a/.github/workflows/pr-comment-handler.md
+++ b/.github/workflows/pr-comment-handler.md
@@ -40,7 +40,7 @@ tools:
   web-fetch:
   bash: true
   github:
-    toolsets: [all]
+    toolsets: [pull_requests, repos, context]
   repo-memory: true
 
 engine: claude


### PR DESCRIPTION
I was able to pin-point this workflow being the driver of the token usage and burning around 8million tokens per day, I am therefore shifting the schedule here to be once a day instead from 6 times a day. 

This also reduces the github toolset used for the job, I want to see if that helps reducing tokens used by this job.