### PR TITLE
Disable Android keystore + bucket log encryption traces separately (perf measurement)

### DIFF
--- a/app/src/org/commcare/android/security/AndroidKeyStore.kt
+++ b/app/src/org/commcare/android/security/AndroidKeyStore.kt
@@ -22,10 +22,15 @@ object AndroidKeyStore {
 
     fun doesKeyExist(alias: String): Boolean = instance.containsAlias(alias)
 
+    /**
+     * The main purpose of this method is to determine if the Android Keystore is supported on the device. It does
+     * this by trying to access the singleton instance of the KeyStore. It's currently returning false for
+     * comparison purposes between keystore-backed vs SecretKeySpec-backed encryption times.
+     */
     fun isKeystoreAvailable(): Boolean =
         try {
             instance
-            true
+            false
         } catch (e: Exception) {
             Logger.exception("Android keystore is not supported on this device", e)
             false

--- a/app/src/org/commcare/android/security/AndroidKeyStore.kt
+++ b/app/src/org/commcare/android/security/AndroidKeyStore.kt
@@ -23,14 +23,13 @@ object AndroidKeyStore {
     fun doesKeyExist(alias: String): Boolean = instance.containsAlias(alias)
 
     /**
-     * The main purpose of this method is to determine if the Android Keystore is supported on the device. It does
-     * this by trying to access the singleton instance of the KeyStore. It's currently returning false for
-     * comparison purposes between keystore-backed vs SecretKeySpec-backed encryption times.
+     * Determines if the Android Keystore is supported on the device. It does this by trying to access the
+     * singleton instance of the KeyStore.
      */
     fun isKeystoreAvailable(): Boolean =
         try {
             instance
-            false
+            true
         } catch (e: Exception) {
             Logger.exception("Android keystore is not supported on this device", e)
             false

--- a/app/src/org/commcare/google/services/analytics/CCPerfMonitoring.kt
+++ b/app/src/org/commcare/google/services/analytics/CCPerfMonitoring.kt
@@ -62,12 +62,13 @@ object CCPerfMonitoring {
         trace: Trace?,
         fileSizeBytes: Long,
         fileExtension: String,
-        keystoreEncrypted: Boolean
+        keystoreEncrypted: Boolean,
+        isLogsFile: Boolean
     ) {
         try {
             val attrs: MutableMap<String, String> = HashMap()
             attrs[ATTR_FILE_SIZE_BYTES] = fileSizeBytes.toString()
-            attrs[ATTR_FILE_TYPE] = fileExtension
+            attrs[ATTR_FILE_TYPE] = fileExtension + (if (isLogsFile) "_logs" else "")
             attrs[ATTR_FILE_KEYSTORE_ENCRYPTED] = keystoreEncrypted.toString()
             stopTracing(trace, attrs)
         } catch (e: java.lang.Exception) {

--- a/app/src/org/commcare/logging/DeviceReportWriter.java
+++ b/app/src/org/commcare/logging/DeviceReportWriter.java
@@ -110,7 +110,8 @@ public class DeviceReportWriter {
                         trace,
                         countingOutputStream.getCount(),
                         XML_EXTENSION,
-                        encryptionWithKeystore
+                        encryptionWithKeystore,
+                        true
                 );
                 countingOutputStream.close();
             } catch (IOException e) {

--- a/app/src/org/commcare/models/database/HybridFileBackedSqlStorage.java
+++ b/app/src/org/commcare/models/database/HybridFileBackedSqlStorage.java
@@ -350,6 +350,7 @@ public class HybridFileBackedSqlStorage<T extends Persistable> extends SqlStorag
                     trace,
                     bos.size(),
                     FilenameUtils.getExtension(filename),
+                    false,
                     false
             );
         }

--- a/app/src/org/commcare/models/encryption/EncryptionIO.java
+++ b/app/src/org/commcare/models/encryption/EncryptionIO.java
@@ -50,6 +50,7 @@ public class EncryptionIO {
                 trace,
                 fileSize,
                 FilenameUtils.getExtension(sourceFilePath),
+                false,
                 false
         );
     }

--- a/app/src/org/commcare/services/CommCareKeyManager.kt
+++ b/app/src/org/commcare/services/CommCareKeyManager.kt
@@ -21,11 +21,13 @@ class CommCareKeyManager {
 
         /**
          * An empty array indicates that the Android Keystore is supported and the key should be retrieved
-         * from the keystore
+         * from the keystore.
+         * The Keystore availability check is currently disabled to allow for comparison of encryption times
+         * between keystore-backed keys and SecretKeySpec-backed keys.
          */
         @JvmStatic
         fun generateLegacyKeyOrEmpty(): ByteArray =
-            if (AndroidKeyStore.isKeystoreAvailable()) {
+            if (false) { // AndroidKeyStore.isKeystoreAvailable()) {
                 ByteArray(0)
             } else {
                 CommCareApplication.instance().createNewSymmetricKey().encoded

--- a/app/src/org/commcare/tasks/SaveToDiskTask.java
+++ b/app/src/org/commcare/tasks/SaveToDiskTask.java
@@ -269,7 +269,13 @@ public class SaveToDiskTask extends
             StreamsUtil.writeFromInputToOutput(is, output);
         } finally {
             output.close();
-            CCPerfMonitoring.INSTANCE.stopFileEncryptionTracing(trace, payload.getLength(), XML_EXTENSION, false);
+            CCPerfMonitoring.INSTANCE.stopFileEncryptionTracing(
+                    trace,
+                    payload.getLength(),
+                    XML_EXTENSION,
+                    false,
+                    false
+            );
         }
     }
 


### PR DESCRIPTION
## Product Description 
In a previous work, we switched to encrypting device reports using Android Keystore, with the goal of evaluating its performance impact before potentially applying the same approach to form submissions and large files. While we have now solid data on encryption using the keystore, the baseline data intended for comparison is incomplete due to the 5-attribute limit in Firebase Performance Tracing. This PR reverts to the previous model to allow for a proper baseline data collection and a proper comparison.

## Technical Summary

Disables android keystore-backed encryption to gather Firebase Performance traces to compare encryption durations across two dimensions:

1. **Keystore-backed vs. `SecretKeySpec`-backed encryption paths.**
2. **Device-log encryption (`DeviceReportWriter`) vs. form/data encryption (`SaveToDiskTask` / `EncryptionIO` / `HybridFileBackedSqlStorage`).**

## Safety Assurance

### Safety story
- **Newly-created records** while running this build will store their AES key inline in the device report record's `aesKey` field, instead of being keystore-wrapped.
- **Reads of records created BEFORE this build** continue to work — `DeviceReportRecord.shouldUseKeystoreKey()` is `getKey().length == 0`, so each record retains its own provenance.
- **Reads of records created during this build remain readable** on builds that re-enable the keystore — they're plain AES keys, not keystore handles.
- Each record's encryption path is fixed at creation time, so there's no mid-life decryption inconsistency for records created on this build. This was successfully tested locally. The steps taken were:
  - Airplane mode was enabled
  - Records were created using the current version in the Playstore, 2.62.0
  - CommCare was then updated to this version, and new records created
  - Airplane mode was disabled
  - Forms and Device reports were uploaded and monitored using HTTP Toolkit

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change