### PR TITLE
Converted Delivery Progress fragment to use offline-first UX

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,7 @@ These are published publicly on Playstore, Github Releases and CommCare Forums
 
 - [Profile Photo Update] PersonalID users can now update their profile photo directly from the side navigation drawer
 - [Back Online Indicator] Refreshable Connect pages now show a green "Back Online" indicator at the top of the page when a sync succeeds after a previous offline failure
+- [Delivery Progress Offline-First] The Connect Delivery Progress page now displays cached delivery data immediately on open, even with no network, and shows inline sync status (success / failure / offline) instead of a blocking loading dialog
 
 #### Important Bug Fixes
 
@@ -75,6 +76,13 @@ we would like to communicate to QA as part of the release testing
   - Turn the network back on and trigger a sync (or wait for the auto-refresh on reconnect). Verify that the bar now shows a green background with "Last synced: Just Now" on the left and "Back Online" plus a WiFi icon on the right, and that it auto-dismisses after a few seconds.
   - Trigger a non-network failure (e.g. a server error) and then a successful sync. Verify that the bar shows the regular green success message **without** the "Back Online" indicator (the Back Online indicator should only appear after an offline failure).
   - Switch the device language to a non-English locale (e.g. French, Spanish, Hindi) and repeat the back-online flow. Verify that the "Back Online" label is shown in the selected language.
+
+- **Delivery Progress offline-first (Connect):**
+  - Open the Connect Delivery Progress page while online with a working network and let it sync. Verify the progress, payment list, payment-confirmation tile, and "Last updated" timestamp all populate as before, and that the green "Sync successful" bar flashes briefly at the top.
+  - Background the app, turn on airplane mode, and reopen the Delivery Progress page. Verify cached delivery data (progress, deliveries, payments, "Last updated" timestamp) appears immediately without waiting for a network call, and that the orange "Offline" indicator with the previous sync time is shown at the top.
+  - Confirm the full-screen blocking loading dialog that used to appear on refresh no longer appears — the inline small progress spinner is the only loading indicator.
+
+
 
 ## CommCare 2.63
 

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -514,7 +514,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
 
             if (job != null) {
                 personalIdManager.updateAppAccess(context, appId, username);
-                ConnectJobHelper.INSTANCE.updateJobProgress(context, job,null,null, (success, error) -> setResultAndFinish(job.getIsUserSuspended()));
+                ConnectJobHelper.INSTANCE.updateJobProgress(context, job, (success, error) -> setResultAndFinish(job.getIsUserSuspended()));
             } else {
                 //Possibly offer to link or de-link PersonalId-managed login
                 personalIdManager.checkPersonalIdLink(context,

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -351,7 +351,7 @@ public class StandardHomeActivity
     public void fetchJobProgressOverNetwork() {
         ConnectJobRecord job = getActiveJob();
         if(job != null && job.getStatus() == ConnectJobRecord.STATUS_DELIVERING) {
-            ConnectJobHelper.INSTANCE.updateDeliveryProgress(this, job, null,null,(success, error) -> {
+            ConnectJobHelper.INSTANCE.updateDeliveryProgress(this, job, (success, error) -> {
                 if (success) {
                     uiController.updateConnectJobProgress();
                 }

--- a/app/src/org/commcare/connect/ConnectJobHelper.kt
+++ b/app/src/org/commcare/connect/ConnectJobHelper.kt
@@ -12,7 +12,6 @@ import org.commcare.connect.network.PersonalIdOrConnectApiErrorHandler
 import org.commcare.connect.network.connect.ConnectApiHandler
 import org.commcare.connect.network.connect.ConnectNetworkClient
 import org.commcare.connect.network.connect.models.ConnectPaymentConfirmationModel
-import org.commcare.connect.network.connect.models.DeliveryAppProgressResponseModel
 import org.commcare.connect.network.connect.models.applyToJob
 import org.commcare.google.services.analytics.AnalyticsParamValue.FINISH_DELIVERY
 import org.commcare.google.services.analytics.AnalyticsParamValue.PAID_DELIVERY
@@ -92,66 +91,35 @@ object ConnectJobHelper {
         baseConnectView: BaseConnectView? = null,
         listener: ConnectActivityCompleteListener,
     ) {
-        val user = ConnectUserDatabaseUtil.getUser(context)
-        object : ConnectApiHandler<DeliveryAppProgressResponseModel>(
-            showLoading,
-            baseConnectView,
-        ) {
-            override fun onSuccess(deliveryAppProgressResponseModel: DeliveryAppProgressResponseModel) {
-                val events = mutableSetOf<String?>()
-
-                if (deliveryAppProgressResponseModel.updatedJob) {
-                    events.add(START_DELIVERY)
-                    ConnectJobUtils.upsertJob(context, job)
-                }
-
-                if (deliveryAppProgressResponseModel.hasDeliveries) {
-                    if (job.getDeliveryProgressPercentage() == 100) {
+        val user = ConnectUserDatabaseUtil.getUser(context)!!
+        CoroutineScope(Dispatchers.IO).launch {
+            val result = ConnectNetworkClient.getInstance().getDeliveryProgress(user, job)
+            result.fold(
+                onSuccess = { model ->
+                    val events = mutableSetOf<String?>()
+                    if (model.updatedJob) {
+                        events.add(START_DELIVERY)
+                    }
+                    if (model.hasDeliveries && job.getDeliveryProgressPercentage() == 100) {
                         events.add(FINISH_DELIVERY)
                     }
-                    ConnectJobUtils.storeDeliveries(
-                        context,
-                        job.deliveries,
-                        job.jobUUID,
-                        true,
-                    )
-                }
-
-                if (deliveryAppProgressResponseModel.hasPayment) {
-                    if (job.payments.isNotEmpty()) {
+                    if (model.hasPayment && job.payments.isNotEmpty()) {
                         events.add(PAID_DELIVERY)
                     }
-                    ConnectJobUtils.storePayments(
-                        context,
-                        job.payments,
-                        job.jobUUID,
-                        true,
-                    )
-                }
 
-                job.syncRelearnTasksPrefs(deliveryAppProgressResponseModel.parsedTasks)
+                    model.applyToJob(job, context)
 
-                events.forEach { event ->
-                    FirebaseAnalyticsUtil.reportCccApiDeliveryProgress(
-                        true,
-                        event,
-                    )
-                }
-
-                listener.connectActivityComplete(true)
-            }
-
-            override fun onFailure(
-                errorCode: PersonalIdOrConnectApiErrorCodes,
-                t: Throwable?,
-            ) {
-                FirebaseAnalyticsUtil.reportCccApiDeliveryProgress(
-                    false,
-                    null,
-                )
-                listener.connectActivityComplete(false)
-            }
-        }.getDeliveries(context, user, job)
+                    events.forEach { event ->
+                        FirebaseAnalyticsUtil.reportCccApiDeliveryProgress(true, event)
+                    }
+                    listener.connectActivityComplete(true)
+                },
+                onFailure = {
+                    FirebaseAnalyticsUtil.reportCccApiDeliveryProgress(false, null)
+                    listener.connectActivityComplete(false)
+                },
+            )
+        }
     }
 
     fun updatePaymentsConfirmed(

--- a/app/src/org/commcare/connect/ConnectJobHelper.kt
+++ b/app/src/org/commcare/connect/ConnectJobHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.commcare.CommCareApplication
 import org.commcare.android.database.connect.models.ConnectJobRecord
 import org.commcare.connect.database.ConnectJobUtils
@@ -74,11 +75,15 @@ object ConnectJobHelper {
                     if (job.passedAssessment()) {
                         FirebaseAnalyticsUtil.reportCccApiLearnProgress(true)
                     }
-                    listener.connectActivityComplete(true)
+                    withContext(Dispatchers.Main) {
+                        listener.connectActivityComplete(true)
+                    }
                 },
                 onFailure = {
                     FirebaseAnalyticsUtil.reportCccApiLearnProgress(false)
-                    listener.connectActivityComplete(false)
+                    withContext(Dispatchers.Main) {
+                        listener.connectActivityComplete(false)
+                    }
                 },
             )
         }
@@ -112,11 +117,15 @@ object ConnectJobHelper {
                     events.forEach { event ->
                         FirebaseAnalyticsUtil.reportCccApiDeliveryProgress(true, event)
                     }
-                    listener.connectActivityComplete(true)
+                    withContext(Dispatchers.Main) {
+                        listener.connectActivityComplete(true)
+                    }
                 },
                 onFailure = {
                     FirebaseAnalyticsUtil.reportCccApiDeliveryProgress(false, null)
-                    listener.connectActivityComplete(false)
+                    withContext(Dispatchers.Main) {
+                        listener.connectActivityComplete(false)
+                    }
                 },
             )
         }

--- a/app/src/org/commcare/connect/ConnectJobHelper.kt
+++ b/app/src/org/commcare/connect/ConnectJobHelper.kt
@@ -42,8 +42,6 @@ object ConnectJobHelper {
     fun updateJobProgress(
         context: Context,
         job: ConnectJobRecord,
-        showLoading: Boolean? = null,
-        baseConnectView: BaseConnectView? = null,
         listener: ConnectActivityCompleteListener,
     ) {
         when (job.status) {
@@ -52,7 +50,7 @@ object ConnectJobHelper {
             }
 
             ConnectJobRecord.STATUS_DELIVERING -> {
-                updateDeliveryProgress(context, job, showLoading, baseConnectView, listener)
+                updateDeliveryProgress(context, job, listener)
             }
 
             else -> {
@@ -92,8 +90,6 @@ object ConnectJobHelper {
     fun updateDeliveryProgress(
         context: Context,
         job: ConnectJobRecord,
-        showLoading: Boolean? = null,
-        baseConnectView: BaseConnectView? = null,
         listener: ConnectActivityCompleteListener,
     ) {
         val user = ConnectUserDatabaseUtil.getUser(context)!!

--- a/app/src/org/commcare/connect/network/ApiConnect.java
+++ b/app/src/org/commcare/connect/network/ApiConnect.java
@@ -108,32 +108,6 @@ public class ApiConnect {
 
     }
 
-    public static void getDeliveries(Context context, @NonNull ConnectUserRecord user, String jobUUID, IApiCallback callback) {
-
-        ConnectSsoHelper.retrievePersonalIdToken(context, user, new ConnectSsoHelper.TokenCallback() {
-            @Override
-            public void tokenRetrieved(AuthInfo.TokenAuth token) {
-                String tokenAuth = HttpUtils.getCredential(token);
-                ApiService apiService = ConnectApiClient.Companion.getClientApi();
-                HashMap<String, String> headers = new HashMap<>();
-                ConnectNetworkHelper.addVersionHeader(headers, API_VERSION_CONNECT);
-                Call<ResponseBody> call = apiService.getConnectDeliveries(tokenAuth, jobUUID, headers);
-                BaseApi.Companion.callApi(context, call, callback,ApiEndPoints.connectDeliveriesURL);
-            }
-
-            @Override
-            public void tokenUnavailable() {
-                callback.processTokenUnavailableError();
-            }
-
-            @Override
-            public void tokenRequestDenied() {
-                callback.processTokenRequestDeniedError();
-            }
-        });
-
-    }
-
     public static void setPaymentsConfirmed(
             Context context,
             @NonNull ConnectUserRecord user,

--- a/app/src/org/commcare/connect/network/ApiService.java
+++ b/app/src/org/commcare/connect/network/ApiService.java
@@ -64,11 +64,6 @@ public interface ApiService {
                                        @HeaderMap Map<String, String> headers,
                                        @Body RequestBody connectClaimJobRequest);
 
-    @GET(ApiEndPoints.connectDeliveriesURL)
-    Call<ResponseBody> getConnectDeliveries(@Header("Authorization") String token,
-                                            @Path("id") String uuid,
-                                            @HeaderMap Map<String, String> headers);
-
     @POST(ApiEndPoints.PAYMENT_CONFIRMAITONS)
     Call<ResponseBody> connectPaymentConfirmations(@Header("Authorization") String token,
                                        @HeaderMap Map<String, String> headers,

--- a/app/src/org/commcare/connect/network/ConnectApiService.kt
+++ b/app/src/org/commcare/connect/network/ConnectApiService.kt
@@ -20,4 +20,11 @@ interface ConnectApiService {
         @Path("id") jobId: String,
         @HeaderMap headers: Map<String, String>,
     ): Response<ResponseBody>
+
+    @GET(ApiEndPoints.connectDeliveriesURL)
+    suspend fun getDeliveryProgress(
+        @Header("Authorization") authorization: String,
+        @Path("id") jobId: String,
+        @HeaderMap headers: Map<String, String>,
+    ): Response<ResponseBody>
 }

--- a/app/src/org/commcare/connect/network/connect/ConnectApiHandler.kt
+++ b/app/src/org/commcare/connect/network/connect/ConnectApiHandler.kt
@@ -1,15 +1,12 @@
 package org.commcare.connect.network.connect
 
 import android.content.Context
-import org.commcare.android.database.connect.models.ConnectJobRecord
 import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.connect.network.ApiConnect
 import org.commcare.connect.network.NoParsingResponseParser
 import org.commcare.connect.network.base.BaseApiHandler
 import org.commcare.connect.network.connect.models.ConnectPaymentConfirmationModel
 import org.commcare.connect.network.connect.parser.ConnectOpportunitiesParser
-import org.commcare.connect.network.connect.parser.DeliveryAppProgressResponseParser
-import org.commcare.connect.network.connect.parser.LearningAppProgressResponseParser
 import org.commcare.interfaces.base.BaseConnectView
 
 /**
@@ -60,19 +57,6 @@ abstract class ConnectApiHandler<T>(
             createCallback(
                 NoParsingResponseParser<T>(),
             ),
-        )
-    }
-
-    fun getDeliveries(
-        context: Context,
-        user: ConnectUserRecord,
-        job: ConnectJobRecord,
-    ) {
-        ApiConnect.getDeliveries(
-            context,
-            user,
-            job.jobUUID,
-            createCallback(DeliveryAppProgressResponseParser<T>(), job),
         )
     }
 

--- a/app/src/org/commcare/connect/network/connect/ConnectNetworkClient.kt
+++ b/app/src/org/commcare/connect/network/connect/ConnectNetworkClient.kt
@@ -1,19 +1,19 @@
 package org.commcare.connect.network.connect
 
 import androidx.annotation.VisibleForTesting
-import kotlinx.coroutines.CancellationException
 import okhttp3.ResponseBody
 import org.commcare.android.database.connect.models.ConnectJobRecord
 import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.connect.network.ApiConnect.API_VERSION_CONNECT
 import org.commcare.connect.network.ConnectApiService
 import org.commcare.connect.network.ConnectNetworkHelper
-import org.commcare.connect.network.LoginInvalidatedException
 import org.commcare.connect.network.base.BaseApiClient
 import org.commcare.connect.network.base.BaseApiHandler.PersonalIdOrConnectApiErrorCodes
 import org.commcare.connect.network.base.ConnectApiException
+import org.commcare.connect.network.connect.models.DeliveryAppProgressResponseModel
 import org.commcare.connect.network.connect.models.LearningAppProgressResponseModel
 import org.commcare.connect.network.connect.parser.ConnectOpportunitiesParser
+import org.commcare.connect.network.connect.parser.DeliveryAppProgressResponseParser
 import org.commcare.connect.network.connect.parser.LearningAppProgressResponseParser
 import org.commcare.connect.network.getAuthorizationHeader
 import org.commcare.connect.network.mapHttpErrorCode
@@ -63,6 +63,16 @@ class ConnectNetworkClient
                 user = user,
                 apiCall = { auth -> apiService.getLearningProgress(auth, job.jobUUID, versionHeaders()) },
                 parse = { code, stream -> LearningAppProgressResponseParser<LearningAppProgressResponseModel>().parse(code, stream, job) },
+            )
+
+        suspend fun getDeliveryProgress(
+            user: ConnectUserRecord,
+            job: ConnectJobRecord,
+        ): Result<DeliveryAppProgressResponseModel> =
+            executeApiCall(
+                user = user,
+                apiCall = { auth -> apiService.getDeliveryProgress(auth, job.jobUUID, versionHeaders()) },
+                parse = { code, stream -> DeliveryAppProgressResponseParser<DeliveryAppProgressResponseModel>().parse(code, stream, job) },
             )
 
         private suspend fun <T> executeApiCall(

--- a/app/src/org/commcare/connect/network/connect/models/DeliveryAppProgressResponseModel.kt
+++ b/app/src/org/commcare/connect/network/connect/models/DeliveryAppProgressResponseModel.kt
@@ -1,8 +1,28 @@
 package org.commcare.connect.network.connect.models
 
+import android.content.Context
+import org.commcare.android.database.connect.models.ConnectJobRecord
+import org.commcare.connect.database.ConnectJobUtils
+
 data class DeliveryAppProgressResponseModel(
     var updatedJob: Boolean = false,
     var hasDeliveries: Boolean = false,
     var hasPayment: Boolean = false,
     var parsedTasks: List<ParsedConnectTask> = emptyList(),
 )
+
+fun DeliveryAppProgressResponseModel.applyToJob(
+    job: ConnectJobRecord,
+    context: Context,
+) {
+    if (updatedJob) {
+        ConnectJobUtils.upsertJob(context, job)
+    }
+    if (hasDeliveries) {
+        ConnectJobUtils.storeDeliveries(context, job.deliveries, job.jobUUID, true)
+    }
+    if (hasPayment) {
+        ConnectJobUtils.storePayments(context, job.payments, job.jobUUID, true)
+    }
+    job.syncRelearnTasksPrefs(parsedTasks)
+}

--- a/app/src/org/commcare/connect/repository/ConnectRepository.kt
+++ b/app/src/org/commcare/connect/repository/ConnectRepository.kt
@@ -12,6 +12,7 @@ import org.commcare.connect.database.ConnectJobUtils.getCompositeJob
 import org.commcare.connect.database.ConnectJobUtils.getCompositeJobs
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.connect.network.connect.ConnectNetworkClient
+import org.commcare.connect.network.connect.models.DeliveryAppProgressResponseModel
 import org.commcare.connect.network.connect.models.LearningAppProgressResponseModel
 import org.commcare.connect.network.connect.models.applyToJob
 
@@ -24,6 +25,7 @@ class ConnectRepository
         companion object {
             const val SYNC_KEY_OPPORTUNITIES = "/opportunities"
             const val SYNC_KEY_LEARNING_PREFIX = "/learning_progress/"
+            const val SYNC_KEY_DELIVERY_PREFIX = "/delivery_progress/"
 
             @Volatile
             private var instance: ConnectRepository? = null
@@ -68,6 +70,23 @@ class ConnectRepository
                 policy = policy,
                 loadCache = { getCompositeJob(CommCareApplication.instance(), job.jobUUID) },
                 networkCall = { fetchLearningProgressFromNetwork(job) },
+                onNetworkSuccess = { responseModel ->
+                    responseModel.applyToJob(job, CommCareApplication.instance())
+                },
+                mapToEmit = { _ -> getCompositeJob(CommCareApplication.instance(), job.jobUUID) },
+            )
+
+        fun getDeliveryProgress(
+            job: ConnectJobRecord,
+            forceRefresh: Boolean = false,
+            policy: RefreshPolicy = RefreshPolicy.ALWAYS,
+        ): Flow<DataState<ConnectJobRecord>> =
+            offlineFirstFlow(
+                syncKey = SYNC_KEY_DELIVERY_PREFIX + job.jobUUID,
+                forceRefresh = forceRefresh,
+                policy = policy,
+                loadCache = { getCompositeJob(CommCareApplication.instance(), job.jobUUID) },
+                networkCall = { fetchDeliveryProgressFromNetwork(job) },
                 onNetworkSuccess = { responseModel ->
                     responseModel.applyToJob(job, CommCareApplication.instance())
                 },
@@ -120,5 +139,10 @@ class ConnectRepository
         private suspend fun fetchLearningProgressFromNetwork(job: ConnectJobRecord): Result<LearningAppProgressResponseModel> {
             val user = requireNotNull(ConnectUserDatabaseUtil.getUser(CommCareApplication.instance())) { "No Connect user found" }
             return networkClient.getLearningProgress(user, job)
+        }
+
+        private suspend fun fetchDeliveryProgressFromNetwork(job: ConnectJobRecord): Result<DeliveryAppProgressResponseModel> {
+            val user = requireNotNull(ConnectUserDatabaseUtil.getUser(CommCareApplication.instance())) { "No Connect user found" }
+            return networkClient.getDeliveryProgress(user, job)
         }
     }

--- a/app/src/org/commcare/connect/viewmodel/ConnectDeliveryProgressViewModel.kt
+++ b/app/src/org/commcare/connect/viewmodel/ConnectDeliveryProgressViewModel.kt
@@ -1,0 +1,36 @@
+package org.commcare.connect.viewmodel
+
+import android.app.Application
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.Job
+import org.commcare.android.database.connect.models.ConnectJobRecord
+import org.commcare.connect.repository.ConnectRepository
+import org.commcare.connect.repository.DataState
+import org.commcare.connect.repository.RefreshPolicy
+
+class ConnectDeliveryProgressViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+    @VisibleForTesting
+    internal var repository: ConnectRepository = ConnectRepository.getInstance(application)
+
+    private val _deliveryProgress = MutableLiveData<DataState<ConnectJobRecord>>()
+    val deliveryProgress: LiveData<DataState<ConnectJobRecord>> = _deliveryProgress
+
+    private var loadDeliveryProgressJob: Job? = null
+
+    fun loadDeliveryProgress(
+        opportunity: ConnectJobRecord,
+        forceRefresh: Boolean = false,
+    ) {
+        loadDeliveryProgressJob?.cancel()
+        loadDeliveryProgressJob =
+            collectInto(
+                flow = repository.getDeliveryProgress(opportunity, forceRefresh, RefreshPolicy.ALWAYS),
+                liveData = _deliveryProgress,
+            )
+    }
+}

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryListFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryListFragment.java
@@ -142,7 +142,7 @@ public class ConnectDeliveryListFragment extends ConnectJobFragment<FragmentConn
     }
 
     private void refreshData() {
-        ConnectJobHelper.INSTANCE.updateDeliveryProgress(getContext(), job, true, this, (success,error) -> {
+        ConnectJobHelper.INSTANCE.updateDeliveryProgress(getContext(), job, (success,error) -> {
             if (success) {
                 updatePendingFilterVisibility();
                 adapter.updateDeliveries(getFilteredDeliveries());

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -80,9 +80,8 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
                 ViewModelProvider.AndroidViewModelFactory.getInstance(requireActivity().getApplication())
         ).get(ConnectDeliveryProgressViewModel.class);
 
-        observeDeliveryProgress();
-
         setupTabViewPager();
+        observeDeliveryProgress();
         setupJobCard();
         setupRefreshAndConfirmationActions();
 

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -81,13 +81,14 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
         ).get(ConnectDeliveryProgressViewModel.class);
 
         setupTabViewPager();
-        observeDeliveryProgress();
         setupJobCard();
         setupRefreshAndConfirmationActions();
 
         updateLastUpdatedText(job.getLastDeliveryUpdate());
         updateCardMessage();
         updatePaymentConfirmationTile(false);
+
+        observeDeliveryProgress();
 
         return view;
     }

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -11,6 +11,7 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavDirections;
 import androidx.navigation.Navigation;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
@@ -27,6 +28,8 @@ import org.commcare.connect.ConnectJobHelper;
 import org.commcare.connect.PersonalIdManager;
 import org.commcare.connect.database.ConnectJobUtils;
 import org.commcare.connect.network.connect.models.ConnectPaymentConfirmationModel;
+import org.commcare.connect.repository.ConnectRepository;
+import org.commcare.connect.viewmodel.ConnectDeliveryProgressViewModel;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.FragmentConnectDeliveryProgressBinding;
 import org.commcare.dalvik.databinding.ViewJobCardBinding;
@@ -52,6 +55,7 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
     private final ArrayList<ConnectPaymentConfirmationModel> paymentsToConfirm = new ArrayList<>();
     private int initialTabPosition = 0;
     private boolean isProgrammaticTabChange = false;
+    private ConnectDeliveryProgressViewModel viewModel;
 
     public static ConnectDeliveryProgressFragment newInstance() {
         return new ConnectDeliveryProgressFragment();
@@ -70,6 +74,14 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
             initialTabPosition = getArguments().getInt(TAB_POSITION, TAB_PROGRESS);
         }
 
+        setWaitDialogEnabled(false);
+        viewModel = new ViewModelProvider(
+                this,
+                ViewModelProvider.AndroidViewModelFactory.getInstance(requireActivity().getApplication())
+        ).get(ConnectDeliveryProgressViewModel.class);
+
+        observeDeliveryProgress();
+
         setupTabViewPager();
         setupJobCard();
         setupRefreshAndConfirmationActions();
@@ -79,6 +91,27 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
         updatePaymentConfirmationTile(false);
 
         return view;
+    }
+
+    private void observeDeliveryProgress() {
+        observeDataState(
+                viewModel.getDeliveryProgress(),
+                cached -> {
+                    job = cached;
+                    onDeliveryProgressUpdated();
+                },
+                success -> {
+                    job = success;
+                    onDeliveryProgressUpdated();
+                }
+        );
+    }
+
+    private void onDeliveryProgressUpdated() {
+        updateLastUpdatedText(job.getLastDeliveryUpdate());
+        updateCardMessage();
+        updatePaymentConfirmationTile(false);
+        viewPagerAdapter.refresh();
     }
 
     private void setupTabViewPager() {
@@ -132,21 +165,7 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
 
     @Override
     public void refresh(boolean forceRefresh) {
-        setWaitDialogEnabled(false);
-        ConnectJobHelper.INSTANCE.updateDeliveryProgress(
-                getContext(),
-                job,
-                true,
-                this,
-                (success, error) -> {
-                    if (success && isAdded()) {
-                        updateLastUpdatedText(new Date());
-                        updateCardMessage();
-                        updatePaymentConfirmationTile(false);
-                        viewPagerAdapter.refresh();
-                    }
-                }
-        );
+        viewModel.loadDeliveryProgress(job, forceRefresh);
     }
 
     private void setupRefreshAndConfirmationActions() {
@@ -330,6 +349,11 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
                     );
             Navigation.findNavController(getBinding().getRoot()).navigate(navDirections);
         }
+    }
+
+    @Override
+    public String getEndpoint() {
+        return ConnectRepository.SYNC_KEY_DELIVERY_PREFIX + job.getJobUUID();
     }
 
     @Override

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
@@ -64,10 +64,9 @@ public class ConnectLearningProgressFragment extends ConnectJobFragment<Fragment
             ViewModelProvider.AndroidViewModelFactory.getInstance(requireActivity().getApplication())
         ).get(ConnectLearningProgressViewModel.class);
 
-        observeLearningProgress();
-
         setupRefreshButton();
         populateJobCard();
+        observeLearningProgress();
         return view;
     }
 

--- a/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
+++ b/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
@@ -84,14 +84,18 @@ class NotificationsSyncWorker(
 
     private fun logResult(syncResult: PNApiResponseStatus) {
         val actionStr = syncAction?.toString()
-        Logger.log(LogTypes.TYPE_MAINTENANCE, "Sync Action: $actionStr completed with success: ${syncResult?.success}")
+        Logger.log(
+            LogTypes.TYPE_MAINTENANCE,
+            "Sync Action: $actionStr completed with success: ${syncResult?.success}",
+        )
     }
 
     private fun initStateFromInputData() {
         val notificationPayloadJson = inputData.getString(NOTIFICATION_PAYLOAD)
         if (notificationPayloadJson != null) {
             val mapType = object : TypeToken<HashMap<String, Any>>() {}.type
-            notificationPayload = Gson().fromJson<HashMap<String, String>>(notificationPayloadJson, mapType)
+            notificationPayload =
+                Gson().fromJson<HashMap<String, String>>(notificationPayloadJson, mapType)
         }
 
         val syncActionStr = inputData.getString(ACTION)
@@ -167,13 +171,11 @@ class NotificationsSyncWorker(
             val opportunityStatus = notificationPayload?.get(OPPORTUNITY_STATUS)
             (
                 (job?.status == STATUS_LEARNING || job?.status == STATUS_AVAILABLE || job?.status == STATUS_AVAILABLE_NEW) &&
-                    OPPORTUNITY_STATUS_LEARN.equals(opportunityStatus)
+                    OPPORTUNITY_STATUS_LEARN == opportunityStatus
             ) ||
                 (
                     job?.status == STATUS_DELIVERING &&
-                        OPPORTUNITY_STATUS_DELIVERY.equals(
-                            opportunityStatus,
-                        )
+                        OPPORTUNITY_STATUS_DELIVERY == opportunityStatus
                 )
         } else {
             true

--- a/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
+++ b/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
@@ -149,8 +149,6 @@ class NotificationsSyncWorker(
                 ConnectJobHelper.updateJobProgress(
                     appContext,
                     job!!,
-                    false,
-                    null,
                     object : ConnectActivityCompleteListener {
                         override fun connectActivityComplete(
                             success: Boolean,

--- a/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
+++ b/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
@@ -162,22 +162,24 @@ class NotificationsSyncWorker(
         }
     }
 
-    private fun checkForOpportunityStatus(): Boolean =
-        if (notificationPayload?.contains(OPPORTUNITY_STATUS) == true && job != null) {
-            val opportunityStatus = notificationPayload?.get(OPPORTUNITY_STATUS)
-            (
-                (job?.status == STATUS_LEARNING || job?.status == STATUS_AVAILABLE || job?.status == STATUS_AVAILABLE_NEW) &&
-                    OPPORTUNITY_STATUS_LEARN.equals(opportunityStatus)
-            ) ||
-                (
-                    job?.status == STATUS_DELIVERING &&
-                        OPPORTUNITY_STATUS_DELIVERY.equals(
-                            opportunityStatus,
-                        )
-                )
-        } else {
-            true
+    private fun checkForOpportunityStatus(): Boolean {
+        val payload = notificationPayload ?: return true
+        val currentJob = job ?: return true
+
+        if (!payload.containsKey(OPPORTUNITY_STATUS)) return true
+
+        val opportunityStatus = payload[OPPORTUNITY_STATUS]
+
+        return when (opportunityStatus) {
+            OPPORTUNITY_STATUS_LEARN -> {
+                currentJob.status in setOf(STATUS_LEARNING, STATUS_AVAILABLE, STATUS_AVAILABLE_NEW)
+            }
+            OPPORTUNITY_STATUS_DELIVERY -> {
+                currentJob.status == STATUS_DELIVERING
+            }
+            else -> false
         }
+    }
 
     private fun getConnectJob(): ConnectJobRecord? {
         val opportunityUUID = notificationPayload?.get(OPPORTUNITY_UUID)

--- a/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
+++ b/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
@@ -165,9 +165,13 @@ class NotificationsSyncWorker(
     private fun checkForOpportunityStatus(): Boolean =
         if (notificationPayload?.contains(OPPORTUNITY_STATUS) == true && job != null) {
             val opportunityStatus = notificationPayload?.get(OPPORTUNITY_STATUS)
-            ((job?.status == STATUS_LEARNING || job?.status == STATUS_AVAILABLE || job?.status == STATUS_AVAILABLE_NEW) &&
-                OPPORTUNITY_STATUS_LEARN.equals(opportunityStatus)) ||
-                (job?.status == STATUS_DELIVERING && OPPORTUNITY_STATUS_DELIVERY.equals(opportunityStatus))
+            (
+                    (job?.status == STATUS_LEARNING || job?.status == STATUS_AVAILABLE || job?.status == STATUS_AVAILABLE_NEW) &&
+                            OPPORTUNITY_STATUS_LEARN.equals(opportunityStatus)
+                    ) ||
+                    (job?.status == STATUS_DELIVERING && OPPORTUNITY_STATUS_DELIVERY.equals(
+                        opportunityStatus
+                    ))
         } else {
             true
         }

--- a/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
+++ b/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
@@ -165,14 +165,9 @@ class NotificationsSyncWorker(
     private fun checkForOpportunityStatus(): Boolean =
         if (notificationPayload?.contains(OPPORTUNITY_STATUS) == true && job != null) {
             val opportunityStatus = notificationPayload?.get(OPPORTUNITY_STATUS)
-            (job?.status == STATUS_LEARNING || job?.status == STATUS_AVAILABLE || job?.status == STATUS_AVAILABLE_NEW) &&
-                OPPORTUNITY_STATUS_LEARN.equals(
-                    opportunityStatus,
-                ) ||
-                job?.status == STATUS_DELIVERING &&
-                OPPORTUNITY_STATUS_DELIVERY.equals(
-                    opportunityStatus,
-                )
+            ((job?.status == STATUS_LEARNING || job?.status == STATUS_AVAILABLE || job?.status == STATUS_AVAILABLE_NEW) &&
+                OPPORTUNITY_STATUS_LEARN.equals(opportunityStatus)) ||
+                (job?.status == STATUS_DELIVERING && OPPORTUNITY_STATUS_DELIVERY.equals(opportunityStatus))
         } else {
             true
         }

--- a/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
+++ b/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
@@ -166,12 +166,15 @@ class NotificationsSyncWorker(
         if (notificationPayload?.contains(OPPORTUNITY_STATUS) == true && job != null) {
             val opportunityStatus = notificationPayload?.get(OPPORTUNITY_STATUS)
             (
-                    (job?.status == STATUS_LEARNING || job?.status == STATUS_AVAILABLE || job?.status == STATUS_AVAILABLE_NEW) &&
-                            OPPORTUNITY_STATUS_LEARN.equals(opportunityStatus)
-                    ) ||
-                    (job?.status == STATUS_DELIVERING && OPPORTUNITY_STATUS_DELIVERY.equals(
-                        opportunityStatus
-                    ))
+                (job?.status == STATUS_LEARNING || job?.status == STATUS_AVAILABLE || job?.status == STATUS_AVAILABLE_NEW) &&
+                    OPPORTUNITY_STATUS_LEARN.equals(opportunityStatus)
+            ) ||
+                (
+                    job?.status == STATUS_DELIVERING &&
+                        OPPORTUNITY_STATUS_DELIVERY.equals(
+                            opportunityStatus,
+                        )
+                )
         } else {
             true
         }

--- a/app/unit-tests/src/org/commcare/connect/network/connect/ConnectNetworkClientTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/connect/ConnectNetworkClientTest.kt
@@ -165,4 +165,53 @@ class ConnectNetworkClientTest {
             val result = client.getLearningProgress(mockUser, mockJob)
             assertTrue(result.isSuccess)
         }
+
+    @Test
+    fun testGetDeliveryProgress_authHeaderFailure_returnsFailure() =
+        runBlocking {
+            val mockJob = mockk<ConnectJobRecord>()
+            every { mockJob.jobUUID } returns "test-uuid"
+            coEvery { getAuthorizationHeader(any()) } returns
+                Result.failure(ConnectApiException(PersonalIdOrConnectApiErrorCodes.TOKEN_DENIED_ERROR))
+
+            val result = client.getDeliveryProgress(mockUser, mockJob)
+
+            assertTrue(result.isFailure)
+            assertEquals(
+                PersonalIdOrConnectApiErrorCodes.TOKEN_DENIED_ERROR,
+                (result.exceptionOrNull() as ConnectApiException).errorCode,
+            )
+        }
+
+    @Test
+    fun testGetDeliveryProgress_http500_returnsServerError() =
+        runBlocking {
+            val mockJob = mockk<ConnectJobRecord>()
+            every { mockJob.jobUUID } returns "test-uuid"
+            val errorBody = "".toResponseBody("application/json".toMediaType())
+            val mockResponse = Response.error<ResponseBody>(500, errorBody)
+            coEvery { mockApiService.getDeliveryProgress(any(), any(), any()) } returns mockResponse
+
+            val result = client.getDeliveryProgress(mockUser, mockJob)
+
+            assertTrue(result.isFailure)
+            assertEquals(
+                PersonalIdOrConnectApiErrorCodes.SERVER_ERROR,
+                (result.exceptionOrNull() as ConnectApiException).errorCode,
+            )
+        }
+
+    @Test
+    fun testGetDeliveryProgress_success_returnsDeliveryProgress() =
+        runBlocking {
+            val mockJob = mockk<ConnectJobRecord>()
+            every { mockJob.jobUUID } returns "test-uuid"
+            val responseBody = "".toResponseBody("application/json".toMediaType())
+            coEvery { mockApiService.getDeliveryProgress(any(), any(), any()) } returns
+                Response.success(
+                    responseBody,
+                )
+            val result = client.getDeliveryProgress(mockUser, mockJob)
+            assertTrue(result.isSuccess)
+        }
 }

--- a/app/unit-tests/src/org/commcare/connect/repository/ConnectRepositoryTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/repository/ConnectRepositoryTest.kt
@@ -16,6 +16,7 @@ import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.connect.database.ConnectJobUtils
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.connect.network.connect.ConnectNetworkClient
+import org.commcare.connect.network.connect.models.DeliveryAppProgressResponseModel
 import org.commcare.connect.network.connect.models.LearningAppProgressResponseModel
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -207,5 +208,59 @@ class ConnectRepositoryTest {
             repository.getLearningProgress(mockJob).toList()
 
             coVerify(exactly = 2) { mockNetworkClient.getLearningProgress(any(), any()) }
+        }
+
+    @Test
+    fun testGetDeliveryProgress_alwaysPolicy_networkCalledEachTime() =
+        runBlocking {
+            val mockJob = mockk<ConnectJobRecord>(relaxed = true)
+            val mockModel = DeliveryAppProgressResponseModel()
+            every { ConnectJobUtils.getCompositeJob(any(), any()) } returns mockJob
+            every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
+            every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
+            coEvery { mockNetworkClient.getDeliveryProgress(any(), any()) } returns Result.success(mockModel)
+
+            // First call
+            repository.getDeliveryProgress(mockJob).toList()
+            // Second call — ALWAYS policy means shouldRefresh always true
+            repository.getDeliveryProgress(mockJob).toList()
+
+            coVerify(exactly = 2) { mockNetworkClient.getDeliveryProgress(any(), any()) }
+        }
+
+    @Test
+    fun testGetDeliveryProgress_withCache_networkSuccess_emitsCachedThenSuccess() =
+        runBlocking {
+            val mockJob = mockk<ConnectJobRecord>(relaxed = true)
+            val mockModel = DeliveryAppProgressResponseModel()
+            every { ConnectJobUtils.getCompositeJob(any(), any()) } returns mockJob
+            every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
+            every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
+            coEvery { mockNetworkClient.getDeliveryProgress(any(), any()) } returns Result.success(mockModel)
+
+            val emissions = repository.getDeliveryProgress(mockJob).toList()
+
+            assertEquals(3, emissions.size)
+            assertTrue(emissions[0] is DataState.Cached)
+            assertTrue(emissions[1] is DataState.Loading)
+            assertTrue(emissions[2] is DataState.Success)
+        }
+
+    @Test
+    fun testGetDeliveryProgress_networkFailure_withCache_emitsError() =
+        runBlocking {
+            val mockJob = mockk<ConnectJobRecord>(relaxed = true)
+            every { ConnectJobUtils.getCompositeJob(any(), any()) } returns mockJob
+            every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
+            every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
+            coEvery { mockNetworkClient.getDeliveryProgress(any(), any()) } returns
+                Result.failure(Exception("Network error"))
+
+            val emissions = repository.getDeliveryProgress(mockJob).toList()
+
+            assertEquals(3, emissions.size)
+            assertTrue(emissions[0] is DataState.Cached)
+            assertTrue(emissions[1] is DataState.Loading)
+            assertTrue(emissions[2] is DataState.Error)
         }
 }

--- a/app/unit-tests/src/org/commcare/connect/viewmodel/ConnectDeliveryProgressViewModelTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/viewmodel/ConnectDeliveryProgressViewModelTest.kt
@@ -1,0 +1,116 @@
+package org.commcare.connect.viewmodel
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import org.commcare.CommCareTestApplication
+import org.commcare.android.database.connect.models.ConnectJobRecord
+import org.commcare.connect.repository.ConnectRepository
+import org.commcare.connect.repository.DataState
+import org.commcare.rules.MainCoroutineRule
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@ExperimentalCoroutinesApi
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class ConnectDeliveryProgressViewModelTest {
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    private val application = ApplicationProvider.getApplicationContext<CommCareTestApplication>()
+    private lateinit var mockRepository: ConnectRepository
+    private lateinit var mockJob: ConnectJobRecord
+    private lateinit var viewModel: ConnectDeliveryProgressViewModel
+
+    @Before
+    fun setUp() {
+        mockRepository = mockk()
+        mockJob = mockk(relaxed = true)
+        viewModel = ConnectDeliveryProgressViewModel(application)
+        viewModel.repository = mockRepository
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun testLoadDeliveryProgress_postsLoadingThenSuccess() {
+        every { mockRepository.getDeliveryProgress(any(), any(), any()) } returns
+            flowOf(
+                DataState.Loading,
+                DataState.Success(mockJob),
+            )
+
+        val results = mutableListOf<DataState<ConnectJobRecord>>()
+        viewModel.deliveryProgress.observeForever { results.add(it) }
+
+        mainCoroutineRule.runBlockingTest {
+            viewModel.loadDeliveryProgress(mockJob)
+        }
+
+        assertEquals(2, results.size)
+        assertEquals(DataState.Loading, results[0])
+        assertTrue(results[1] is DataState.Success)
+        assertEquals(mockJob, (results[1] as DataState.Success).data)
+    }
+
+    @Test
+    fun testLoadDeliveryProgress_secondCall_cancelsFirstCollection() {
+        val secondJob = mockk<ConnectJobRecord>(relaxed = true)
+
+        // First flow suspends after Loading so it never posts Success
+        every { mockRepository.getDeliveryProgress(mockJob, any(), any()) } returns
+            flow {
+                emit(DataState.Loading)
+                awaitCancellation()
+            }
+        every { mockRepository.getDeliveryProgress(secondJob, any(), any()) } returns
+            flowOf(DataState.Success(secondJob))
+
+        val results = mutableListOf<DataState<ConnectJobRecord>>()
+        viewModel.deliveryProgress.observeForever { results.add(it) }
+
+        mainCoroutineRule.runBlockingTest {
+            viewModel.loadDeliveryProgress(mockJob)
+            viewModel.loadDeliveryProgress(secondJob)
+        }
+
+        assertTrue(results.any { it is DataState.Loading })
+        assertTrue(results.last() is DataState.Success)
+        assertEquals(secondJob, (results.last() as DataState.Success).data)
+    }
+
+    @Test
+    fun testLoadDeliveryProgress_postsError_onFailure() {
+        every { mockRepository.getDeliveryProgress(any(), any(), any()) } returns
+            flowOf(
+                DataState.Loading,
+                DataState.Error(),
+            )
+
+        val results = mutableListOf<DataState<ConnectJobRecord>>()
+        viewModel.deliveryProgress.observeForever { results.add(it) }
+
+        mainCoroutineRule.runBlockingTest {
+            viewModel.loadDeliveryProgress(mockJob)
+        }
+
+        assertEquals(2, results.size)
+        assertTrue(results[1] is DataState.Error)
+    }
+}


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-2263

## Product Description
Introduces offline-first behavior on the Delivery Progress page:
* Cached opportunity data is displayed immediately on page load
* Modal wait dialog during network call replaced with an inline animation at top of page
* Sync success/failure indicated at top of page when network call completes
* Auto-refresh when network restored (if it was disconnected when entering the page)

Demo video showing:
* 0:04 - Entering the page with network (refreshes and shows success)
* 0:06 - Manual refresh, success (shows success message)
* 0:16 - Manual refresh, failure after disabling network (shows error with "Offline" indicator)
* 0:28 - Manual refresh, success after restoring network (shows success and "Back Online")
* 0:41 - Entering page with network disabled (shows failure with "Offline")
* 0:49 - App auto-refresh after network restored (shows success and "Back Online")


https://github.com/user-attachments/assets/ec430961-5296-41b2-b235-2ab7ad231056



## Technical Summary
The changes in this PR are meant to mirror the UX that was first implemented in [this PR](https://github.com/dimagi/commcare-android/pull/3606/changes#diff-37f1fdb3dfa81f18fe05d3b73b70f2dea83a32449ae7d7c29807f36145588a3a) for the Connect Home and Learning Progress pages.

Changes:
* Added delivery progress functionality in ConnectRepository
* Created modern caller for the delivery progress API call
* Updated response model to handle persistence after successful API call
* Added ConnectDeliveryProgressViewModel
* Connected everything together in ConnectDeliveryProgressFragment
* Cleanup: Deleted the old API call for delivery progress in ConnectApiHandler (no longer used)

Note two small additional changes based on feedback from coderabbit about a thread marshaling error and possible NPE. These issues also existed in the implementation on the Learning Progress page, so I fixed both errors in both places as part of this PR. Commit: [1519381](https://github.com/dimagi/commcare-android/pull/3724/commits/1519381feba209c6b504954b25e5431daf5a815c)

## Safety Assurance

### Safety story
Dev tested the changes on the Delivery Progress page, including:
* Loading the page while offline + online
* Starting offline and then restoring the connection and verifying auto-refresh
* Testing manual refresh calls while online + offline

### Automated test coverage
New unit tests for offline-first UX on the Delivery Progress page:
* 3x ConnectNetworkClientTest: Testing 2 server error scenarios and success scenario
* 3x ConnectRepositoryTest: Testing "always" policy, emitting cache followed by success, handling network failure
* 3x NEW ConnectDeliveryProgressViewModelTest: Testing success, failure, and second call cancelling the first collection
