### PR TITLE
CCCT-2355 Handle Missing Integrity headers Error on Start Configuration

### DIFF
--- a/app/src/org/commcare/connect/network/connectId/PersonalIdApiHandler.java
+++ b/app/src/org/commcare/connect/network/connectId/PersonalIdApiHandler.java
@@ -103,6 +103,7 @@ public abstract class PersonalIdApiHandler<T> extends BaseApiHandler<T> {
             PersonalIdSessionData sessionData
     ) {
         sessionData.setSessionFailureCode(errorCode);
+        sessionData.setSessionFailureSubcode(errorSubCode);
         switch (errorCode) {
             case "LOCKED_ACCOUNT":
                 onFailure(PersonalIdOrConnectApiErrorCodes.ACCOUNT_LOCKED_ERROR, null);
@@ -112,7 +113,6 @@ public abstract class PersonalIdApiHandler<T> extends BaseApiHandler<T> {
                         LogTypes.TYPE_MAINTENANCE,
                         "Integrity error with subcode " + errorSubCode
                 );
-                sessionData.setSessionFailureSubcode(errorSubCode);
                 onFailure(PersonalIdOrConnectApiErrorCodes.INTEGRITY_ERROR, null);
                 return true;
             case "INVALID_TOKEN":

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -61,6 +61,7 @@ import org.javarosa.core.services.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
+import java.util.function.Consumer;
 
 import static com.google.android.play.core.integrity.model.IntegrityDialogResponseCode.DIALOG_SUCCESSFUL;
 import static org.commcare.utils.Permissions.shouldShowPermissionRationale;
@@ -341,30 +342,11 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
             body.put("device", model);
         }
 
-        integrityTokenApiRequestHelper.withIntegrityToken(
-                body,
-                new IntegrityTokenViewModel.IntegrityTokenCallback() {
-                    @Override
-                    public void onTokenReceived(
-                            @NotNull String requestHash,
-                            @NotNull StandardIntegrityManager.StandardIntegrityToken integrityTokenResponse
-                    ) {
-                        makeStartConfigurationCall(requestHash, body, integrityTokenResponse);
-                    }
-
-                    @Override
-                    public void onTokenFailure(@NotNull Exception exception) {
-                        String errorCode = IntegrityTokenApiRequestHelper.Companion.getCodeForException(
-                                exception
-                        );
-                        FirebaseAnalyticsUtil.reportPersonalIdConfigurationIntegritySubmission(
-                                errorCode
-                        );
-
-                        makeStartConfigurationCall(null, body, null);
-                    }
-                }
-        );
+        fetchIntegrityTokenAndStartConfiguration(body, exception -> {
+            String errorCode = IntegrityTokenApiRequestHelper.Companion.getCodeForException(exception);
+            FirebaseAnalyticsUtil.reportPersonalIdConfigurationIntegritySubmission(errorCode);
+            makeStartConfigurationCall(null, body, null);
+        });
     }
 
     @Override
@@ -554,6 +536,21 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                                 personalIdSessionDataViewModel.getPersonalIdSessionData().getSessionFailureSubcode()
                         );
                         break;
+                    case MISSING_DATA_ERROR: {
+                        String subCode = personalIdSessionDataViewModel.getPersonalIdSessionData().getSessionFailureSubcode();
+                        boolean isIntegrityHeadersMissing = BaseApiHandler.PersonalIdApiSubErrorCodes.INTEGRITY_HEADERS.name().equals(subCode);
+                        if (isIntegrityHeadersMissing && token.isEmpty()) {
+                            retryWithNewIntegrityToken(body);
+                        } else if (isIntegrityHeadersMissing) {
+                            onConfigurationFailure(
+                                    AnalyticsParamValue.START_CONFIGURATION_INTEGRITY_CHECK_FAILURE,
+                                    getString(R.string.personalid_configuration_process_failed_subtitle)
+                            );
+                        } else {
+                            navigateFailure(failureCode, t);
+                        }
+                        break;
+                    }
                     default:
                         navigateFailure(failureCode, t);
                         break;
@@ -606,6 +603,37 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
             // Dialog failed to launch or some error occurred
             handleIntegrityFailure(subError, "Integrity dialog failed to launch " + e.getMessage());
         });
+    }
+
+    private void retryWithNewIntegrityToken(HashMap<String, String> body) {
+        fetchIntegrityTokenAndStartConfiguration(body, exception -> onConfigurationFailure(
+                AnalyticsParamValue.START_CONFIGURATION_INTEGRITY_CHECK_FAILURE,
+                getString(R.string.personalid_configuration_process_failed_subtitle)
+        ));
+    }
+
+    private void fetchIntegrityTokenAndStartConfiguration(
+            HashMap<String, String> body,
+            Consumer<Exception> onTokenFailure
+    ) {
+        integrityTokenApiRequestHelper.withIntegrityToken(
+                body,
+                new IntegrityTokenViewModel.IntegrityTokenCallback() {
+                    @Override
+                    public void onTokenReceived(
+                            @NotNull String requestHash,
+                            @NotNull StandardIntegrityManager.StandardIntegrityToken integrityTokenResponse
+                    ) {
+                        makeStartConfigurationCall(requestHash, body, integrityTokenResponse);
+                    }
+
+
+                    @Override
+                    public void onTokenFailure(@NotNull Exception exception) {
+                        onTokenFailure.accept(exception);
+                    }
+                }
+        );
     }
 
     private void handleIntegrityFailure(String subError, String logMessage) {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -525,10 +525,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
 
                 switch (failureCode) {
                     case FORBIDDEN_ERROR:
-                        onConfigurationFailure(
-                                AnalyticsParamValue.START_CONFIGURATION_INTEGRITY_CHECK_FAILURE,
-                                getString(R.string.personalid_configuration_process_failed_subtitle)
-                        );
+                        onIntegrityConfigurationError();
                         break;
                     case INTEGRITY_ERROR:
                         handleIntegritySubError(
@@ -542,10 +539,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                         if (isIntegrityHeadersMissing && token.isEmpty()) {
                             retryWithNewIntegrityToken(body);
                         } else if (isIntegrityHeadersMissing) {
-                            onConfigurationFailure(
-                                    AnalyticsParamValue.START_CONFIGURATION_INTEGRITY_CHECK_FAILURE,
-                                    getString(R.string.personalid_configuration_process_failed_subtitle)
-                            );
+                            onIntegrityConfigurationError();
                         } else {
                             navigateFailure(failureCode, t);
                         }
@@ -557,6 +551,13 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                 }
             }
         }.makeStartConfigurationCall(requireActivity(), body, token, requestHash, newSessionData);
+    }
+
+    private void onIntegrityConfigurationError() {
+        onConfigurationFailure(
+                AnalyticsParamValue.START_CONFIGURATION_INTEGRITY_CHECK_FAILURE,
+                getString(R.string.personalid_configuration_process_failed_subtitle)
+        );
     }
 
     private void handleIntegritySubError(
@@ -606,10 +607,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
     }
 
     private void retryWithNewIntegrityToken(HashMap<String, String> body) {
-        fetchIntegrityTokenAndStartConfiguration(body, exception -> onConfigurationFailure(
-                AnalyticsParamValue.START_CONFIGURATION_INTEGRITY_CHECK_FAILURE,
-                getString(R.string.personalid_configuration_process_failed_subtitle)
-        ));
+        fetchIntegrityTokenAndStartConfiguration(body, exception -> onIntegrityConfigurationError());
     }
 
     private void fetchIntegrityTokenAndStartConfiguration(

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -538,8 +538,11 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                         boolean isIntegrityHeadersMissing = BaseApiHandler.PersonalIdApiSubErrorCodes.INTEGRITY_HEADERS.name().equals(subCode);
                         if (isIntegrityHeadersMissing) {
                             if (!token.isEmpty()) {
-                                Logger.exception("Missing Data error related to ingerity headers",
-                                        new Exception("Missing integrity headers when token is present"));
+                                Logger.exception("Missing Data error related to Integrity check headers",
+                                        new Exception("Missing integrity headers even when token is present"));
+                            } else {
+                                Logger.exception("Missing Data error related to Integrity check headers",
+                                        new Exception("Missing integrity headers due to an empty token"));
                             }
                             onIntegrityConfigurationError();
                         } else {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -536,11 +536,16 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                     case MISSING_DATA_ERROR: {
                         String subCode = personalIdSessionDataViewModel.getPersonalIdSessionData().getSessionFailureSubcode();
                         boolean isIntegrityHeadersMissing = BaseApiHandler.PersonalIdApiSubErrorCodes.INTEGRITY_HEADERS.name().equals(subCode);
-                        if (isIntegrityHeadersMissing && token.isEmpty()) {
-                            retryWithNewIntegrityToken(body);
-                        } else if (isIntegrityHeadersMissing) {
+                        if (isIntegrityHeadersMissing) {
+                            if (!token.isEmpty()) {
+                                Logger.exception("Missing Data error related to ingerity headers",
+                                        new Exception("Missing integrity headers when token is present"));
+                            }
                             onIntegrityConfigurationError();
                         } else {
+                            Logger.exception("Personal ID start configuration failed",
+                                    new Exception("Missing Data error with subcode "
+                                            + subCode));
                             navigateFailure(failureCode, t);
                         }
                         break;
@@ -604,10 +609,6 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
             // Dialog failed to launch or some error occurred
             handleIntegrityFailure(subError, "Integrity dialog failed to launch " + e.getMessage());
         });
-    }
-
-    private void retryWithNewIntegrityToken(HashMap<String, String> body) {
-        fetchIntegrityTokenAndStartConfiguration(body, exception -> onIntegrityConfigurationError());
     }
 
     private void fetchIntegrityTokenAndStartConfiguration(

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhoneFragmentStartConfigurationTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhoneFragmentStartConfigurationTest.kt
@@ -5,9 +5,12 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.play.core.integrity.StandardIntegrityManager
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.commcare.CommCareTestApplication
+import org.commcare.android.CommCareViewModelProvider
+import org.commcare.android.integrity.IntegrityTokenViewModel
 import org.commcare.android.logging.ReportingUtils
 import org.commcare.connect.network.ApiService
 import org.commcare.connect.network.base.BaseApiClient
@@ -25,6 +28,10 @@ import org.junit.Assume.assumeFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
 
@@ -274,7 +281,117 @@ class PersonalIdPhoneFragmentStartConfigurationTest : BasePersonalIdPhoneFragmen
         )
     }
 
+    // ========== Integrity Retry Tests ==========
+
+    @Test
+    fun testStartConfiguration_missingDataIntegrityHeaders_noToken_retriesAndSucceeds() {
+        setupIntegrityTokenFailThenSucceed()
+        setupFragmentForRequest()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setBody("""{"error_code": "MISSING_DATA", "error_sub_code": "INTEGRITY_HEADERS"}"""),
+        )
+        mockWebServer.enqueue(createSuccessResponse())
+
+        clickContinueButton()
+
+        mockWebServer.takeRequest()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        mockWebServer.takeRequest()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertEquals(
+            "Should navigate to biometric config after successful integrity token retry",
+            R.id.personalid_biometric_config,
+            navController.currentDestination!!.id,
+        )
+    }
+
+    @Test
+    fun testStartConfiguration_missingDataIntegrityHeaders_tokenPresent_noRetry() {
+        setupFragmentForRequest()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setBody("""{"error_code": "MISSING_DATA", "error_sub_code": "INTEGRITY_HEADERS"}"""),
+        )
+
+        clickContinueButton()
+
+        mockWebServer.takeRequest()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertEquals("Should make exactly one request with no retry", 1, mockWebServer.requestCount)
+        assertEquals(
+            "Should navigate to failure screen without retrying",
+            R.id.personalid_message_display,
+            navController.currentDestination!!.id,
+        )
+    }
+
+    @Test
+    fun testStartConfiguration_missingDataIntegrityHeaders_noToken_retryTokenFails_showsError() {
+        setupIntegrityTokenAlwaysFail()
+        setupFragmentForRequest()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setBody("""{"error_code": "MISSING_DATA", "error_sub_code": "INTEGRITY_HEADERS"}"""),
+        )
+
+        clickContinueButton()
+
+        mockWebServer.takeRequest()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertEquals("Should make exactly one request when retry token fails", 1, mockWebServer.requestCount)
+        assertEquals(
+            "Should navigate to failure screen when retry token fails",
+            R.id.personalid_message_display,
+            navController.currentDestination!!.id,
+        )
+        val expectedMessage = activity.getString(R.string.personalid_configuration_process_failed_subtitle)
+        val actualMessage = navController.currentBackStackEntry!!.arguments!!.getString("message")
+        assertEquals("Error message should match integrity failure message", expectedMessage, actualMessage)
+    }
+
     // ========== Helper Methods ==========
+
+    private fun setupIntegrityTokenFailThenSucceed() {
+        val field = CommCareViewModelProvider::class.java.getDeclaredField("integrityTokenViewModel")
+        field.isAccessible = true
+        val mockViewModel = field.get(null) as IntegrityTokenViewModel
+        val mockToken = mock(StandardIntegrityManager.StandardIntegrityToken::class.java)
+        `when`(mockToken.token()).thenReturn(TEST_INTEGRITY_TOKEN)
+
+        doAnswer { invocation ->
+            val callback = invocation.arguments[2] as IntegrityTokenViewModel.IntegrityTokenCallback
+            callback.onTokenFailure(RuntimeException("Token unavailable"))
+            null
+        }.doAnswer { invocation ->
+            val callback = invocation.arguments[2] as IntegrityTokenViewModel.IntegrityTokenCallback
+            val requestHash = invocation.arguments[0] as String
+            callback.onTokenReceived(requestHash, mockToken)
+            null
+        }.`when`(mockViewModel)
+            .requestIntegrityToken(any(), any(), any())
+    }
+
+    private fun setupIntegrityTokenAlwaysFail() {
+        val field = CommCareViewModelProvider::class.java.getDeclaredField("integrityTokenViewModel")
+        field.isAccessible = true
+        val mockViewModel = field.get(null) as IntegrityTokenViewModel
+
+        doAnswer { invocation ->
+            val callback = invocation.arguments[2] as IntegrityTokenViewModel.IntegrityTokenCallback
+            callback.onTokenFailure(RuntimeException("Token unavailable"))
+            null
+        }.`when`(mockViewModel).requestIntegrityToken(any(), any(), any())
+    }
 
     private fun setupFragmentForRequest() {
         val phoneInput = fragment.view!!.findViewById<EditText>(R.id.connect_primary_phone_input)

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhoneFragmentStartConfigurationTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhoneFragmentStartConfigurationTest.kt
@@ -5,12 +5,9 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.android.play.core.integrity.StandardIntegrityManager
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.commcare.CommCareTestApplication
-import org.commcare.android.CommCareViewModelProvider
-import org.commcare.android.integrity.IntegrityTokenViewModel
 import org.commcare.android.logging.ReportingUtils
 import org.commcare.connect.network.ApiService
 import org.commcare.connect.network.base.BaseApiClient
@@ -21,17 +18,12 @@ import org.commcare.utils.HashUtils
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.doAnswer
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.any
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
 
@@ -281,34 +273,6 @@ class PersonalIdPhoneFragmentStartConfigurationTest : BasePersonalIdPhoneFragmen
         )
     }
 
-    // ========== Integrity Retry Tests ==========
-
-    @Test
-    fun testStartConfiguration_missingDataIntegrityHeaders_noToken_retriesAndSucceeds() {
-        setupIntegrityTokenFailThenSucceed()
-        setupFragmentForRequest()
-
-        mockWebServer.enqueue(
-            MockResponse()
-                .setResponseCode(400)
-                .setBody("""{"error_code": "MISSING_DATA", "error_sub_code": "INTEGRITY_HEADERS"}"""),
-        )
-        mockWebServer.enqueue(createSuccessResponse())
-
-        clickContinueButton()
-
-        mockWebServer.takeRequest()
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
-        mockWebServer.takeRequest()
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
-
-        assertEquals(
-            "Should navigate to biometric config after successful integrity token retry",
-            R.id.personalid_biometric_config,
-            navController.currentDestination!!.id,
-        )
-    }
-
     @Test
     fun testStartConfiguration_missingDataIntegrityHeaders_tokenPresent_noRetry() {
         setupFragmentForRequest()
@@ -324,74 +288,14 @@ class PersonalIdPhoneFragmentStartConfigurationTest : BasePersonalIdPhoneFragmen
         mockWebServer.takeRequest()
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertEquals("Should make exactly one request with no retry", 1, mockWebServer.requestCount)
         assertEquals(
-            "Should navigate to failure screen without retrying",
+            "Should navigate to failure screen",
             R.id.personalid_message_display,
             navController.currentDestination!!.id,
         )
-    }
-
-    @Test
-    fun testStartConfiguration_missingDataIntegrityHeaders_noToken_retryTokenFails_showsError() {
-        setupIntegrityTokenAlwaysFail()
-        setupFragmentForRequest()
-
-        mockWebServer.enqueue(
-            MockResponse()
-                .setResponseCode(400)
-                .setBody("""{"error_code": "MISSING_DATA", "error_sub_code": "INTEGRITY_HEADERS"}"""),
-        )
-
-        clickContinueButton()
-
-        mockWebServer.takeRequest()
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
-
-        assertEquals("Should make exactly one request when retry token fails", 1, mockWebServer.requestCount)
-        assertEquals(
-            "Should navigate to failure screen when retry token fails",
-            R.id.personalid_message_display,
-            navController.currentDestination!!.id,
-        )
-        val expectedMessage = activity.getString(R.string.personalid_configuration_process_failed_subtitle)
-        val actualMessage = navController.currentBackStackEntry!!.arguments!!.getString("message")
-        assertEquals("Error message should match integrity failure message", expectedMessage, actualMessage)
     }
 
     // ========== Helper Methods ==========
-
-    private fun setupIntegrityTokenFailThenSucceed() {
-        val field = CommCareViewModelProvider::class.java.getDeclaredField("integrityTokenViewModel")
-        field.isAccessible = true
-        val mockViewModel = field.get(null) as IntegrityTokenViewModel
-        val mockToken = mock(StandardIntegrityManager.StandardIntegrityToken::class.java)
-        `when`(mockToken.token()).thenReturn(TEST_INTEGRITY_TOKEN)
-
-        doAnswer { invocation ->
-            val callback = invocation.arguments[2] as IntegrityTokenViewModel.IntegrityTokenCallback
-            callback.onTokenFailure(RuntimeException("Token unavailable"))
-            null
-        }.doAnswer { invocation ->
-            val callback = invocation.arguments[2] as IntegrityTokenViewModel.IntegrityTokenCallback
-            val requestHash = invocation.arguments[0] as String
-            callback.onTokenReceived(requestHash, mockToken)
-            null
-        }.`when`(mockViewModel)
-            .requestIntegrityToken(any(), any(), any())
-    }
-
-    private fun setupIntegrityTokenAlwaysFail() {
-        val field = CommCareViewModelProvider::class.java.getDeclaredField("integrityTokenViewModel")
-        field.isAccessible = true
-        val mockViewModel = field.get(null) as IntegrityTokenViewModel
-
-        doAnswer { invocation ->
-            val callback = invocation.arguments[2] as IntegrityTokenViewModel.IntegrityTokenCallback
-            callback.onTokenFailure(RuntimeException("Token unavailable"))
-            null
-        }.`when`(mockViewModel).requestIntegrityToken(any(), any(), any())
-    }
 
     private fun setupFragmentForRequest() {
         val phoneInput = fragment.view!!.findViewById<EditText>(R.id.connect_primary_phone_input)


### PR DESCRIPTION
### [CCCT-2355](https://dimagi.atlassian.net/browse/CCCT-2355)

## Product Description

Fixes a PersonalID configuration crash where the server rejects the start-configuration request because the integrity token was missing from the request headers. 

Some Useful notes to review:

- We make the call to the server without token in the first place as token is not always mandatory depending on whether the user is pre-invited or not. 
- I have also enhanced logging around this issue for us to be sure that this issue only happens due to token being empty. 

## Safety Assurance

### Safety story

Minimum risks, Error handling mostly with existing code pathway

### Automated test coverage

Added tests in `PersonalIdPhoneFragmentStartConfigurationTest` 

[CCCT-2355]: https://dimagi.atlassian.net/browse/CCCT-2355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ