### PR TITLE
[Hotfix] SAAS-19802 Fix Combobox.autoCorrectCapitalization choice match check

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -24,6 +24,17 @@ These notes are only published internally in [CommCare Change log wiki](https://
 along with the public release notes above
 -->
 
+### QA Notes
+
+- **Combobox capitalization fix:**
+  - **Setup:** Use a form with a lookup-table-backed multiple-choice question configured with `appearance="combobox"`, followed by a Numeric ID or Phone Number question on the same screen.
+  - **Focus retention in following questions (the user-visible bug being fixed):**
+    - Open the form, select or type a valid choice in the combobox, then move to the Numeric ID / Phone Number question.
+    - Tap the field and type a multiple digit value in one go. Verify the field retains focus throughout — no need to re-tap after each digit.
+  - **Combobox case correction (existing behaviour, should still work):**
+    - Type a valid choice in **lowercase** (e.g. "apple" when the choice list contains "Apple") and tap away. Verify the field is rewritten to the canonical casing "Apple".
+    - Type the same choice in **mixed case** (e.g. "ApPlE") and lose focus. Verify it's rewritten to "Apple".
+    - Type a value that **doesn't match any choice** and lose focus. Verify the field is left unchanged.
 
 ## CommCare 2.63
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,29 @@
 This file is meant as an easy way for us to collate notes and change logs across releases. 
 -->
 
+## CommCare 2.63.1
+
+### Release Notes
+
+<!--
+These are published publicly on Playstore, Github Releases and CommCare Forums
+-->
+
+#### What's New
+
+
+#### Important Bug Fixes
+
+- Fix bug causing form widgets to lose focus when a Combobox dropdown on the same screen is re-validated.
+
+#### Internal Release Notes
+<!--
+Release notes that are not applicable for wider CommCare users but only for specific projects.
+These notes are only published internally in [CommCare Change log wiki](https://dimagi.atlassian.net/wiki/spaces/internal/pages/2145058874/CommCare+Mobile+Changelog)
+along with the public release notes above
+-->
+
+
 ## CommCare 2.63
 
 ### Release Notes

--- a/app/src/org/commcare/views/Combobox.java
+++ b/app/src/org/commcare/views/Combobox.java
@@ -99,11 +99,19 @@ public class Combobox extends AppCompatAutoCompleteTextView {
      */
     public void autoCorrectCapitalization() {
         String enteredText = getText().toString();
-        if (enteredText != null && !choices.contains(enteredText) &&
+        if (enteredText != null && !isValidChoice(enteredText) &&
                 choicesAllLowerCase.contains(enteredText.toLowerCase())) {
             int index = choicesAllLowerCase.indexOf(enteredText.toLowerCase());
             setText(choices.get(index).getDisplayText());
         }
     }
 
+    private boolean isValidChoice(String text) {
+        for (ComboItem comboItem : choices) {
+            if (comboItem.getDisplayText().equals(text)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/app/unit-tests/src/org/commcare/views/ComboboxTest.kt
+++ b/app/unit-tests/src/org/commcare/views/ComboboxTest.kt
@@ -1,5 +1,6 @@
 package org.commcare.views
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.commcare.CommCareTestApplication
@@ -59,7 +60,7 @@ class ComboboxTest {
     }
 
     private fun newCombobox(vararg displayTexts: String): Combobox {
-        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val context = ApplicationProvider.getApplicationContext<Context>()
         val items = displayTexts.mapIndexed { i, label -> ComboItem(label, label, i) }
         val choicesVector = Vector(items)
         val adapter = ComboboxAdapter(context, items.toTypedArray(), permissiveFilterRule())

--- a/app/unit-tests/src/org/commcare/views/ComboboxTest.kt
+++ b/app/unit-tests/src/org/commcare/views/ComboboxTest.kt
@@ -1,0 +1,87 @@
+package org.commcare.views
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.commcare.CommCareTestApplication
+import org.commcare.adapters.ComboboxAdapter
+import org.javarosa.core.model.ComboItem
+import org.javarosa.core.model.ComboboxFilterRule
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Vector
+
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class ComboboxTest {
+    @Test
+    fun autoCorrectCapitalization_rewritesWrongCaseToCanonical() {
+        val combobox = newCombobox("Apple", "Banana", "Cherry")
+        combobox.setText("apple")
+
+        combobox.autoCorrectCapitalization()
+
+        assertEquals("Apple", combobox.text.toString())
+    }
+
+    @Test
+    fun autoCorrectCapitalization_leavesCanonicalCasingUntouched() {
+        val combobox = newCombobox("Apple", "Banana")
+        combobox.setText("Apple")
+        val originalEditable = combobox.text
+
+        combobox.autoCorrectCapitalization()
+
+        assertEquals("Apple", combobox.text.toString())
+        // Same Editable instance — autoCorrectCapitalization should not have called setText.
+        assertSameEditable(originalEditable, combobox.text)
+    }
+
+    @Test
+    fun autoCorrectCapitalization_leavesUnknownTextUntouched() {
+        val combobox = newCombobox("Apple", "Banana")
+        combobox.setText("xyz")
+
+        combobox.autoCorrectCapitalization()
+
+        assertEquals("xyz", combobox.text.toString())
+    }
+
+    @Test
+    fun autoCorrectCapitalization_leavesEmptyTextUntouched() {
+        val combobox = newCombobox("Apple", "Banana")
+        combobox.setText("")
+
+        combobox.autoCorrectCapitalization()
+
+        assertEquals("", combobox.text.toString())
+    }
+
+    private fun newCombobox(vararg displayTexts: String): Combobox {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val items = displayTexts.mapIndexed { i, label -> ComboItem(label, label, i) }
+        val choicesVector = Vector(items)
+        val adapter = ComboboxAdapter(context, items.toTypedArray(), permissiveFilterRule())
+        return Combobox(context, choicesVector, adapter)
+    }
+
+    private fun permissiveFilterRule(): ComboboxFilterRule =
+        object : ComboboxFilterRule {
+            override fun choiceShouldBeShown(
+                choice: ComboItem,
+                textEntered: CharSequence,
+            ): Boolean = true
+
+            override fun shouldRestrictTyping(): Boolean = false
+        }
+
+    private fun assertSameEditable(
+        expected: CharSequence,
+        actual: CharSequence,
+    ) {
+        if (expected !== actual) {
+            throw AssertionError("Expected the same Editable instance (no setText call), but got a different one")
+        }
+    }
+}

--- a/app/unit-tests/src/org/commcare/views/ComboboxTest.kt
+++ b/app/unit-tests/src/org/commcare/views/ComboboxTest.kt
@@ -17,7 +17,7 @@ import java.util.Vector
 @RunWith(AndroidJUnit4::class)
 class ComboboxTest {
     @Test
-    fun autoCorrectCapitalization_rewritesWrongCaseToCanonical() {
+    fun `autoCorrectCapitalization rewrites wrong case to expected casing`() {
         val combobox = newCombobox("Apple", "Banana", "Cherry")
         combobox.setText("apple")
 
@@ -27,7 +27,7 @@ class ComboboxTest {
     }
 
     @Test
-    fun autoCorrectCapitalization_leavesCanonicalCasingUntouched() {
+    fun `autoCorrectCapitalization leaves expected casing untouched`() {
         val combobox = newCombobox("Apple", "Banana")
         combobox.setText("Apple")
         val originalEditable = combobox.text
@@ -40,7 +40,7 @@ class ComboboxTest {
     }
 
     @Test
-    fun autoCorrectCapitalization_leavesUnknownTextUntouched() {
+    fun `autoCorrectCapitalization leaves unknown text untouched`() {
         val combobox = newCombobox("Apple", "Banana")
         combobox.setText("xyz")
 
@@ -50,7 +50,7 @@ class ComboboxTest {
     }
 
     @Test
-    fun autoCorrectCapitalization_leavesEmptyTextUntouched() {
+    fun `autoCorrectCapitalization leaves empty text untouched`() {
         val combobox = newCombobox("Apple", "Banana")
         combobox.setText("")
 


### PR DESCRIPTION
## Product Description
Fixes a bug causing string/numeric questions to lose focus while users are entering data. For each character/digit typed, the form controller performs a pass through the form's triggerables. During this process, existing questions are re-evaluated. Because the `ComboboxWidget` current value within `autoCorrectCapitalization` was always `false`, a new value was being set, causing the input focus to be reassigned:

https://github.com/user-attachments/assets/d3f7c374-152b-474e-b935-4ba3ac7dfe29

Ticket: https://dimagi.atlassian.net/browse/SAAS-19802

Related PRs:
- https://github.com/dimagi/commcare-android/pull/3515 
- https://github.com/dimagi/commcare-core/pull/1516

## Technical Summary
`autoCorrectCapitalization` had a latent bug in its guard:

```java
if (enteredText != null && !choices.contains(enteredText) && ...)
```

`choices` is `Vector<ComboItem>` and `enteredText` is `String`. `ComboItem.equals(Object)` (commcare-core) only returns `true` for another `ComboItem`, so `choices.contains(enteredText)` was **always false**. The intended "skip the case-fix when the user already typed the canonical form" branch never fired, so a `setText(...)` ran every
time the field lost focus on a valid value — silent extra work plus an unnecessary TextWatcher pass.

## Safety Assurance

### Safety story
- This was successfully tested locally.
- Added new tests to assess the correct behavior of the `autoCorrectCapitalization()` method

### Automated test coverage
`app/unit-tests/src/org/commcare/views/ComboboxTest.kt` — four tests,
all passing locally 

## Labels and Review
- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
