### PR TITLE
Supporting Subtitle in Action Bar

### DIFF
--- a/app/res/layout/appbar_layout.xml
+++ b/app/res/layout/appbar_layout.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
-        app:titleTextColor="@android:color/white" />
+        app:titleTextColor="@android:color/white"
+        app:subtitleTextColor="@android:color/white"/>
 
 </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/org/commcare/activities/CommonBaseActivity.java
+++ b/app/src/org/commcare/activities/CommonBaseActivity.java
@@ -32,6 +32,26 @@ public class CommonBaseActivity extends AppCompatActivity {
         }
     }
 
+    /**
+     * Sets the action bar title with no subtitle, clearing any subtitle a previous page set so the
+     * bar keeps its single-line appearance.
+     */
+      public void setActionBarTitle(@Nullable CharSequence title) {
+        setActionBarTitle(title, null);
+      }
+
+      /**
+      * Sets the action bar title and an optional second line. Pass a {@code null} subtitle for the
+      * standard single-line bar; a non-null subtitle renders below the title.
+      */
+      public void setActionBarTitle(@Nullable CharSequence title, @Nullable CharSequence subtitle) {
+          ActionBar actionBar = getSupportActionBar();
+          if (actionBar != null) {
+              actionBar.setTitle(title);
+              actionBar.setSubtitle(subtitle);
+          }
+      }
+
     @Override
     public boolean onMenuOpened(int featureId, Menu menu) {
         wasOptionsMenuOpen = true;

--- a/app/src/org/commcare/activities/CommonBaseActivity.java
+++ b/app/src/org/commcare/activities/CommonBaseActivity.java
@@ -36,21 +36,21 @@ public class CommonBaseActivity extends AppCompatActivity {
      * Sets the action bar title with no subtitle, clearing any subtitle a previous page set so the
      * bar keeps its single-line appearance.
      */
-      public void setActionBarTitle(@Nullable CharSequence title) {
+    public void setActionBarTitle(@Nullable CharSequence title) {
         setActionBarTitle(title, null);
-      }
+    }
 
-      /**
-      * Sets the action bar title and an optional second line. Pass a {@code null} subtitle for the
-      * standard single-line bar; a non-null subtitle renders below the title.
-      */
-      public void setActionBarTitle(@Nullable CharSequence title, @Nullable CharSequence subtitle) {
-          ActionBar actionBar = getSupportActionBar();
-          if (actionBar != null) {
-              actionBar.setTitle(title);
-              actionBar.setSubtitle(subtitle);
-          }
-      }
+    /**
+     * Sets the action bar title and an optional second line. Pass a {@code null} subtitle for the
+     * standard single-line bar; a non-null subtitle renders below the title.
+     */
+    public void setActionBarTitle(@Nullable CharSequence title, @Nullable CharSequence subtitle) {
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setTitle(title);
+            actionBar.setSubtitle(subtitle);
+        }
+    }
 
     @Override
     public boolean onMenuOpened(int featureId, Menu menu) {


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/CCCT-2513

## Product Description
No user visible changes in this PR (supporting upcoming changes)

## Technical Summary
Supports showing a subtitle in the action bar via two changes:
* Set subtitle text white in action bar layout (to ensure correct coloring)
* Helper methods to set and clear the subtitle (so it doesn't remain when a caller fails to clear it manually).

## Safety Assurance

### Safety story
The subtitle isn't being used anywhere yet so this is a no-opp change for now.
It will be used in the upcoming UI refactors for opp intro, learning progress, and delivery progress.

For now, I tested by manually inserting a call to setActionBarTitle in the opp intro page:
<img width="640" height="1387" alt="image" src="https://github.com/user-attachments/assets/49f95a47-938e-4912-9955-59cebd5e60b7" />


### Automated test coverage
None
