### PR TITLE
QA-8500 Fix Overlapping Relearn Task Messages (V2)

### DIFF
--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -98,10 +98,7 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
             TextView tvJobTitle = viewJobCard.findViewById(R.id.tv_job_title);
             TextView tvViewMore = viewJobCard.findViewById(R.id.tv_view_more);
             TextView tvJobDescription = viewJobCard.findViewById(R.id.tv_job_description);
-            TextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
-            TextView tvJobTime = viewJobCard.findViewById(R.id.tv_job_time);
             TextView connectJobEndDate = viewJobCard.findViewById(R.id.connect_job_end_date);
-            CardView cvRelearnTasksPending = viewJobCard.findViewById(R.id.cv_relearn_tasks_pending);
 
             tvJobTitle.setText(job.getTitle());
             tvViewMore.setVisibility(View.GONE);
@@ -112,24 +109,30 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
             String formattedEndDate = ConnectDateUtils.INSTANCE.formatDate(job.getProjectEndDate());
             connectJobEndDate.setText(activity.getString(dateMessageStringRes, formattedEndDate));
 
-            String workingHours = job.getWorkingHours();
-            boolean showHours = workingHours != null;
-            if (job.isRelearnTaskPending()) {
-                cvRelearnTasksPending.setVisibility(View.VISIBLE);
-                tvJobTime.setVisibility(View.GONE);
-                hoursTitle.setVisibility(View.GONE);
-            } else if (showHours) {
-                tvJobTime.setText(workingHours);
-                cvRelearnTasksPending.setVisibility(View.GONE);
-                tvJobTime.setVisibility(View.VISIBLE);
-                hoursTitle.setVisibility(View.VISIBLE);
-            } else {
-                cvRelearnTasksPending.setVisibility(View.GONE);
-                tvJobTime.setVisibility(View.GONE);
-                hoursTitle.setVisibility(View.GONE);
-            }
-
+            syncJobCardVisibility(job);
             updateConnectJobProgress();
+        }
+    }
+
+    private void syncJobCardVisibility(ConnectJobRecord job) {
+        CardView cvRelearnTasksPending = viewJobCard.findViewById(R.id.cv_relearn_tasks_pending);
+        TextView tvJobTime = viewJobCard.findViewById(R.id.tv_job_time);
+        TextView hoursTitle = viewJobCard.findViewById(R.id.tvDailyVisitTitle);
+
+        String workingHours = job.getWorkingHours();
+        if (job.isRelearnTaskPending()) {
+            cvRelearnTasksPending.setVisibility(View.VISIBLE);
+            tvJobTime.setVisibility(View.GONE);
+            hoursTitle.setVisibility(View.GONE);
+        } else if (workingHours != null) {
+            tvJobTime.setText(workingHours);
+            cvRelearnTasksPending.setVisibility(View.GONE);
+            tvJobTime.setVisibility(View.VISIBLE);
+            hoursTitle.setVisibility(View.VISIBLE);
+        } else {
+            cvRelearnTasksPending.setVisibility(View.GONE);
+            tvJobTime.setVisibility(View.GONE);
+            hoursTitle.setVisibility(View.GONE);
         }
     }
 
@@ -188,6 +191,8 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
         if (job == null) {
             return;
         }
+
+        syncJobCardVisibility(job);
 
         RecyclerView recyclerView = viewJobCard.findViewById(R.id.rdDeliveryTypeList);
         if (job.getStatus() != STATUS_DELIVERING || job.isFinished() || job.isRelearnTaskPending()) {

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -143,6 +143,7 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
                 (success, error) -> {
                     if (success && isAdded()) {
                         updateLastUpdatedText(new Date());
+                        setupJobCard();
                         updateCardMessage();
                         updatePaymentConfirmationTile(false);
                         viewPagerAdapter.refresh();


### PR DESCRIPTION
### [QA-8500](https://dimagi.atlassian.net/browse/QA-8500)

## Product Description

The job tile on the CommCare app home screen and the Connect delivery progress screen each surface two related Connect messages: an orange "Complete assigned tasks to continue delivering services." warning card when there are pending relearn tasks, and a green "All required tasks have been completed. You may continue with delivery activities." banner immediately after the user finishes those tasks. Prior to this fix, both could be shown at the same time after the relearn tasks were completed. This PR ensures only the appropriate message is visible at any given time on both surfaces.

## Technical Summary

Two preferences in `ConnectJobPreferences` drive the two messages independently:

- `KEY_RELEARN_TASK_PENDING` → orange warning card (`cv_relearn_tasks_pending`), read via `ConnectJobRecord.isRelearnTaskPending()`.
- `KEY_RELEARN_TASKS_COMPLETED_TIME_MS` → green completion banner, read via `ConnectJobRecord.shouldShowRelearnTasksCompletedMessage()` (visible for a 6-hour window after completion).

`ConnectJobRecord.syncRelearnTasksPrefs()` keeps the two prefs mutually exclusive after each sync, but the UI was not re-binding the orange warning card's visibility on every refresh. After a successful sync that flipped the prefs from "pending" to "recently completed", `updateCardMessage()` re-evaluated the message text and showed the green banner, while the orange card remained `VISIBLE` from its earlier one-time setup. Both became visible simultaneously.

**Changes:**

- **`ConnectDeliveryProgressFragment.java`**: `refresh()`'s success callback now calls `setupJobCard()` alongside `updateCardMessage()`, so the orange card visibility is re-evaluated from the post-sync prefs on every refresh.
- **`StandardHomeActivityUIController.java`**: Extracted the relearn-pending visibility branch from `setupConnectJobTile()` into a new private helper `syncJobCardVisibility(ConnectJobRecord)`, and call it from both `setupConnectJobTile()` (initial setup) and `updateConnectJobProgress()` (every refresh).

**Why the home screen needed a new helper but the delivery progress screen did not:**

On the delivery progress screen, the orange warning card visibility lives inside a small, self-contained method (`setupJobCard()` → `ConnectViewUtils.setupCardViewForJob()`) whose sole purpose is to bind the job card. Calling it from the refresh callback is cheap and has no side effects on unrelated UI, so the fix there is a one-line `setupJobCard()` invocation.

On the home screen, the equivalent logic lives inline inside `setupConnectJobTile()`, mixed with one-time setup work that should not be re-run on every refresh: assigning the `viewJobCard`, `connectMessageCard`, and `connectMessageWarningIcon` field references; constructing and attaching a fresh `ConnectProgressJobSummaryAdapter` and `LinearLayoutManager` to the recycler view; finding the job title/description/end-date `TextView`s; and toggling top-level `viewJobCard` visibility. Calling `setupConnectJobTile()` from `updateConnectJobProgress()` would re-execute all of that on every refresh (rebuilding the adapter, replacing layout managers, re-walking the view tree for child IDs that haven't changed) and would also cause infinite recursion, since `setupConnectJobTile()` already calls `updateConnectJobProgress()` at the end of its initial-setup path. Extracting just the relearn/hours visibility branch into `syncJobCardVisibility(job)` lets us re-run only the part that depends on per-refresh state, without disturbing the one-time setup.

## Safety Assurance

### Safety story

**What gives confidence:**
- I built and ran the app on my personal test device and exercised the relearn-task flow end-to-end multiple times. On each cycle I confirmed the orange warning and the green completed message never appear simultaneously on either surface (the CommCare home screen job tile and the Connect delivery progress screen).
- The diff is narrow and tightly scoped to the two surfaces that render the relearn-task messages. No model logic or preference logic was changed.
- The extracted helper on the home screen contains the same body as the previous inline branch, so behavior on initial setup is unchanged.

**Risks to review:**
- The home-screen refactor moves view lookups (`findViewById` for `cv_relearn_tasks_pending`, `tv_job_time`, `tvDailyVisitTitle`) into the new helper, which now runs on every refresh as well as on initial setup. This is a small extra cost per refresh and is benign on a normal device, but worth a glance.
- On the delivery progress screen, `setupJobCard()` now re-runs in the refresh callback. It re-attaches click listeners and re-binds the title, end date, working hours, and buttons in addition to the relearn card visibility. This is idempotent but slightly heavier than only re-running the relearn branch.
- The fix relies on `syncRelearnTasksPrefs()` correctly producing mutually exclusive pref state by the time the refresh callback fires. If a future code path leaves the two prefs inconsistent at read time, both messages could appear again. There is no defense-in-depth guard at the read site (e.g. in `shouldShowRelearnTasksCompletedMessage()`); that was discussed and explicitly deferred to keep this change minimal.
- I did not add or run automated tests for this path; verification is manual only.

### Automated test coverage

No new automated tests were added. The change is a UI re-binding fix that depends on view lifecycle and is exercised through the manual flow described above. Existing model-level tests for `ConnectJobRecord` continue to cover `isRelearnTaskPending()` and `shouldShowRelearnTasksCompletedMessage()` semantics.

[QA-8500]: https://dimagi.atlassian.net/browse/QA-8500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ