### PR TITLE
Personal ID: bump device compatibility to Android 9 

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,7 @@ These are published publicly on Playstore, Github Releases and CommCare Forums
 
 #### What's New
 
+- Deprecated PersonalID support for devices on Android OS less than Android 9.
 - [Profile Photo Update] PersonalID users can now update their profile photo directly from the side navigation drawer
 - Reduced frequency of required biometric or pin unlocks for PersonalID and Connect  
 - [Back Online Indicator] Refreshable Connect pages now show a green "Back Online" indicator at the top of the page when a sync succeeds after a previous offline failure

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -525,6 +525,7 @@ android {
         unitTests.all {
             // Needed for robolectric tests to work with kxml for some bizarre reason
             jvmArgs '-noverify'
+            maxHeapSize = "2g"
             systemProperty 'robolectric.logging.enable', true
             systemProperty 'robolectric.logging', 'stdout'
         }

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -314,7 +314,7 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
 
     @Override
     protected boolean shouldShowDrawer() {
-        return PersonalIdManager.getInstance().checkDeviceCompability();
+        return shouldShowDrawerAfterCheck();
     }
 
     @Override

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -510,7 +510,7 @@ public class PersonalIdManager {
     }
 
     public boolean checkDeviceCompability() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N;
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.P;
     }
 
     public int getFailureAttempt() {

--- a/app/src/org/commcare/navdrawer/NavDrawerHelper.kt
+++ b/app/src/org/commcare/navdrawer/NavDrawerHelper.kt
@@ -1,11 +1,14 @@
 package org.commcare.navdrawer
 
+import androidx.annotation.VisibleForTesting
 import androidx.preference.PreferenceManager
 import org.commcare.CommCareApplication
 import androidx.core.content.edit
 
 object NavDrawerHelper {
-    private const val SIDE_DRAWER_SHOWN: String = "side-drawer-shown"
+
+    @VisibleForTesting
+    const val SIDE_DRAWER_SHOWN: String = "side-drawer-shown"
 
     fun drawerShownBefore(): Boolean {
         val prefs = PreferenceManager.getDefaultSharedPreferences(CommCareApplication.instance())

--- a/app/src/org/commcare/navdrawer/NavDrawerHelper.kt
+++ b/app/src/org/commcare/navdrawer/NavDrawerHelper.kt
@@ -1,12 +1,10 @@
 package org.commcare.navdrawer
 
-import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import org.commcare.CommCareApplication
-import androidx.core.content.edit
 
 object NavDrawerHelper {
-
     private const val SIDE_DRAWER_SHOWN: String = "side-drawer-shown"
 
     fun drawerShownBefore(): Boolean {

--- a/app/src/org/commcare/navdrawer/NavDrawerHelper.kt
+++ b/app/src/org/commcare/navdrawer/NavDrawerHelper.kt
@@ -7,8 +7,7 @@ import androidx.core.content.edit
 
 object NavDrawerHelper {
 
-    @VisibleForTesting
-    const val SIDE_DRAWER_SHOWN: String = "side-drawer-shown"
+    private const val SIDE_DRAWER_SHOWN: String = "side-drawer-shown"
 
     fun drawerShownBefore(): Boolean {
         val prefs = PreferenceManager.getDefaultSharedPreferences(CommCareApplication.instance())

--- a/app/unit-tests/src/org/commcare/android/tests/personalid/PersonalIdDrawerVisibilityTest.kt
+++ b/app/unit-tests/src/org/commcare/android/tests/personalid/PersonalIdDrawerVisibilityTest.kt
@@ -1,0 +1,236 @@
+package org.commcare.android.tests.personalid
+
+import android.os.Build
+import androidx.preference.PreferenceManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.commcare.CommCareApplication
+import org.commcare.CommCareTestApplication
+import org.commcare.activities.CommCareSetupActivity
+import org.commcare.activities.LoginActivity
+import org.commcare.activities.StandardHomeActivity
+import org.commcare.android.database.connect.models.ConnectUserRecord
+import org.commcare.android.util.TestAppInstaller
+import org.commcare.connect.PersonalIdManager
+import org.commcare.connect.database.ConnectAppDatabaseUtil
+import org.commcare.connect.database.ConnectDatabaseHelper
+import org.commcare.connect.database.ConnectJobUtils
+import org.commcare.connect.database.ConnectMessagingDatabaseHelper
+import org.commcare.connect.database.ConnectUserDatabaseUtil
+import org.commcare.dalvik.R
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.MockedStatic
+import org.mockito.Mockito.CALLS_REAL_METHODS
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.spy
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+import java.util.Date
+
+/**
+ * Tests that the nav drawer is shown or hidden correctly
+ */
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class PersonalIdDrawerVisibilityTest {
+    private lateinit var spyManager: PersonalIdManager
+    private lateinit var mockedPersonalIdManager: MockedStatic<PersonalIdManager>
+    private lateinit var mockedConnectUserDb: MockedStatic<ConnectUserDatabaseUtil>
+
+    @Before
+    fun setUp() {
+        clearPrefs()
+        (CommCareTestApplication.instance() as CommCareTestApplication).initWorkManager()
+        TestAppInstaller.installAppAndLogin(TEST_APP_PATH, TEST_USER, TEST_PASSWORD)
+
+        spyManager = spy(PersonalIdManager.getInstance())
+        doNothing().whenever(spyManager).init(any())
+        doReturn(false).whenever(spyManager).isloggedIn()
+
+        mockedPersonalIdManager = mockStatic(PersonalIdManager::class.java, CALLS_REAL_METHODS)
+        mockedPersonalIdManager.`when`<PersonalIdManager> { PersonalIdManager.getInstance() }.thenReturn(spyManager)
+
+        mockkStatic(
+            ConnectDatabaseHelper::class,
+            ConnectJobUtils::class,
+            ConnectMessagingDatabaseHelper::class,
+            ConnectAppDatabaseUtil::class,
+        )
+        every { ConnectDatabaseHelper.isDbBroken() } returns false
+        every { ConnectJobUtils.getAppRecord(any(), any()) } returns null
+        every { ConnectMessagingDatabaseHelper.getMessagingChannels(any()) } returns emptyList()
+        every { ConnectAppDatabaseUtil.getReleaseToggles(any()) } returns emptyList()
+
+        mockedConnectUserDb = mockStatic(ConnectUserDatabaseUtil::class.java, CALLS_REAL_METHODS)
+        mockedConnectUserDb
+            .`when`<ConnectUserRecord> { ConnectUserDatabaseUtil.getUser(any()) }
+            .thenReturn(ConnectUserRecord("", "", "", "Test User", "", Date(), null, false, "", false))
+    }
+
+    @After
+    fun tearDown() {
+        mockedPersonalIdManager.close()
+        mockedConnectUserDb.close()
+        unmockkAll()
+        clearPrefs()
+    }
+
+    // ======== CommCareSetupActivity ========
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O_MR1])
+    fun `setup activity no drawer below Android 9 when logged in`() {
+        setLoggedIn(true)
+        val activity = Robolectric.buildActivity(CommCareSetupActivity::class.java).create().get()
+        assertNull("Drawer should not be set up below Android 9", activity.drawerAdapter)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    fun `setup activity shows drawer on Android 9 and above when logged in`() {
+        setLoggedIn(true)
+        val activity = Robolectric.buildActivity(CommCareSetupActivity::class.java).create().get()
+        assertNotNull("Drawer should be set up on Android 9+ when PersonalId is logged in", activity.drawerAdapter)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    fun `setup activity no drawer when not logged in`() {
+        val activity = Robolectric.buildActivity(CommCareSetupActivity::class.java).create().get()
+        assertNull("Drawer should not be set up when PersonalId is not logged in", activity.drawerAdapter)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O_MR1])
+    fun `setup activity shows drawer when previously shown regardless of Android version`() {
+        // Simulate a prior session where Personal ID was logged in on Android 9+
+        setLoggedIn(true)
+        doReturn(true).whenever(spyManager).checkDeviceCompability()
+        Robolectric.buildActivity(CommCareSetupActivity::class.java).create()
+
+        // Next launch: drawer persists from prior session
+        setLoggedIn(false)
+        doReturn(false).whenever(spyManager).checkDeviceCompability()
+        val activity = Robolectric.buildActivity(CommCareSetupActivity::class.java).create().get()
+        assertNotNull("Drawer should be set up if previously shown, regardless of Android version", activity.drawerAdapter)
+    }
+
+    // ======== LoginActivity ========
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O_MR1])
+    fun `login activity no drawer below Android 9 when logged in`() {
+        setLoggedIn(true)
+        val activity = Robolectric.buildActivity(LoginActivity::class.java).create().get()
+        assertNull("Drawer should not be set up below Android 9", activity.drawerAdapter)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    fun `login activity shows drawer on Android 9 and above when logged in`() {
+        setLoggedIn(true)
+        val activity = Robolectric.buildActivity(LoginActivity::class.java).create().get()
+        assertNotNull("Drawer should be set up on Android 9+ when PersonalId is logged in", activity.drawerAdapter)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    fun `login activity no drawer when not logged in`() {
+        val activity = Robolectric.buildActivity(LoginActivity::class.java).create().get()
+        assertNull("Drawer should not be set up when PersonalId is not logged in", activity.drawerAdapter)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O_MR1])
+    fun `login activity shows drawer when previously shown regardless of Android version`() {
+        // Simulate a prior session where Personal ID was logged in on Android 9+.
+        setLoggedIn(true)
+        doReturn(true).whenever(spyManager).checkDeviceCompability()
+        Robolectric.buildActivity(LoginActivity::class.java).create()
+
+        // Next launch: drawer persists from prior session
+        setLoggedIn(false)
+        doReturn(false).whenever(spyManager).checkDeviceCompability()
+        val activity = Robolectric.buildActivity(LoginActivity::class.java).create().get()
+        assertNotNull("Drawer should be set up if previously shown, regardless of Android version", activity.drawerAdapter)
+    }
+
+    // ======== StandardHomeActivity ========
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O_MR1])
+    fun `home activity no drawer below Android 9 when logged in`() {
+        setLoggedIn(true)
+        val activity = Robolectric.buildActivity(StandardHomeActivity::class.java).create().get()
+        assertNull("Drawer should not be set up below Android 9", activity.drawerAdapter)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    fun `home activity shows drawer on Android 9 and above when logged in`() {
+        setLoggedIn(true)
+        val activity = Robolectric.buildActivity(StandardHomeActivity::class.java).create().get()
+        assertNotNull("Drawer should be set up on Android 9+ when PersonalId is logged in", activity.drawerAdapter)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    fun `home activity no drawer when not logged in`() {
+        val activity = Robolectric.buildActivity(StandardHomeActivity::class.java).create().get()
+        assertNull("Drawer should not be set up when PersonalId is not logged in", activity.drawerAdapter)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O_MR1])
+    fun `home activity shows drawer when previously shown regardless of Android version`() {
+        // Simulate a prior session where Personal ID was logged in on Android 9+.
+        setLoggedIn(true)
+        doReturn(true).whenever(spyManager).checkDeviceCompability()
+        Robolectric.buildActivity(StandardHomeActivity::class.java).create()
+
+        // Next launch: drawer persists from prior session
+        setLoggedIn(false)
+        doReturn(false).whenever(spyManager).checkDeviceCompability()
+        val activity = Robolectric.buildActivity(StandardHomeActivity::class.java).create().get()
+        assertNotNull("Drawer should be set up if previously shown, regardless of Android version", activity.drawerAdapter)
+    }
+
+    // ======== Helpers ========
+
+    /**
+     * Returns the adapter on [R.id.nav_drawer_recycler] if the drawer was set up,
+     * or `null` if the drawer controller was never initialized.
+     */
+    private val android.app.Activity.drawerAdapter: RecyclerView.Adapter<*>?
+        get() = findViewById<RecyclerView?>(R.id.nav_drawer_recycler)?.adapter
+
+    private fun setLoggedIn(loggedIn: Boolean) {
+        doReturn(loggedIn).whenever(spyManager).isloggedIn()
+    }
+
+    private fun clearPrefs() {
+        PreferenceManager
+            .getDefaultSharedPreferences(CommCareApplication.instance())
+            .edit()
+            .clear()
+            .apply()
+    }
+
+    companion object {
+        private const val TEST_APP_PATH = "jr://resource/commcare-apps/form_nav_tests/profile.ccpr"
+        private const val TEST_USER = "test"
+        private const val TEST_PASSWORD = "123"
+    }
+}


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CCCT-2202

## Technical Summary

Makes [one other change ](https://github.com/dimagi/commcare-android/commit/830244abd35844adfdd58b3f6019c1587bf4bd2f) which is to use the same method for showing drawer in the setup screen as Login and home Screen, this means that we are using the same sets of check on all of these screens to show the drawer and this will allow any current user who is on devices < Android 9 to see the "personal id sign in" option even if they log out of Personal ID.  These users won't be able to sign up though if they uninstall the CC app and reinstall it since our preferences only persist locally on phone in the application sandbox. 

## Safety Assurance

### Safety story

Small OS version bump that controls whether we show the Personal ID drawer on devices. The change will affect a very small set of devices based on [analytics](https://dimagi.atlassian.net/browse/CCCT-2202?focusedCommentId=469955). 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
