### PR TITLE
Fix Nav Drawer Photo Launcher Registration Crash

### DIFF
--- a/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerActivity.kt
@@ -1,8 +1,11 @@
 package org.commcare.navdrawer
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import org.commcare.activities.CommCareActivity
 import org.commcare.connect.ConnectActivityCompleteListener
 import org.commcare.connect.ConnectNavHelper.unlockAndGoToConnectJobsList
@@ -17,9 +20,14 @@ import org.javarosa.core.services.Logger
 
 abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
     private var drawerController: BaseDrawerController? = null
+    private lateinit var takePhotoLauncher: ActivityResultLauncher<Intent>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        takePhotoLauncher =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                drawerController?.handlePhotoResult(result)
+            }
         checkForDrawerSetUp()
         if (drawerController != null) {
             NotificationBroadcastHelper.registerForNotifications(this, this) {
@@ -58,6 +66,7 @@ abstract class BaseDrawerActivity<T> : CommCareActivity<T>() {
                 this,
                 drawerRefs,
                 shouldHighlightSeatedApp(),
+                takePhotoLauncher,
             ) { navItemType: NavItemType, recordId: String? ->
                 handleDrawerItemClick(navItemType, recordId)
             }

--- a/app/src/org/commcare/navdrawer/BaseDrawerController.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerController.kt
@@ -6,8 +6,8 @@ import android.graphics.Color
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.GravityCompat
@@ -42,11 +42,11 @@ class BaseDrawerController(
     private val activity: CommCareActivity<*>,
     private val binding: DrawerViewRefs,
     private val highlightSeatedApp: Boolean,
+    private val takePhotoLauncher: ActivityResultLauncher<Intent>,
     private val onItemClicked: (NavItemType, String?) -> Unit,
 ) {
     private lateinit var drawerToggle: ActionBarDrawerToggle
     private lateinit var navDrawerAdapter: NavDrawerAdapter
-    private lateinit var takePhotoLauncher: ActivityResultLauncher<Intent>
     private var hasRefreshed = false
     private var showingError = false
     var lastPhotoUploadFailed: Boolean = false
@@ -63,7 +63,6 @@ class BaseDrawerController(
     fun setupDrawer() {
         setupActionBarDrawerToggle()
         initializeAdapter()
-        initTakePhotoLauncher()
         setupListeners()
         setupViews()
         refreshDrawerContent()
@@ -337,19 +336,14 @@ class BaseDrawerController(
 
     fun handleOptionsItem(item: MenuItem): Boolean = drawerToggle.onOptionsItemSelected(item)
 
-    private fun initTakePhotoLauncher() {
-        takePhotoLauncher =
-            activity.registerForActivityResult(
-                ActivityResultContracts.StartActivityForResult(),
-            ) { result ->
-                if (result.resultCode == RESULT_OK) {
-                    result.data
-                        ?.getStringExtra(MicroImageActivity.MICRO_IMAGE_BASE_64_RESULT_KEY)
-                        ?.let { photoBase64 ->
-                            uploadUserPhoto(photoBase64)
-                        }
+    fun handlePhotoResult(result: ActivityResult) {
+        if (result.resultCode == RESULT_OK) {
+            result.data
+                ?.getStringExtra(MicroImageActivity.MICRO_IMAGE_BASE_64_RESULT_KEY)
+                ?.let { photoBase64 ->
+                    uploadUserPhoto(photoBase64)
                 }
-            }
+        }
     }
 
     private fun launchCameraForPhotoEdit() {


### PR DESCRIPTION
## Technical Summary

This PR fixes a flaky BrowserStack CI test failure. 

The nav drawer's photo-edit launcher was being registered during drawer setup, which can run after the activity reaches `STARTED` and violates the `registerForActivityResult` contract. It now registers once in `BaseDrawerActivity.onCreate` and is injected into `BaseDrawerController`, so rebuilding the controller no longer re-registers it.

In CI the illegal re-registration crashed the activity mid-test whenever a home-screen test triggered a UI rebuild after the activity had resumed. Because drawer visibility is gated on a persisted preference, whether a given test hit the crash depended on shard ordering, which is why it surfaced as a flaky cascade of Espresso failures across home-screen tests.

## Safety Assurance

### Safety story

What gives me confidence:
- I ran the change on a device and verified there are no regressions in the PersonalID profile photo update feature (open drawer, take/replace photo, failed-upload warning state).
- The diff is narrow and the registration now follows the documented Android contract (register before `STARTED`); I verified the lifecycle ordering so `BaseDrawerActivity.onCreate` registers the launcher before `onCreateSessionSafe → setupUI` ever builds a controller.

Risks to review:
- `BaseDrawerActivity` is the shared base for drawer-bearing activities, so the registration move affects all of them, not just the home screen.
- The original failure only reproduces on the BrowserStack Espresso suite (needs a device); I could not run that suite locally, so CI is the real confirmation that the cascade of home-screen test failures clears.