### PR TITLE
SAAS-19802 Fix Combobox.autoCorrectCapitalization choice match check

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -28,6 +28,8 @@ These notes are only published internally in [CommCare Change log wiki](https://
 along with the public release notes above
 -->
 
+- Fix bug causing form widgets to lose focus when a Combobox dropdown on the same screen is re-validated.
+
 ### QA Notes
 
 <!--

--- a/app/src/org/commcare/views/Combobox.java
+++ b/app/src/org/commcare/views/Combobox.java
@@ -99,11 +99,19 @@ public class Combobox extends AppCompatAutoCompleteTextView {
      */
     public void autoCorrectCapitalization() {
         String enteredText = getText().toString();
-        if (enteredText != null && !choices.contains(enteredText) &&
+        if (enteredText != null && !isValidChoice(enteredText) &&
                 choicesAllLowerCase.contains(enteredText.toLowerCase())) {
             int index = choicesAllLowerCase.indexOf(enteredText.toLowerCase());
             setText(choices.get(index).getDisplayText());
         }
     }
 
+    private boolean isValidChoice(String text) {
+        for (ComboItem comboItem : choices) {
+            if (comboItem.getDisplayText().equals(text)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/app/unit-tests/src/org/commcare/views/ComboboxTest.kt
+++ b/app/unit-tests/src/org/commcare/views/ComboboxTest.kt
@@ -1,0 +1,87 @@
+package org.commcare.views
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.commcare.CommCareTestApplication
+import org.commcare.adapters.ComboboxAdapter
+import org.javarosa.core.model.ComboItem
+import org.javarosa.core.model.ComboboxFilterRule
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Vector
+
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class ComboboxTest {
+    @Test
+    fun autoCorrectCapitalization_rewritesWrongCaseToCanonical() {
+        val combobox = newCombobox("Apple", "Banana", "Cherry")
+        combobox.setText("apple")
+
+        combobox.autoCorrectCapitalization()
+
+        assertEquals("Apple", combobox.text.toString())
+    }
+
+    @Test
+    fun autoCorrectCapitalization_leavesCanonicalCasingUntouched() {
+        val combobox = newCombobox("Apple", "Banana")
+        combobox.setText("Apple")
+        val originalEditable = combobox.text
+
+        combobox.autoCorrectCapitalization()
+
+        assertEquals("Apple", combobox.text.toString())
+        // Same Editable instance — autoCorrectCapitalization should not have called setText.
+        assertSameEditable(originalEditable, combobox.text)
+    }
+
+    @Test
+    fun autoCorrectCapitalization_leavesUnknownTextUntouched() {
+        val combobox = newCombobox("Apple", "Banana")
+        combobox.setText("xyz")
+
+        combobox.autoCorrectCapitalization()
+
+        assertEquals("xyz", combobox.text.toString())
+    }
+
+    @Test
+    fun autoCorrectCapitalization_leavesEmptyTextUntouched() {
+        val combobox = newCombobox("Apple", "Banana")
+        combobox.setText("")
+
+        combobox.autoCorrectCapitalization()
+
+        assertEquals("", combobox.text.toString())
+    }
+
+    private fun newCombobox(vararg displayTexts: String): Combobox {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val items = displayTexts.mapIndexed { i, label -> ComboItem(label, label, i) }
+        val choicesVector = Vector(items)
+        val adapter = ComboboxAdapter(context, items.toTypedArray(), permissiveFilterRule())
+        return Combobox(context, choicesVector, adapter)
+    }
+
+    private fun permissiveFilterRule(): ComboboxFilterRule =
+        object : ComboboxFilterRule {
+            override fun choiceShouldBeShown(
+                choice: ComboItem,
+                textEntered: CharSequence,
+            ): Boolean = true
+
+            override fun shouldRestrictTyping(): Boolean = false
+        }
+
+    private fun assertSameEditable(
+        expected: CharSequence,
+        actual: CharSequence,
+    ) {
+        if (expected !== actual) {
+            throw AssertionError("Expected the same Editable instance (no setText call), but got a different one")
+        }
+    }
+}


### PR DESCRIPTION
## Product Description
Fixes a bug causing string/numeric questions to lose focus while users are entering data. For each character/digit typed, the form controller performs a pass through the form's triggerables. During this process, existing questions are re-evaluated. Because the `ComboboxWidget` current value within `autoCorrectCapitalization` was always `false`, a new value was being set, causing the input focus to be reassigned:

https://github.com/user-attachments/assets/d3f7c374-152b-474e-b935-4ba3ac7dfe29

Ticket: https://dimagi.atlassian.net/browse/SAAS-19802

Related PRs:
- https://github.com/dimagi/commcare-android/pull/3515 
- https://github.com/dimagi/commcare-core/pull/1516

## Technical Summary
`autoCorrectCapitalization` had a latent bug in its guard:

```java
if (enteredText != null && !choices.contains(enteredText) && ...)
```

`choices` is `Vector<ComboItem>` and `enteredText` is `String`. `ComboItem.equals(Object)` (commcare-core) only returns `true` for another `ComboItem`, so `choices.contains(enteredText)` was **always false**. The intended "skip the case-fix when the user already typed the canonical form" branch never fired, so a `setText(...)` ran every
time the field lost focus on a valid value — silent extra work plus an unnecessary TextWatcher pass.

## Safety Assurance

### Safety story
- This was successfully tested locally.
- Added new tests to assess the correct behavior of the `autoCorrectCapitalization()` method

### Automated test coverage
`app/unit-tests/src/org/commcare/views/ComboboxTest.kt` — four tests,
all passing locally 

## Labels and Review
- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
