### PR TITLE
Added codecov config to only report the code coverage, never fail

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Small change for code coverage, stopping the report from failing the build if coverage goes down.
We only want this tool to report on code coverage, never fail the build.

The added codecov.yml set the reporting to "informational".