### PR TITLE
CCCT-2457 PersonalId Profile Screen Phase Two

### DIFF
--- a/app/res/layout/activity_personalid_profile.xml
+++ b/app/res/layout/activity_personalid_profile.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="org.commcare.activities.connect.PersonalIdProfileActivity">
+
+    <include
+        android:id="@+id/include_tool_bar"
+        layout="@layout/appbar_layout"
+        android:theme="@style/ToolbarThemeOverlay" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/profile_nav_host"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph_personalid_profile" />
+
+</LinearLayout>

--- a/app/res/navigation/nav_graph_personalid_profile.xml
+++ b/app/res/navigation/nav_graph_personalid_profile.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph_personalid_profile"
+    app:startDestination="@id/personalid_profile_fragment">
+
+    <fragment
+        android:id="@+id/personalid_profile_fragment"
+        android:name="org.commcare.fragments.personalId.PersonalIdProfileFragment"
+        android:label="@string/personalid_profile_title">
+        <action
+            android:id="@+id/action_profile_to_edit_profile"
+            app:destination="@id/personalid_edit_profile_fragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/personalid_edit_profile_fragment"
+        android:name="org.commcare.fragments.personalId.PersonalIdEditProfileFragment"
+        android:label="@string/personalid_edit_profile_title">
+        <action
+            android:id="@+id/action_edit_profile_to_email_verification"
+            app:destination="@id/personalid_email_verification_fragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/personalid_email_verification_fragment"
+        android:name="org.commcare.fragments.personalId.PersonalIdEmailVerificationFragment"
+        android:label="@string/personalid_email_verification_appbar_title"
+        tools:layout="@layout/fragment_personalid_email_verification">
+        <argument
+            android:name="email"
+            app:argType="string" />
+        <argument
+            android:name="workflow"
+            app:argType="org.commcare.fragments.personalId.EmailWorkFlow" />
+        <argument
+            android:name="emailOtpRequestCount"
+            app:argType="integer" />
+    </fragment>
+</navigation>

--- a/app/src/org/commcare/activities/connect/PersonalIdProfileActivity.kt
+++ b/app/src/org/commcare/activities/connect/PersonalIdProfileActivity.kt
@@ -1,10 +1,20 @@
 package org.commcare.activities.connect
 
 import android.os.Bundle
-import org.commcare.activities.CommCareActivity
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.NavigationUI
+import org.commcare.activities.NavigationHostCommCareActivity
+import org.commcare.dalvik.R
 
-class PersonalIdProfileActivity : CommCareActivity<PersonalIdProfileActivity>() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+class PersonalIdProfileActivity : NavigationHostCommCareActivity<PersonalIdProfileActivity>() {
+    override fun getLayoutResource(): Int = R.layout.activity_personalid_profile
+
+    override fun getHostFragment(): NavHostFragment = supportFragmentManager.findFragmentById(R.id.profile_nav_host) as NavHostFragment
+
+    override fun onPostCreate(savedInstanceState: Bundle?) {
+        super.onPostCreate(savedInstanceState)
+        NavigationUI.setupActionBarWithNavController(this, navController)
     }
+
+    override fun onSupportNavigateUp(): Boolean = navController.navigateUp() || super.onSupportNavigateUp()
 }

--- a/app/src/org/commcare/fragments/personalId/PersonalIdEditProfileFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdEditProfileFragment.kt
@@ -1,0 +1,15 @@
+package org.commcare.fragments.personalId
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class PersonalIdEditProfileFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = View(requireContext())
+}

--- a/app/src/org/commcare/fragments/personalId/PersonalIdProfileFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdProfileFragment.kt
@@ -1,0 +1,15 @@
+package org.commcare.fragments.personalId
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class PersonalIdProfileFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = View(requireContext())
+}


### PR DESCRIPTION
### [CCCT-2457](https://dimagi.atlassian.net/browse/CCCT-2457)

## Technical Summary

[Phase 2](https://github.com/dimagi/commcare-android/blob/5b85ad6afd79bf4c47271886c0fac40bda335100/docs/superpowers/plans/2026-05-14-manage-profile.md#L108-L133) of the Manage Profile feature: sets up the navigation scaffolding that later phases build on.

There's not really much new UI to show for this.

## Safety Assurance

### Safety story

What gives me confidence:
- I ran the app on an emulator, temporarily revealing the drawer link, and confirmed the Profile screen opens.
- The change is additive and dark-launched — the new activity is not reachable through the UI until a later phase reveals the drawer link.

Risks to review:
- Shared Safe Args class: this graph and `nav_graph_personalid.xml` both define the `PersonalIdEmailVerificationFragment` destination, and their argument sets must stay in sync or the build breaks. Nothing automated guards this coupling.
- The screen fragments are placeholders rendering empty views; there is no screen behavior to verify in this phase.

[CCCT-2457]: https://dimagi.atlassian.net/browse/CCCT-2457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ