### PR TITLE
CCCT-2428 Close Messaging Screen When Unlock Prompt Is Dismissed

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -20,6 +20,7 @@ These are published publicly on Playstore, Github Releases and CommCare Forums
 #### Important Bug Fixes
 
 - Fixed the back arrow on the camera capture screen so it correctly returns to the previous screen
+- Fixed an issue where Connect messages opened from a notification could be viewed without completing the unlock prompt
 
 #### Internal Release Notes
 

--- a/app/src/org/commcare/activities/connect/ConnectMessagingActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectMessagingActivity.java
@@ -149,6 +149,8 @@ public class ConnectMessagingActivity extends NavigationHostCommCareActivity<Con
                     } else {
                         handleChannelForValidity(channelId);
                     }
+                } else {
+                    finish();
                 }
             });
         }


### PR DESCRIPTION
### [CCCT-2428](https://dimagi.atlassian.net/browse/CCCT-2428)

## Product Description

When the Connect messaging screen is opened from a push notification, dismissing the biometric/PIN unlock prompt now closes the screen instead of leaving the channel list visible and interactive. Messages can no longer be viewed without completing the unlock.

## Technical Summary

`ConnectMessagingActivity`'s nav host renders its start destination (the channel list) immediately on launch, while the unlock prompt is shown on top via `PersonalIdUnlocker.unlock(...)`. The unlock callback only handled the success branch, so a dismissed prompt left the already-rendered channel list accessible. The fix finishes the activity on unlock failure, matching the existing gate convention in `ConnectUnlockFragment`.

## Safety Assurance

### Safety story

What gives confidence:
- I ran the change on a device: reproduced the original bug, then confirmed that dismissing the unlock prompt now closes the messaging screen.
- I verified the successful-auth path still opens the channel/message screen as before.

Risks to review:
- No automated test covers this notification-launched unlock path.

[CCCT-2428]: https://dimagi.atlassian.net/browse/CCCT-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ