### PR TITLE
Add troubleshooting logging for casedb instance crash in entity list

### DIFF
--- a/app/src/org/commcare/activities/EntitySelectActivity.java
+++ b/app/src/org/commcare/activities/EntitySelectActivity.java
@@ -443,6 +443,9 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
             rebuildHeaders();
 
             if (adapter == null) {
+                CrashUtil.log("EntitySelectActivity.loadEntities called from refreshView() " +
+                        "; currentCommand=" + getSessionCommand() + "; selectDatum=" + getSelectDatum() +
+                        "; isFinishing=" + isFinishing());
                 loadEntities();
             } else {
                 refreshTimer.start(this);
@@ -472,6 +475,16 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         }
     }
 
+    // temporary for troubleshooting purposes
+    public String getSessionCommand(){
+        return (session == null || session.getCommand() == null) ? "null" : session.getCommand();
+    }
+
+    // temporary for troubleshooting purposes
+    public String getSelectDatum() {
+        return selectDatum == null ? "null" : selectDatum.getDataId() + " " + selectDatum.getValue();
+    }
+
     public boolean loadEntities() {
         if (adapter != null) {
             // Store extra data to be reloaded upon load task completion
@@ -481,7 +494,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         if (loader == null && !EntityLoaderTask.attachToActivity(this)) {
             if (session.getCommand() == null) {
                 CrashUtil.log("EntitySelectActivity.loadEntities with null session command" +
-                        "; selectDatum=" + (selectDatum == null ? "null" : selectDatum.getDataId()) +
+                        "; currentCommand=" + getSessionCommand() + "; selectDatum=" + getSelectDatum() +
                         "; isFinishing=" + isFinishing());
             }
             setProgressText(StringUtils.getStringRobust(this, R.string.entity_list_initializing));
@@ -520,7 +533,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
     @Override
     protected void onPause() {
         super.onPause();
-
+        CrashUtil.log("onPause called started");
         if (refreshTimer != null) {
             refreshTimer.stop();
         }
@@ -531,20 +544,24 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
         hereFunctionHandler.forbidGpsUse();
         hereFunctionHandler.unregisterListener();
+        CrashUtil.log("onPause called finished");
     }
 
     @Override
     protected void onStop() {
         super.onStop();
+        CrashUtil.log("onStop called started");
         if (refreshTimer != null) {
             refreshTimer.stop();
         }
         saveLastQueryString();
+        CrashUtil.log("onStop called finished");
     }
 
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        CrashUtil.log("onDestroy called started");
         if (loader != null) {
             if (isFinishing()) {
                 loader.cancel(true);
@@ -556,6 +573,7 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         if (adapter != null) {
             adapter.signalKilled();
         }
+        CrashUtil.log("onDestroy called finished");
     }
 
     public void onEntitySelected(int itemPosition) {
@@ -918,6 +936,9 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
         if (locationChangedWhileLoading) {
             Log.i("HereFunctionHandler", "location changed while reloading");
             locationChangedWhileLoading = false;
+            CrashUtil.log("EntitySelectActivity.loadEntities called from deliverLoadResult() " +
+                    "; currentCommand=" + getSessionCommand() + "; selectDatum=" + getSelectDatum() +
+                    "; isFinishing=" + isFinishing());
             loadEntities();
         }
     }
@@ -1067,6 +1088,9 @@ public class EntitySelectActivity extends SaveSessionCommCareActivity
 
     @Override
     public void onEvalLocationChanged() {
+        CrashUtil.log("EntitySelectActivity.loadEntities called from onEvalLocationChanged() " +
+                "; currentCommand=" + getSessionCommand() + "; selectDatum=" + getSelectDatum() +
+                "; isFinishing=" + isFinishing());
         if (isFinishing() || session == null || session.getCommand() == null) {
             CrashUtil.log("EntitySelectActivity.onEvalLocationChanged with null session command" +
                     "; isFinishing=" + isFinishing());

--- a/app/src/org/commcare/activities/HomeScreenBaseActivity.java
+++ b/app/src/org/commcare/activities/HomeScreenBaseActivity.java
@@ -13,6 +13,7 @@ import static org.commcare.activities.DriftHelper.shouldShowDriftWarning;
 import static org.commcare.activities.DriftHelper.updateLastDriftWarningTime;
 import static org.commcare.activities.EntitySelectActivity.EXTRA_ENTITY_KEY;
 import static org.commcare.appupdate.AppUpdateController.IN_APP_UPDATE_REQUEST_CODE;
+import static org.commcare.utils.CrashUtil.getTopCallerChain;
 
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -810,6 +811,8 @@ public abstract class HomeScreenBaseActivity<T> extends SyncCapableCommCareActiv
         AndroidSessionWrapper currentState =
                 CommCareApplication.instance().getCurrentSessionWrapper();
         String currentCommand = currentState.getSession().getCommand();
+        CrashUtil.log("Leading stack trace frames: " + getTopCallerChain() +
+                "; currentCommand: " + currentCommand);
         if (currentCommand == null || currentCommand.equals(Menu.TRAINING_MENU_ROOT)) {
             // We're stepping back from either the root module menu or the training root menu, so
             // go home

--- a/app/src/org/commcare/tasks/EntityLoaderTask.java
+++ b/app/src/org/commcare/tasks/EntityLoaderTask.java
@@ -19,6 +19,7 @@ import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.Logger;
 import org.javarosa.xpath.XPathException;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -41,6 +42,7 @@ public class EntityLoaderTask
     private final EntityLoaderHelper entityLoaderHelper;
     private Exception mException = null;
     private boolean provideDetailProgressUpdates;
+    private String availableInstances;
 
     /**
      * Creates a new instance
@@ -53,6 +55,8 @@ public class EntityLoaderTask
         entityLoaderHelper = new EntityLoaderHelper(detail, entityDatum, evalCtx, false, null);
         // we only want to provide progress updates for the new caching config
         provideDetailProgressUpdates = detail.shouldOptimize();
+        availableInstances = Arrays.toString(evalCtx.getInstanceIds().toArray())
+                + "; mainInstance=" + (evalCtx.getMainInstance() == null ? "null" : "present");
     }
 
     @Override
@@ -84,7 +88,8 @@ public class EntityLoaderTask
             return null;
         } catch (RuntimeException e) {
             Logger.log(LogTypes.SOFT_ASSERT, "Loading entities failed for " + getSessionShortDetail() +
-                    "; session expiring at: " + getSessionExpirationTime());
+                    "; session expiring at: " + getSessionExpirationTime() +
+                    "; available instances: " + availableInstances);
             throw e;
         }
     }

--- a/app/src/org/commcare/utils/CrashUtil.java
+++ b/app/src/org/commcare/utils/CrashUtil.java
@@ -56,4 +56,28 @@ public class CrashUtil {
             FirebaseCrashlytics.getInstance().log(message);
         }
     }
+
+    // temporary for troubleshooting purposes only
+    public static String getTopCallerChain() {
+        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+        StringBuilder sb = new StringBuilder();
+        int FRAMES_TO_SKIP = 3;
+        int MAX_CHAIN_LENGTH = 5;
+        int limit = Math.min(FRAMES_TO_SKIP + MAX_CHAIN_LENGTH, stackTrace.length);
+        for (int i = FRAMES_TO_SKIP; i < limit; i++) {
+            sb.append(getSimpleClassName(stackTrace[i].getClassName()))
+                    .append(".")
+                    .append(stackTrace[i].getMethodName())
+                    .append(":")
+                    .append(stackTrace[i].getLineNumber());
+            if (i < limit - 1) {
+                sb.append(" <- ");
+            }
+        }
+        return sb.toString();
+    }
+
+    private static String getSimpleClassName(String fullyqualifiedClassName) {
+        return fullyqualifiedClassName.substring(fullyqualifiedClassName.lastIndexOf('.') + 1);
+    }
 }

--- a/app/src/org/commcare/utils/EntitySelectRefreshTimer.java
+++ b/app/src/org/commcare/utils/EntitySelectRefreshTimer.java
@@ -30,6 +30,9 @@ public class EntitySelectRefreshTimer {
                     public void run() {
                         activity.runOnUiThread(() -> {
                             if (!cancelled) {
+                                CrashUtil.log("EntitySelectActivity.loadEntities called from within EntitySelectRefreshTimer " +
+                                        "; currentCommand=" + activity.getSessionCommand() +
+                                        "; selectDatum=" + activity.getSelectDatum());
                                 activity.loadEntities();
                             }
                         });


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
No user-facing changes. Instrumentation only (Crashlytics breadcrumbs / soft-assert logs).

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
Adds diagnostic logging to investigate the crash:

> `RuntimeException: Unable to expand reference instance(casedb)/casedb/case[@case_type = 'menage'][@status = 'open'], no appropriate instance in evaluation context`

The crash occurs in the background `EntityLoaderTask` when the evaluation context built for the load contains no `casedb` instance — i.e. the live session command at load time does not declare it (or is null/diverged from the command captured at activity creation).

This branch is **instrumentation only**; it does not change behavior. What it logs:
- **Entry points into `loadEntities()`** — `refreshView()`, the refresh timer, `deliverLoadResult()` (the deferred location reload), and `onEvalLocationChanged()` — each records the live session command, selectDatum, and `isFinishing()`.
- **`EntityLoaderTask` failure path** — the available instance ids and whether a main instance is present at the moment the load throws (most direct evidence of why `casedb` is missing).
- **Activity lifecycle ordering** — `onPause`/`onStop`/`onDestroy` breadcrumbs, so the crash trail shows whether the load completed after the user navigated away.
- **`HomeScreenBaseActivity`** — caller chain + current command on back / end-of-form navigation.

Leading hypothesis: the `deliverLoadResult()` deferred GPS reload (case lists using `here()`) fires after the user has navigated away — the loader callback is not tied to activity visibility — and reloads **unguarded** against a session that has already advanced/cleared. The logs are intended to confirm this before committing to a fix.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Inherently low risk: every change is a log statement. `CrashUtil.log` is internally gated on `crashlyticsEnabled` and does not throw; new accessors null-check their fields; no control flow, data, or storage is modified. No impact on existing data.

⚠️ All additions are marked temporary for troubleshooting and must be reverted before this reaches a release line (the new `EntitySelectActivity` accessors and `CrashUtil.getTopCallerChain()` are not intended to ship).

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
None — logging-only change, no behavioral coverage applicable.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No QA required beyond confirming the app builds and runs; there are no behavioral changes to regress.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)