### PR TITLE
Fixes drawer gone invisible on setup activity

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -314,7 +314,7 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
 
     @Override
     protected boolean shouldShowDrawer() {
-        return shouldShowDrawerAfterCheck();
+        return shouldShowDrawerAfterCheck(false);
     }
 
     @Override

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -1013,7 +1013,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
 
     @Override
     protected boolean shouldShowDrawer() {
-        return shouldShowDrawerAfterCheck();
+        return shouldShowDrawerAfterCheck(true);
     }
 
     @Override

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -332,7 +332,7 @@ public class StandardHomeActivity
     protected boolean shouldShowDrawer() {
         if (!rootContainerReadyToShowDrawer)
             return false;   // wait for root content to get load through xml
-        return shouldShowDrawerAfterCheck();
+        return shouldShowDrawerAfterCheck(true);
     }
 
     @Override

--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -168,7 +168,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
         drawerController?.openDrawer()
     }
 
-    protected fun shouldShowDrawerAfterCheck(): Boolean {
+    protected fun shouldShowDrawerAfterCheck(requirePersonalIDLogin: Boolean): Boolean {
         if (drawerShownBefore()) {
             return true
         }
@@ -176,7 +176,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
         val personalIdManager = PersonalIdManager.getInstance()
         personalIdManager.init(this)
         val showDrawer =
-            personalIdManager.isloggedIn() &&
+            (!requirePersonalIDLogin || personalIdManager.isloggedIn()) &&
                 personalIdManager.checkDeviceCompability()
 
         if (showDrawer) {

--- a/app/unit-tests/src/org/commcare/android/tests/personalid/PersonalIdDrawerVisibilityTest.kt
+++ b/app/unit-tests/src/org/commcare/android/tests/personalid/PersonalIdDrawerVisibilityTest.kt
@@ -107,9 +107,9 @@ class PersonalIdDrawerVisibilityTest {
 
     @Test
     @Config(sdk = [Build.VERSION_CODES.P])
-    fun `setup activity no drawer when not logged in`() {
+    fun `setup activity shows drawer on Android 9 and above even when not logged in`() {
         val activity = Robolectric.buildActivity(CommCareSetupActivity::class.java).create().get()
-        assertNull("Drawer should not be set up when PersonalId is not logged in", activity.drawerAdapter)
+        assertNotNull("Drawer should be set up on Android 9+ regardless of PersonalId login status", activity.drawerAdapter)
     }
 
     @Test


### PR DESCRIPTION
## Product Description

I introduced an issue in https://github.com/dimagi/commcare-android/pull/3747 where while trying to make setupActivity use the same drawer check as other screens, I unknowingly required PersonalID login for drawer to show up. Instead, SetupActivity should always show drawer even when the user is not logged into a PersonalID account. 


## Safety Assurance

### Safety story

Small fix, updated tests to relflect the desired behaviour


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
