### PR TITLE
CCCT-2301 Add Unit Tests For PersonalIdNameFragment

### DIFF
--- a/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdNameFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdNameFragmentTest.kt
@@ -1,0 +1,83 @@
+package org.commcare.fragments.personalId
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.Navigation
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+import org.commcare.activities.connect.PersonalIdActivity
+import org.commcare.activities.connect.viewmodel.PersonalIdSessionDataViewModel
+import org.commcare.android.database.connect.models.PersonalIdSessionData
+import org.commcare.dalvik.R
+import org.junit.After
+import org.junit.Before
+import org.robolectric.Robolectric
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * Base test class for PersonalIdNameFragment tests.
+ * Sets up a PersonalIdActivity, populates the session ViewModel, and replaces the
+ * default start fragment with PersonalIdNameFragment under a TestNavHostController.
+ */
+abstract class BasePersonalIdNameFragmentTest {
+    protected lateinit var activityController: ActivityController<PersonalIdActivity>
+    protected lateinit var activity: PersonalIdActivity
+    protected lateinit var fragment: PersonalIdNameFragment
+    protected lateinit var navController: TestNavHostController
+
+    protected open fun buildSessionData(): PersonalIdSessionData =
+        PersonalIdSessionData(
+            requiredLock = PersonalIdSessionData.PIN,
+            demoUser = false,
+            token = TEST_SESSION_TOKEN,
+        )
+
+    @Before
+    open fun setUp() {
+        activityController = Robolectric.buildActivity(PersonalIdActivity::class.java)
+        activity =
+            activityController
+                .create()
+                .start()
+                .resume()
+                .get()
+
+        // Seed the session ViewModel before swapping in the name fragment so onCreateView reads it.
+        val sessionData = buildSessionData()
+        activity.runOnUiThread {
+            val viewModel = ViewModelProvider(activity)[PersonalIdSessionDataViewModel::class.java]
+            viewModel.personalIdSessionData = sessionData
+        }
+        ShadowLooper.idleMainLooper()
+
+        val navHostFragment =
+            activity.supportFragmentManager
+                .findFragmentById(R.id.nav_host_fragment_connectid) as NavHostFragment
+
+        navController = TestNavHostController(ApplicationProvider.getApplicationContext())
+        navController.setGraph(R.navigation.nav_graph_personalid)
+        navController.setCurrentDestination(R.id.personalid_name)
+
+        activity.runOnUiThread {
+            Navigation.setViewNavController(navHostFragment.requireView(), navController)
+            val nameFragment = PersonalIdNameFragment()
+            navHostFragment.childFragmentManager
+                .beginTransaction()
+                .replace(R.id.nav_host_fragment_connectid, nameFragment)
+                .commitNow()
+            fragment = nameFragment
+        }
+
+        ShadowLooper.idleMainLooper()
+    }
+
+    @After
+    open fun tearDown() {
+        activityController.pause().stop().destroy()
+    }
+
+    companion object {
+        const val TEST_SESSION_TOKEN: String = "test_session_token_abc"
+    }
+}

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdNameFragmentAddOrVerifyNameTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdNameFragmentAddOrVerifyNameTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.material.button.MaterialButton
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import org.commcare.CommCareTestApplication
 import org.commcare.activities.connect.viewmodel.PersonalIdSessionDataViewModel
 import org.commcare.connect.network.ApiService
@@ -25,6 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
+import java.util.concurrent.TimeUnit
 
 /**
  * Tests the `addOrVerifyName` API integration of [PersonalIdNameFragment]. Uses MockWebServer to
@@ -96,10 +98,18 @@ class PersonalIdNameFragmentAddOrVerifyNameTest : BasePersonalIdNameFragmentTest
         ShadowLooper.idleMainLooper()
     }
 
+    /**
+     * Reads the next request with a bounded wait so a missing dispatch fails fast instead of
+     * hanging the suite, then drains delayed UI work so callbacks can run before assertions.
+     */
     private fun drainHttp() {
-        mockWebServer.takeRequest()
+        takeRequestOrFail()
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
     }
+
+    private fun takeRequestOrFail(timeoutSeconds: Long = 5): RecordedRequest =
+        mockWebServer.takeRequest(timeoutSeconds, TimeUnit.SECONDS)
+            ?: throw AssertionError("Expected an HTTP request within ${timeoutSeconds}s but none arrived")
 
     // ========== Request payload ==========
 
@@ -109,8 +119,7 @@ class PersonalIdNameFragmentAddOrVerifyNameTest : BasePersonalIdNameFragmentTest
 
         typeAndContinue("  Margaret Hamilton  ")
 
-        val request = mockWebServer.takeRequest()
-        assertNotNull(request)
+        val request = takeRequestOrFail()
         assertEquals("/users/check_name", request.path)
         assertEquals("POST", request.method)
 
@@ -125,7 +134,7 @@ class PersonalIdNameFragmentAddOrVerifyNameTest : BasePersonalIdNameFragmentTest
 
         typeAndContinue("Ada Lovelace")
 
-        val request = mockWebServer.takeRequest()
+        val request = takeRequestOrFail()
         val authHeader = request.headers["Authorization"]
         assertNotNull("Authorization header should be present", authHeader)
         assertTrue(
@@ -169,6 +178,10 @@ class PersonalIdNameFragmentAddOrVerifyNameTest : BasePersonalIdNameFragmentTest
         assertTrue("Pre-click sanity check: button must be enabled before continue", continueButton().isEnabled)
 
         activity.runOnUiThread { continueButton().performClick() }
+        // Drain only the immediately-posted UI work — running delayed tasks would let the
+        // enqueued mock response settle and weaken the "immediately disabled" guarantee
+        // this test exists to defend.
+        ShadowLooper.idleMainLooper()
 
         assertFalse(
             "Continue button should be disabled the instant verifyOrAddName runs",

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdNameFragmentAddOrVerifyNameTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdNameFragmentAddOrVerifyNameTest.kt
@@ -125,7 +125,6 @@ class PersonalIdNameFragmentAddOrVerifyNameTest : BasePersonalIdNameFragmentTest
 
         val body = request.body.readUtf8()
         assertTrue("Body should carry the trimmed name", body.contains("\"name\":\"Margaret Hamilton\""))
-        assertFalse("Body should not include the surrounding whitespace", body.contains("  Margaret Hamilton  "))
     }
 
     @Test

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdNameFragmentAddOrVerifyNameTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdNameFragmentAddOrVerifyNameTest.kt
@@ -1,0 +1,279 @@
+package org.commcare.fragments.personalId
+
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.widget.EditText
+import android.widget.TextView
+import androidx.lifecycle.ViewModelProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.button.MaterialButton
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.commcare.CommCareTestApplication
+import org.commcare.activities.connect.viewmodel.PersonalIdSessionDataViewModel
+import org.commcare.connect.network.ApiService
+import org.commcare.connect.network.base.BaseApiClient
+import org.commcare.connect.network.connectId.PersonalIdApiClient
+import org.commcare.dalvik.R
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * Tests the `addOrVerifyName` API integration of [PersonalIdNameFragment]. Uses MockWebServer to
+ * intercept the actual HTTP request so we can assert both the request payload and the fragment's
+ * response handling (navigation, error UI, retry-button state, session-data updates).
+ */
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class PersonalIdNameFragmentAddOrVerifyNameTest : BasePersonalIdNameFragmentTest() {
+    private lateinit var mockWebServer: MockWebServer
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        setupMockWebServer()
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        val apiServiceField = PersonalIdApiClient::class.java.getDeclaredField("apiService")
+        apiServiceField.isAccessible = true
+        apiServiceField.set(null, null)
+        mockWebServer.shutdown()
+    }
+
+    private fun setupMockWebServer() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        val apiService =
+            BaseApiClient
+                .buildRetrofitClient(mockWebServer.url("/").toString(), PersonalIdApiClient.API_VERSION)
+                .create(ApiService::class.java)
+
+        val apiServiceField = PersonalIdApiClient::class.java.getDeclaredField("apiService")
+        apiServiceField.isAccessible = true
+        apiServiceField.set(null, apiService)
+    }
+
+    // ========== Helpers ==========
+
+    private fun successResponse(): MockResponse =
+        MockResponse()
+            .setResponseCode(200)
+            .setBody(
+                """
+                {
+                    "account_exists": false,
+                    "photo": null
+                }
+                """.trimIndent(),
+            )
+
+    private fun nameInput(): EditText = fragment.requireView().findViewById(R.id.nameTextValue)
+
+    private fun continueButton(): MaterialButton = fragment.requireView().findViewById(R.id.personalid_name_continue_button)
+
+    private fun errorView(): TextView = fragment.requireView().findViewById(R.id.personalid_name_error)
+
+    private fun setName(value: String) {
+        activity.runOnUiThread { nameInput().setText(value) }
+        ShadowLooper.idleMainLooper()
+    }
+
+    private fun typeAndContinue(name: String) {
+        setName(name)
+        activity.runOnUiThread { continueButton().performClick() }
+        ShadowLooper.idleMainLooper()
+    }
+
+    private fun drainHttp() {
+        mockWebServer.takeRequest()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+    }
+
+    // ========== Request payload ==========
+
+    @Test
+    fun `submitting a name sends a POST to check_name with the trimmed value`() {
+        mockWebServer.enqueue(successResponse())
+
+        typeAndContinue("  Margaret Hamilton  ")
+
+        val request = mockWebServer.takeRequest()
+        assertNotNull(request)
+        assertEquals("/users/check_name", request.path)
+        assertEquals("POST", request.method)
+
+        val body = request.body.readUtf8()
+        assertTrue("Body should carry the trimmed name", body.contains("\"name\":\"Margaret Hamilton\""))
+        assertFalse("Body should not include the surrounding whitespace", body.contains("  Margaret Hamilton  "))
+    }
+
+    @Test
+    fun `request authorization header uses the session token`() {
+        mockWebServer.enqueue(successResponse())
+
+        typeAndContinue("Ada Lovelace")
+
+        val request = mockWebServer.takeRequest()
+        val authHeader = request.headers["Authorization"]
+        assertNotNull("Authorization header should be present", authHeader)
+        assertTrue(
+            "Authorization header should be a token-auth using the session token",
+            authHeader!!.contains(TEST_SESSION_TOKEN),
+        )
+    }
+
+    // ========== Success path ==========
+
+    @Test
+    fun `a successful response navigates to the backup-code screen`() {
+        mockWebServer.enqueue(successResponse())
+
+        typeAndContinue("Ada Lovelace")
+
+        drainHttp()
+
+        assertEquals(R.id.personalid_backup_code, navController.currentDestination?.id)
+    }
+
+    @Test
+    fun `a successful response stores the trimmed name on the session view model`() {
+        mockWebServer.enqueue(successResponse())
+
+        typeAndContinue("  Ada Lovelace  ")
+
+        drainHttp()
+
+        val viewModel = ViewModelProvider(activity)[PersonalIdSessionDataViewModel::class.java]
+        assertEquals("Ada Lovelace", viewModel.personalIdSessionData.userName)
+    }
+
+    @Test
+    fun `clicking continue immediately disables the button to prevent duplicate requests`() {
+        // Enqueue but don't let the response settle — the button must already be disabled before any
+        // dispatch completes.
+        mockWebServer.enqueue(successResponse())
+
+        setName("Ada Lovelace")
+        assertTrue("Pre-click sanity check: button must be enabled before continue", continueButton().isEnabled)
+
+        activity.runOnUiThread { continueButton().performClick() }
+
+        assertFalse(
+            "Continue button should be disabled the instant verifyOrAddName runs",
+            continueButton().isEnabled,
+        )
+    }
+
+    // ========== Retryable failures ==========
+
+    @Test
+    fun `a 500 server error shows the inline error and re-enables the continue button`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal Server Error"),
+        )
+
+        typeAndContinue("Ada Lovelace")
+
+        drainHttp()
+
+        assertEquals(R.id.personalid_name, navController.currentDestination?.id)
+        assertEquals(View.VISIBLE, errorView().visibility)
+        assertEquals(
+            activity.getString(R.string.recovery_network_server_error),
+            errorView().text.toString(),
+        )
+        assertTrue(
+            "Retryable failures should re-enable the continue button",
+            continueButton().isEnabled,
+        )
+    }
+
+    // ========== Non-retryable / routed-to-message-screen failures ==========
+
+    @Test
+    fun `a LOCKED_ACCOUNT error routes the user to the failure message screen`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(401)
+                .setBody("""{"error_code": "LOCKED_ACCOUNT"}"""),
+        )
+
+        typeAndContinue("Ada Lovelace")
+
+        drainHttp()
+
+        assertEquals(R.id.personalid_message_display, navController.currentDestination?.id)
+        val args = navController.currentBackStackEntry?.arguments
+        assertEquals(
+            activity.getString(R.string.personalid_configuration_process_failed_title),
+            args?.getString("title"),
+        )
+        assertEquals(
+            activity.getString(R.string.personalid_configuration_locked_account),
+            args?.getString("message"),
+        )
+    }
+
+    @Test
+    fun `a 403 PHONE_NOT_VALIDATED error shows the inline forbidden error and does not navigate`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(403)
+                .setBody("""{"error_code": "PHONE_NOT_VALIDATED"}"""),
+        )
+
+        typeAndContinue("Ada Lovelace")
+
+        drainHttp()
+
+        assertEquals(R.id.personalid_name, navController.currentDestination?.id)
+        assertEquals(View.VISIBLE, errorView().visibility)
+        assertEquals(
+            activity.getString(R.string.network_forbidden_error),
+            errorView().text.toString(),
+        )
+        assertFalse(
+            "FORBIDDEN_ERROR is not retryable, so the button should stay disabled",
+            continueButton().isEnabled,
+        )
+    }
+
+    // ========== Enter-key shortcut ==========
+
+    @Test
+    fun `pressing enter with an empty name does not fire an API request`() {
+        // Don't enqueue — any dispatch would trip MockWebServer with an unmatched request.
+        activity.runOnUiThread { nameInput().onEditorAction(EditorInfo.IME_ACTION_DONE) }
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertEquals("No HTTP traffic should be generated", 0, mockWebServer.requestCount)
+        assertEquals(R.id.personalid_name, navController.currentDestination?.id)
+    }
+
+    @Test
+    fun `pressing enter with a filled name triggers verifyOrAddName and navigates on success`() {
+        mockWebServer.enqueue(successResponse())
+
+        setName("Ada Lovelace")
+        activity.runOnUiThread { nameInput().onEditorAction(EditorInfo.IME_ACTION_DONE) }
+        ShadowLooper.idleMainLooper()
+
+        drainHttp()
+
+        assertEquals(R.id.personalid_backup_code, navController.currentDestination?.id)
+    }
+}

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdNameFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdNameFragmentTest.kt
@@ -1,0 +1,89 @@
+package org.commcare.fragments.personalId
+
+import android.view.View
+import android.widget.EditText
+import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.button.MaterialButton
+import org.commcare.CommCareTestApplication
+import org.commcare.dalvik.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * UI-only unit tests for PersonalIdNameFragment. Verifies initial state and the name TextWatcher
+ * that drives the continue button. Network/navigation behavior — including the enter-key
+ * shortcut, which can only meaningfully fire when the API is involved — lives in
+ * [PersonalIdNameFragmentAddOrVerifyNameTest].
+ */
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class PersonalIdNameFragmentTest : BasePersonalIdNameFragmentTest() {
+    // ========== Helpers ==========
+
+    private fun nameInput(): EditText = fragment.requireView().findViewById(R.id.nameTextValue)
+
+    private fun continueButton(): MaterialButton = fragment.requireView().findViewById(R.id.personalid_name_continue_button)
+
+    private fun errorView(): TextView = fragment.requireView().findViewById(R.id.personalid_name_error)
+
+    private fun setName(value: String) {
+        activity.runOnUiThread { nameInput().setText(value) }
+        ShadowLooper.idleMainLooper()
+    }
+
+    // ========== Initial UI state ==========
+
+    @Test
+    fun `continue button is disabled before any name is typed`() {
+        assertFalse(continueButton().isEnabled)
+    }
+
+    @Test
+    fun `name input is empty on first render`() {
+        assertEquals("", nameInput().text.toString())
+    }
+
+    @Test
+    fun `error text view starts hidden`() {
+        assertEquals(View.GONE, errorView().visibility)
+    }
+
+    // ========== TextWatcher behavior ==========
+
+    @Test
+    fun `typing a non-empty name enables the continue button`() {
+        setName("Ada Lovelace")
+
+        assertTrue(continueButton().isEnabled)
+    }
+
+    @Test
+    fun `clearing the name disables the continue button again`() {
+        setName("Ada Lovelace")
+        assertTrue(continueButton().isEnabled)
+
+        setName("")
+
+        assertFalse(continueButton().isEnabled)
+    }
+
+    @Test
+    fun `whitespace-only input does not enable the continue button`() {
+        setName("    ")
+
+        assertFalse(continueButton().isEnabled)
+    }
+
+    @Test
+    fun `leading and trailing whitespace still enables the continue button when a name is present`() {
+        setName("  Grace Hopper  ")
+
+        assertTrue(continueButton().isEnabled)
+    }
+}


### PR DESCRIPTION
### [CCCT-2301](https://dimagi.atlassian.net/browse/CCCT-2301)

## Technical Summary

Adds Robolectric unit tests for `PersonalIdNameFragment`. The fragment previously had no unit coverage; this PR backfills that gap with two test classes plus a shared base.

## Safety Assurance

### Safety story

What gives confidence:
- I ran the tests locally and saw all 17 tests pass.
- Test-only change: no production code was touched, so the diff cannot regress runtime behavior.
- New tests follow the patterns already in use for the sibling phone and biometric fragments, including the `MockWebServer` + `PersonalIdApiClient.apiService` field-injection approach.

Risks to review:
- The `MockWebServer` setup mutates a static `apiService` field on `PersonalIdApiClient` via reflection and restores it in `tearDown`. If a future test forgets to restore it (or the field name changes), unrelated tests can flake — same risk that already exists in `PersonalIdPhoneFragmentStartConfigurationTest`.
- The enter-key "empty input" test asserts that no HTTP request is made, but relies on `TextView.onEditorAction(IME_ACTION_DONE)` actually invoking the editor-action listener under Robolectric. If a Robolectric upgrade changes that behavior the test could pass trivially.

### Automated test coverage

This PR *is* the automated test coverage. The 17 new tests exercise: initial UI state, the name-input → continue-button gating, request payload + auth header for `/users/check_name`, the success path (navigation + session-data write), retryable failure UI (500), non-retryable failure UI (403 `PHONE_NOT_VALIDATED`), routed failures (401 `LOCKED_ACCOUNT` → message screen), and the enter-key shortcut.

[CCCT-2301]: https://dimagi.atlassian.net/browse/CCCT-2301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ