### PR TITLE
CCCT-2597 Add Responsive Rectangle Reticle Overlay View

### DIFF
--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -151,4 +151,13 @@
         <attr name="icon" format="reference" />
         <attr name="navigable" format="boolean" />
     </declare-styleable>
+
+    <declare-styleable name="RectangleOverlayView">
+        <attr name="reticleScrimColor" format="color" />
+        <attr name="reticleStrokeColor" format="color" />
+        <attr name="reticleOutlineColor" format="color" />
+        <attr name="reticleStrokeWidth" format="dimension" />
+        <attr name="reticleOutlineWidth" format="dimension" />
+        <attr name="reticleMarginRatio" format="float" />
+    </declare-styleable>
 </resources>

--- a/app/res/values/colors.xml
+++ b/app/res/values/colors.xml
@@ -185,6 +185,7 @@
     <color name="burnt_amber">#C67E13</color>
     <color name="rich_amber_gold">#BF9A17</color>
     <color name="black_60">#99000000</color>
+    <color name="black_80">#CC000000</color>
 
     <color name="ic_backup">#14006C</color>
     <color name="icon_tint_dark_gray">#333333</color>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -130,6 +130,8 @@
 
     <dimen name="connect_message_input_corner_radius">50dp</dimen>
     <dimen name="connect_message_input_stroke_width">0.5dp</dimen>
+    <dimen name="reticle_stroke_width">3dp</dimen>
+    <dimen name="reticle_outline_width">1dp</dimen>
     <dimen name="connect_message_corner_radius">16dp</dimen>
 
     <dimen name="corner_radius_small_5dp">5dp</dimen>

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -294,4 +294,12 @@
         <item name="android:track">@drawable/switch_track</item>
     </style>
 
+    <style name="Widget.CommCare.RectangleOverlayView" parent="">
+        <item name="reticleScrimColor">@color/black_60</item>
+        <item name="reticleOutlineColor">@color/black_80</item>
+        <item name="reticleStrokeColor">@color/white</item>
+        <item name="reticleStrokeWidth">@dimen/reticle_stroke_width</item>
+        <item name="reticleOutlineWidth">@dimen/reticle_outline_width</item>
+    </style>
+
 </resources>

--- a/app/src/org/commcare/views/RectangleOverlayView.kt
+++ b/app/src/org/commcare/views/RectangleOverlayView.kt
@@ -6,7 +6,7 @@ import android.graphics.Paint
 import android.graphics.RectF
 import android.util.AttributeSet
 import android.view.View
-import androidx.core.content.ContextCompat
+import androidx.core.content.withStyledAttributes
 import org.commcare.dalvik.R
 
 /**
@@ -23,28 +23,34 @@ class RectangleOverlayView
     ) : View(context, attrs, defStyleAttr) {
         private var reticleRect: RectF? = null
 
-        private val scrimPaint =
-            Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                style = Paint.Style.FILL
-                color = ContextCompat.getColor(context, R.color.black_60)
-            }
+        private var reticleMarginRatio = DEFAULT_RETICLE_MARGIN_RATIO
 
-        private val strokeWidthPx = resources.getDimension(R.dimen.reticle_stroke_width)
-        private val outlineWidthPx = resources.getDimension(R.dimen.reticle_outline_width)
+        private val scrimPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+        private val outlinePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.STROKE }
+        private val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.STROKE }
 
-        private val outlinePaint =
-            Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                style = Paint.Style.STROKE
-                color = ContextCompat.getColor(context, R.color.black_80)
-                strokeWidth = strokeWidthPx + 2 * outlineWidthPx
-            }
+        init {
+            context.withStyledAttributes(
+                attrs,
+                R.styleable.RectangleOverlayView,
+                defStyleAttr,
+                R.style.Widget_CommCare_RectangleOverlayView,
+            ) {
+                reticleMarginRatio =
+                    getFloat(
+                        R.styleable.RectangleOverlayView_reticleMarginRatio,
+                        DEFAULT_RETICLE_MARGIN_RATIO,
+                    )
+                val strokeWidthPx = getDimension(R.styleable.RectangleOverlayView_reticleStrokeWidth, 0f)
+                val outlineWidthPx = getDimension(R.styleable.RectangleOverlayView_reticleOutlineWidth, 0f)
 
-        private val strokePaint =
-            Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                style = Paint.Style.STROKE
-                color = ContextCompat.getColor(context, R.color.white)
-                strokeWidth = strokeWidthPx
+                scrimPaint.color = getColor(R.styleable.RectangleOverlayView_reticleScrimColor, 0)
+                outlinePaint.color = getColor(R.styleable.RectangleOverlayView_reticleOutlineColor, 0)
+                outlinePaint.strokeWidth = strokeWidthPx + 2 * outlineWidthPx
+                strokePaint.color = getColor(R.styleable.RectangleOverlayView_reticleStrokeColor, 0)
+                strokePaint.strokeWidth = strokeWidthPx
             }
+        }
 
         override fun onSizeChanged(
             w: Int,
@@ -54,7 +60,7 @@ class RectangleOverlayView
         ) {
             super.onSizeChanged(w, h, oldw, oldh)
             if (w > 0 && h > 0) {
-                val margin = RETICLE_MARGIN_RATIO * w
+                val margin = reticleMarginRatio * minOf(w, h)
                 reticleRect = RectF(margin, margin, w - margin, h - margin)
             }
         }
@@ -75,6 +81,6 @@ class RectangleOverlayView
         }
 
         companion object {
-            const val RETICLE_MARGIN_RATIO = 0.08f
+            const val DEFAULT_RETICLE_MARGIN_RATIO = 0.08f
         }
     }

--- a/app/src/org/commcare/views/RectangleOverlayView.kt
+++ b/app/src/org/commcare/views/RectangleOverlayView.kt
@@ -1,0 +1,80 @@
+package org.commcare.views
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.View
+import androidx.core.content.ContextCompat
+import org.commcare.dalvik.R
+
+/**
+ * Responsive rectangular reticle drawn over a camera preview to help the user
+ * center the subject. The reticle is a centered rectangle inset by an equal margin on
+ * all sides, recomputed from the view size; it does not crop or alter the captured frame.
+ */
+class RectangleOverlayView
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : View(context, attrs, defStyleAttr) {
+        private var reticleRect: RectF? = null
+
+        private val scrimPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.FILL
+                color = ContextCompat.getColor(context, R.color.black_60)
+            }
+
+        private val strokeWidthPx = resources.getDimension(R.dimen.reticle_stroke_width)
+        private val outlineWidthPx = resources.getDimension(R.dimen.reticle_outline_width)
+
+        private val outlinePaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.STROKE
+                color = ContextCompat.getColor(context, R.color.black_80)
+                strokeWidth = strokeWidthPx + 2 * outlineWidthPx
+            }
+
+        private val strokePaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.STROKE
+                color = ContextCompat.getColor(context, R.color.white)
+                strokeWidth = strokeWidthPx
+            }
+
+        override fun onSizeChanged(
+            w: Int,
+            h: Int,
+            oldw: Int,
+            oldh: Int,
+        ) {
+            super.onSizeChanged(w, h, oldw, oldh)
+            if (w > 0 && h > 0) {
+                val margin = RETICLE_MARGIN_RATIO * w
+                reticleRect = RectF(margin, margin, w - margin, h - margin)
+            }
+        }
+
+        override fun onDraw(canvas: Canvas) {
+            super.onDraw(canvas)
+            val rect = reticleRect ?: return
+            val viewWidth = width.toFloat()
+            val viewHeight = height.toFloat()
+
+            canvas.drawRect(0f, 0f, viewWidth, rect.top, scrimPaint)
+            canvas.drawRect(0f, rect.bottom, viewWidth, viewHeight, scrimPaint)
+            canvas.drawRect(0f, rect.top, rect.left, rect.bottom, scrimPaint)
+            canvas.drawRect(rect.right, rect.top, viewWidth, rect.bottom, scrimPaint)
+
+            canvas.drawRect(rect, outlinePaint)
+            canvas.drawRect(rect, strokePaint)
+        }
+
+        companion object {
+            const val RETICLE_MARGIN_RATIO = 0.08f
+        }
+    }


### PR DESCRIPTION
### [CCCT-2597](https://dimagi.atlassian.net/browse/CCCT-2597)

## Technical Summary

Adds `RectangleOverlayView`, a self-contained custom `View` for the upcoming MUAC camera capture flow. It draws a centered rectangular reticle — a dim scrim around a clear center plus a high-contrast white-on-dark border — sized responsively as a uniform inset (`0.08 × width`) recomputed on size change.

## Safety Assurance

### Safety story

What gives confidence:
- I verified rendering via a temporary preview harness on both an emulator and a physical Motorola device (Android 16): the reticle draws as a centered rectangle with equal margins, a correct dim scrim, and a border legible on both light and dark backgrounds.

This is just for reference to show how it looks.
<img width="250" height="555" alt="Screenshot_20260630_201240" src="https://github.com/user-attachments/assets/f61f4fda-54b8-42fd-a00d-9ab3236c0da1" />

- The diff is narrow and additive — one new `View` plus two color/dimension resources; no existing code paths are touched.

[CCCT-2597]: https://dimagi.atlassian.net/browse/CCCT-2597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ