### PR TITLE
CCCT-2596 Extract BaseCameraActivity From MicroImageActivity

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -570,7 +570,7 @@
         <activity android:name="org.commcare.recovery.measures.ExecuteRecoveryMeasuresActivity"/>
         <activity android:name="org.commcare.activities.PromptCCReinstallActivity"/>
         <activity
-            android:name="org.commcare.fragments.MicroImageActivity"
+            android:name="org.commcare.activities.camera.MicroImageActivity"
             android:screenOrientation="portrait"/>
         <!-- Start Collect Manifest -->
 

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -519,8 +519,8 @@
     <string name="personalid_second_device_login_title">Iniciar sesión en un segundo dispositivo</string>
     <string name="personalid_second_device_login_message">Sesión cerrada en %s, último uso: %s. Solo se puede iniciar sesión con PersonalID en un dispositivo a la vez.</string>
     <string name="personalid_second_device_login_message_no_date">Se ha cerrado la sesión en %s. Solo se puede iniciar sesión con PersonalID en un dispositivo a la vez.</string>
-    <string name="personalid_camera_permission_title">Permiso de cámara</string>
-    <string name="personalid_camera_permission_msg">Para tomar una foto, CommCare necesita permiso para usar la cámara de tu dispositivo.</string>
+    <string name="camera_permission_title">Permiso de cámara</string>
+    <string name="camera_permission_msg">Para tomar una foto, CommCare necesita permiso para usar la cámara de tu dispositivo.</string>
     <string name="personalid_capture_photo">Tomar foto</string>
     <string name="personalid_configuration_locked_account">Su cuenta ha sido bloqueada. Por favor, contacte con el servicio de asistencia.</string>
     <string name="personalid_work_history_title">Mi Historial Laboral</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -519,8 +519,8 @@ License.
     <string name="personalid_second_device_login_title">Connexion sur un deuxième appareil</string>
     <string name="personalid_second_device_login_message">Vous avez été déconnecté(e) de %s, dernière utilisation le %s. L\'identifiant PersonalID ne peut être utilisé que sur un seul appareil à la fois.</string>
     <string name="personalid_second_device_login_message_no_date">Vous avez été déconnecté(e) de %s. L\'identifiant PersonalID ne peut être utilisé que sur un seul appareil à la fois.</string>
-    <string name="personalid_camera_permission_title">Autorisation pour la caméra</string>
-    <string name="personalid_camera_permission_msg">Afin de prendre une photo, CommCare a besoin de l\'autorisation d\'utiliser l\'appareil photo de votre appareil.</string>
+    <string name="camera_permission_title">Autorisation pour la caméra</string>
+    <string name="camera_permission_msg">Afin de prendre une photo, CommCare a besoin de l\'autorisation d\'utiliser l\'appareil photo de votre appareil.</string>
     <string name="personalid_capture_photo">Prendre une photo</string>
     <string name="personalid_work_history_title">Mon Historique de Travail</string>
     <string name="personalid_work_history">Historique de Travail</string>

--- a/app/res/values-ha/strings.xml
+++ b/app/res/values-ha/strings.xml
@@ -359,8 +359,8 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="personalid_second_device_login_title">Shiga a Na\'ura ta Biyu</string>
     <string name="personalid_second_device_login_message">An fita daga %s, an yi amfani da %s na ƙarshe. PersonalID za a iya shiga kawai akan na\'ura ɗaya a lokaci guda.</string>
     <string name="personalid_second_device_login_message_no_date">An fita daga %s. Ana iya shiga PersonalID akan na\'ura ɗaya kawai a lokaci guda.</string>
-    <string name="personalid_camera_permission_title">Izini don kyamara</string>
-    <string name="personalid_camera_permission_msg">Domin ɗaukar hoto, CommCare yana buƙatar izinin amfani da kyamarar na\'urarka.</string>
+    <string name="camera_permission_title">Izini don kyamara</string>
+    <string name="camera_permission_msg">Domin ɗaukar hoto, CommCare yana buƙatar izinin amfani da kyamarar na\'urarka.</string>
     <string name="personalid_capture_photo">Ɗauki Hoto</string>
     <string name="personalid_work_history_title">Tarihin Aikina</string>
     <string name="personalid_work_history">Tarihin Aiki</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -515,8 +515,8 @@ License.
     <string name="personalid_second_device_login_title">दूसरे डिवाइस पर लॉग इन करें</string>
     <string name="personalid_second_device_login_message">%s से लॉग आउट किया गया, आखिरी बार %s इस्तेमाल किया गया था। PersonalID से एक समय में सिर्फ़ एक डिवाइस पर लॉग इन किया जा सकता है।</string>
     <string name="personalid_second_device_login_message_no_date">%s से लॉग आउट कर दिया गया है। PersonalID से एक समय में सिर्फ़ एक डिवाइस पर ही लॉग इन किया जा सकता है।</string>
-    <string name="personalid_camera_permission_title">कैमरे के लिए अनुमति</string>
-    <string name="personalid_camera_permission_msg">तस्वीर लेने के लिए, CommCare को आपके डिवाइस के कैमरे का उपयोग करने की अनुमति चाहिए।</string>
+    <string name="camera_permission_title">कैमरे के लिए अनुमति</string>
+    <string name="camera_permission_msg">तस्वीर लेने के लिए, CommCare को आपके डिवाइस के कैमरे का उपयोग करने की अनुमति चाहिए।</string>
     <string name="personalid_capture_photo">तस्वीर लें</string>
     <string name="personalid_configuration_locked_account">आपका खाता लॉक कर दिया गया है। कृपया सहायता से संपर्क करें</string>
     <string name="personalid_work_history_title">मेरा कार्य इतिहास</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -526,8 +526,8 @@
     <string name="personalid_second_device_login_title">Iniciar sessão no segundo dispositivo</string>
     <string name="personalid_second_device_login_message">Sessão encerrada em %s, último acesso em %s. O PersonalID só pode ser utilizado num dispositivo de cada vez.</string>
     <string name="personalid_second_device_login_message_no_date">Sessão encerrada de %s. O PersonalID só pode ser acedido num dispositivo de cada vez.</string>
-    <string name="personalid_camera_permission_title">Permissão para câmara</string>
-    <string name="personalid_camera_permission_msg">Para tirar uma fotografia, o CommCare precisa de permissão para utilizar a câmara do seu dispositivo.</string>
+    <string name="camera_permission_title">Permissão para câmara</string>
+    <string name="camera_permission_msg">Para tirar uma fotografia, o CommCare precisa de permissão para utilizar a câmara do seu dispositivo.</string>
     <string name="personalid_capture_photo">Capturar foto</string>
     <string name="personalid_work_history_title">Meu Histórico de Trabalho</string>
     <string name="personalid_work_history">Histórico de Trabalho</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -525,8 +525,8 @@
     <string name="personalid_second_device_login_title">Ingia kwenye Kifaa cha Pili</string>
     <string name="personalid_second_device_login_message">Imetoka kwenye %s, imetumika mara ya mwisho %s. PersonalID kinaweza kuingia kwenye kifaa kimoja tu kwa wakati mmoja.</string>
     <string name="personalid_second_device_login_message_no_date">Umetoka kwenye %s. PersonalID kinaweza kuingia kwenye kifaa kimoja tu kwa wakati mmoja.</string>
-    <string name="personalid_camera_permission_title">Ruhusa ya kamera</string>
-    <string name="personalid_camera_permission_msg">Ili kupiga picha, CommCare inahitaji ruhusa ya kutumia kamera ya kifaa chako.</string>
+    <string name="camera_permission_title">Ruhusa ya kamera</string>
+    <string name="camera_permission_msg">Ili kupiga picha, CommCare inahitaji ruhusa ya kutumia kamera ya kifaa chako.</string>
     <string name="personalid_capture_photo">Piga Picha</string>
     <string name="personalid_work_history_title">Historia Yangu ya Kazi</string>
     <string name="personalid_work_history">Historia ya Kazi</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -511,8 +511,8 @@
     <string name="personalid_second_device_login_title">ኣብ ካልኣይ መሳርሒ እቶ</string>
     <string name="personalid_second_device_login_message">ካብ %s ወጺኡ፣ ንመወዳእታ ግዜ ዝተጠቕመሉ %s። PersonalID ኣብ ሓደ እዋን ኣብ ሓደ መሳርሒ ጥራይ እዩ ክኣቱ ዝኽእል።</string>
     <string name="personalid_second_device_login_message_no_date">ካብ %s ወጺኡ። PersonalID ኣብ ሓደ እዋን ኣብ ሓደ መሳርሒ ጥራይ እዩ ክኣቱ ዝኽእል።</string>
-    <string name="personalid_camera_permission_title">ፍቓድ ንካሜራ</string>
-    <string name="personalid_camera_permission_msg">ስእሊ ንምውሳድ፡ ኮምኬር ናይ መሳርሒኻ ካሜራ ንኽጥቀም ፍቓድ የድልዮ።</string>
+    <string name="camera_permission_title">ፍቓድ ንካሜራ</string>
+    <string name="camera_permission_msg">ስእሊ ንምውሳድ፡ ኮምኬር ናይ መሳርሒኻ ካሜራ ንኽጥቀም ፍቓድ የድልዮ።</string>
     <string name="personalid_capture_photo">ስእሊ ምቕራጽ</string>
     <string name="personalid_work_history_title">ታሪኽ ስራሐይ</string>
     <string name="personalid_work_history">ታሪኽ ስራሕ</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -744,8 +744,8 @@
     <string name="personalid_error_message_login_different_device">Please continue on the new device, or configure your account again.</string>
     <string name="personalid_reconfigure">Reconfigure</string>
     <string name="personalid_dismiss">Dismiss</string>
-    <string name="camera_permission_title">Permission for camera</string>
-    <string name="camera_permission_msg">In order to take a picture, CommCare needs permission to use your device camera.</string>
+    <string name="camera_permission_title" cc:translatable="true">Permission for camera</string>
+    <string name="camera_permission_msg" cc:translatable="true">In order to take a picture, CommCare needs permission to use your device camera.</string>
     <string name="personalid_capture_photo">Capture Photo</string>
     <string name="personalid_incorrect_otp">You have entered the wrong 6-digit passcode. Please try again.</string>
     <string name="personalid_too_many_otp_attempts">You have made too many attempts to send OTP. Please wait and try again whenever the resend button is visible.</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -744,8 +744,8 @@
     <string name="personalid_error_message_login_different_device">Please continue on the new device, or configure your account again.</string>
     <string name="personalid_reconfigure">Reconfigure</string>
     <string name="personalid_dismiss">Dismiss</string>
-    <string name="personalid_camera_permission_title">Permission for camera</string>
-    <string name="personalid_camera_permission_msg">In order to take a picture, CommCare needs permission to use your device camera.</string>
+    <string name="camera_permission_title">Permission for camera</string>
+    <string name="camera_permission_msg">In order to take a picture, CommCare needs permission to use your device camera.</string>
     <string name="personalid_capture_photo">Capture Photo</string>
     <string name="personalid_incorrect_otp">You have entered the wrong 6-digit passcode. Please try again.</string>
     <string name="personalid_too_many_otp_attempts">You have made too many attempts to send OTP. Please wait and try again whenever the resend button is visible.</string>

--- a/app/src/org/commcare/activities/camera/BaseCameraActivity.kt
+++ b/app/src/org/commcare/activities/camera/BaseCameraActivity.kt
@@ -8,10 +8,11 @@ import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
 import androidx.camera.core.UseCase
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
@@ -25,6 +26,13 @@ import org.javarosa.core.services.Logger
 import org.javarosa.core.services.locale.Localization
 import java.util.concurrent.ExecutionException
 
+/**
+ * Base activity for CameraX-backed screens. Handles the camera permission flow, provider
+ * acquisition, and lifecycle binding of a preview plus a capture use case.
+ *
+ * Subclasses supply the layout, title, camera selector, target resolution, and the
+ * concrete capture use case (e.g. image capture or analysis).
+ */
 abstract class BaseCameraActivity :
     CommonBaseActivity(),
     RuntimePermissionRequester {
@@ -45,7 +53,7 @@ abstract class BaseCameraActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(getContentLayout())
-        cameraView = findViewById(R.id.view_finder)
+        cameraView = getCameraView()
         supportActionBar?.apply {
             setTitle(getTitleRes())
             setDisplayHomeAsUpEnabled(true)
@@ -70,8 +78,8 @@ abstract class BaseCameraActivity :
                         this,
                         this,
                         -1, // actually not required due to launcher activity
-                        getString(R.string.personalid_camera_permission_title),
-                        getString(R.string.personalid_camera_permission_msg),
+                        getString(R.string.camera_permission_title),
+                        getString(R.string.camera_permission_msg),
                     )
                 dialog.showNonPersistentDialog(this)
             } else {
@@ -89,28 +97,32 @@ abstract class BaseCameraActivity :
     protected fun startCamera() {
         val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
         cameraProviderFuture.addListener({
-            val cameraProvider: ProcessCameraProvider
-            try {
-                cameraProvider = cameraProviderFuture.get()
-            } catch (e: ExecutionException) {
-                logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e)
-                return@addListener
-            } catch (e: InterruptedException) {
-                logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e)
+            if (isFinishing || isDestroyed) {
                 return@addListener
             }
-            bindUseCases(cameraProvider)
+            try {
+                val cameraProvider = cameraProviderFuture.get()
+                bindUseCases(cameraProvider)
+            } catch (e: ExecutionException) {
+                logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e)
+            } catch (e: InterruptedException) {
+                logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e)
+            } catch (e: IllegalStateException) {
+                logErrorAndExit("Error binding camera use cases", "microimage.camera.start.failed", e)
+            } catch (e: IllegalArgumentException) {
+                logErrorAndExit("Error binding camera use cases", "microimage.camera.start.failed", e)
+            }
         }, ContextCompat.getMainExecutor(this))
     }
 
     private fun bindUseCases(cameraProvider: ProcessCameraProvider) {
-        val targetRotation = windowManager.defaultDisplay.rotation
+        val targetRotation = ContextCompat.getDisplayOrDefault(this).rotation
         val targetResolution = getTargetResolution()
 
         val previewBuilder = Preview.Builder().setTargetRotation(targetRotation)
-        targetResolution?.let { previewBuilder.setTargetResolution(it) }
+        targetResolution.let { previewBuilder.setResolutionSelector(buildResolutionSelector(it)) }
         val preview = previewBuilder.build()
-        preview.setSurfaceProvider(cameraView!!.surfaceProvider)
+        preview.surfaceProvider = cameraView!!.surfaceProvider
 
         val captureUseCase = buildCaptureUseCase(targetResolution, targetRotation)
 
@@ -118,8 +130,28 @@ abstract class BaseCameraActivity :
         cameraProvider.bindToLifecycle(this, getCameraSelector(), preview, captureUseCase)
     }
 
+    /**
+     * Builds a [ResolutionSelector] bound to [targetResolution]. The bound size is normalized to
+     * the sensor's natural landscape orientation, since [ResolutionStrategy] matches against
+     * sensor-oriented sizes rather than rotating to the target rotation like the deprecated
+     * `setTargetResolution`.
+     */
+    protected fun buildResolutionSelector(targetResolution: Size): ResolutionSelector {
+        val boundSize =
+            if (targetResolution.height > targetResolution.width) {
+                Size(targetResolution.height, targetResolution.width)
+            } else {
+                targetResolution
+            }
+        return ResolutionSelector
+            .Builder()
+            .setResolutionStrategy(
+                ResolutionStrategy(boundSize, ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER),
+            ).build()
+    }
+
     protected fun logErrorAndExit(
-        logMessage: String?,
+        logMessage: String,
         userMessageKey: String,
         e: Throwable?,
     ) {
@@ -129,7 +161,7 @@ abstract class BaseCameraActivity :
             Logger.exception(logMessage, e)
         }
         Toast.makeText(this, Localization.get(userMessageKey), Toast.LENGTH_LONG).show()
-        setResult(AppCompatActivity.RESULT_CANCELED)
+        setResult(RESULT_CANCELED)
         finish()
     }
 
@@ -139,9 +171,11 @@ abstract class BaseCameraActivity :
     @StringRes
     protected abstract fun getTitleRes(): Int
 
+    protected abstract fun getCameraView(): PreviewView
+
     protected abstract fun getCameraSelector(): CameraSelector
 
-    protected abstract fun getTargetResolution(): Size?
+    protected abstract fun getTargetResolution(): Size
 
     protected abstract fun buildCaptureUseCase(
         targetResolution: Size?,

--- a/app/src/org/commcare/activities/camera/BaseCameraActivity.kt
+++ b/app/src/org/commcare/activities/camera/BaseCameraActivity.kt
@@ -103,14 +103,20 @@ abstract class BaseCameraActivity :
             try {
                 val cameraProvider = cameraProviderFuture.get()
                 bindUseCases(cameraProvider)
-            } catch (e: ExecutionException) {
-                logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e)
-            } catch (e: InterruptedException) {
-                logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e)
-            } catch (e: IllegalStateException) {
-                logErrorAndExit("Error binding camera use cases", "microimage.camera.start.failed", e)
-            } catch (e: IllegalArgumentException) {
-                logErrorAndExit("Error binding camera use cases", "microimage.camera.start.failed", e)
+            } catch (e: Exception) {
+                when (e) {
+                    is ExecutionException, is InterruptedException -> {
+                        logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e)
+                    }
+
+                    is IllegalStateException, is IllegalArgumentException -> {
+                        logErrorAndExit("Error binding camera use cases", "microimage.camera.start.failed", e)
+                    }
+
+                    else -> {
+                        logErrorAndExit("Unknown error occurred while starting camera", "microimage.camera.start.failed", e)
+                    }
+                }
             }
         }, ContextCompat.getMainExecutor(this))
     }

--- a/app/src/org/commcare/activities/camera/BaseCameraActivity.kt
+++ b/app/src/org/commcare/activities/camera/BaseCameraActivity.kt
@@ -1,0 +1,152 @@
+package org.commcare.activities.camera
+
+import android.Manifest
+import android.os.Bundle
+import android.util.Size
+import android.view.MenuItem
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.LayoutRes
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.Preview
+import androidx.camera.core.UseCase
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import org.commcare.activities.CommonBaseActivity
+import org.commcare.dalvik.R
+import org.commcare.interfaces.RuntimePermissionRequester
+import org.commcare.util.LogTypes
+import org.commcare.utils.Permissions
+import org.commcare.views.dialogs.DialogCreationHelpers
+import org.javarosa.core.services.Logger
+import org.javarosa.core.services.locale.Localization
+import java.util.concurrent.ExecutionException
+
+abstract class BaseCameraActivity :
+    CommonBaseActivity(),
+    RuntimePermissionRequester {
+    @JvmField
+    protected var cameraView: PreviewView? = null
+
+    private val cameraPermissionRequestLauncher =
+        registerForActivityResult(
+            ActivityResultContracts.RequestPermission(),
+        ) { isGranted ->
+            if (isGranted) {
+                startCamera()
+            } else {
+                logErrorAndExit("Error acquiring camera permission", "microimage.camera.permission.denied", null)
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(getContentLayout())
+        cameraView = findViewById(R.id.view_finder)
+        supportActionBar?.apply {
+            setTitle(getTitleRes())
+            setDisplayHomeAsUpEnabled(true)
+        }
+        onCameraViewReady()
+        checkForCameraPermission()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressedDispatcher.onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    private fun checkForCameraPermission() {
+        if (Permissions.missingAppPermission(this, Manifest.permission.CAMERA)) {
+            if (Permissions.shouldShowPermissionRationale(this, Manifest.permission.CAMERA)) {
+                val dialog =
+                    DialogCreationHelpers.buildPermissionRequestDialog(
+                        this,
+                        this,
+                        -1, // actually not required due to launcher activity
+                        getString(R.string.personalid_camera_permission_title),
+                        getString(R.string.personalid_camera_permission_msg),
+                    )
+                dialog.showNonPersistentDialog(this)
+            } else {
+                requestNeededPermissions(-1)
+            }
+        } else {
+            startCamera()
+        }
+    }
+
+    override fun requestNeededPermissions(requestCode: Int) {
+        cameraPermissionRequestLauncher.launch(Manifest.permission.CAMERA)
+    }
+
+    protected fun startCamera() {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
+        cameraProviderFuture.addListener({
+            val cameraProvider: ProcessCameraProvider
+            try {
+                cameraProvider = cameraProviderFuture.get()
+            } catch (e: ExecutionException) {
+                logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e)
+                return@addListener
+            } catch (e: InterruptedException) {
+                logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e)
+                return@addListener
+            }
+            bindUseCases(cameraProvider)
+        }, ContextCompat.getMainExecutor(this))
+    }
+
+    private fun bindUseCases(cameraProvider: ProcessCameraProvider) {
+        val targetRotation = windowManager.defaultDisplay.rotation
+        val targetResolution = getTargetResolution()
+
+        val previewBuilder = Preview.Builder().setTargetRotation(targetRotation)
+        targetResolution?.let { previewBuilder.setTargetResolution(it) }
+        val preview = previewBuilder.build()
+        preview.setSurfaceProvider(cameraView!!.surfaceProvider)
+
+        val captureUseCase = buildCaptureUseCase(targetResolution, targetRotation)
+
+        cameraProvider.unbindAll()
+        cameraProvider.bindToLifecycle(this, getCameraSelector(), preview, captureUseCase)
+    }
+
+    protected fun logErrorAndExit(
+        logMessage: String?,
+        userMessageKey: String,
+        e: Throwable?,
+    ) {
+        if (e == null) {
+            Logger.log(LogTypes.TYPE_EXCEPTION, logMessage)
+        } else {
+            Logger.exception(logMessage, e)
+        }
+        Toast.makeText(this, Localization.get(userMessageKey), Toast.LENGTH_LONG).show()
+        setResult(AppCompatActivity.RESULT_CANCELED)
+        finish()
+    }
+
+    @LayoutRes
+    protected abstract fun getContentLayout(): Int
+
+    @StringRes
+    protected abstract fun getTitleRes(): Int
+
+    protected abstract fun getCameraSelector(): CameraSelector
+
+    protected abstract fun getTargetResolution(): Size?
+
+    protected abstract fun buildCaptureUseCase(
+        targetResolution: Size?,
+        targetRotation: Int,
+    ): UseCase
+
+    protected open fun onCameraViewReady() {}
+}

--- a/app/src/org/commcare/activities/camera/MicroImageActivity.java
+++ b/app/src/org/commcare/activities/camera/MicroImageActivity.java
@@ -1,21 +1,17 @@
-package org.commcare.fragments;
+package org.commcare.activities.camera;
 
-import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.media.Image;
-import android.os.Bundle;
 import android.util.Base64;
 import android.util.Size;
-import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.Toast;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.mlkit.common.MlKitException;
 import com.google.mlkit.vision.common.InputImage;
 import com.google.mlkit.vision.common.internal.ImageConvertUtils;
@@ -24,42 +20,27 @@ import com.google.mlkit.vision.face.FaceDetection;
 import com.google.mlkit.vision.face.FaceDetector;
 import com.google.mlkit.vision.face.FaceDetectorOptions;
 
-import org.commcare.activities.CommonBaseActivity;
 import org.commcare.dalvik.R;
-import org.commcare.interfaces.RuntimePermissionRequester;
-import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidUtil;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.ImageSizeTooLargeException;
 import org.commcare.utils.MediaUtil;
-import org.commcare.utils.Permissions;
 import org.commcare.views.FaceCaptureView;
-import org.commcare.views.dialogs.CommCareAlertDialog;
-import org.commcare.views.dialogs.DialogCreationHelpers;
 import org.javarosa.core.services.Logger;
-import org.javarosa.core.services.locale.Localization;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.camera.core.CameraSelector;
 import androidx.camera.core.ImageAnalysis;
 import androidx.camera.core.ImageCapture;
 import androidx.camera.core.ImageProxy;
-import androidx.camera.core.Preview;
 import androidx.camera.core.UseCase;
-import androidx.camera.lifecycle.ProcessCameraProvider;
-import androidx.camera.view.PreviewView;
 import androidx.core.content.ContextCompat;
 
-public class MicroImageActivity extends CommonBaseActivity implements ImageAnalysis.Analyzer, FaceCaptureView.ImageStabilizedListener, RuntimePermissionRequester {
+public class MicroImageActivity extends BaseCameraActivity implements ImageAnalysis.Analyzer, FaceCaptureView.ImageStabilizedListener {
     public static final String MICRO_IMAGE_BASE_64_RESULT_KEY = "micro_image_base_64_result_key";
     public static final String MICRO_IMAGE_MAX_DIMENSION_PX_EXTRA = "micro_image_max_dimension_px_extra";
     public static final String MICRO_IMAGE_MAX_SIZE_BYTES_EXTRA = "micro_image_max_size_bytes_extra";
@@ -67,37 +48,35 @@ public class MicroImageActivity extends CommonBaseActivity implements ImageAnaly
     private static final int DEFAULT_MICRO_IMAGE_MAX_SIZE_BYTES = 2 * 1024;
     public static final String BASE_64_IMAGE_PREFIX = "data:image/webp;base64,";
 
-    private PreviewView cameraView;
     private FaceCaptureView faceCaptureView;
     private Bitmap inputImage;
     private ImageView cameraShutterButton;
     private boolean isGooglePlayServicesAvailable = false;
 
-    ActivityResultLauncher<String> cameraPermissionRequestLauncher = registerForActivityResult(
-            new ActivityResultContracts.RequestPermission(),
-            isGranted -> {
-                if (isGranted) {
-                    startCamera();
-                } else {
-                    logErrorAndExit("Error acquiring camera permission", "microimage.camera.permission.denied", null);
-                }
-            }
-    );
+    @Override
+    protected int getContentLayout() {
+        return R.layout.micro_image_widget;
+    }
 
     @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.micro_image_widget);
+    protected int getTitleRes() {
+        return R.string.micro_image_activity_title;
+    }
 
+    @Override
+    protected CameraSelector getCameraSelector() {
+        return CameraSelector.DEFAULT_FRONT_CAMERA;
+    }
+
+    @Override
+    protected Size getTargetResolution() {
+        return new Size(faceCaptureView.getImageWidth(), faceCaptureView.getImageHeight());
+    }
+
+    @Override
+    protected void onCameraViewReady() {
         faceCaptureView = findViewById(R.id.face_overlay);
-        cameraView = findViewById(R.id.view_finder);
         cameraShutterButton = findViewById(R.id.camera_shutter_button);
-
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            actionBar.setTitle(R.string.micro_image_activity_title);
-            actionBar.setDisplayHomeAsUpEnabled(true);
-        }
         isGooglePlayServicesAvailable = AndroidUtil.isGooglePlayServicesAvailable(this);
         if (isGooglePlayServicesAvailable) {
             faceCaptureView.setImageStabilizedListener(this);
@@ -105,79 +84,15 @@ public class MicroImageActivity extends CommonBaseActivity implements ImageAnaly
             faceCaptureView.setCaptureMode(FaceCaptureView.CaptureMode.ManualMode);
             cameraShutterButton.setVisibility(View.VISIBLE);
         }
-        checkForCameraPermission();
     }
 
     @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        if (item.getItemId() == android.R.id.home) {
-            getOnBackPressedDispatcher().onBackPressed();
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
-    private void checkForCameraPermission() {
-        if (Permissions.missingAppPermission(this, Manifest.permission.CAMERA)) {
-            if (Permissions.shouldShowPermissionRationale(this, Manifest.permission.CAMERA)) {
-                CommCareAlertDialog dialog =
-                        DialogCreationHelpers.buildPermissionRequestDialog(this, this,
-                                -1, // actually not required due to launcher activity
-                                getString(R.string.personalid_camera_permission_title),
-                                getString(R.string.personalid_camera_permission_msg));
-                dialog.showNonPersistentDialog(this);
-            } else {
-                requestNeededPermissions(-1);
-            }
-        } else {
-            startCamera();
-        }
-    }
-
-    @Override
-    public void requestNeededPermissions(int requestCode) {
-        cameraPermissionRequestLauncher.launch(Manifest.permission.CAMERA);
-    }
-
-    private void startCamera() {
-        ListenableFuture<ProcessCameraProvider> cameraProviderFuture = ProcessCameraProvider.getInstance(this);
-
-        cameraProviderFuture.addListener(() -> {
-            ProcessCameraProvider cameraProvider;
-            try {
-                cameraProvider = cameraProviderFuture.get();
-            } catch (ExecutionException | InterruptedException e) {
-                logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e);
-                return;
-            }
-            bindUseCases(cameraProvider);
-        }, ContextCompat.getMainExecutor(this));
-    }
-
-    private void bindUseCases(ProcessCameraProvider cameraProvider) {
-        int targetRotation = getWindowManager().getDefaultDisplay().getRotation();
-        Size targetResolution = new Size(faceCaptureView.getImageWidth(), faceCaptureView.getImageHeight());
-
-        // Preview use case
-        Preview preview = new Preview.Builder()
-                .setTargetResolution(targetResolution)
-                .setTargetRotation(targetRotation)
-                .build();
-        preview.setSurfaceProvider(cameraView.getSurfaceProvider());
-
-        UseCase imageAnalyzerOrCapture;
+    protected UseCase buildCaptureUseCase(Size targetResolution, int targetRotation) {
         if (faceCaptureView.getCaptureMode() == FaceCaptureView.CaptureMode.FaceDetectionMode) {
-            imageAnalyzerOrCapture = buildImageAnalysisUseCase(targetResolution, targetRotation);
+            return buildImageAnalysisUseCase(targetResolution, targetRotation);
         } else {
-            imageAnalyzerOrCapture = buildImageCaptureUseCase(targetResolution);
+            return buildImageCaptureUseCase(targetResolution);
         }
-        CameraSelector cameraSelector = CameraSelector.DEFAULT_FRONT_CAMERA;
-
-        // Unbind any previous use cases before binding new ones
-        cameraProvider.unbindAll();
-
-        // Bind the use cases to the camera
-        cameraProvider.bindToLifecycle(this, cameraSelector, preview, imageAnalyzerOrCapture);
     }
 
     private UseCase buildImageAnalysisUseCase(Size targetResolution, int targetRotation) {
@@ -189,17 +104,6 @@ public class MicroImageActivity extends CommonBaseActivity implements ImageAnaly
 
         imageAnalyzer.setAnalyzer(ContextCompat.getMainExecutor(getApplicationContext()), this);
         return imageAnalyzer;
-    }
-
-    private void logErrorAndExit(String logMessage, String userMessageKey, Throwable e) {
-        if (e == null) {
-            Logger.log(LogTypes.TYPE_EXCEPTION, logMessage);
-        } else {
-            Logger.exception(logMessage, e);
-        }
-        Toast.makeText(this, Localization.get(userMessageKey), Toast.LENGTH_LONG).show();
-        setResult(AppCompatActivity.RESULT_CANCELED);
-        finish();
     }
 
     // Set up image capture use case, for when Google Services is not available

--- a/app/src/org/commcare/activities/camera/MicroImageActivity.java
+++ b/app/src/org/commcare/activities/camera/MicroImageActivity.java
@@ -38,6 +38,7 @@ import androidx.camera.core.ImageAnalysis;
 import androidx.camera.core.ImageCapture;
 import androidx.camera.core.ImageProxy;
 import androidx.camera.core.UseCase;
+import androidx.camera.view.PreviewView;
 import androidx.core.content.ContextCompat;
 
 public class MicroImageActivity extends BaseCameraActivity implements ImageAnalysis.Analyzer, FaceCaptureView.ImageStabilizedListener {
@@ -63,11 +64,18 @@ public class MicroImageActivity extends BaseCameraActivity implements ImageAnaly
         return R.string.micro_image_activity_title;
     }
 
+    @NonNull
+    @Override
+    protected PreviewView getCameraView() {
+        return findViewById(R.id.view_finder);
+    }
+
     @Override
     protected CameraSelector getCameraSelector() {
         return CameraSelector.DEFAULT_FRONT_CAMERA;
     }
 
+    @NonNull
     @Override
     protected Size getTargetResolution() {
         return new Size(faceCaptureView.getImageWidth(), faceCaptureView.getImageHeight());
@@ -91,14 +99,14 @@ public class MicroImageActivity extends BaseCameraActivity implements ImageAnaly
         if (faceCaptureView.getCaptureMode() == FaceCaptureView.CaptureMode.FaceDetectionMode) {
             return buildImageAnalysisUseCase(targetResolution, targetRotation);
         } else {
-            return buildImageCaptureUseCase(targetResolution);
+            return buildImageCaptureUseCase(targetResolution, targetRotation);
         }
     }
 
     private UseCase buildImageAnalysisUseCase(Size targetResolution, int targetRotation) {
         ImageAnalysis imageAnalyzer = new ImageAnalysis.Builder()
                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                .setTargetResolution(targetResolution)
+                .setResolutionSelector(buildResolutionSelector(targetResolution))
                 .setTargetRotation(targetRotation)
                 .build();
 
@@ -107,8 +115,11 @@ public class MicroImageActivity extends BaseCameraActivity implements ImageAnaly
     }
 
     // Set up image capture use case, for when Google Services is not available
-    private UseCase buildImageCaptureUseCase(Size targetResolution) {
-        ImageCapture imageCapture = new ImageCapture.Builder().setTargetResolution(targetResolution).build();
+    private UseCase buildImageCaptureUseCase(Size targetResolution, int targetRotation) {
+        ImageCapture imageCapture = new ImageCapture.Builder()
+                .setResolutionSelector(buildResolutionSelector(targetResolution))
+                .setTargetRotation(targetRotation)
+                .build();
 
         cameraShutterButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
@@ -1,7 +1,7 @@
 package org.commcare.fragments.personalId;
 
-import static org.commcare.fragments.MicroImageActivity.MICRO_IMAGE_MAX_DIMENSION_PX_EXTRA;
-import static org.commcare.fragments.MicroImageActivity.MICRO_IMAGE_MAX_SIZE_BYTES_EXTRA;
+import static org.commcare.activities.camera.MicroImageActivity.MICRO_IMAGE_MAX_DIMENSION_PX_EXTRA;
+import static org.commcare.activities.camera.MicroImageActivity.MICRO_IMAGE_MAX_SIZE_BYTES_EXTRA;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -28,7 +28,7 @@ import org.commcare.connect.network.PersonalIdOrConnectApiErrorHandler;
 import org.commcare.connect.network.connectId.PersonalIdApiHandler;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.ScreenPersonalidPhotoCaptureBinding;
-import org.commcare.fragments.MicroImageActivity;
+import org.commcare.activities.camera.MicroImageActivity;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.utils.MediaUtil;
 import org.jetbrains.annotations.NotNull;

--- a/app/src/org/commcare/navdrawer/BaseDrawerController.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerController.kt
@@ -16,6 +16,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import org.commcare.CommCareApplication
 import org.commcare.activities.CommCareActivity
+import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.connect.ConnectActivityCompleteListener
 import org.commcare.connect.ConnectConstants
 import org.commcare.connect.ConnectNavHelper
@@ -26,7 +27,6 @@ import org.commcare.connect.network.PersonalIdOrConnectApiErrorHandler
 import org.commcare.connect.network.connectId.PersonalIdApiHandler
 import org.commcare.dalvik.BuildConfig
 import org.commcare.dalvik.R
-import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.personalId.PersonalIdFeatureFlagChecker.Companion.isFeatureEnabled
 import org.commcare.personalId.PersonalIdFeatureFlagChecker.FeatureFlag.Companion.MANAGE_PROFILE

--- a/app/src/org/commcare/navdrawer/BaseDrawerController.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerController.kt
@@ -26,7 +26,7 @@ import org.commcare.connect.network.PersonalIdOrConnectApiErrorHandler
 import org.commcare.connect.network.connectId.PersonalIdApiHandler
 import org.commcare.dalvik.BuildConfig
 import org.commcare.dalvik.R
-import org.commcare.fragments.MicroImageActivity
+import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.personalId.PersonalIdFeatureFlagChecker.Companion.isFeatureEnabled
 import org.commcare.personalId.PersonalIdFeatureFlagChecker.FeatureFlag.Companion.MANAGE_PROFILE

--- a/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdPhotoCaptureFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdPhotoCaptureFragmentTest.kt
@@ -12,12 +12,12 @@ import androidx.navigation.NavDestination
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import okhttp3.mockwebserver.MockResponse
+import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.android.database.connect.models.PersonalIdSessionData
 import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectDatabaseHelper
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
-import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.MediaUtil
 import org.commcare.utils.MockAndroidKeyStoreProvider

--- a/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdPhotoCaptureFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdPhotoCaptureFragmentTest.kt
@@ -17,7 +17,7 @@ import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectDatabaseHelper
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
-import org.commcare.fragments.MicroImageActivity
+import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.MediaUtil
 import org.commcare.utils.MockAndroidKeyStoreProvider

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragmentTest.kt
@@ -9,12 +9,12 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.commcare.CommCareTestApplication
+import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.connect.ConnectConstants
 import org.commcare.connect.database.ConnectDatabaseHelper
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
-import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.MediaUtil
 import org.hamcrest.MatcherAssert.assertThat

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragmentTest.kt
@@ -14,7 +14,7 @@ import org.commcare.connect.ConnectConstants
 import org.commcare.connect.database.ConnectDatabaseHelper
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
-import org.commcare.fragments.MicroImageActivity
+import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.MediaUtil
 import org.hamcrest.MatcherAssert.assertThat


### PR DESCRIPTION
### [CCCT-2596](https://dimagi.atlassian.net/browse/CCCT-2596)

## Technical Summary

The shared CameraX plumbing — CAMERA permission flow, provider acquisition, preview binding, action bar, and error exit — moves into a new abstract `BaseCameraActivity`, with everything mode-specific (camera selector, target resolution, capture use case, view setup) exposed as hooks. `MicroImageActivity` is refactored onto the base with its PersonalID face-detection flow unchanged. Both activities also relocate from `org.commcare.fragments` to a new `org.commcare.activities.camera` package, since they are activities, not fragments.

## Safety Assurance

### Safety story

What gives me confidence:
- I built the app and exercised the PersonalID "Take Profile Photo" flow on a device — the camera launches, detects a face, and saves the photo as before.
- The change is a behavior-preserving extraction plus package move; `MicroImageActivity`'s logic is unchanged, only relocated into base hooks.
- Existing `PersonalIdPhotoCaptureFragmentTest` covers the launch + result contract and passes; ktlint and a full `compileCommcareDebugSources` are clean, including the Kotlin↔Java interop.

[CCCT-2596]: https://dimagi.atlassian.net/browse/CCCT-2596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ