### PR TITLE
CCCT-2400 Fix Back Button On Image Capture Screen

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,6 +17,8 @@ These are published publicly on Playstore, Github Releases and CommCare Forums
 
 #### Important Bug Fixes
 
+- Fixed the back arrow on the camera capture screen so it correctly returns to the previous screen
+
 #### Internal Release Notes
 
 <!--

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -78,6 +78,11 @@ we would like to communicate to QA as part of the release testing
   - Trigger a non-network failure (e.g. a server error) and then a successful sync. Verify that the bar shows the regular green success message **without** the "Back Online" indicator (the Back Online indicator should only appear after an offline failure).
   - Switch the device language to a non-English locale (e.g. French, Spanish, Hindi) and repeat the back-online flow. Verify that the "Back Online" label is shown in the selected language.
 
+- **Back button on camera capture screen:**
+  - During PersonalID signup for a new phone number, get to the photo capture step and tap **Take Photo** to open the camera. Tap the back arrow in the top toolbar. Verify that the camera closes and you are returned to the photo capture screen.
+  - From a signed-in PersonalID session, open the side navigation drawer and tap the user image, then Continue. Tap the back arrow in the camera screen's top toolbar. Verify that the camera closes and you are returned to the previous screen with no photo change.
+  - In both flows, verify the device's system back button continues to work the same way.
+
 ## CommCare 2.63
 
 ### Release Notes

--- a/app/src/org/commcare/fragments/MicroImageActivity.java
+++ b/app/src/org/commcare/fragments/MicroImageActivity.java
@@ -10,6 +10,7 @@ import android.media.Image;
 import android.os.Bundle;
 import android.util.Base64;
 import android.util.Size;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.Toast;
@@ -105,6 +106,15 @@ public class MicroImageActivity extends CommonBaseActivity implements ImageAnaly
             cameraShutterButton.setVisibility(View.VISIBLE);
         }
         checkForCameraPermission();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            getOnBackPressedDispatcher().onBackPressed();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private void checkForCameraPermission() {


### PR DESCRIPTION
### [CCCT-2400](https://dimagi.atlassian.net/browse/CCCT-2400)

## Product Description

The toolbar back arrow on the PersonalID camera capture screen (`MicroImageActivity`) was non-functional. After this change, tapping the toolbar back arrow closes the camera and returns the user to the previous screen. Affects both the PersonalID signup photo capture step and the profile photo update flow launched from the side navigation drawer.

## Technical Summary

`MicroImageActivity` calls `setDisplayHomeAsUpEnabled(true)` to show the up arrow but never handled clicks on it: neither `MicroImageActivity` nor its superclass `CommonBaseActivity` overrides `onOptionsItemSelected`, and the manifest entry has no `parentActivityName`, so `AppCompatActivity`'s default handling of `android.R.id.home` returned `false` (no-op). The system back button worked because that path goes through `Activity.onBackPressed()` -> `finish()` directly.

The fix overrides `onOptionsItemSelected` in `MicroImageActivity` to route the home item to `getOnBackPressedDispatcher().onBackPressed()`, which is the same path the system back gesture uses. This matches the pattern in `CommCareActivity` (modernized to use the back-pressed dispatcher rather than the deprecated `onBackPressed()`).

## Safety Assurance

### Safety story

What gives me confidence:
- I built and ran the change on a device, exercising both entry points: PersonalID signup photo capture and the profile photo edit flow from the side navigation drawer. In both flows, the toolbar back arrow now closes the camera and the system back button continues to behave the same way.
- The new code path goes through the standard `OnBackPressedDispatcher`, the same dispatcher the system back button already uses on this activity.

Risks to review:
- No automated test was added; verification relies on the manual repro above and the QA Notes in `RELEASES.md`.
- `MicroImageActivity` is reused by any future entry point into camera capture; reviewers should confirm that closing the camera via the toolbar (i.e. without capturing) is acceptable for all current callers (`PersonalIdPhotoCaptureFragment` and `BaseDrawerController`). Both currently handle `RESULT_CANCELED`, which is the default result when no `setResult()` is called before `finish()`.

[CCCT-2400]: https://dimagi.atlassian.net/browse/CCCT-2400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ