### PR TITLE
CI-766 Fix Connect Delivery Progress And Job Intro Crashes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,6 +25,8 @@ along with the public release notes above
 
 - Fix bug causing form widgets to lose focus when a Combobox dropdown on the same screen is re-validated.
 - Fixed a crash that could occur when navigating back from a case list that uses the GPS `here()` function
+- Fixed a crash caused by tapping a payment unit row more than once on the Connect delivery progress screen
+- Fixed a crash that could occur when leaving a Connect opportunity's intro screen before its Start Learning request finished
 
 ### QA Notes
 <!--

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,8 +25,6 @@ along with the public release notes above
 
 - Fix bug causing form widgets to lose focus when a Combobox dropdown on the same screen is re-validated.
 - Fixed a crash that could occur when navigating back from a case list that uses the GPS `here()` function
-- Fixed a crash caused by tapping a payment unit row more than once on the Connect delivery progress screen
-- Fixed a crash that could occur when leaving a Connect opportunity's intro screen before its Start Learning request finished
 
 ### QA Notes
 <!--
@@ -46,8 +44,6 @@ we would like to communicate to QA as part of the release testing
 
 - **GPS `here()` crash regression:** Using an app configuration that has `here()` in a case list (e.g. a case list that shows distance to GPS coordinates), navigate to that case list and wait for it to fully load. Press Back. Verify the app returns to the previous screen without crashing.
 - **GPS `here()` case list refresh:** Using the same app configuration, navigate to the case list and allow GPS to acquire a location fix. Move to a different location (or simulate a location change) while the list is displayed. Verify the case list automatically refreshes and distance values update accordingly.
-- Verify tapping payment-unit rows on the Connect delivery progress screen — including rapid double-taps and two-finger simultaneous taps — opens the deliveries list without crashing or double-navigating.
-- Verify backing out of a brand new Connect opportunity's intro screen right after tapping Start Learning (easiest with poor connectivity) does not crash once the request completes.
 
 
 ## CommCare 2.64
@@ -75,6 +71,8 @@ These are published publicly on Playstore, Github Releases and CommCare Forums
 - Fixed the back arrow on the camera capture screen so it correctly returns to the previous screen
 - Fixed an issue where Connect messages opened from a notification could be viewed without completing the unlock prompt
 - Fixed PersonalID app linking so a failed fingerprint scan no longer skips you past the login screen; you can retry the unlock and linking completes once it succeeds
+- Fixed a crash caused by tapping a payment unit row more than once on the Connect delivery progress screen
+- Fixed a crash that could occur when leaving a Connect opportunity's intro screen before its Start Learning request finished
 
 
 ### QA Notes
@@ -194,6 +192,9 @@ we would like to communicate to QA as part of the release testing
   - PersonalID logged in, offline / network failure: same "Opportunity not found" toast and jobs-list landing — no retry prompt, no stuck loading dialog.
   - Malformed link (extra path segments, wrong host, or missing UUID): treated as a normal app launch, no toast, no crash.
   - After any of the above, background and reopen the app from recents and verify the link is not reprocessed.
+
+- Verify tapping payment-unit rows on the Connect delivery progress screen — including rapid double-taps and two-finger simultaneous taps — opens the deliveries list without crashing or double-navigating.
+- Verify backing out of a brand new Connect opportunity's intro screen right after tapping Start Learning (easiest with poor connectivity) does not crash once the request completes.
 
 
 ## CommCare 2.63

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -46,6 +46,8 @@ we would like to communicate to QA as part of the release testing
 
 - **GPS `here()` crash regression:** Using an app configuration that has `here()` in a case list (e.g. a case list that shows distance to GPS coordinates), navigate to that case list and wait for it to fully load. Press Back. Verify the app returns to the previous screen without crashing.
 - **GPS `here()` case list refresh:** Using the same app configuration, navigate to the case list and allow GPS to acquire a location fix. Move to a different location (or simulate a location change) while the list is displayed. Verify the case list automatically refreshes and distance values update accordingly.
+- Verify tapping payment-unit rows on the Connect delivery progress screen — including rapid double-taps and two-finger simultaneous taps — opens the deliveries list without crashing or double-navigating.
+- Verify backing out of a brand new Connect opportunity's intro screen right after tapping Start Learning (easiest with poor connectivity) does not crash once the request completes.
 
 
 ## CommCare 2.64

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressDeliveryFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressDeliveryFragment.java
@@ -7,7 +7,8 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.RequiresApi;
-import androidx.navigation.Navigation;
+import androidx.navigation.NavController;
+import androidx.navigation.fragment.NavHostFragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -105,14 +106,24 @@ public class ConnectDeliveryProgressDeliveryFragment extends ConnectJobFragment<
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         if (adapter == null) {
             adapter = new ConnectDeliveryProgressReportAdapter(
-                    getContext(), deliveryProgressList, unitName -> Navigation.findNavController(recyclerView)
-                    .navigate(ConnectDeliveryProgressFragmentDirections
-                            .actionConnectJobDeliveryProgressFragmentToConnectDeliveryFragment(unitName))
+                    getContext(), deliveryProgressList, this::navigateToDeliveries
             );
             recyclerView.setAdapter(adapter);
         } else {
             recyclerView.setAdapter(adapter);
             adapter.updateData(deliveryProgressList);
+        }
+    }
+
+    private void navigateToDeliveries(String unitName) {
+        NavController navController = NavHostFragment.findNavController(this);
+
+        if (navController.getCurrentDestination() != null
+                && navController.getCurrentDestination().getId() == R.id.connect_job_delivery_progress_fragment) {
+            navController.navigate(
+                    ConnectDeliveryProgressFragmentDirections
+                            .actionConnectJobDeliveryProgressFragmentToConnectDeliveryFragment(unitName)
+            );
         }
     }
 

--- a/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
@@ -121,6 +121,11 @@ public class ConnectJobIntroFragment extends ConnectJobFragment<FragmentConnectJ
         new ConnectApiHandler<Boolean>() {
             @Override
             public void onFailure(@NonNull PersonalIdOrConnectApiErrorCodes errorCode, @Nullable Throwable t) {
+                reportApiCall(false);
+                if (!isAdded() || getView() == null) {
+                    return;
+                }
+
                 String error = PersonalIdOrConnectApiErrorHandler.handle(requireActivity(), errorCode, t);
                 if (PersonalIdOrConnectApiErrorHandler.isNetworkError(errorCode)) {
                     showError(getString(R.string.failed_to_start_learning));
@@ -131,7 +136,6 @@ public class ConnectJobIntroFragment extends ConnectJobFragment<FragmentConnectJ
                             false,
                             R.string.ok);
                 }
-                reportApiCall(false);
             }
 
             @Override
@@ -142,7 +146,7 @@ public class ConnectJobIntroFragment extends ConnectJobFragment<FragmentConnectJ
                 job.setStatus(ConnectJobRecord.STATUS_LEARNING);
                 ConnectJobUtils.upsertJob(getContext(), job);
 
-                if (!isAdded()) {
+                if (!isAdded() || getView() == null) {
                     return;
                 }
 


### PR DESCRIPTION
### [CI-766](https://dimagi.atlassian.net/browse/CI-766)

## Product Description

Fixes two Connect crashes reported on the Readers project:

- Tapping a payment-unit row on the delivery progress screen more than once in quick succession (e.g. a two-finger tap, or taps queued behind a busy main thread) crashed the app.
- Leaving a brand new opportunity's intro screen while its Start Learning request was still in flight crashed the app when the response arrived.

## Technical Summary

The ticket only reported that the app crashes for Readers project users starting June 28, so I queried Firebase crash data in BigQuery — crashes since June 25 (a day before the Readers project started just to be safe), filtered to the project's app/domain — to surface likely culprits; this PR fixes two of them. I highly suspect that the crash shown in the video on the ticket is traditional CommCare. But, the two Connect related crashes I saw were quick, easy wins, so I decided to go ahead and raise a PR for those 2 even though they may not be what's causing the crash in the video on the ticket.

Both fixes guard race conditions:

- Delivery progress row taps only navigate if the NavController is still on the delivery progress destination, and the controller is resolved through the fragment instead of the (possibly already detached) row view.
- The Start Learning API callbacks return early when the fragment is detached or its view is destroyed, instead of touching the activity and view.

For easy reference, here are links to the 2 crashes in Firebase that this PR fixes:
- [Crash 1](https://console.firebase.google.com/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/a0a29bf69fbe21450c8b93a43931f146?time=90d&types=crash&sessionEventKey=6A46A9D201B300011DEF2278FB4198BE_2236443423138947080)
- [Crash 2](https://console.firebase.google.com/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/b4fccd14c4005d2afcab1c54b0277c07?time=90d&types=crash&sessionEventKey=6A4608FF003B0001558E1CDFBBBC3AF6_2236353040060775135)

## Safety Assurance

### Safety story

What gives confidence:

- I reproduced both crashes on a physical device (using temporary debug code to force the race timing) and verified the same steps no longer crash with these fixes applied.
- Both changes are narrow guards on existing code paths that only take effect in the raced conditions.

Risks to review:

- Neither flow has automated test coverage; verification was manual.
- When a guard triggers, the tap or callback is dropped silently (no navigation or error UI). The screen is gone or has already navigated in those cases, but it is a behavior change in those races.

[CI-766]: https://dimagi.atlassian.net/browse/CI-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ