### PR TITLE
CCCT-2489 Add Workflow Parameter To PersonalID Continue Analytics

### DIFF
--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
@@ -174,7 +174,8 @@ public class PersonalIdBackupCodeFragment extends BasePersonalIdFragment {
     }
 
     private void handleBackupCodeSubmission() {
-        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(), null);
+        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(), null,
+                PersonalIdWorkflow.CONFIGURATION);
         if (isRecovery) {
             confirmBackupCode();
         } else {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBiometricConfigFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBiometricConfigFragment.java
@@ -222,7 +222,8 @@ public class PersonalIdBiometricConfigFragment extends BasePersonalIdFragment {
     }
 
     private void onFingerprintButtonClicked() {
-        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(),CONTINUE_WITH_FINGERPRINT);
+        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(),
+                CONTINUE_WITH_FINGERPRINT, PersonalIdWorkflow.CONFIGURATION);
         BiometricsHelper.ConfigurationStatus status = BiometricsHelper.checkFingerprintStatus(getActivity(),
                 biometricManager);
 
@@ -271,7 +272,8 @@ public class PersonalIdBiometricConfigFragment extends BasePersonalIdFragment {
     }
 
     private void onPinButtonClicked() {
-        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(),CONTINUE_WITH_PIN);
+        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(),
+                CONTINUE_WITH_PIN, PersonalIdWorkflow.CONFIGURATION);
         BiometricsHelper.ConfigurationStatus status = BiometricsHelper.checkPinStatus(getActivity(),
                 biometricManager);
 

--- a/app/src/org/commcare/fragments/personalId/PersonalIdEmailFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdEmailFragment.kt
@@ -129,7 +129,11 @@ class PersonalIdEmailFragment : BasePersonalIdFragment() {
             showError(getString(R.string.personalid_email_invalid_format))
             return
         }
-        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(javaClass.simpleName, null)
+        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(
+            javaClass.simpleName,
+            null,
+            PersonalIdWorkflow.fromEmailWorkFlow(workflow),
+        )
         clearError()
         enableContinueButton(false)
 
@@ -150,7 +154,11 @@ class PersonalIdEmailFragment : BasePersonalIdFragment() {
     }
 
     private fun skipEmail() {
-        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(javaClass.simpleName, "skip")
+        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(
+            javaClass.simpleName,
+            "skip",
+            PersonalIdWorkflow.fromEmailWorkFlow(workflow),
+        )
         EmailHelper.routeAfterEmailDeclined(
             fragment = this,
             workflow = workflow,

--- a/app/src/org/commcare/fragments/personalId/PersonalIdEmailVerificationFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdEmailVerificationFragment.kt
@@ -160,7 +160,11 @@ class PersonalIdEmailVerificationFragment : BasePersonalIdFragment() {
             Logger.exception("Invalid email otp", Exception("Invalid email otp length error - ${otp.length}"))
             return
         }
-        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(javaClass.simpleName, null)
+        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(
+            javaClass.simpleName,
+            null,
+            PersonalIdWorkflow.fromEmailWorkFlow(workflow),
+        )
         clearError()
         enableVerifyButton(false)
 

--- a/app/src/org/commcare/fragments/personalId/PersonalIdNameFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdNameFragment.java
@@ -83,7 +83,8 @@ public class PersonalIdNameFragment extends BasePersonalIdFragment {
     }
 
     private void verifyOrAddName() {
-        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(),null);
+        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(), null,
+                PersonalIdWorkflow.CONFIGURATION);
         clearError();
         enableContinueButton(false);
         new PersonalIdApiHandler<PersonalIdSessionData>() {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneFragment.java
@@ -320,7 +320,8 @@ public class PersonalIdPhoneFragment extends BasePersonalIdFragment implements C
     private void onContinueClicked() {
         FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(
                 this.getClass().getSimpleName(),
-                null
+                null,
+                PersonalIdWorkflow.CONFIGURATION
         );
         enableContinueButton(false);
         startConfigurationRequest();

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhoneVerificationFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhoneVerificationFragment.java
@@ -379,6 +379,8 @@ public class PersonalIdPhoneVerificationFragment extends BasePersonalIdFragment 
     }
 
     private void verifyOtp() {
+        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(), null,
+                PersonalIdWorkflow.CONFIGURATION);
         binding.connectPhoneVerifyButton.setEnabled(false);
         clearOtpError();
         String otpCode = binding.customOtpView.getCodeValue();

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
@@ -83,6 +83,8 @@ public class PersonalIdPhotoCaptureFragment extends BasePersonalIdFragment {
     }
 
     private void uploadImageAndCompleteProfile() {
+        FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(), null,
+                PersonalIdWorkflow.CONFIGURATION);
         clearError();
         disableSaveButton();
         disableTakePhotoButton();

--- a/app/src/org/commcare/fragments/personalId/PersonalIdWorkflow.kt
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdWorkflow.kt
@@ -1,0 +1,29 @@
+package org.commcare.fragments.personalId
+
+/**
+ * PersonalID work flow
+ *
+ *  - [CONFIGURATION]: the PersonalID sign-up / account recovery -  configuration flow
+ *  - [USER_PROMPT]: the user is acting on a prompt surfaced outside the config flow,
+ *    e.g. the email-collection prompt shown to a logged-in user from
+ *    {@code StandardHomeActivity} (EmailOfferHelper.checkEmailCollection).
+ *  - [EDIT_PROFILE]: reserved for the future edit-profile feature.
+ */
+enum class PersonalIdWorkflow {
+    CONFIGURATION,
+    USER_PROMPT,
+    EDIT_PROFILE,
+    ;
+
+    /** Stable lowercase string emitted to analytics ("configuration", "user_prompt", "edit_profile"). */
+    val analyticsValue: String get() = name.lowercase()
+
+    companion object {
+        @JvmStatic
+        fun fromEmailWorkFlow(flow: EmailWorkFlow): PersonalIdWorkflow =
+            when (flow) {
+                EmailWorkFlow.EXISTING_USER -> USER_PROMPT
+                EmailWorkFlow.REGISTRATION, EmailWorkFlow.RECOVERY -> CONFIGURATION
+            }
+    }
+}

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
@@ -43,6 +43,7 @@ public class CCAnalyticsParam {
     static final String PARAM_API_NEW_JOBS = "ccc_api_new_jobs";
     public static final String PERSONAL_ID_CONTINUE_CLICKED_INFO =
             "personal_id_continue_button_clicked_info";
+    public static final String PERSONAL_ID_WORKFLOW = "personalid_flow";
     static final String NOTIFICATION_EVENT_TYPE = "event_type";
     static final String NOTIFICATION_ACTION = "action";
     static final String NOTIFICATION_ID = "notification_id";

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -17,6 +17,7 @@ import org.commcare.DiskUtils;
 import org.commcare.android.database.connect.models.ConnectReleaseToggleRecord;
 import org.commcare.android.logging.ReportingUtils;
 import org.commcare.connect.PersonalIdManager;
+import org.commcare.fragments.personalId.PersonalIdWorkflow;
 import org.commcare.dalvik.BuildConfig;
 import org.commcare.preferences.MainConfigurablePreferences;
 import org.commcare.suite.model.OfflineUserRestore;
@@ -674,12 +675,14 @@ public class FirebaseAnalyticsUtil {
         reportEvent(CCAnalyticsEvent.LOGIN_CLICK);
     }
 
-    public static void reportPersonalIDContinueClicked(String screenName, @Nullable String info) {
+    public static void reportPersonalIDContinueClicked(String screenName, @Nullable String info,
+            PersonalIdWorkflow workflow) {
         Bundle params = new Bundle();
         params.putString(FirebaseAnalytics.Param.SCREEN_NAME, screenName);
         if (info != null) {
             params.putString(CCAnalyticsParam.PERSONAL_ID_CONTINUE_CLICKED_INFO, info);
         }
+        params.putString(CCAnalyticsParam.PERSONAL_ID_WORKFLOW, workflow.getAnalyticsValue());
         reportEvent(CCAnalyticsEvent.PERSONAL_ID_CONTINUE_CLICKED, params);
     }
 

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdWorkflowTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdWorkflowTest.kt
@@ -1,0 +1,32 @@
+package org.commcare.fragments.personalId
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PersonalIdWorkflowTest {
+    // --- fromEmailWorkFlow ---
+
+    @Test
+    fun `fromEmailWorkFlow maps EXISTING_USER to USER_PROMPT`() {
+        assertEquals(
+            PersonalIdWorkflow.USER_PROMPT,
+            PersonalIdWorkflow.fromEmailWorkFlow(EmailWorkFlow.EXISTING_USER),
+        )
+    }
+
+    @Test
+    fun `fromEmailWorkFlow maps REGISTRATION to CONFIGURATION`() {
+        assertEquals(
+            PersonalIdWorkflow.CONFIGURATION,
+            PersonalIdWorkflow.fromEmailWorkFlow(EmailWorkFlow.REGISTRATION),
+        )
+    }
+
+    @Test
+    fun `fromEmailWorkFlow maps RECOVERY to CONFIGURATION`() {
+        assertEquals(
+            PersonalIdWorkflow.CONFIGURATION,
+            PersonalIdWorkflow.fromEmailWorkFlow(EmailWorkFlow.RECOVERY),
+        )
+    }
+}


### PR DESCRIPTION
### [CCCT-2489](https://dimagi.atlassian.net/browse/CCCT-2489)

## Technical Summary

Adds a `personalid_flow` parameter to the `personal_id_continue_clicked` analytics event to track the origin of the Continue button press.
- New `PersonalIdWorkflow` enum (`CONFIGURATION` / `USER_PROMPT` / `EDIT_PROFILE`, the last reserved for the future edit-profile feature), threaded through `FirebaseAnalyticsUtil.reportPersonalIDContinueClicked` as a required argument.
- Config-flow fragments pass `CONFIGURATION`; the email screens derive the value from their existing `EmailWorkFlow` (existing-user prompt → `USER_PROMPT`, registration/recovery → `CONFIGURATION`).
- Adds the previously-missing Continue event to `PersonalIdPhoneVerificationFragment` and `PersonalIdPhotoCaptureFragment` so they also report the workflow.

## Safety Assurance

### Safety story

What gives me confidence:
- I ran the unit tests and reviewed the full diff.
- The diff is narrow and analytics-only — it adds a fire-and-forget logging parameter and does not change navigation, auth, or UI behavior.
- The new `fromEmailWorkFlow` mapping is covered by unit tests.

### Automated test coverage

`PersonalIdWorkflowTest` covers the `fromEmailWorkFlow` mapping for all three `EmailWorkFlow` values (existing-user → user_prompt, registration/recovery → configuration).

[CCCT-2489]: https://dimagi.atlassian.net/browse/CCCT-2489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ