### PR TITLE
Fixed a check on actively saving to disk (task must be non-null AND n…

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -1263,7 +1263,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
      * pendingNav is started so the user reaches the notification's target.
      */
     protected void triggerUserQuitInputForExternalNav(Intent pendingNav) {
-        if (mSaveToDiskTask != null) {
+        if (mSaveToDiskTask != null && mSaveToDiskTask.getStatus() != AsyncTask.Status.FINISHED) {
             Logger.exception("Navigation during form save", new Exception(
                     "User attempted to navigate from a push notification during form save."
             ));
@@ -1415,6 +1415,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
                         Toast.makeText(this,
                                 Localization.get("form.entry.complete.save.success"), Toast.LENGTH_SHORT).show();
                     }
+                    consumePendingNavAfterSave();
                     finishReturnInstance();
                     return;
                 case INVALID_ANSWER:


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-2396

## Product Description
Fixes a couple bugs around navigation when a user clicks a notification while in form entry.

## Technical Summary
1. When checking if a save is in progress already, need to check that the task is not FINISHED (not just non-null)
2. After saving an incomplete form, restored the line that navigates on