### PR TITLE
[Hotfix] MOB-171 Fix GPS Here() race condition crash on back Navigation

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,37 @@
 This file is meant as an easy way for us to collate notes and change logs across releases. 
 -->
 
+## CommCare 2.63.1
+
+### Release Notes
+
+<!--
+These are published publicly on Playstore, Github Releases and CommCare Forums
+-->
+
+#### What's New
+
+
+#### Important Bug Fixes
+
+- Fixed a crash that could occur when navigating back from a case list that uses the GPS `here()` function
+
+#### Internal Release Notes
+
+<!--
+Release notes that are not applicable for wider CommCare users but only for specific projects.
+These notes are only published internally in [CommCare Change log wiki](https://dimagi.atlassian.net/wiki/spaces/internal/pages/2145058874/CommCare+Mobile+Changelog)
+along with the public release notes above
+-->
+
+### QA Notes
+
+<!--
+These are for internal use and for us to keep track of important notes that
+we would like to communicate to QA as part of the release testing
+-->
+
+
 ## CommCare 2.63
 
 ### Release Notes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -32,6 +32,8 @@ These are for internal use and for us to keep track of important notes that
 we would like to communicate to QA as part of the release testing
 -->
 
+- **GPS `here()` crash regression:** Using an app configuration that has `here()` in a case list (e.g. a case list that shows distance to GPS coordinates), navigate to that case list and wait for it to fully load. Press Back. Verify the app returns to the previous screen without crashing.
+- **GPS `here()` case list refresh:** Using the same app configuration, navigate to the case list and allow GPS to acquire a location fix. Move to a different location (or simulate a location change) while the list is displayed. Verify the case list automatically refreshes and distance values update accordingly.
 
 ## CommCare 2.63
 

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -1068,6 +1068,8 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     @Override
     public void onEvalLocationChanged() {
         if (isFinishing() || session == null || session.getCommand() == null) {
+            CrashUtil.log("EntitySelectActivity.onEvalLocationChanged with null session command" +
+                    "; isFinishing=" + isFinishing());
             return;
         }
         boolean loaded = loadEntities();

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -28,6 +28,7 @@ import com.jakewharton.rxbinding2.widget.AdapterViewItemClickEvent;
 import com.jakewharton.rxbinding2.widget.RxAdapterView;
 
 import org.commcare.CommCareApplication;
+import org.commcare.utils.CrashUtil;
 import org.commcare.activities.components.EntitySelectCalloutSetup;
 import org.commcare.activities.components.EntitySelectViewSetup;
 import org.commcare.adapters.EntityListAdapter;
@@ -372,7 +373,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     @Override
     protected void onStart() {
         super.onStart();
-        hereFunctionHandler.registerListener(this);
     }
 
     @Override
@@ -382,6 +382,8 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             setResult(RESULT_CANCELED, i);
             finish();
         } else if (!isFinishing() && !isStartingDetailActivity) {
+            hereFunctionHandler.registerListener(this);
+
             if (adapter != null) {
                 adapter.registerDataSetObserver(mListStateObserver);
             }
@@ -477,6 +479,11 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         }
 
         if (loader == null && !EntityLoaderTask.attachToActivity(this)) {
+            if (session.getCommand() == null) {
+                CrashUtil.log("EntitySelectActivity.loadEntities with null session command" +
+                        "; selectDatum=" + (selectDatum == null ? "null" : selectDatum.getDataId()) +
+                        "; isFinishing=" + isFinishing());
+            }
             setProgressText(StringUtils.getStringRobust(this, R.string.entity_list_initializing));
             EntityLoaderTask entityLoader = new EntityLoaderTask(shortSelect, selectDatum, evalContext());
             entityLoader.attachListener(this);
@@ -523,6 +530,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         }
 
         hereFunctionHandler.forbidGpsUse();
+        hereFunctionHandler.unregisterListener();
     }
 
     @Override
@@ -532,7 +540,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             refreshTimer.stop();
         }
         saveLastQueryString();
-        hereFunctionHandler.unregisterListener();
     }
 
     @Override

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -1067,6 +1067,12 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
     @Override
     public void onEvalLocationChanged() {
+        // Location callbacks are delivered on the main looper but can land after
+        // the session has been mutated (e.g. command popped on back-navigation).
+        // Skip if the activity is gone or the session no longer points here.
+        if (isFinishing() || session == null || session.getCommand() == null) {
+            return;
+        }
         boolean loaded = loadEntities();
         if (!loaded) {
             locationChangedWhileLoading = true;

--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -1067,9 +1067,6 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
     @Override
     public void onEvalLocationChanged() {
-        // Location callbacks are delivered on the main looper but can land after
-        // the session has been mutated (e.g. command popped on back-navigation).
-        // Skip if the activity is gone or the session no longer points here.
         if (isFinishing() || session == null || session.getCommand() == null) {
             return;
         }


### PR DESCRIPTION
### [MOB-171](https://dimagi.atlassian.net/browse/MOB-171)

## Product Description

Fixed a fatal crash affecting app configurations that use the `here()` XPath function in case lists. When a user pressed Back from such a case list, a GPS Binder IPC race condition could cause the entity loader to run with a `null` session command, resulting in an empty `EvaluationContext` that could not resolve the `casedb` instance.

## Technical Summary

**Root Cause (GPS Binder IPC Race Condition):**

1. `EntitySelectActivity` evaluates `here()` during entity loading → GPS location updates start via `LocationManager.requestLocationUpdates(..., mainLooper)`
2. Entity load completes → `deliverLoadResult()` sets `loader = null` (enabling a future re-trigger)
3. User presses Back → `onPause()` → `forbidGpsUse()` → `removeLocationUpdates()` — GPS deregistered, but a Binder callback already dispatched to the main Looper queue cannot be recalled
4. Parent activity's `onActivityResult()` fires (this happens between `onPause` and `onStop` per Android lifecycle) → `processCanceledGetCommandOrCase()` → `stepBack()` → `session.currentCmd = null`
5. In-flight GPS Binder callback fires on main thread → `onLocationChanged()` → `listener != null` (not yet unregistered — that was in `onStop`) → `onEvalLocationChanged()` → `loadEntities()`
6. `loader == null` (from step 2) → creates new `EntityLoaderTask` with `evalContext()`
7. `evalContext()` → `session.getEvaluationContext(iif, null, null)` → returns `new EvaluationContext(null)` with no form instances
8. Background task calls `expandReferenceList` → `retrieveInstance("casedb")` → **RuntimeException** → rethrown fatally

**Why only `here()` apps are affected:** Without `here()`, GPS is never started, so no Binder callbacks are ever dispatched.

**Fix:** Move `hereFunctionHandler.unregisterListener()` from `onStop()` to `onPause()`, immediately after `forbidGpsUse()`. This nulls the listener before `onActivityResult()` can modify session state, so the in-flight GPS callback sees `listener == null` and never calls `onEvalLocationChanged()`. But in case it gets called, there is now a safeguard that prevents the `onEvalLocationChanged()` to be called when activity is finishing or session is `null`.

Symmetrically, `hereFunctionHandler.registerListener(this)` is moved from `onStart()` to `onResumeSessionSafe()` (the valid-session branch, before `allowGpsUse()`), keeping registration and deregistration in the same `onResume/onPause` lifecycle pair.

A `CrashUtil.log` diagnostic is also added in `loadEntities()` to surface the null-command condition non-fatally in Crashlytics, confirming the hypothesis if it recurs.

## Safety Assurance

### Safety story
- The crash was reproducible after commenting out the code that stops location updates, disabling mobile data to force the provider to rely on GPS hardware, and moving around to generate additional location updates that could trigger the issue. 
  - With the changes in this PR, the crash was no longer observed under the same conditions, suggesting the fix is effective.
  - The case list refresh on location updates was also verified and continues to work as expected.
- Another aspect worth noting is that the Android lifecycle guarantee (`onActivityResult` fires between `onPause` and `onStop`) directly validates the fix
- The `here()` GPS flow is only active for app configurations that explicitly use the `here()` XPath function in case lists, limiting the blast radius

### Automated test coverage

No automated test coverage for this specific lifecycle/GPS interaction. The race condition is timing-dependent and involves Android Binder IPC, making it difficult to unit test. The `CrashUtil.log` diagnostic will surface non-fatally in Crashlytics if the condition is ever triggered again.

[MOB-171]: https://dimagi.atlassian.net/browse/MOB-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ