### PR TITLE
remove hardcoded method param for local Passphrase

### DIFF
--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -258,7 +258,6 @@ public class PersonalIdManager {
                     username,
                     false,
                     "",
-                    false,
                     false
             );
         }

--- a/app/src/org/commcare/connect/database/ConnectAppDatabaseUtil.java
+++ b/app/src/org/commcare/connect/database/ConnectAppDatabaseUtil.java
@@ -41,11 +41,10 @@ public class ConnectAppDatabaseUtil {
      * @param connectIdLinked Whether the app is linked to ConnectID
      * @param passwordOrPin   User's password or PIN
      * @param workerLinked    Whether the app is linked to a worker
-     * @param localPassphrase Whether using local passphrase
      * @return The stored record
      * throw error if storage operations fail
      */
-    public static ConnectLinkedAppRecord storeApp(Context context, String appId, String userId, boolean connectIdLinked, String passwordOrPin, boolean workerLinked, boolean localPassphrase) {
+    public static ConnectLinkedAppRecord storeApp(Context context, String appId, String userId, boolean connectIdLinked, String passwordOrPin, boolean workerLinked) {
 
         ConnectLinkedAppRecord record = getConnectLinkedAppRecord(context, appId, userId);
         if (record == null) {
@@ -55,7 +54,7 @@ public class ConnectAppDatabaseUtil {
         }
 
         record.setPersonalIdLinked(connectIdLinked);
-        record.setIsUsingLocalPassphrase(localPassphrase);
+        record.setIsUsingLocalPassphrase(false);
 
         if (workerLinked) {
             //If passed in false, we'll leave the setting unchanged

--- a/app/src/org/commcare/login/ConnectCredentialResolver.kt
+++ b/app/src/org/commcare/login/ConnectCredentialResolver.kt
@@ -44,7 +44,6 @@ class ConnectCredentialResolver(
             true,
             generateAppPassword(),
             true,
-            false,
         )
 
     private fun generateAppPassword(): String {

--- a/app/unit-tests/src/org/commcare/login/ConnectCredentialResolverTest.kt
+++ b/app/unit-tests/src/org/commcare/login/ConnectCredentialResolverTest.kt
@@ -67,7 +67,7 @@ class ConnectCredentialResolverTest {
         every { ConnectAppDatabaseUtil.getConnectLinkedAppRecord(context, "app-1", "alice") } returns null
         val created = recordWith(password = "generated", localPassphrase = true)
         every {
-            ConnectAppDatabaseUtil.storeApp(context, "app-1", "alice", true, any(), true, false)
+            ConnectAppDatabaseUtil.storeApp(context, "app-1", "alice", true, any(), true)
         } returns created
 
         val result = resolver.resolve("app-1", "alice", createIfNeeded = true)
@@ -92,7 +92,7 @@ class ConnectCredentialResolverTest {
         } returns null
         val created = recordWith(password = "ignored", localPassphrase = true)
         every {
-            ConnectAppDatabaseUtil.storeApp(context, "app-1", "alice", true, capture(passwordSlot), true, false)
+            ConnectAppDatabaseUtil.storeApp(context, "app-1", "alice", true, capture(passwordSlot), true)
         } returns created
 
         resolver.resolve("app-1", "alice", createIfNeeded = true)


### PR DESCRIPTION
## Product Description

Minor code clean up that came up while investigating https://dimagi.atlassian.net/browse/CCCT-2490

## Technical Summary

PR removes a method param with a fix `false` value. 

## Safety Assurance

### Safety story

PR is a no-op


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
