### PR TITLE
CI-668 Tag Job List Rows With Opportunity UUID For AI Testing

### DIFF
--- a/app/src/org/commcare/adapters/JobListConnectHomeAppsAdapter.java
+++ b/app/src/org/commcare/adapters/JobListConnectHomeAppsAdapter.java
@@ -145,6 +145,7 @@ public class JobListConnectHomeAppsAdapter extends RecyclerView.Adapter<Recycler
             ConnectJobListItemCorruptBinding binding,
             ConnectLoginJobListModel connectLoginJobListModel
     ) {
+        binding.getRoot().setTag(connectLoginJobListModel.getUuid());
         binding.tvTitle.setText(connectLoginJobListModel.getName());
     }
 
@@ -154,6 +155,7 @@ public class JobListConnectHomeAppsAdapter extends RecyclerView.Adapter<Recycler
             ConnectLoginJobListModel connectLoginJobListModel,
             OnJobSelectionClick launcher
     ) {
+        binding.getRoot().setTag(connectLoginJobListModel.getUuid());
         binding.tvTitle.setText(connectLoginJobListModel.getName());
         if (isExpiryDateUnderFiveDays(connectLoginJobListModel.getDate())) {
             int redColor = ContextCompat.getColor(mContext, R.color.dark_red_brick_red);

--- a/app/src/org/commcare/adapters/JobListConnectHomeAppsAdapter.java
+++ b/app/src/org/commcare/adapters/JobListConnectHomeAppsAdapter.java
@@ -145,7 +145,7 @@ public class JobListConnectHomeAppsAdapter extends RecyclerView.Adapter<Recycler
             ConnectJobListItemCorruptBinding binding,
             ConnectLoginJobListModel connectLoginJobListModel
     ) {
-        binding.getRoot().setTag(connectLoginJobListModel.getUuid());
+        binding.getRoot().setTag("opp_uuid: " + connectLoginJobListModel.getUuid());
         binding.tvTitle.setText(connectLoginJobListModel.getName());
     }
 
@@ -155,7 +155,7 @@ public class JobListConnectHomeAppsAdapter extends RecyclerView.Adapter<Recycler
             ConnectLoginJobListModel connectLoginJobListModel,
             OnJobSelectionClick launcher
     ) {
-        binding.getRoot().setTag(connectLoginJobListModel.getUuid());
+        binding.getRoot().setTag("opp_uuid: " + connectLoginJobListModel.getUuid());
         binding.tvTitle.setText(connectLoginJobListModel.getName());
         if (isExpiryDateUnderFiveDays(connectLoginJobListModel.getDate())) {
             int redColor = ContextCompat.getColor(mContext, R.color.dark_red_brick_red);


### PR DESCRIPTION
### [CI-668](https://dimagi.atlassian.net/browse/CI-668)

## Product Description

No user-visible changes. This adds an internal hook so automated AI UI testing can identify individual opportunity rows in the job list by their backend UUID.

## Technical Summary

In `JobListConnectHomeAppsAdapter`, both `bind(...)` overloads (corrupt and non-corrupt job rows) now call `binding.getRoot().setTag("opp_uuid: " + connectLoginJobListModel.getUuid())` on the row's root `CardView`. Setting the tag inside `bind` (rather than at view-holder creation) ensures the tag tracks the currently-bound row as RecyclerView recycles views. Section-header rows are unaffected since they don't represent opportunities.

## Safety Assurance

### Safety story

What gives confidence:
- I ran the app and verified via Android Studio's Layout Inspector that the `opp_uuid: <uuid>` tag is present on each opportunity row's root view.
- Diff is two lines in a single adapter file; no behavior change to existing rendering or click handling.
- `setTag` on the root view is a no-op for the rendered UI — it only attaches metadata for tooling.

Risks to review:
- The tag is set on every `onBindViewHolder` pass; for very large job lists this is a trivial extra allocation per bind but worth a glance.
- No automated test covers the tag value; regressions would only be caught by the AI testing harness or manual Layout Inspector checks.

### Automated test coverage

None added. The change is purely a metadata hook for external AI UI testing; verifying it in a unit/instrumentation test would essentially re-assert the line itself.

[CI-668]: https://dimagi.atlassian.net/browse/CI-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ