### PR TITLE
CCCT-2427 Keep Unlock Prompt Open On Recoverable Biometric Failure

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -20,6 +20,7 @@ These are published publicly on Playstore, Github Releases and CommCare Forums
 #### Important Bug Fixes
 
 - Fixed the back arrow on the camera capture screen so it correctly returns to the previous screen
+- Fixed PersonalID app linking so a failed fingerprint scan no longer skips you past the login screen; you can retry the unlock and linking completes once it succeeds
 
 #### Internal Release Notes
 

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -85,7 +85,9 @@ object PersonalIdUnlocker {
                     callback.connectActivityComplete(true)
                 }
 
-                override fun onAuthenticationFailed() = callback.connectActivityComplete(false)
+                // A recoverable failure (e.g. an unrecognized fingerprint). The system
+                // prompt stays open for the user to retry.
+                override fun onAuthenticationFailed() = Unit
             }
 
         when {


### PR DESCRIPTION
### [CCCT-2427](https://dimagi.atlassian.net/browse/CCCT-2427)

## Product Description

When linking a traditional (username/password) app to PersonalID, an unrecognized fingerprint no longer skips the user past the login screen. The biometric prompt stays open so the user can retry, and linking completes once the unlock succeeds. Cancelling or dismissing the prompt still proceeds to the app home, unchanged.

## Technical Summary

`onAuthenticationFailed` in the PersonalID unlock callback (`PersonalIdUnlocker.performUnlock`) was treating a recoverable biometric rejection as a terminal failure — it called `connectActivityComplete(false)`, which propagated through `unlockAndLinkConnect` → `LoginActivity.setResultAndFinish(false)` and dismissed the login screen while the system prompt was still open, also short-circuiting the link. Per the AndroidX `BiometricPrompt` contract, `onAuthenticationFailed` is non-terminal (prompt stays open for retry); only `onAuthenticationError` (cancel/dismiss/lockout) and `onAuthenticationSucceeded` end the session. The fix makes `onAuthenticationFailed` a no-op, matching the existing pattern in `PersonalIdBiometricConfigFragment`.

## Safety Assurance

### Safety story

What gives confidence:
- I manually reproduced the bug on a device and verified the fix: scanning the wrong finger now keeps the prompt open with no background transition to app home, and a subsequent correct scan links the app.

Risks to review:
- No automated test covers this behavior — the callback is an inline anonymous object and not unit-testable without extracting it. Verification was manual.
- Behavior change for existing users on the login→link flow; reviewers should confirm the cancel/dismiss path still transitions to app home as expected.

[CCCT-2427]: https://dimagi.atlassian.net/browse/CCCT-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ