### PR TITLE
Ccct 2321:  integrity delay UX Issue

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -645,6 +645,13 @@ public abstract class CommCareActivity<R> extends CommonBaseActivity
         }
     }
 
+    public void showProgressDialogIfNeeded(int taskId) {
+        CustomProgressDialog current = getCurrentProgressDialog();
+        if (current == null || current.getTaskId() != taskId) {
+            showProgressDialog(taskId);
+        }
+    }
+
     @Override
     public CustomProgressDialog getCurrentProgressDialog() {
         return (CustomProgressDialog)getSupportFragmentManager().

--- a/app/src/org/commcare/connect/network/base/BaseApi.kt
+++ b/app/src/org/commcare/connect/network/base/BaseApi.kt
@@ -18,54 +18,68 @@ import retrofit2.Response
 import java.io.IOException
 
 class BaseApi {
-
     companion object {
         fun callApi(
             context: Context,
             call: Call<ResponseBody>,
             callback: IApiCallback,
-            endPoint: String
+            endPoint: String,
         ) {
             showProgressDialog(context)
-            call.enqueue(object : Callback<ResponseBody?> {
-                override fun onResponse(
-                    call: Call<ResponseBody?>,
-                    response: Response<ResponseBody?>
-                ) {
-                    dismissProgressDialog(context)
-                    if (response.isSuccessful && response.body() != null) {
-                        // Handle success
-                        try {
-                            response.body()!!.byteStream().use { responseStream ->
-                                callback.processSuccess(response.code(), responseStream)
+            call.enqueue(
+                object : Callback<ResponseBody?> {
+                    override fun onResponse(
+                        call: Call<ResponseBody?>,
+                        response: Response<ResponseBody?>,
+                    ) {
+                        dismissProgressDialog(context)
+                        if (response.isSuccessful && response.body() != null) {
+                            // Handle success
+                            try {
+                                response.body()!!.byteStream().use { responseStream ->
+                                    callback.processSuccess(response.code(), responseStream)
+                                }
+                            } catch (e: IOException) {
+                                Logger.exception("Error reading response stream", e)
+                                // Handle error when reading the stream
+                                callback.processFailure(response.code(), endPoint, "", e)
                             }
-                        } catch (e: IOException) {
-                            Logger.exception("Error reading response stream", e);
-                            // Handle error when reading the stream
-                            callback.processFailure(response.code(), endPoint, "",e)
-                        }
-                    } else {
-                        val stream = if (response.errorBody() != null) response.errorBody()!!
-                            .byteStream() else null
-                        try {
-                            val errorBody = NetworkUtils.getErrorBody(stream)
-                            logFailedResponse(response.message(), response.code(), endPoint, errorBody)
-                            callback.processFailure(response.code(), endPoint, errorBody, Throwable("Unknown failure with ${response.code()} for $endPoint"))
-                        } finally {
-                            StreamsUtil.closeStream(stream)
+                        } else {
+                            val stream =
+                                if (response.errorBody() != null) {
+                                    response
+                                        .errorBody()!!
+                                        .byteStream()
+                                } else {
+                                    null
+                                }
+                            try {
+                                val errorBody = NetworkUtils.getErrorBody(stream)
+                                logFailedResponse(response.message(), response.code(), endPoint, errorBody)
+                                callback.processFailure(
+                                    response.code(),
+                                    endPoint,
+                                    errorBody,
+                                    Throwable("Unknown failure with ${response.code()} for $endPoint"),
+                                )
+                            } finally {
+                                StreamsUtil.closeStream(stream)
+                            }
                         }
                     }
-                }
 
-                override fun onFailure(call: Call<ResponseBody?>, t: Throwable) {
-                    dismissProgressDialog(context)
-                    // Handle network errors, etc.
-                    logNetworkError(t, endPoint)
-                    callback.processNetworkFailure(t)
-                }
-            })
+                    override fun onFailure(
+                        call: Call<ResponseBody?>,
+                        t: Throwable,
+                    ) {
+                        dismissProgressDialog(context)
+                        // Handle network errors, etc.
+                        logNetworkError(t, endPoint)
+                        callback.processNetworkFailure(t)
+                    }
+                },
+            )
         }
-
 
         fun showProgressDialog(context: Context) {
             if (context is CommCareActivity<*>) {
@@ -85,5 +99,4 @@ class BaseApi {
             }
         }
     }
-
 }

--- a/app/src/org/commcare/connect/network/base/BaseApi.kt
+++ b/app/src/org/commcare/connect/network/base/BaseApi.kt
@@ -71,7 +71,7 @@ class BaseApi {
             if (context is CommCareActivity<*>) {
                 val handler = Handler(context.getMainLooper())
                 handler.post {
-                    (context as CommCareActivity<*>).showProgressDialog(ConnectConstants.NETWORK_ACTIVITY_ID)
+                    (context as CommCareActivity<*>).showProgressDialogIfNeeded(ConnectConstants.NETWORK_ACTIVITY_ID)
                 }
             }
         }

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -81,6 +81,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
     private ActivityResultLauncher<IntentSenderRequest> resolutionLauncher;
     private String playServicesError;
     private ActivityResultLauncher<IntentSenderRequest> playServicesResolutionLauncher;
+    private boolean isRequestInProgress = false;
 
     private static final String[] REQUIRED_PERMISSIONS = new String[]{
             Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION
@@ -279,7 +280,9 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
     }
 
     private void updateContinueButtonState() {
-        enableContinueButton(allowedToContinue());
+        if (!isRequestInProgress) {
+            enableContinueButton(allowedToContinue());
+        }
     }
 
     private boolean allowedToContinue() {
@@ -325,6 +328,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
     }
 
     private void startConfigurationRequest() {
+        isRequestInProgress = true;
         clearError();
         phone = PhoneNumberHelper.buildPhoneNumber(
                 binding.countryCode.getText().toString(),
@@ -493,6 +497,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
         new PersonalIdApiHandler<PersonalIdSessionData>() {
             @Override
             public void onSuccess(PersonalIdSessionData sessionData) {
+                isRequestInProgress = false;
                 personalIdSessionDataViewModel.getPersonalIdSessionData().setPhoneNumber(phone);
 
                 FirebaseAnalyticsUtil.flagPersonalIDDemoUser(sessionData.getDemoUser());
@@ -519,6 +524,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                     @NonNull PersonalIdOrConnectApiErrorCodes failureCode,
                     @Nullable Throwable t
             ) {
+                isRequestInProgress = false;
                 if (handleCommonSignupFailures(failureCode)) {
                     return;
                 }

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -33,6 +33,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.play.core.integrity.StandardIntegrityManager;
 import com.google.android.play.core.integrity.model.IntegrityDialogTypeCode;
 
+import org.commcare.activities.CommCareActivity;
 import org.commcare.activities.connect.viewmodel.PersonalIdSessionDataViewModel;
 import org.commcare.android.database.connect.models.PersonalIdSessionData;
 import org.commcare.android.integrity.IntegrityTokenApiRequestHelper;
@@ -64,6 +65,8 @@ import java.util.HashMap;
 import java.util.function.Consumer;
 
 import static com.google.android.play.core.integrity.model.IntegrityDialogResponseCode.DIALOG_SUCCESSFUL;
+
+import static org.commcare.connect.ConnectConstants.NETWORK_ACTIVITY_ID;
 import static org.commcare.utils.Permissions.shouldShowPermissionRationale;
 
 public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements CommCareLocationListener {
@@ -328,7 +331,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
     }
 
     private void startConfigurationRequest() {
-        isRequestInProgress = true;
+        setRequestProgressState(true);
         clearError();
         phone = PhoneNumberHelper.buildPhoneNumber(
                 binding.countryCode.getText().toString(),
@@ -497,7 +500,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
         new PersonalIdApiHandler<PersonalIdSessionData>() {
             @Override
             public void onSuccess(PersonalIdSessionData sessionData) {
-                isRequestInProgress = false;
+                setRequestProgressState(false);
                 personalIdSessionDataViewModel.getPersonalIdSessionData().setPhoneNumber(phone);
 
                 FirebaseAnalyticsUtil.flagPersonalIDDemoUser(sessionData.getDemoUser());
@@ -524,7 +527,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                     @NonNull PersonalIdOrConnectApiErrorCodes failureCode,
                     @Nullable Throwable t
             ) {
-                isRequestInProgress = false;
+                setRequestProgressState(false);
                 if (handleCommonSignupFailures(failureCode)) {
                     return;
                 }
@@ -541,7 +544,7 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                         break;
                     case MISSING_DATA_ERROR: {
                         String subCode = personalIdSessionDataViewModel.getPersonalIdSessionData().getSessionFailureSubcode();
-                        boolean isIntegrityHeadersMissing = BaseApiHandler.PersonalIdApiSubErrorCodes.INTEGRITY_HEADERS.name().equals(subCode);
+                        boolean isIntegrityHeadersMissing = PersonalIdApiSubErrorCodes.INTEGRITY_HEADERS.name().equals(subCode);
                         if (isIntegrityHeadersMissing) {
                             if (!token.isEmpty()) {
                                 Logger.exception("Missing Data error related to Integrity check headers",
@@ -565,6 +568,15 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
                 }
             }
         }.makeStartConfigurationCall(requireActivity(), body, token, requestHash, newSessionData);
+    }
+
+    private void setRequestProgressState(boolean inProgress) {
+        isRequestInProgress = inProgress;
+        if (isRequestInProgress) {
+            ((CommCareActivity<?>)requireActivity()).showProgressDialogIfNeeded(NETWORK_ACTIVITY_ID);
+        } else {
+            ((CommCareActivity<?>)requireActivity()).dismissProgressDialogForTask(NETWORK_ACTIVITY_ID);
+        }
     }
 
     private void onIntegrityConfigurationError() {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -572,10 +572,15 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
 
     private void setRequestProgressState(boolean inProgress) {
         isRequestInProgress = inProgress;
-        if (isRequestInProgress) {
-            ((CommCareActivity<?>)requireActivity()).showProgressDialogIfNeeded(NETWORK_ACTIVITY_ID);
-        } else {
-            ((CommCareActivity<?>)requireActivity()).dismissProgressDialogForTask(NETWORK_ACTIVITY_ID);
+        Activity activity = getActivity();
+        if (activity != null) {
+            activity.runOnUiThread(() -> {
+                if (inProgress) {
+                    ((CommCareActivity<?>)activity).showProgressDialogIfNeeded(NETWORK_ACTIVITY_ID);
+                } else {
+                    ((CommCareActivity<?>)activity).dismissProgressDialogForTask(NETWORK_ACTIVITY_ID);
+                }
+            });
         }
     }
 

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhoneFragmentStartConfigurationTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhoneFragmentStartConfigurationTest.kt
@@ -159,7 +159,7 @@ class PersonalIdPhoneFragmentStartConfigurationTest : BasePersonalIdPhoneFragmen
 
         // Assert
         mockWebServer.takeRequest()
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        ShadowLooper.idleMainLooper()
 
         assertEquals(
             "Should navigate to biometric config fragment on success",
@@ -183,7 +183,7 @@ class PersonalIdPhoneFragmentStartConfigurationTest : BasePersonalIdPhoneFragmen
 
         // Assert
         mockWebServer.takeRequest()
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        ShadowLooper.idleMainLooper()
 
         assertEquals(
             "Should navigate to message display screen on forbidden error",
@@ -216,7 +216,7 @@ class PersonalIdPhoneFragmentStartConfigurationTest : BasePersonalIdPhoneFragmen
 
         // Assert
         mockWebServer.takeRequest()
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        ShadowLooper.idleMainLooper()
 
         val errorView = fragment.view!!.findViewById<android.widget.TextView>(R.id.personalid_phone_error)
         assertEquals(
@@ -253,7 +253,7 @@ class PersonalIdPhoneFragmentStartConfigurationTest : BasePersonalIdPhoneFragmen
 
         // Assert
         mockWebServer.takeRequest()
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        ShadowLooper.idleMainLooper()
 
         // Verify navigation to message display occurred
         assertEquals(
@@ -286,7 +286,7 @@ class PersonalIdPhoneFragmentStartConfigurationTest : BasePersonalIdPhoneFragmen
         clickContinueButton()
 
         mockWebServer.takeRequest()
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        ShadowLooper.idleMainLooper()
 
         assertEquals(
             "Should navigate to failure screen",


### PR DESCRIPTION
## Product Description
https://dimagi.atlassian.net/browse/CCCT-2321


Before (with a hardcoded delay into Integirty Token request)


https://github.com/user-attachments/assets/1bca483e-bd9b-4107-99b2-bbfb2fd979af


After (with a hardcoded delay into Integirty Token request)


https://github.com/user-attachments/assets/1343b17f-be28-4f51-a05a-cdfc37dd2346



## Technical Summary

1. User clicks Continue → onContinueClicked() disables the button and calls startConfigurationRequest()
2. While the integrity token request is pending, onLocationResult() / onLocationServiceChange() / the phone text watcher / consent checkbox can all fire updateContinueButtonState() → which re-enables the button if allowedToContinue() returns true

The fix is to track isRequestInProgress and guard updateContinueButtonState() against it.

## Safety Assurance

### Safety story

- Verified that only one dialog appears at a moment even if we called `showProgressDialogIfNeeded` twice with the same task id
- Verfied that the dialog shows up correctly for rest of the fragments in the Personal ID flow. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


Best Reviewed Commit by Commit