### PR TITLE
Restart to install screen when last app is uninstalled

### DIFF
--- a/app/src/org/commcare/activities/SingleAppManagerActivity.java
+++ b/app/src/org/commcare/activities/SingleAppManagerActivity.java
@@ -179,8 +179,13 @@ public class SingleAppManagerActivity extends CommCareActivity {
         FirebaseAnalyticsUtil.reportAppManagerAction(AnalyticsParamValue.UNINSTALL_APP);
         CommCareApplication.instance().expireUserSession();
         AppLifecycleUtils.uninstall(appRecord);
-        CommCareLifecycleUtils.restartCommCare(
-                SingleAppManagerActivity.this, AppManagerActivity.class, false);
+
+        if (MultipleAppsUtil.appRecordArray().length == 0) {
+            CommCareLifecycleUtils.restartCommCare(this, false);
+        } else {
+            CommCareLifecycleUtils.restartCommCare(
+                    SingleAppManagerActivity.this, AppManagerActivity.class, false);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
When uninstalling an app from the App Manager, CommCare always restarted to `AppManagerActivity`. If the uninstalled app was the **last** installed app, that left the user on an empty app-manager screen.

This change picks the restart target based on whether any installed app records remain after uninstall:
- **0 apps left** → `DispatchActivity` (routes to the install/setup screen)
- **1+ apps left** → `AppManagerActivity` (unchanged behavior)

## Notes
- The count comes from `MultipleAppsUtil.appRecordArray()`, read after `AppLifecycleUtils.uninstall(...)`, which removes the `ApplicationRecord` from global storage before returning on success.
- If `uninstall(...)` aborts mid-way (e.g. a file/db can't be deleted), the record remains in storage, so the count stays `>= 1` and we safely route to `AppManagerActivity`.

> [!NOTE]
> Base is `fix-flaky-instrumentation-tests` (stacked PR) — this branch was split off from it. Rebase onto `master` once the base branch merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)