### PR TITLE
Legacy Apache fix for Maps usage

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -411,6 +411,10 @@
             android:name="com.google.android.maps"
             android:required="false" />
 
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
+
         <activity android:name="org.commcare.activities.MessageActivity" />
 
         <receiver


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CI-709

## Product Description
No visible change to user, but fixes a crash for some users running SDK 28 (Android 9) or newer when entering the entity map page.

## Technical Summary
Specifying legacy Apache library usage in the manifest.
This addresses a crash that can happen when accessing a Google Maps interface inside CommCare.
The issue is that devices running older than SDK 28 automatically include the legacy Apache code, so Maps (which may use that code) works. But on newer devices, the legacy code is only included if the manifest explicitly says to do so, which is what our change does.

Stack trace: ([example](https://console.firebase.google.com/u/0/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/ec5d385398404bc36c8e5978d93a268d?time=7d&types=crash&sessionEventKey=6A27E8DA013A0001430ED806322C4548_2227791755130443448&sessionTab=data&userInfoQuery=b376c4af07ec7cef43ab))
Fatal Exception: java.lang.NoClassDefFoundError: Failed resolution of: Lorg/apache/http/ProtocolVersion;
       at m6.cv.a(:com.google.android.gms.dynamite_mapsdynamite@252431035@25.24.31 (260400-0):217)
       at m6.cc.a(:com.google.android.gms.dynamite_mapsdynamite@252431035@25.24.31 (260400-0):202)
       at m6.cc.run(:com.google.android.gms.dynamite_mapsdynamite@252431035@25.24.31 (260400-0):6)

## Safety Assurance

### Safety story
Verified the maps interface still works for me (I wasn't crashing before).
This is a pretty safe change for two reasons:
* It only includes code, nothing has to call that code
* The required flag is set to false, so nothing breaks if the code can't be imported (but it should always work anyway)

### Automated test coverage
No changes