### PR TITLE
CCCT-2309 Add Unit Tests For Notification History

### DIFF
--- a/app/src/org/commcare/activities/connect/viewmodel/PushNotificationViewModel.kt
+++ b/app/src/org/commcare/activities/connect/viewmodel/PushNotificationViewModel.kt
@@ -2,86 +2,70 @@ package org.commcare.activities.connect.viewmodel
 
 import android.app.Application
 import android.content.Context
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.application
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.commcare.android.database.connect.models.PushNotificationRecord
 import org.commcare.connect.database.NotificationRecordDatabaseHelper
 import org.commcare.pn.workermanager.NotificationsSyncWorkerManager
 import org.commcare.utils.PushNotificationApiHelper
 import org.commcare.utils.PushNotificationApiHelper.retrieveLatestPushNotifications
+import org.commcare.utils.coroutines.DispatcherProvider
 
-class PushNotificationViewModel
-    @JvmOverloads
-    constructor(
-        application: Application,
-        private val ioDispatcher: CoroutineDispatcher = dispatcherOverride ?: Dispatchers.IO,
-    ) : AndroidViewModel(application) {
-        private val _fetchApiError =
-            MutableLiveData<String>()
-        val fetchApiError: LiveData<String> =
-            _fetchApiError
+class PushNotificationViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+    private val _fetchApiError =
+        MutableLiveData<String>()
+    val fetchApiError: LiveData<String> =
+        _fetchApiError
 
-        private val _allNotifications = MutableLiveData<List<PushNotificationRecord>>()
-        val allNotifications: LiveData<List<PushNotificationRecord>> = _allNotifications
-        private val _isLoading = MutableLiveData<Boolean>()
-        val isLoading: LiveData<Boolean> = _isLoading
+    private val _allNotifications = MutableLiveData<List<PushNotificationRecord>>()
+    val allNotifications: LiveData<List<PushNotificationRecord>> = _allNotifications
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> = _isLoading
 
-        fun loadNotifications(
-            isRefreshed: Boolean,
-            context: Context,
-        ) {
-            viewModelScope.launch(ioDispatcher) {
-                _isLoading.postValue(true)
-                // Load from DB first
-                if (!isRefreshed) {
-                    val cachedNotifications =
-                        NotificationRecordDatabaseHelper
-                            .getAllNotifications(context)
-                            .orEmpty()
-                            .sortedByDescending { it.createdDate }
-                    if (cachedNotifications.isNotEmpty()) {
-                        _isLoading.postValue(false)
-                    }
-                    _allNotifications.postValue(cachedNotifications)
+    fun loadNotifications(
+        isRefreshed: Boolean,
+        context: Context,
+    ) {
+        viewModelScope.launch(DispatcherProvider.io()) {
+            _isLoading.postValue(true)
+            // Load from DB first
+            if (!isRefreshed) {
+                val cachedNotifications =
+                    NotificationRecordDatabaseHelper
+                        .getAllNotifications(context)
+                        .orEmpty()
+                        .sortedByDescending { it.createdDate }
+                if (cachedNotifications.isNotEmpty()) {
+                    _isLoading.postValue(false)
                 }
-
-                val latestPushNotificationsFromApi = retrieveLatestPushNotifications(context)
-                latestPushNotificationsFromApi
-                    .onSuccess {
-                        val currentNotifications = _allNotifications.value.orEmpty()
-                        NotificationsSyncWorkerManager(
-                            context = application,
-                            showNotification = false,
-                            syncNotification = false,
-                        ).startSyncWorkers(PushNotificationApiHelper.convertPNRecordsToPayload(it))
-                        val updatedNotifications =
-                            (it + currentNotifications)
-                                .distinctBy { it.notificationId }
-                                .sortedByDescending { it.createdDate }
-                        _isLoading.postValue(false)
-                        _allNotifications.postValue(updatedNotifications)
-                    }.onFailure {
-                        _isLoading.postValue(false)
-                        _fetchApiError.postValue(it.message)
-                    }
+                _allNotifications.postValue(cachedNotifications)
             }
-        }
 
-        companion object {
-            // Notification loading runs on Dispatchers.IO, a real background thread pool. Robolectric
-            // only drives the main looper and can't deterministically schedule or wait on that pool,
-            // making such tests flaky. This lets tests swap in a test dispatcher so loading runs
-            // synchronously. The activity creates this ViewModel and loads immediately, so the override
-            // must be set before construction (a post-construction setter would race) - hence a
-            // companion field.
-            @VisibleForTesting
-            internal var dispatcherOverride: CoroutineDispatcher? = null
+            val latestPushNotificationsFromApi = retrieveLatestPushNotifications(context)
+            latestPushNotificationsFromApi
+                .onSuccess {
+                    val currentNotifications = _allNotifications.value.orEmpty()
+                    NotificationsSyncWorkerManager(
+                        context = application,
+                        showNotification = false,
+                        syncNotification = false,
+                    ).startSyncWorkers(PushNotificationApiHelper.convertPNRecordsToPayload(it))
+                    val updatedNotifications =
+                        (it + currentNotifications)
+                            .distinctBy { it.notificationId }
+                            .sortedByDescending { it.createdDate }
+                    _isLoading.postValue(false)
+                    _allNotifications.postValue(updatedNotifications)
+                }.onFailure {
+                    _isLoading.postValue(false)
+                    _fetchApiError.postValue(it.message)
+                }
         }
     }
+}

--- a/app/src/org/commcare/activities/connect/viewmodel/PushNotificationViewModel.kt
+++ b/app/src/org/commcare/activities/connect/viewmodel/PushNotificationViewModel.kt
@@ -2,11 +2,13 @@ package org.commcare.activities.connect.viewmodel
 
 import android.app.Application
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.application
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.commcare.android.database.connect.models.PushNotificationRecord
@@ -15,57 +17,71 @@ import org.commcare.pn.workermanager.NotificationsSyncWorkerManager
 import org.commcare.utils.PushNotificationApiHelper
 import org.commcare.utils.PushNotificationApiHelper.retrieveLatestPushNotifications
 
-class PushNotificationViewModel(
-    application: Application,
-) : AndroidViewModel(application) {
-    private val _fetchApiError =
-        MutableLiveData<String>()
-    val fetchApiError: LiveData<String> =
-        _fetchApiError
+class PushNotificationViewModel
+    @JvmOverloads
+    constructor(
+        application: Application,
+        private val ioDispatcher: CoroutineDispatcher = dispatcherOverride ?: Dispatchers.IO,
+    ) : AndroidViewModel(application) {
+        private val _fetchApiError =
+            MutableLiveData<String>()
+        val fetchApiError: LiveData<String> =
+            _fetchApiError
 
-    private val _allNotifications = MutableLiveData<List<PushNotificationRecord>>()
-    val allNotifications: LiveData<List<PushNotificationRecord>> = _allNotifications
-    private val _isLoading = MutableLiveData<Boolean>()
-    val isLoading: LiveData<Boolean> = _isLoading
+        private val _allNotifications = MutableLiveData<List<PushNotificationRecord>>()
+        val allNotifications: LiveData<List<PushNotificationRecord>> = _allNotifications
+        private val _isLoading = MutableLiveData<Boolean>()
+        val isLoading: LiveData<Boolean> = _isLoading
 
-    fun loadNotifications(
-        isRefreshed: Boolean,
-        context: Context,
-    ) {
-        viewModelScope.launch(Dispatchers.IO) {
-            _isLoading.postValue(true)
-            // Load from DB first
-            if (!isRefreshed) {
-                val cachedNotifications =
-                    NotificationRecordDatabaseHelper
-                        .getAllNotifications(context)
-                        .orEmpty()
-                        .sortedByDescending { it.createdDate }
-                if (cachedNotifications.isNotEmpty()) {
-                    _isLoading.postValue(false)
-                }
-                _allNotifications.postValue(cachedNotifications)
-            }
-
-            val latestPushNotificationsFromApi = retrieveLatestPushNotifications(context)
-            latestPushNotificationsFromApi
-                .onSuccess {
-                    val currentNotifications = _allNotifications.value.orEmpty()
-                    NotificationsSyncWorkerManager(
-                        context = application,
-                        showNotification = false,
-                        syncNotification = false,
-                    ).startSyncWorkers(PushNotificationApiHelper.convertPNRecordsToPayload(it))
-                    val updatedNotifications =
-                        (it + currentNotifications)
-                            .distinctBy { it.notificationId }
+        fun loadNotifications(
+            isRefreshed: Boolean,
+            context: Context,
+        ) {
+            viewModelScope.launch(ioDispatcher) {
+                _isLoading.postValue(true)
+                // Load from DB first
+                if (!isRefreshed) {
+                    val cachedNotifications =
+                        NotificationRecordDatabaseHelper
+                            .getAllNotifications(context)
+                            .orEmpty()
                             .sortedByDescending { it.createdDate }
-                    _isLoading.postValue(false)
-                    _allNotifications.postValue(updatedNotifications)
-                }.onFailure {
-                    _isLoading.postValue(false)
-                    _fetchApiError.postValue(it.message)
+                    if (cachedNotifications.isNotEmpty()) {
+                        _isLoading.postValue(false)
+                    }
+                    _allNotifications.postValue(cachedNotifications)
                 }
+
+                val latestPushNotificationsFromApi = retrieveLatestPushNotifications(context)
+                latestPushNotificationsFromApi
+                    .onSuccess {
+                        val currentNotifications = _allNotifications.value.orEmpty()
+                        NotificationsSyncWorkerManager(
+                            context = application,
+                            showNotification = false,
+                            syncNotification = false,
+                        ).startSyncWorkers(PushNotificationApiHelper.convertPNRecordsToPayload(it))
+                        val updatedNotifications =
+                            (it + currentNotifications)
+                                .distinctBy { it.notificationId }
+                                .sortedByDescending { it.createdDate }
+                        _isLoading.postValue(false)
+                        _allNotifications.postValue(updatedNotifications)
+                    }.onFailure {
+                        _isLoading.postValue(false)
+                        _fetchApiError.postValue(it.message)
+                    }
+            }
+        }
+
+        companion object {
+            // Notification loading runs on Dispatchers.IO, a real background thread pool. Robolectric
+            // only drives the main looper and can't deterministically schedule or wait on that pool,
+            // making such tests flaky. This lets tests swap in a test dispatcher so loading runs
+            // synchronously. The activity creates this ViewModel and loads immediately, so the override
+            // must be set before construction (a post-construction setter would race) - hence a
+            // companion field.
+            @VisibleForTesting
+            internal var dispatcherOverride: CoroutineDispatcher? = null
         }
     }
-}

--- a/app/src/org/commcare/utils/PushNotificationApiHelper.kt
+++ b/app/src/org/commcare/utils/PushNotificationApiHelper.kt
@@ -7,7 +7,6 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.commcare.android.database.connect.models.PushNotificationRecord
@@ -37,6 +36,7 @@ import org.commcare.connect.network.connectId.parser.NotificationParseResult
 import org.commcare.pn.helper.NotificationBroadcastHelper
 import org.commcare.pn.workers.MessagingChannelsKeySyncWorker
 import org.commcare.preferences.NotificationPrefs
+import org.commcare.utils.coroutines.DispatcherProvider
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -49,15 +49,15 @@ object PushNotificationApiHelper {
         context: Context,
         listener: ConnectActivityCompleteListener,
     ) {
-        CoroutineScope(Dispatchers.IO).launch {
+        CoroutineScope(DispatcherProvider.io()).launch {
             retrieveLatestPushNotifications(context)
                 .onSuccess {
-                    withContext(Dispatchers.Main) {
+                    withContext(DispatcherProvider.main()) {
                         //  switching to main to touch views
                         listener.connectActivityComplete(true)
                     }
                 }.onFailure {
-                    withContext(Dispatchers.Main) {
+                    withContext(DispatcherProvider.main()) {
                         //  switching to main to touch views
                         listener.connectActivityComplete(false)
                     }
@@ -77,7 +77,7 @@ object PushNotificationApiHelper {
             object : PersonalIdApiHandler<NotificationParseResult>() {
                 override fun onSuccess(parseResult: NotificationParseResult) {
                     scheduleMessagingChannelsKeySync(context)
-                    CoroutineScope(Dispatchers.IO).launch {
+                    CoroutineScope(DispatcherProvider.io()).launch {
                         val (savedNotifications, savedNotificationIds) = processParsedDataIntoDB(context, parseResult)
 
                         // Update notification preferences and send broadcasts

--- a/app/src/org/commcare/utils/coroutines/DispatcherProvider.kt
+++ b/app/src/org/commcare/utils/coroutines/DispatcherProvider.kt
@@ -1,0 +1,12 @@
+package org.commcare.utils.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+object DispatcherProvider {
+    fun io(): CoroutineDispatcher = Dispatchers.IO
+
+    fun main(): CoroutineDispatcher = Dispatchers.Main
+
+    fun default(): CoroutineDispatcher = Dispatchers.Default
+}

--- a/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
@@ -1,39 +1,44 @@
 package org.commcare.activities
 
+import android.content.Intent
 import android.view.MenuItem
 import android.view.View
 import androidx.lifecycle.ViewModelProvider
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.Runs
-import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import okhttp3.mockwebserver.MockResponse
 import org.commcare.CommCareTestApplication
 import org.commcare.activities.connect.ConnectActivity
 import org.commcare.activities.connect.ConnectMessagingActivity
 import org.commcare.activities.connect.viewmodel.PushNotificationViewModel
+import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.android.database.connect.models.PushNotificationRecord
 import org.commcare.connect.ConnectConstants
 import org.commcare.connect.PersonalIdManager
+import org.commcare.connect.database.ConnectMessagingDatabaseHelper
+import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.connect.database.NotificationRecordDatabaseHelper
+import org.commcare.connect.network.PersonalIdMockApiServer
 import org.commcare.dalvik.R
 import org.commcare.google.services.analytics.AnalyticsParamValue
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.pn.helper.NotificationBroadcastHelper
 import org.commcare.pn.workermanager.NotificationsSyncWorkerManager
 import org.commcare.preferences.NotificationPrefs
-import org.commcare.utils.PushNotificationApiHelper
 import org.commcare.utils.coroutines.DispatcherProvider
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -58,10 +63,13 @@ class PushNotificationActivityTest {
     private lateinit var activityController: ActivityController<PushNotificationActivity>
     private lateinit var activity: PushNotificationActivity
 
+    // MAIN_LOOPER mode reproduces production threading; this test touches views, so callbacks must
+    // run on the main looper (driven deterministically via drainHttp).
+    private val mockApi = PersonalIdMockApiServer(PersonalIdMockApiServer.CallbackMode.MAIN_LOOPER)
+    private val mockWebServer get() = mockApi.server
+
     private val dbReadCount = AtomicInteger(0)
-    private val apiCallCount = AtomicInteger(0)
     private var dbNotifications: List<PushNotificationRecord> = emptyList()
-    private var apiResult: suspend () -> Result<List<PushNotificationRecord>> = { Result.success(emptyList()) }
     private lateinit var savedPersonalIdStatus: PersonalIdManager.PersonalIdStatus
 
     private val recyclerView: RecyclerView
@@ -71,8 +79,11 @@ class PushNotificationActivityTest {
 
     @Before
     fun setUp() {
-        // Run the ViewModel's coroutine on a deterministic test dispatcher instead of
-        // the real Dispatchers.IO thread pool, so notification loading is synchronous.
+        // scheduleMessagingChannelsKeySync enqueues a real WorkManager job during a successful load.
+        (CommCareTestApplication.instance() as CommCareTestApplication).initWorkManager()
+        mockApi.start()
+
+        // The helper's internal scope runs inline so a load completes within drainHttp.
         mockkObject(DispatcherProvider)
         every { DispatcherProvider.io() } returns UnconfinedTestDispatcher()
 
@@ -82,21 +93,37 @@ class PushNotificationActivityTest {
         savedPersonalIdStatus = personalIdManager.status
         personalIdManager.status = PersonalIdManager.PersonalIdStatus.LoggedIn
 
-        mockkObject(NotificationRecordDatabaseHelper)
-        mockkObject(PushNotificationApiHelper)
-        mockkConstructor(NotificationsSyncWorkerManager::class)
-        mockkStatic(FirebaseAnalyticsUtil::class)
+        // A real (non-mock) user so the helper gets credentials and the click path's connect-access
+        // logic runs for real; hasConnectAccess = true keeps turnOnConnectAccess a no-op.
+        val user =
+            ConnectUserRecord("", "test_user", "test_password", "", "", Date(), "", false, "", true)
+        mockkStatic(ConnectUserDatabaseUtil::class)
+        every { ConnectUserDatabaseUtil.getUser(any()) } returns user
 
+        mockkStatic(ConnectMessagingDatabaseHelper::class)
+        every { ConnectMessagingDatabaseHelper.getMessagingChannels(any()) } returns emptyList()
+
+        mockkObject(NotificationRecordDatabaseHelper)
         every { NotificationRecordDatabaseHelper.getAllNotifications(any()) } answers {
             dbReadCount.incrementAndGet()
             dbNotifications
         }
         every { NotificationRecordDatabaseHelper.updateReadStatus(any(), any(), any()) } just Runs
-        coEvery { PushNotificationApiHelper.retrieveLatestPushNotifications(any()) } coAnswers {
-            apiCallCount.incrementAndGet()
-            apiResult()
+        every { NotificationRecordDatabaseHelper.updateColumnForNotifications(any(), any(), any()) } returns Unit
+        val storedSlot = slot<List<PushNotificationRecord>>()
+        every { NotificationRecordDatabaseHelper.storeNotifications(any(), capture(storedSlot)) } answers {
+            storedSlot.captured.map { it.notificationId }
         }
+
+        // Suppress the helper's success broadcast so it does not re-trigger the activity's reload
+        // receiver into an endless load loop; registerForNotifications stays real for the reload test.
+        mockkObject(NotificationBroadcastHelper)
+        every { NotificationBroadcastHelper.sendNewNotificationBroadcast(any()) } just Runs
+
+        mockkConstructor(NotificationsSyncWorkerManager::class)
         every { anyConstructed<NotificationsSyncWorkerManager>().startSyncWorkers(any()) } just Runs
+
+        mockkStatic(FirebaseAnalyticsUtil::class)
         every { FirebaseAnalyticsUtil.reportNotificationEvent(any(), any(), any(), any()) } just Runs
     }
 
@@ -109,6 +136,7 @@ class PushNotificationActivityTest {
                 // Ignore teardown errors for already-finished activities
             }
         }
+        mockApi.shutdown()
         unmockkAll()
         PersonalIdManager.getInstance().status = savedPersonalIdStatus
     }
@@ -123,6 +151,25 @@ class PushNotificationActivityTest {
                 .visible()
                 .get()
     }
+
+    private fun notificationJson(record: PushNotificationRecord): String =
+        buildString {
+            append("{")
+            append(""""notification_id":"${record.notificationId}",""")
+            append(""""title":"${record.title}",""")
+            append(""""body":"${record.body}",""")
+            append(""""notification_type":"PUSH",""")
+            append(""""timestamp":"2023-01-01T12:00:00Z",""")
+            append(""""action":"${record.action}",""")
+            append(""""opportunity_uuid":"${record.opportunityUUID}",""")
+            append(""""payment_uuid":"${record.paymentUUID}"""")
+            append("}")
+        }
+
+    private fun responseBody(records: List<PushNotificationRecord>): String =
+        """{"notifications":[${records.joinToString(",") { notificationJson(it) }}]}"""
+
+    private fun completeLoad(records: List<PushNotificationRecord>) = mockApi.completeLoad(records, ::responseBody)
 
     private fun buildRecord(
         id: String,
@@ -146,20 +193,17 @@ class PushNotificationActivityTest {
     @Test
     fun `notifications from local storage are shown in the list`() {
         dbNotifications = listOf(buildRecord("a"), buildRecord("b"))
-        // Keep the api call pending so the list is populated from local storage alone
-        val pendingApiCall = CompletableDeferred<Result<List<PushNotificationRecord>>>()
-        apiResult = { pendingApiCall.await() }
 
         launchActivity()
 
+        // The api request is left pending so the list is populated from local storage alone.
         ShadowLooper.idleMainLooper()
         assertEquals(View.VISIBLE, recyclerView.visibility)
         assertEquals(View.GONE, emptyView.visibility)
         assertEquals(2, recyclerView.adapter!!.itemCount)
 
-        pendingApiCall.complete(Result.success(emptyList()))
+        completeLoad(emptyList())
 
-        ShadowLooper.idleMainLooper()
         assertEquals(View.VISIBLE, recyclerView.visibility)
         assertEquals(2, recyclerView.adapter!!.itemCount)
     }
@@ -168,25 +212,23 @@ class PushNotificationActivityTest {
     fun `empty state is shown when there are no notifications`() {
         launchActivity()
 
-        ShadowLooper.idleMainLooper()
+        completeLoad(emptyList())
+
         assertEquals(View.VISIBLE, emptyView.visibility)
         assertEquals(View.GONE, recyclerView.visibility)
     }
 
     @Test
     fun `list and empty state stay hidden while notifications are loading`() {
-        val pendingApiCall = CompletableDeferred<Result<List<PushNotificationRecord>>>()
-        apiResult = { pendingApiCall.await() }
-
         launchActivity()
 
+        // The api request is left pending to observe the loading state.
         ShadowLooper.idleMainLooper()
         assertEquals(View.GONE, recyclerView.visibility)
         assertEquals(View.GONE, emptyView.visibility)
 
-        pendingApiCall.complete(Result.success(listOf(buildRecord("a"))))
+        completeLoad(listOf(buildRecord("a")))
 
-        ShadowLooper.idleMainLooper()
         assertEquals(View.VISIBLE, recyclerView.visibility)
         assertEquals(View.GONE, emptyView.visibility)
         assertEquals(1, recyclerView.adapter!!.itemCount)
@@ -196,15 +238,12 @@ class PushNotificationActivityTest {
     fun `new api notifications are merged with cached ones and sorted newest first`() {
         // The API returns only new notifications; the cached one comes from local storage.
         dbNotifications = listOf(buildRecord("cached", Date(1000L)))
-        val pendingApiCall = CompletableDeferred<Result<List<PushNotificationRecord>>>()
-        apiResult = { pendingApiCall.await() }
 
         launchActivity()
 
         // Let the cached list from local storage publish before the api responds.
         ShadowLooper.idleMainLooper()
-        pendingApiCall.complete(Result.success(listOf(buildRecord("api", Date(2000L)))))
-        ShadowLooper.idleMainLooper()
+        completeLoad(listOf(buildRecord("api", Date(2000L))))
 
         // Assert the merge on the ViewModel's output: a second non-empty submitList would diff
         // on a background thread that idleMainLooper does not flush, so the adapter is unreliable.
@@ -227,24 +266,26 @@ class PushNotificationActivityTest {
 
     @Test
     fun `a toast is shown when fetching notifications fails`() {
-        apiResult = { Result.failure(Exception("Network error")) }
-
         launchActivity()
 
+        mockWebServer.enqueue(MockResponse().setResponseCode(500).setBody("error"))
+        mockApi.drainHttp()
         ShadowLooper.idleMainLooper()
-        assertEquals("Network error", ShadowToast.getTextOfLatestToast())
+
+        assertTrue(ShadowToast.getTextOfLatestToast().orEmpty().isNotEmpty())
     }
 
     @Test
     fun `cloud sync menu item refreshes from the server without re-reading local storage`() {
         launchActivity()
-        ShadowLooper.idleMainLooper()
-        assertEquals(1, apiCallCount.get())
+        completeLoad(emptyList())
+        assertEquals(1, mockWebServer.requestCount)
+        assertEquals(1, dbReadCount.get())
 
         assertTrue(activity.onOptionsItemSelected(menuItemWithId(R.id.notification_cloud_sync)))
+        completeLoad(emptyList())
 
-        ShadowLooper.idleMainLooper()
-        assertEquals(2, apiCallCount.get())
+        assertEquals(2, mockWebServer.requestCount)
         assertEquals(1, dbReadCount.get())
     }
 
@@ -260,20 +301,23 @@ class PushNotificationActivityTest {
     @Test
     fun `a new notification broadcast reloads notifications from local storage`() {
         launchActivity()
-        ShadowLooper.idleMainLooper()
+        completeLoad(emptyList())
         assertEquals(1, dbReadCount.get())
-        assertEquals(1, apiCallCount.get())
+        assertEquals(1, mockWebServer.requestCount)
 
-        NotificationBroadcastHelper.sendNewNotificationBroadcast(activity)
+        // Deliver the broadcast directly so the activity's real receiver reloads; the helper's own
+        // broadcast is stubbed out.
+        LocalBroadcastManager
+            .getInstance(activity)
+            .sendBroadcast(Intent(NotificationBroadcastHelper.ACTION_NEW_NOTIFICATIONS))
 
         ShadowLooper.idleMainLooper()
         assertEquals(2, dbReadCount.get())
     }
 
     private fun launchAndClickFirstNotification(record: PushNotificationRecord) {
-        apiResult = { Result.success(listOf(record)) }
         launchActivity()
-        ShadowLooper.idleMainLooper()
+        completeLoad(listOf(record))
         assertEquals(View.VISIBLE, recyclerView.visibility)
         recyclerView.findViewHolderForAdapterPosition(0)!!.itemView.performClick()
     }

--- a/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
@@ -1,8 +1,8 @@
 package org.commcare.activities
 
-import android.content.Intent
 import android.view.MenuItem
 import android.view.View
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -17,9 +17,15 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.commcare.CommCareTestApplication
-import org.commcare.adapters.PushNotificationAdapter
+import org.commcare.activities.connect.ConnectActivity
+import org.commcare.activities.connect.ConnectMessagingActivity
+import org.commcare.activities.connect.viewmodel.PushNotificationViewModel
 import org.commcare.android.database.connect.models.PushNotificationRecord
+import org.commcare.connect.ConnectConstants
+import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.NotificationRecordDatabaseHelper
 import org.commcare.dalvik.R
 import org.commcare.google.services.analytics.AnalyticsParamValue
@@ -27,13 +33,11 @@ import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.pn.helper.NotificationBroadcastHelper
 import org.commcare.pn.workermanager.NotificationsSyncWorkerManager
 import org.commcare.preferences.NotificationPrefs
-import org.commcare.utils.FirebaseMessagingUtil
 import org.commcare.utils.PushNotificationApiHelper
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,6 +50,7 @@ import org.robolectric.shadows.ShadowToast
 import java.util.Date
 import java.util.concurrent.atomic.AtomicInteger
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Config(application = CommCareTestApplication::class)
 @RunWith(AndroidJUnit4::class)
 class PushNotificationActivityTest {
@@ -56,6 +61,7 @@ class PushNotificationActivityTest {
     private val apiCallCount = AtomicInteger(0)
     private var dbNotifications: List<PushNotificationRecord> = emptyList()
     private var apiResult: suspend () -> Result<List<PushNotificationRecord>> = { Result.success(emptyList()) }
+    private lateinit var savedPersonalIdStatus: PersonalIdManager.PersonalIdStatus
 
     private val recyclerView: RecyclerView
         get() = activity.findViewById(R.id.rvNotifications)
@@ -64,11 +70,20 @@ class PushNotificationActivityTest {
 
     @Before
     fun setUp() {
+        // Run the ViewModel's coroutine on a deterministic test dispatcher instead of
+        // the real Dispatchers.IO thread pool, so notification loading is synchronous.
+        PushNotificationViewModel.dispatcherOverride = UnconfinedTestDispatcher()
+
+        // getIntentForPNClick is exercised for real, so cccCheckPassed() must see a logged-in
+        // user. init() is a no-op unless status == NotIntroduced, so setting LoggedIn is enough.
+        val personalIdManager = PersonalIdManager.getInstance()
+        savedPersonalIdStatus = personalIdManager.status
+        personalIdManager.status = PersonalIdManager.PersonalIdStatus.LoggedIn
+
         mockkObject(NotificationRecordDatabaseHelper)
         mockkObject(PushNotificationApiHelper)
         mockkConstructor(NotificationsSyncWorkerManager::class)
         mockkStatic(FirebaseAnalyticsUtil::class)
-        mockkStatic(FirebaseMessagingUtil::class)
 
         every { NotificationRecordDatabaseHelper.getAllNotifications(any()) } answers {
             dbReadCount.incrementAndGet()
@@ -93,6 +108,8 @@ class PushNotificationActivityTest {
             }
         }
         unmockkAll()
+        PushNotificationViewModel.dispatcherOverride = null
+        PersonalIdManager.getInstance().status = savedPersonalIdStatus
     }
 
     private fun launchActivity() {
@@ -106,38 +123,21 @@ class PushNotificationActivityTest {
                 .get()
     }
 
-    private fun waitFor(
-        description: String,
-        condition: () -> Boolean,
-    ) {
-        val deadline = System.currentTimeMillis() + 5000
-        while (!condition()) {
-            if (System.currentTimeMillis() > deadline) {
-                fail("Timed out waiting for $description")
-            }
-            ShadowLooper.idleMainLooper()
-            Thread.sleep(10)
-        }
-    }
-
-    private fun layoutRecyclerView() {
-        recyclerView.measure(
-            View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY),
-            View.MeasureSpec.makeMeasureSpec(1920, View.MeasureSpec.EXACTLY),
-        )
-        recyclerView.layout(0, 0, 1080, 1920)
-    }
-
     private fun buildRecord(
         id: String,
         date: Date = Date(0L),
+        action: String = ConnectConstants.CCC_DEST_PAYMENTS,
+        opportunityUuid: String = "",
+        paymentUuid: String = "",
     ): PushNotificationRecord =
         PushNotificationRecord().apply {
             notificationId = id
-            action = "ccc_payment_page"
+            this.action = action
             title = "Title $id"
             body = "Body $id"
             createdDate = date
+            opportunityUUID = opportunityUuid
+            paymentUUID = paymentUuid
         }
 
     private fun menuItemWithId(id: Int): MenuItem = mockk { every { itemId } returns id }
@@ -151,23 +151,24 @@ class PushNotificationActivityTest {
 
         launchActivity()
 
-        waitFor("notification list to become visible") { recyclerView.visibility == View.VISIBLE }
+        ShadowLooper.idleMainLooper()
+        assertEquals(View.VISIBLE, recyclerView.visibility)
         assertEquals(View.GONE, emptyView.visibility)
         assertEquals(2, recyclerView.adapter!!.itemCount)
 
         pendingApiCall.complete(Result.success(emptyList()))
 
-        waitFor("list to stay populated after api returns nothing new") {
-            ShadowLooper.idleMainLooper()
-            recyclerView.visibility == View.VISIBLE && recyclerView.adapter!!.itemCount == 2
-        }
+        ShadowLooper.idleMainLooper()
+        assertEquals(View.VISIBLE, recyclerView.visibility)
+        assertEquals(2, recyclerView.adapter!!.itemCount)
     }
 
     @Test
     fun `empty state is shown when there are no notifications`() {
         launchActivity()
 
-        waitFor("empty state to become visible") { emptyView.visibility == View.VISIBLE }
+        ShadowLooper.idleMainLooper()
+        assertEquals(View.VISIBLE, emptyView.visibility)
         assertEquals(View.GONE, recyclerView.visibility)
     }
 
@@ -178,34 +179,37 @@ class PushNotificationActivityTest {
 
         launchActivity()
 
-        waitFor("list to be hidden during load") { recyclerView.visibility == View.GONE }
+        ShadowLooper.idleMainLooper()
+        assertEquals(View.GONE, recyclerView.visibility)
         assertEquals(View.GONE, emptyView.visibility)
 
         pendingApiCall.complete(Result.success(listOf(buildRecord("a"))))
 
-        waitFor("list to become visible") { recyclerView.visibility == View.VISIBLE }
+        ShadowLooper.idleMainLooper()
+        assertEquals(View.VISIBLE, recyclerView.visibility)
         assertEquals(View.GONE, emptyView.visibility)
         assertEquals(1, recyclerView.adapter!!.itemCount)
     }
 
     @Test
-    fun `api notifications are merged with cached ones and sorted newest first`() {
+    fun `new api notifications are merged with cached ones and sorted newest first`() {
+        // The API returns only new notifications; the cached one comes from local storage.
         dbNotifications = listOf(buildRecord("cached", Date(1000L)))
-        apiResult = {
-            Result.success(
-                listOf(
-                    buildRecord("api", Date(2000L)),
-                    buildRecord("cached", Date(1000L)),
-                ),
-            )
-        }
+        val pendingApiCall = CompletableDeferred<Result<List<PushNotificationRecord>>>()
+        apiResult = { pendingApiCall.await() }
 
         launchActivity()
 
-        waitFor("merged list to be shown") { recyclerView.adapter?.itemCount == 2 }
-        val adapter = recyclerView.adapter as PushNotificationAdapter
-        assertEquals("api", adapter.currentList[0].notificationId)
-        assertEquals("cached", adapter.currentList[1].notificationId)
+        // Let the cached list from local storage publish before the api responds.
+        ShadowLooper.idleMainLooper()
+        pendingApiCall.complete(Result.success(listOf(buildRecord("api", Date(2000L)))))
+        ShadowLooper.idleMainLooper()
+
+        // Assert the merge on the ViewModel's output: a second non-empty submitList would diff
+        // on a background thread that idleMainLooper does not flush, so the adapter is unreliable.
+        val viewModel = ViewModelProvider(activity)[PushNotificationViewModel::class.java]
+        val merged = viewModel.allNotifications.value!!
+        assertEquals(listOf("api", "cached"), merged.map { it.notificationId })
 
         verify { anyConstructed<NotificationsSyncWorkerManager>().startSyncWorkers(any()) }
     }
@@ -216,7 +220,7 @@ class PushNotificationActivityTest {
 
         launchActivity()
 
-        waitFor("notification read status to update") { NotificationPrefs.getNotificationReadStatus(activity) }
+        ShadowLooper.idleMainLooper()
         assertTrue(NotificationPrefs.getNotificationReadStatus(activity))
     }
 
@@ -226,17 +230,20 @@ class PushNotificationActivityTest {
 
         launchActivity()
 
-        waitFor("error toast to be shown") { ShadowToast.getTextOfLatestToast() == "Network error" }
+        ShadowLooper.idleMainLooper()
+        assertEquals("Network error", ShadowToast.getTextOfLatestToast())
     }
 
     @Test
     fun `cloud sync menu item refreshes from the server without re-reading local storage`() {
         launchActivity()
-        waitFor("initial load to complete") { apiCallCount.get() == 1 }
+        ShadowLooper.idleMainLooper()
+        assertEquals(1, apiCallCount.get())
 
         assertTrue(activity.onOptionsItemSelected(menuItemWithId(R.id.notification_cloud_sync)))
 
-        waitFor("refresh api call") { apiCallCount.get() == 2 }
+        ShadowLooper.idleMainLooper()
+        assertEquals(2, apiCallCount.get())
         assertEquals(1, dbReadCount.get())
     }
 
@@ -252,50 +259,112 @@ class PushNotificationActivityTest {
     @Test
     fun `a new notification broadcast reloads notifications from local storage`() {
         launchActivity()
-        waitFor("initial load to complete") { dbReadCount.get() == 1 && apiCallCount.get() == 1 }
+        ShadowLooper.idleMainLooper()
+        assertEquals(1, dbReadCount.get())
+        assertEquals(1, apiCallCount.get())
 
         NotificationBroadcastHelper.sendNewNotificationBroadcast(activity)
 
-        waitFor("reload triggered by broadcast") { dbReadCount.get() == 2 }
+        ShadowLooper.idleMainLooper()
+        assertEquals(2, dbReadCount.get())
+    }
+
+    private fun launchAndClickFirstNotification(record: PushNotificationRecord) {
+        apiResult = { Result.success(listOf(record)) }
+        launchActivity()
+        ShadowLooper.idleMainLooper()
+        assertEquals(View.VISIBLE, recyclerView.visibility)
+        recyclerView.findViewHolderForAdapterPosition(0)!!.itemView.performClick()
     }
 
     @Test
-    fun `clicking a notification reports analytics and opens the target screen`() {
-        val record = buildRecord("a")
-        apiResult = { Result.success(listOf(record)) }
+    fun `clicking a payment notification reports analytics, marks it read, and opens ConnectActivity`() {
+        val record = buildRecord("a", action = ConnectConstants.CCC_DEST_PAYMENTS, paymentUuid = "pay-1")
 
-        launchActivity()
-        waitFor("notification list to become visible") { recyclerView.visibility == View.VISIBLE }
-        layoutRecyclerView()
-
-        val targetIntent = Intent(activity, DispatchActivity::class.java)
-        every { FirebaseMessagingUtil.getIntentForPNClick(any(), any()) } returns targetIntent
-
-        recyclerView.findViewHolderForAdapterPosition(0)!!.itemView.performClick()
+        launchAndClickFirstNotification(record)
 
         verify {
             FirebaseAnalyticsUtil.reportNotificationEvent(
                 AnalyticsParamValue.NOTIFICATION_EVENT_TYPE_CLICK,
                 AnalyticsParamValue.REPORT_NOTIFICATION_CLICK_NOTIFICATION_HISTORY,
-                record.action,
+                record.getNotificationActionFromRecord(),
                 record.notificationId,
             )
         }
         verify { NotificationRecordDatabaseHelper.updateReadStatus(any(), "a", true) }
-        assertEquals(targetIntent.component, shadowOf(activity).nextStartedActivity.component)
+
+        val started = shadowOf(activity).nextStartedActivity
+        assertEquals(ConnectActivity::class.java.name, started.component!!.className)
+        assertEquals(ConnectConstants.CCC_DEST_PAYMENTS, started.getStringExtra(ConnectConstants.REDIRECT_ACTION))
+        assertEquals("pay-1", started.getStringExtra(ConnectConstants.PAYMENT_UUID))
     }
 
     @Test
-    fun `clicking a notification without a target intent does not open a screen`() {
-        apiResult = { Result.success(listOf(buildRecord("a"))) }
+    fun `clicking a learn-progress notification opens ConnectActivity for the opportunity`() {
+        val record =
+            buildRecord("a", action = ConnectConstants.CCC_DEST_LEARN_PROGRESS, opportunityUuid = "opp-learn")
 
-        launchActivity()
-        waitFor("notification list to become visible") { recyclerView.visibility == View.VISIBLE }
-        layoutRecyclerView()
+        launchAndClickFirstNotification(record)
 
-        every { FirebaseMessagingUtil.getIntentForPNClick(any(), any()) } returns null
+        val started = shadowOf(activity).nextStartedActivity
+        assertEquals(ConnectActivity::class.java.name, started.component!!.className)
+        assertEquals(ConnectConstants.CCC_DEST_LEARN_PROGRESS, started.getStringExtra(ConnectConstants.REDIRECT_ACTION))
+        assertEquals("opp-learn", started.getStringExtra(ConnectConstants.OPPORTUNITY_UUID))
+    }
 
-        recyclerView.findViewHolderForAdapterPosition(0)!!.itemView.performClick()
+    @Test
+    fun `clicking a delivery-progress notification opens ConnectActivity for the opportunity`() {
+        val record =
+            buildRecord("a", action = ConnectConstants.CCC_DEST_DELIVERY_PROGRESS, opportunityUuid = "opp-deliver")
+
+        launchAndClickFirstNotification(record)
+
+        val started = shadowOf(activity).nextStartedActivity
+        assertEquals(ConnectActivity::class.java.name, started.component!!.className)
+        assertEquals(
+            ConnectConstants.CCC_DEST_DELIVERY_PROGRESS,
+            started.getStringExtra(ConnectConstants.REDIRECT_ACTION),
+        )
+        assertEquals("opp-deliver", started.getStringExtra(ConnectConstants.OPPORTUNITY_UUID))
+    }
+
+    @Test
+    fun `clicking an opportunity-summary notification opens ConnectActivity for the opportunity`() {
+        val record =
+            buildRecord(
+                "a",
+                action = ConnectConstants.CCC_DEST_OPPORTUNITY_SUMMARY_PAGE,
+                opportunityUuid = "opp-summary",
+            )
+
+        launchAndClickFirstNotification(record)
+
+        val started = shadowOf(activity).nextStartedActivity
+        assertEquals(ConnectActivity::class.java.name, started.component!!.className)
+        assertEquals(
+            ConnectConstants.CCC_DEST_OPPORTUNITY_SUMMARY_PAGE,
+            started.getStringExtra(ConnectConstants.REDIRECT_ACTION),
+        )
+        assertEquals("opp-summary", started.getStringExtra(ConnectConstants.OPPORTUNITY_UUID))
+    }
+
+    @Test
+    fun `clicking a message notification opens ConnectMessagingActivity`() {
+        val record = buildRecord("a", action = ConnectConstants.CCC_MESSAGE)
+
+        launchAndClickFirstNotification(record)
+
+        val started = shadowOf(activity).nextStartedActivity
+        assertEquals(ConnectMessagingActivity::class.java.name, started.component!!.className)
+        assertEquals(ConnectConstants.CCC_MESSAGE, started.getStringExtra(ConnectConstants.REDIRECT_ACTION))
+    }
+
+    @Test
+    fun `clicking a notification does not navigate when the user is not logged in`() {
+        PersonalIdManager.getInstance().status = PersonalIdManager.PersonalIdStatus.Registering
+        val record = buildRecord("a", action = ConnectConstants.CCC_DEST_PAYMENTS)
+
+        launchAndClickFirstNotification(record)
 
         assertNull(shadowOf(activity).nextStartedActivity)
     }

--- a/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
@@ -1,0 +1,302 @@
+package org.commcare.activities
+
+import android.content.Intent
+import android.view.MenuItem
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import org.commcare.CommCareTestApplication
+import org.commcare.adapters.PushNotificationAdapter
+import org.commcare.android.database.connect.models.PushNotificationRecord
+import org.commcare.connect.database.NotificationRecordDatabaseHelper
+import org.commcare.dalvik.R
+import org.commcare.google.services.analytics.AnalyticsParamValue
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
+import org.commcare.pn.helper.NotificationBroadcastHelper
+import org.commcare.pn.workermanager.NotificationsSyncWorkerManager
+import org.commcare.preferences.NotificationPrefs
+import org.commcare.utils.FirebaseMessagingUtil
+import org.commcare.utils.PushNotificationApiHelper
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+import org.robolectric.shadows.ShadowToast
+import java.util.Date
+import java.util.concurrent.atomic.AtomicInteger
+
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class PushNotificationActivityTest {
+    private lateinit var activityController: ActivityController<PushNotificationActivity>
+    private lateinit var activity: PushNotificationActivity
+
+    private val dbReadCount = AtomicInteger(0)
+    private val apiCallCount = AtomicInteger(0)
+    private var dbNotifications: List<PushNotificationRecord> = emptyList()
+    private var apiResult: suspend () -> Result<List<PushNotificationRecord>> = { Result.success(emptyList()) }
+
+    private val recyclerView: RecyclerView
+        get() = activity.findViewById(R.id.rvNotifications)
+    private val emptyView: View
+        get() = activity.findViewById(R.id.tvNoNotifications)
+
+    @Before
+    fun setUp() {
+        mockkObject(NotificationRecordDatabaseHelper)
+        mockkObject(PushNotificationApiHelper)
+        mockkConstructor(NotificationsSyncWorkerManager::class)
+        mockkStatic(FirebaseAnalyticsUtil::class)
+        mockkStatic(FirebaseMessagingUtil::class)
+
+        every { NotificationRecordDatabaseHelper.getAllNotifications(any()) } answers {
+            dbReadCount.incrementAndGet()
+            dbNotifications
+        }
+        every { NotificationRecordDatabaseHelper.updateReadStatus(any(), any(), any()) } just Runs
+        coEvery { PushNotificationApiHelper.retrieveLatestPushNotifications(any()) } coAnswers {
+            apiCallCount.incrementAndGet()
+            apiResult()
+        }
+        every { anyConstructed<NotificationsSyncWorkerManager>().startSyncWorkers(any()) } just Runs
+        every { FirebaseAnalyticsUtil.reportNotificationEvent(any(), any(), any(), any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        if (::activityController.isInitialized) {
+            try {
+                activityController.pause().stop().destroy()
+            } catch (_: IllegalStateException) {
+                // Ignore teardown errors for already-finished activities
+            }
+        }
+        unmockkAll()
+    }
+
+    private fun launchActivity() {
+        activityController = Robolectric.buildActivity(PushNotificationActivity::class.java)
+        activity =
+            activityController
+                .create()
+                .start()
+                .resume()
+                .visible()
+                .get()
+    }
+
+    private fun waitFor(
+        description: String,
+        condition: () -> Boolean,
+    ) {
+        val deadline = System.currentTimeMillis() + 5000
+        while (!condition()) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("Timed out waiting for $description")
+            }
+            ShadowLooper.idleMainLooper()
+            Thread.sleep(10)
+        }
+    }
+
+    private fun layoutRecyclerView() {
+        recyclerView.measure(
+            View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(1920, View.MeasureSpec.EXACTLY),
+        )
+        recyclerView.layout(0, 0, 1080, 1920)
+    }
+
+    private fun buildRecord(
+        id: String,
+        date: Date = Date(0L),
+    ): PushNotificationRecord =
+        PushNotificationRecord().apply {
+            notificationId = id
+            action = "ccc_payment_page"
+            title = "Title $id"
+            body = "Body $id"
+            createdDate = date
+        }
+
+    private fun menuItemWithId(id: Int): MenuItem = mockk { every { itemId } returns id }
+
+    @Test
+    fun `notifications from local storage are shown in the list`() {
+        dbNotifications = listOf(buildRecord("a"), buildRecord("b"))
+        // Keep the api call pending so the list is populated from local storage alone
+        val pendingApiCall = CompletableDeferred<Result<List<PushNotificationRecord>>>()
+        apiResult = { pendingApiCall.await() }
+
+        launchActivity()
+
+        waitFor("notification list to become visible") { recyclerView.visibility == View.VISIBLE }
+        assertEquals(View.GONE, emptyView.visibility)
+        assertEquals(2, recyclerView.adapter!!.itemCount)
+
+        pendingApiCall.complete(Result.success(emptyList()))
+
+        waitFor("list to stay populated after api returns nothing new") {
+            ShadowLooper.idleMainLooper()
+            recyclerView.visibility == View.VISIBLE && recyclerView.adapter!!.itemCount == 2
+        }
+    }
+
+    @Test
+    fun `empty state is shown when there are no notifications`() {
+        launchActivity()
+
+        waitFor("empty state to become visible") { emptyView.visibility == View.VISIBLE }
+        assertEquals(View.GONE, recyclerView.visibility)
+    }
+
+    @Test
+    fun `list and empty state stay hidden while notifications are loading`() {
+        val pendingApiCall = CompletableDeferred<Result<List<PushNotificationRecord>>>()
+        apiResult = { pendingApiCall.await() }
+
+        launchActivity()
+
+        waitFor("list to be hidden during load") { recyclerView.visibility == View.GONE }
+        assertEquals(View.GONE, emptyView.visibility)
+
+        pendingApiCall.complete(Result.success(listOf(buildRecord("a"))))
+
+        waitFor("list to become visible") { recyclerView.visibility == View.VISIBLE }
+        assertEquals(View.GONE, emptyView.visibility)
+        assertEquals(1, recyclerView.adapter!!.itemCount)
+    }
+
+    @Test
+    fun `api notifications are merged with cached ones and sorted newest first`() {
+        dbNotifications = listOf(buildRecord("cached", Date(1000L)))
+        apiResult = {
+            Result.success(
+                listOf(
+                    buildRecord("api", Date(2000L)),
+                    buildRecord("cached", Date(1000L)),
+                ),
+            )
+        }
+
+        launchActivity()
+
+        waitFor("merged list to be shown") { recyclerView.adapter?.itemCount == 2 }
+        val adapter = recyclerView.adapter as PushNotificationAdapter
+        assertEquals("api", adapter.currentList[0].notificationId)
+        assertEquals("cached", adapter.currentList[1].notificationId)
+
+        verify { anyConstructed<NotificationsSyncWorkerManager>().startSyncWorkers(any()) }
+    }
+
+    @Test
+    fun `notifications are marked as read when the screen shows them`() {
+        NotificationPrefs.setNotificationAsUnread(ApplicationProvider.getApplicationContext<CommCareTestApplication>())
+
+        launchActivity()
+
+        waitFor("notification read status to update") { NotificationPrefs.getNotificationReadStatus(activity) }
+        assertTrue(NotificationPrefs.getNotificationReadStatus(activity))
+    }
+
+    @Test
+    fun `a toast is shown when fetching notifications fails`() {
+        apiResult = { Result.failure(Exception("Network error")) }
+
+        launchActivity()
+
+        waitFor("error toast to be shown") { ShadowToast.getTextOfLatestToast() == "Network error" }
+    }
+
+    @Test
+    fun `cloud sync menu item refreshes from the server without re-reading local storage`() {
+        launchActivity()
+        waitFor("initial load to complete") { apiCallCount.get() == 1 }
+
+        assertTrue(activity.onOptionsItemSelected(menuItemWithId(R.id.notification_cloud_sync)))
+
+        waitFor("refresh api call") { apiCallCount.get() == 2 }
+        assertEquals(1, dbReadCount.get())
+    }
+
+    @Test
+    fun `home menu item closes the screen`() {
+        launchActivity()
+
+        assertTrue(activity.onOptionsItemSelected(menuItemWithId(android.R.id.home)))
+
+        assertTrue(activity.isFinishing)
+    }
+
+    @Test
+    fun `a new notification broadcast reloads notifications from local storage`() {
+        launchActivity()
+        waitFor("initial load to complete") { dbReadCount.get() == 1 && apiCallCount.get() == 1 }
+
+        NotificationBroadcastHelper.sendNewNotificationBroadcast(activity)
+
+        waitFor("reload triggered by broadcast") { dbReadCount.get() == 2 }
+    }
+
+    @Test
+    fun `clicking a notification reports analytics and opens the target screen`() {
+        val record = buildRecord("a")
+        apiResult = { Result.success(listOf(record)) }
+
+        launchActivity()
+        waitFor("notification list to become visible") { recyclerView.visibility == View.VISIBLE }
+        layoutRecyclerView()
+
+        val targetIntent = Intent(activity, DispatchActivity::class.java)
+        every { FirebaseMessagingUtil.getIntentForPNClick(any(), any()) } returns targetIntent
+
+        recyclerView.findViewHolderForAdapterPosition(0)!!.itemView.performClick()
+
+        verify {
+            FirebaseAnalyticsUtil.reportNotificationEvent(
+                AnalyticsParamValue.NOTIFICATION_EVENT_TYPE_CLICK,
+                AnalyticsParamValue.REPORT_NOTIFICATION_CLICK_NOTIFICATION_HISTORY,
+                record.action,
+                record.notificationId,
+            )
+        }
+        verify { NotificationRecordDatabaseHelper.updateReadStatus(any(), "a", true) }
+        assertEquals(targetIntent.component, shadowOf(activity).nextStartedActivity.component)
+    }
+
+    @Test
+    fun `clicking a notification without a target intent does not open a screen`() {
+        apiResult = { Result.success(listOf(buildRecord("a"))) }
+
+        launchActivity()
+        waitFor("notification list to become visible") { recyclerView.visibility == View.VISIBLE }
+        layoutRecyclerView()
+
+        every { FirebaseMessagingUtil.getIntentForPNClick(any(), any()) } returns null
+
+        recyclerView.findViewHolderForAdapterPosition(0)!!.itemView.performClick()
+
+        assertNull(shadowOf(activity).nextStartedActivity)
+    }
+}

--- a/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
@@ -34,6 +34,7 @@ import org.commcare.pn.helper.NotificationBroadcastHelper
 import org.commcare.pn.workermanager.NotificationsSyncWorkerManager
 import org.commcare.preferences.NotificationPrefs
 import org.commcare.utils.PushNotificationApiHelper
+import org.commcare.utils.coroutines.DispatcherProvider
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -72,7 +73,8 @@ class PushNotificationActivityTest {
     fun setUp() {
         // Run the ViewModel's coroutine on a deterministic test dispatcher instead of
         // the real Dispatchers.IO thread pool, so notification loading is synchronous.
-        PushNotificationViewModel.dispatcherOverride = UnconfinedTestDispatcher()
+        mockkObject(DispatcherProvider)
+        every { DispatcherProvider.io() } returns UnconfinedTestDispatcher()
 
         // getIntentForPNClick is exercised for real, so cccCheckPassed() must see a logged-in
         // user. init() is a no-op unless status == NotIntroduced, so setting LoggedIn is enough.
@@ -108,7 +110,6 @@ class PushNotificationActivityTest {
             }
         }
         unmockkAll()
-        PushNotificationViewModel.dispatcherOverride = null
         PersonalIdManager.getInstance().status = savedPersonalIdStatus
     }
 

--- a/app/unit-tests/src/org/commcare/connect/network/PersonalIdMockApiServer.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/PersonalIdMockApiServer.kt
@@ -1,0 +1,138 @@
+package org.commcare.connect.network
+
+import android.os.Handler
+import android.os.Looper
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.commcare.connect.network.base.BaseApiClient
+import org.commcare.connect.network.connectId.PersonalIdApiClient
+import org.robolectric.shadows.ShadowLooper
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reusable [MockWebServer] harness that points [PersonalIdApiClient] at a local mock server so
+ * PersonalID API calls hit it.
+ *
+ * [CallbackMode.MAIN_LOOPER] reproduces production threading for UI tests: Retrofit posts callbacks
+ * to the main looper and [drainHttp] runs them deterministically. [CallbackMode.DIRECT] runs
+ * callbacks inline on the OkHttp dispatcher thread for tests that don't touch views and simply
+ * await a suspend call.
+ */
+class PersonalIdMockApiServer(
+    private val callbackMode: CallbackMode = CallbackMode.MAIN_LOOPER,
+) {
+    enum class CallbackMode { MAIN_LOOPER, DIRECT }
+
+    lateinit var server: MockWebServer
+        private set
+    private lateinit var httpDispatcher: Dispatcher
+
+    @Volatile
+    private var dispatchCallbacks = true
+
+    fun start() {
+        dispatchCallbacks = true
+        server = MockWebServer()
+        server.start()
+
+        val retrofit =
+            BaseApiClient
+                .buildRetrofitClient(server.url("/").toString(), PersonalIdApiClient.API_VERSION)
+                .newBuilder()
+                .callbackExecutor { runnable ->
+                    if (!dispatchCallbacks) return@callbackExecutor
+                    when (callbackMode) {
+                        CallbackMode.MAIN_LOOPER -> Handler(Looper.getMainLooper()).post(runnable)
+                        CallbackMode.DIRECT -> runnable.run()
+                    }
+                }.build()
+        httpDispatcher = (retrofit.callFactory() as OkHttpClient).dispatcher
+        setPersonalIdApiService(retrofit.create(ApiService::class.java))
+    }
+
+    fun shutdown() {
+        dispatchCallbacks = false
+        setPersonalIdApiService(null)
+        server.shutdown()
+    }
+
+    /**
+     * Reads the next request with a bounded wait so a missing dispatch fails fast instead of
+     * hanging the suite.
+     */
+    fun takeRequestOrFail(timeoutSeconds: Long = 5): RecordedRequest =
+        server.takeRequest(timeoutSeconds, TimeUnit.SECONDS)
+            ?: throw AssertionError("Expected an HTTP request within ${timeoutSeconds}s but none arrived")
+
+    /**
+     * Waits for the next request to reach the mock server and its response callback to be posted to
+     * the main looper, then drains UI work so the callback runs before assertions. Only meaningful
+     * in [CallbackMode.MAIN_LOOPER].
+     */
+    fun drainHttp() {
+        takeRequestOrFail()
+        awaitHttpCallbackPosted()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+    }
+
+    /**
+     * Enqueues a primary-fetch response whose body is built from [items] and, when [acknowledges] is
+     * true and [items] is non-empty, a follow-up acknowledge response — mirroring Connect API flows
+     * where a non-empty fetch triggers a second round-trip. Pass `acknowledges = false` for flows
+     * that fetch without an acknowledge step. [bodyBuilder] serializes the items to a response body.
+     */
+    fun <T> enqueueLoad(
+        items: List<T>,
+        bodyBuilder: (List<T>) -> String,
+        acknowledges: Boolean = true,
+    ) {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(bodyBuilder(items)))
+        if (acknowledges && items.isNotEmpty()) {
+            server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        }
+    }
+
+    /**
+     * Drains the fetch (and the acknowledge round-trip, when [acknowledges] is true and [items] is
+     * non-empty), then flushes UI work.
+     */
+    fun <T> drainLoad(
+        items: List<T>,
+        acknowledges: Boolean = true,
+    ) {
+        drainHttp()
+        if (acknowledges && items.isNotEmpty()) {
+            drainHttp()
+        }
+        ShadowLooper.idleMainLooper()
+    }
+
+    /** Convenience for [enqueueLoad] followed by [drainLoad]. */
+    fun <T> completeLoad(
+        items: List<T>,
+        bodyBuilder: (List<T>) -> String,
+        acknowledges: Boolean = true,
+    ) {
+        enqueueLoad(items, bodyBuilder, acknowledges)
+        drainLoad(items, acknowledges)
+    }
+
+    private fun awaitHttpCallbackPosted(timeoutMs: Long = 5000) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (httpDispatcher.runningCallsCount() > 0) {
+            if (System.currentTimeMillis() >= deadline) {
+                throw AssertionError("HTTP call did not complete within ${timeoutMs}ms")
+            }
+            Thread.sleep(10)
+        }
+    }
+
+    private fun setPersonalIdApiService(apiService: ApiService?) {
+        val apiServiceField = PersonalIdApiClient::class.java.getDeclaredField("apiService")
+        apiServiceField.isAccessible = true
+        apiServiceField.set(null, apiService)
+    }
+}

--- a/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdConfigurationTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdConfigurationTest.kt
@@ -1,8 +1,6 @@
 package org.commcare.fragments.personalId
 
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.view.View
 import androidx.annotation.CallSuper
 import androidx.annotation.IdRes
@@ -14,8 +12,6 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.play.core.integrity.StandardIntegrityManager
-import okhttp3.Dispatcher
-import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.commcare.activities.connect.PersonalIdActivity
@@ -23,9 +19,7 @@ import org.commcare.activities.connect.viewmodel.PersonalIdSessionDataViewModel
 import org.commcare.android.CommCareViewModelProvider
 import org.commcare.android.database.connect.models.PersonalIdSessionData
 import org.commcare.android.integrity.IntegrityTokenViewModel
-import org.commcare.connect.network.ApiService
-import org.commcare.connect.network.base.BaseApiClient
-import org.commcare.connect.network.connectId.PersonalIdApiClient
+import org.commcare.connect.network.PersonalIdMockApiServer
 import org.commcare.dalvik.R
 import org.junit.After
 import org.junit.Before
@@ -36,7 +30,6 @@ import org.mockito.kotlin.any
 import org.robolectric.Robolectric
 import org.robolectric.android.controller.ActivityController
 import org.robolectric.shadows.ShadowLooper
-import java.util.concurrent.TimeUnit
 
 const val TEST_INTEGRITY_TOKEN: String = "test_integrity_token_12345"
 
@@ -62,20 +55,16 @@ abstract class BasePersonalIdConfigurationTest<T : BasePersonalIdFragment> {
     protected lateinit var fragment: T
     protected lateinit var navController: TestNavHostController
 
-    // Only initialized for tests that opt in via setupMockWebServer()
-    protected lateinit var mockWebServer: MockWebServer
-    private lateinit var httpDispatcher: Dispatcher
-
-    // Used to avoid late callbacks to the main looper (i.e. an unanswered call failing on server shutdown)
-    // They would leak into the next test and run against a destroyed fragment.
-    @Volatile
-    private var dispatchHttpCallbacks = true
+    // Points PersonalIdApiClient at a local mock server reproducing production main-looper threading.
+    private val mockApiServer = PersonalIdMockApiServer(PersonalIdMockApiServer.CallbackMode.MAIN_LOOPER)
+    protected val mockWebServer: MockWebServer
+        get() = mockApiServer.server
 
     @Before
     @CallSuper
     open fun setUp() {
         setupMockIntegrityTokenViewModel()
-        setupMockWebServer()
+        mockApiServer.start()
     }
 
     @After
@@ -84,7 +73,7 @@ abstract class BasePersonalIdConfigurationTest<T : BasePersonalIdFragment> {
         val viewModelField = CommCareViewModelProvider::class.java.getDeclaredField("integrityTokenViewModel")
         viewModelField.isAccessible = true
         viewModelField.set(null, null)
-        tearDownMockWebServer()
+        mockApiServer.shutdown()
     }
 
     protected fun bootActivity() {
@@ -168,79 +157,9 @@ abstract class BasePersonalIdConfigurationTest<T : BasePersonalIdFragment> {
         Navigation.setViewNavController(view, navController)
     }
 
-    /**
-     * Starts a [MockWebServer] and points [PersonalIdApiClient] at it so PersonalID API calls hit
-     * the mock server. Tests that call this from `setUp` must call [tearDownMockWebServer] from
-     * `tearDown`.
-     *
-     * On a device Retrofit posts callbacks to the main thread, but on the JVM it invokes them
-     * directly on the OkHttp dispatcher thread, where Robolectric view access is unsafe and
-     * thread-local Mockito static mocks do not intercept. An explicit main-looper
-     * `callbackExecutor` restores production threading; [drainHttp] then runs the callback on the
-     * test thread deterministically.
-     */
-    private fun setupMockWebServer() {
-        dispatchHttpCallbacks = true
-        mockWebServer = MockWebServer()
-        mockWebServer.start()
+    protected fun takeRequestOrFail(timeoutSeconds: Long = 5): RecordedRequest = mockApiServer.takeRequestOrFail(timeoutSeconds)
 
-        val retrofit =
-            BaseApiClient
-                .buildRetrofitClient(mockWebServer.url("/").toString(), PersonalIdApiClient.API_VERSION)
-                .newBuilder()
-                .callbackExecutor {
-                    if (dispatchHttpCallbacks) {
-                        Handler(Looper.getMainLooper()).post(it)
-                    }
-                }.build()
-        httpDispatcher = (retrofit.callFactory() as OkHttpClient).dispatcher
-        setPersonalIdApiService(retrofit.create(ApiService::class.java))
-    }
-
-    private fun tearDownMockWebServer() {
-        dispatchHttpCallbacks = false
-        setPersonalIdApiService(null)
-        mockWebServer.shutdown()
-    }
-
-    private fun setPersonalIdApiService(apiService: ApiService?) {
-        val apiServiceField = PersonalIdApiClient::class.java.getDeclaredField("apiService")
-        apiServiceField.isAccessible = true
-        apiServiceField.set(null, apiService)
-    }
-
-    /**
-     * Reads the next request with a bounded wait so a missing dispatch fails fast instead of
-     * hanging the suite.
-     */
-    protected fun takeRequestOrFail(timeoutSeconds: Long = 5): RecordedRequest =
-        mockWebServer.takeRequest(timeoutSeconds, TimeUnit.SECONDS)
-            ?: throw AssertionError("Expected an HTTP request within ${timeoutSeconds}s but none arrived")
-
-    /**
-     * Waits for the next request to reach the mock server and its response callback to be posted
-     * to the main looper, then drains UI work so the callback runs before assertions.
-     */
-    protected fun drainHttp() {
-        takeRequestOrFail()
-        awaitHttpCallbackPosted()
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
-    }
-
-    /**
-     * Blocks until the OkHttp dispatcher finishes the in-flight call, which (because of the
-     * main-looper callback executor) means the Retrofit callback has been posted and a subsequent
-     * looper drain is guaranteed to run it.
-     */
-    private fun awaitHttpCallbackPosted(timeoutMs: Long = 5000) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (httpDispatcher.runningCallsCount() > 0) {
-            if (System.currentTimeMillis() >= deadline) {
-                throw AssertionError("HTTP call did not complete within ${timeoutMs}ms")
-            }
-            Thread.sleep(10)
-        }
-    }
+    protected fun drainHttp() = mockApiServer.drainHttp()
 
     private fun setupMockIntegrityTokenViewModel() {
         val mockToken = mock(StandardIntegrityManager.StandardIntegrityToken::class.java)


### PR DESCRIPTION
### [CCCT-2309](https://dimagi.atlassian.net/browse/CCCT-2309)

## Safety Assurance

### Safety story

What gives confidence:
- This is a test-only change — it adds `PushNotificationActivityTest` and touches no production code, so it cannot alter app behavior.
- I ran the suite locally (`./gradlew testCommcareDebugUnitTest --tests PushNotificationActivityTest`): all 11 tests pass.

### Automated test coverage

Adds `PushNotificationActivityTest` (11 cases) covering the notification-history screen end to end through the Activity + ViewModel + adapter, mocking only the DB/API/worker/analytics boundaries: local-cache display, empty state, loading state, API-merge-and-sort, mark-as-read, fetch-error toast, cloud-sync refresh, home navigation, new-notification broadcast reload, and notification click (analytics + target intent, and the no-intent case).

[CCCT-2309]: https://dimagi.atlassian.net/browse/CCCT-2309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ