### PR TITLE
thoroughly clear intent extras to fix an issue where login retriggers…

### DIFF
--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -379,6 +379,7 @@ public class DispatchActivity extends AppCompatActivity {
     }
 
     private void clearSessionEndpointIntentExtras() {
+        getIntent().removeExtra(SESSION_REQUEST);
         getIntent().removeExtra(SESSION_ENDPOINT_APP_ID);
         getIntent().removeExtra(SESSION_ENDPOINT_ID);
     }
@@ -444,8 +445,8 @@ public class DispatchActivity extends AppCompatActivity {
                         i.putStringArrayListExtra(SESSION_ENDPOINT_ARGUMENTS_LIST, argsList);
                         i.putExtra(CC_LAUNCH_REQUIRE_SYNC,
                                 getIntent().getBooleanExtra(CC_LAUNCH_REQUIRE_SYNC, false));
-                        clearSessionEndpointIntentExtras();
                     }
+                    clearSessionEndpointIntentExtras();
                     if (i != null) {
                         i.putExtra(WAS_EXTERNAL, true);
                         i.putExtra(EXIT_AFTER_FORM_SUBMISSION,

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -7,13 +7,11 @@ import static org.commcare.connect.ConnectAppUtils.IS_LAUNCH_FROM_CONNECT;
 import static org.commcare.connect.ConnectConstants.CONNECT_MANAGED_LOGIN;
 import static org.commcare.connect.ConnectConstants.NOTIFICATION_ID;
 import static org.commcare.connect.ConnectConstants.PERSONALID_MANAGED_LOGIN;
-import static org.commcare.connect.ConnectConstants.REDIRECT_ACTION;
 import static org.commcare.utils.FirebaseMessagingUtil.getNotificationActionFromIntent;
 
 import android.content.Intent;
 import android.os.Bundle;
 
-import androidx.annotation.NonNull;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -371,7 +369,7 @@ public class DispatchActivity extends AppCompatActivity {
         i.putExtra(LoginActivity.MANUAL_SWITCH_TO_PW_MODE, userManuallyEnteredPasswordMode);
         i.putExtra(PERSONALID_MANAGED_LOGIN, personalIdManagedLogin);
         startFromLogin = false;
-        clearSessionEndpointAppId();
+        clearSessionEndpointIntentExtras();
         startActivityForResult(i, HOME_SCREEN);
     }
 
@@ -380,8 +378,9 @@ public class DispatchActivity extends AppCompatActivity {
                 CommCareApplication.instance().isConsumerApp();
     }
 
-    private void clearSessionEndpointAppId() {
+    private void clearSessionEndpointIntentExtras() {
         getIntent().removeExtra(SESSION_ENDPOINT_APP_ID);
+        getIntent().removeExtra(SESSION_ENDPOINT_ID);
     }
 
     /**
@@ -445,10 +444,7 @@ public class DispatchActivity extends AppCompatActivity {
                         i.putStringArrayListExtra(SESSION_ENDPOINT_ARGUMENTS_LIST, argsList);
                         i.putExtra(CC_LAUNCH_REQUIRE_SYNC,
                                 getIntent().getBooleanExtra(CC_LAUNCH_REQUIRE_SYNC, false));
-
-                        // Session Endpoint extra is no longer needed. If not removed, it triggers
-                        // the external launch logic in subsequent logins
-                        getIntent().removeExtra(SESSION_ENDPOINT_ID);
+                        clearSessionEndpointIntentExtras();
                     }
                     if (i != null) {
                         i.putExtra(WAS_EXTERNAL, true);


### PR DESCRIPTION
## Product Description

No ticket, Bug Fix for notification redirect into the CommCare App 


https://github.com/user-attachments/assets/9bb2ceaa-de5a-4594-98d3-720990e4118d


## Technical Summary

We were not clearning session endpoint extras properly while launching Home Activity. 

## Safety Assurance

### Safety story

Tested and verified bug fix
PR does a more thorough job for an exisitng clean up in the same code path


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
