### PR TITLE
Report attachment-count vs filesystem mismatch at form save

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -450,6 +450,10 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
     }
 
+    public int getFormAttachmentCount() {
+        return formAttachmentCount;
+    }
+
     public void showFormAttachmentLimitReachedError() {
         String title = StringUtils.getStringRobust(this, R.string.form_attachment_limit_reached_title);
         String msg = StringUtils.getStringRobust(this, R.string.form_attachment_limit_reached,

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -879,6 +879,8 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             return;
         }
 
+        reportAttachmentCountMismatch();
+        
         if (complete) {
             HiddenPreferences.clearInterruptedFormState();
             HiddenPreferences.clearInterruptedSSD();
@@ -893,6 +895,19 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         }
         mSaveToDiskTask.setFormSavedListener(this);
         mSaveToDiskTask.executeParallel();
+    }
+
+    private void reportAttachmentCountMismatch() {
+        int numAttachmentsOnDisk = FileUtil.countMediaFiles(FormEntryInstanceState.getInstanceFolder());
+        if (numAttachmentsOnDisk == -1) {
+            return;
+        }
+        if (numAttachmentsOnDisk < formAttachmentCount) {
+            Logger.exception(
+                    "Form attachment count mismatch at save — "
+                            + "in-memory=" + formAttachmentCount + " on-disk=" + numAttachmentsOnDisk,
+                    new Throwable());
+        }
     }
 
     public void discardChangesAndExit() {

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -906,7 +906,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
             Logger.exception(
                     "Form attachment count mismatch at save — "
                             + "in-memory=" + formAttachmentCount + " on-disk=" + numAttachmentsOnDisk,
-                    new Throwable());
+                    new IllegalStateException("Form attachment count mismatch"));
         }
     }
 

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -37,6 +37,7 @@ import org.commcare.preferences.HiddenPreferences;
 import org.commcare.preferences.MainConfigurablePreferences;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.BlockingActionsManager;
+import org.commcare.utils.CrashUtil;
 import org.commcare.utils.DelayedBlockingAction;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.FormUploadUtil;
@@ -245,6 +246,9 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
         if (this instanceof MediaCapableWidget &&
                 getContext() instanceof FormEntryActivity activity) {
                 activity.incrementAttachmentCount();
+
+            CrashUtil.log("Attachment count incremented for question " + mPrompt.getIndex() + ". Current count: "
+                    + activity.getFormAttachmentCount());
         }
     }
 
@@ -252,6 +256,9 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
         if (this instanceof MediaCapableWidget &&
                 getContext() instanceof FormEntryActivity activity) {
             activity.decrementAttachmentCount();
+
+            CrashUtil.log("Attachment count decremented for question " + mPrompt.getIndex() + ". Current count: "
+                    + activity.getFormAttachmentCount());
         }
     }
 


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-19082

## Technical Summary

Adds a diagnostic check to compares the in-memory form attachments count against the actual number of media files in the form's instance folder when the form is being saved. If the number of media files is lower than what's expected, a non-fatal exception is logged, surfacing the mismatch in Crashlytics. The save itself is unaffected — this is purely diagnostic.

This is part of a work to identify and diagnose reported missing media files when there is evidence in the form that a media was capture. 

## Safety Assurance

### Safety story
This just adds a diagnostic log, it doesn't block, retry, or alter the save.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change