### PR TITLE
[Hotfix] Log BadPaddingException details during encrypted file submission (SAAS-19864)

### DIFF
--- a/app/src/org/commcare/network/EncryptedFileBody.java
+++ b/app/src/org/commcare/network/EncryptedFileBody.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.security.Key;
 
 import javax.annotation.Nullable;
+import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
 
@@ -71,7 +72,7 @@ public class EncryptedFileBody extends RequestBody {
         } catch (InputIOException iioe) {
             // This is to investigate an issue causing 'pad block corrupted' errors when decrypting files.
             Throwable cause = iioe.getWrapped() != null ? iioe.getWrapped().getCause() : null;
-            if (cause instanceof javax.crypto.BadPaddingException) {
+            if (cause instanceof BadPaddingException) {
                 Logger.exception(
                         "Bad padding exception when decrypting file: " + file.getName() + " length=" + file.length(),
                         iioe.getWrapped()

--- a/app/src/org/commcare/network/EncryptedFileBody.java
+++ b/app/src/org/commcare/network/EncryptedFileBody.java
@@ -4,6 +4,7 @@ import org.commcare.utils.FormUploadUtil;
 import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.io.StreamsUtil.InputIOException;
 import org.javarosa.core.io.StreamsUtil.OutputIOException;
+import org.javarosa.core.services.Logger;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -68,6 +69,14 @@ public class EncryptedFileBody extends RequestBody {
         try (CipherInputStream cis = new CipherInputStream(fis, cipher)) {
             StreamsUtil.writeFromInputToOutputUnmanaged(cis, sink.outputStream());
         } catch (InputIOException iioe) {
+            // This is to investigate an issue causing 'pad block corrupted' errors when decrypting files.
+            Throwable cause = iioe.getWrapped() != null ? iioe.getWrapped().getCause() : null;
+            if (cause instanceof javax.crypto.BadPaddingException) {
+                Logger.exception(
+                        "Bad padding exception when decrypting file: " + file.getName() + " length=" + file.length(),
+                        iioe.getWrapped()
+                );
+            }
             //Here we want to retain the fundamental problem of the _input_ being responsible for the issue
             //so we can differentiate between bad reads and bad network
             throw iioe;


### PR DESCRIPTION
## Product Description
No user-facing changes. This adds diagnostic logging only.

## Technical Summary
Ticket: [SAAS-19864 — Form stuck in quarantine, unable to be reprocessed](https://dimagi.atlassian.net/browse/SAAS-19864)

When an encrypted form/media file fails to decrypt while streaming a submission, the underlying `javax.crypto.BadPaddingException: pad block corrupt` is wrapped by Android's `CipherInputStream` into an `IOException`, then re-wrapped by `StreamsUtil` into an `InputIOException`. By the time it surfaces in `FormUploadUtil.submitEntity`, all we log is the generic wrapped message — we have no idea **which** file failed or why.

In SAAS-19864, the suspicion is around a truncated/partially-written encrypted file whose ciphertext is no longer a valid block-padded length, so every decrypt attempt throws `BadPaddingException` and the form stays quarantined.

This change inspects the wrapped cause in `EncryptedFileBody.writeTo`, and when it is a `BadPaddingException`, logs the offending **file name and length** before rethrowing. That lets us confirm the culprit file and whether its length is consistent with a truncated write (a valid AES/ECB/PKCS5 ciphertext length is always a multiple of 16). The exception is still rethrown unchanged, so control flow is unaffected.

## Safety Assurance

### Safety story
Logging-only change inside an existing `catch (InputIOException)` block. The original `throw iioe;` is preserved, so submission/quarantine behavior is identical; we only emit one additional `Logger.exception` entry when the wrapped cause is a `BadPaddingException`. No data is read or written beyond `file.getName()` / `file.length()`. Inherently low blast radius.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly (low — logging only)
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
