### PR TITLE
Audio quality profiles behind an Dev gated App Preference

### DIFF
--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -527,6 +527,16 @@
         <item>Unsent</item>
         <item>Saved</item>
     </string-array>
+    <string-array name="pref_audio_quality_profile_vals">
+        <item>smallest</item>
+        <item>balanced</item>
+        <item>default</item>
+    </string-array>
+    <string-array name="pref_audio_quality_profile_labels">
+        <item>Smallest</item>
+        <item>Balanced</item>
+        <item>System Default</item>
+    </string-array>
     <string-array name="pref_password_show_options">
         <item>always_hidden</item>
         <item>default_show</item>

--- a/app/res/xml/preferences_developer.xml
+++ b/app/res/xml/preferences_developer.xml
@@ -93,6 +93,13 @@
         android:entryValues="@array/pref_load_form_payload_as_vals"
         android:key="cc-form-payload-status"
         android:title="Load form payload status"/>
+    <androidx.preference.ListPreference
+        android:defaultValue="default"
+        android:enabled="true"
+        android:entries="@array/pref_audio_quality_profile_labels"
+        android:entryValues="@array/pref_audio_quality_profile_vals"
+        android:key="cc-audio-quality-profile"
+        android:title="Default Audio Quality"/>
     <org.commcare.preferences.FilePreference
         android:defaultValue=""
         android:enabled="true"

--- a/app/src/org/commcare/preferences/DeveloperPreferences.java
+++ b/app/src/org/commcare/preferences/DeveloperPreferences.java
@@ -49,6 +49,7 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     private static final String HOME_REPORT_ENABLED = "cc-home-report";
     private static final String AUTO_PURGE_ENABLED = "cc-auto-purge";
     private static final String LOAD_FORM_PAYLOAD_AS = "cc-form-payload-status";
+    private static final String AUDIO_QUALITY_PROFILE = "cc-audio-quality-profile";
     private static final String DETAIL_TAB_SWIPE_ACTION_ENABLED = "cc-detail-final-swipe-enabled";
     private static final String USE_ROOT_MENU_AS_HOME_SCREEN = "cc-use-root-menu-as-home-screen";
     private static final String SHOW_ADB_ENTITY_LIST_TRACES = "cc-show-entity-trace-outputs";
@@ -83,6 +84,7 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     static {
         WHITELISTED_DEVELOPER_PREF_KEYS.add(SUPERUSER_ENABLED);
         WHITELISTED_DEVELOPER_PREF_KEYS.add(SHOW_UPDATE_OPTIONS_SETTING);
+        WHITELISTED_DEVELOPER_PREF_KEYS.add(AUDIO_QUALITY_PROFILE);
         WHITELISTED_DEVELOPER_PREF_KEYS.add(AUTO_PURGE_ENABLED);
         WHITELISTED_DEVELOPER_PREF_KEYS.add(ALTERNATE_QUESTION_LAYOUT_ENABLED);
         WHITELISTED_DEVELOPER_PREF_KEYS.add(ENABLE_CERTIFICATE_TRANSPARENCY);
@@ -379,6 +381,15 @@ public class DeveloperPreferences extends CommCarePreferenceFragment {
     public static String formLoadPayloadStatus() {
         SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
         return properties.getString(LOAD_FORM_PAYLOAD_AS, FormRecord.STATUS_SAVED);
+    }
+
+    public static String getAudioQualityProfile() {
+        SharedPreferences properties = CommCareApplication.instance().getCurrentApp().getAppPreferences();
+        String value = properties.getString(AUDIO_QUALITY_PROFILE, PrefValues.AUDIO_QUALITY_DEFAULT);
+        if (PrefValues.AUDIO_QUALITY_DEFAULT.equals(value)) {
+            value = PrefValues.AUDIO_QUALITY_SMALLEST;
+        }
+        return value;
     }
 
     /**

--- a/app/src/org/commcare/preferences/PrefValues.java
+++ b/app/src/org/commcare/preferences/PrefValues.java
@@ -18,6 +18,10 @@ public class PrefValues {
     public final static String NO = "no";
     public final static String NONE = "none";
 
+    public final static String AUDIO_QUALITY_SMALLEST = "smallest";
+    public final static String AUDIO_QUALITY_BALANCED = "balanced";
+    public final static String AUDIO_QUALITY_DEFAULT = "default";
+
     public final static String TRUE = "True";
     public final static String FALSE = "False";
 

--- a/app/src/org/commcare/views/widgets/AudioRecordingHelper.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingHelper.java
@@ -2,26 +2,55 @@ package org.commcare.views.widgets;
 
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
+import android.media.MediaFormat;
 import android.media.MediaRecorder;
 import android.os.Build;
 
+import org.commcare.preferences.DeveloperPreferences;
+import org.commcare.preferences.PrefValues;
 import org.commcare.util.LogTypes;
 import org.javarosa.core.services.Logger;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static android.media.MediaFormat.MIMETYPE_AUDIO_AAC;
 
 public class AudioRecordingHelper {
     private static final int HEAAC_SAMPLE_RATE = 44100;
     private static final int AMRNB_SAMPLE_RATE = 8000;
+    private static final int OPUS_SAMPLE_RATE = 48000;
+    private static final int BALANCED_BIT_RATE = 24000;
 
-    public MediaRecorder setupRecorder(String fileName) {
+    static final class EncoderProfile {
+        final int encoder, samplerate, bitrate, container;
+        public EncoderProfile(int encoder, int samplerate) {
+            this(encoder, samplerate, -1);
+        }
+        public EncoderProfile(int encoder, int samplerate, int bitrate) {
+            this(encoder, samplerate, bitrate, MediaRecorder.OutputFormat.MPEG_4);
+        }
+        public EncoderProfile(int encoder, int samplerate, int bitrate, int container) {
+            this.encoder = encoder;
+            this.samplerate = samplerate;
+            this.bitrate = bitrate;
+            this.container = container;
+        }
+    }
+
+
+    public MediaRecorder setupRecorder(String fileName, String profile) {
         MediaRecorder recorder = new MediaRecorder();
 
-        boolean isHeAacSupported = isHeAacEncoderSupported();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        EncoderProfile encoder = filterBestSupportedEncoder(profile);
+
+        if (PrefValues.AUDIO_QUALITY_SMALLEST.equals(profile) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             recorder.setAudioSource(MediaRecorder.AudioSource.VOICE_COMMUNICATION);
+        } else if (PrefValues.AUDIO_QUALITY_BALANCED.equals(profile)) {
+            recorder.setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION);
         } else {
             recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
         }
@@ -29,21 +58,23 @@ public class AudioRecordingHelper {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             recorder.setPrivacySensitive(true);
         }
-        recorder.setAudioSamplingRate(isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE);
-        recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
-        if (isHeAacSupported) {
-            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.HE_AAC);
-        } else {
-            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
+
+        recorder.setOutputFormat(encoder.container);
+        recorder.setAudioEncoder(encoder.encoder);
+        recorder.setAudioSamplingRate(encoder.samplerate);
+
+        if (encoder.bitrate != -1) {
+            recorder.setAudioEncodingBitRate(encoder.bitrate);
         }
+
         recorder.setOutputFile(fileName);
 
         try {
             recorder.prepare();
             Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Preparing recording: " + fileName
-                    + " | " + (isHeAacSupported ? HEAAC_SAMPLE_RATE : AMRNB_SAMPLE_RATE)
-                    + " | " + (isHeAacSupported ? MediaRecorder.AudioEncoder.HE_AAC :
-                    MediaRecorder.AudioEncoder.AMR_NB));
+                    + " | " + encoder.samplerate
+                    + " | " + encoder.encoder
+                    + " | " + encoder.bitrate);
 
         } catch (IOException e) {
             e.printStackTrace();
@@ -52,7 +83,28 @@ public class AudioRecordingHelper {
     }
 
     // Checks whether the device supports High Efficiency AAC (HE-AAC) audio codec
-    private boolean isHeAacEncoderSupported() {
+    private EncoderProfile filterBestSupportedEncoder(String profileKey) {
+
+        List<EncoderProfile> encoderPreference = new ArrayList<>();
+
+        if (PrefValues.AUDIO_QUALITY_BALANCED.equals(profileKey)) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                encoderPreference.add(new EncoderProfile(MediaRecorder.AudioEncoder.OPUS,
+                        OPUS_SAMPLE_RATE, BALANCED_BIT_RATE, MediaRecorder.OutputFormat.OGG));
+            }
+            encoderPreference.add(new EncoderProfile(MediaRecorder.AudioEncoder.HE_AAC, HEAAC_SAMPLE_RATE, BALANCED_BIT_RATE));
+            encoderPreference.add(new EncoderProfile(MediaRecorder.AudioEncoder.AAC, HEAAC_SAMPLE_RATE, BALANCED_BIT_RATE));
+        } else {
+            encoderPreference.add(new EncoderProfile(MediaRecorder.AudioEncoder.HE_AAC, HEAAC_SAMPLE_RATE));
+            encoderPreference.add(new EncoderProfile(MediaRecorder.AudioEncoder.AMR_NB, AMRNB_SAMPLE_RATE));
+        }
+
+        HashSet<Integer> encoders = new HashSet<>();
+
+        //Always available
+        encoders.add(MediaRecorder.AudioEncoder.AAC);
+        encoders.add(MediaRecorder.AudioEncoder.AMR_NB);
+
         int numCodecs = MediaCodecList.getCodecCount();
 
         for (int i = 0; i < numCodecs; i++) {
@@ -63,6 +115,10 @@ public class AudioRecordingHelper {
             }
 
             for (String supportedType : codecInfo.getSupportedTypes()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+                        supportedType.equalsIgnoreCase(MediaFormat.MIMETYPE_AUDIO_OPUS)) {
+                    encoders.add(MediaRecorder.AudioEncoder.OPUS);
+                }
                 if (supportedType.equalsIgnoreCase(MIMETYPE_AUDIO_AAC)) {
                     MediaCodecInfo.CodecCapabilities cap = codecInfo.getCapabilitiesForType(MIMETYPE_AUDIO_AAC);
                     MediaCodecInfo.CodecProfileLevel[] profileLevels = cap.profileLevels;
@@ -70,13 +126,20 @@ public class AudioRecordingHelper {
                         int profile = profileLevel.profile;
                         if (profile == MediaCodecInfo.CodecProfileLevel.AACObjectHE
                                 || profile == MediaCodecInfo.CodecProfileLevel.AACObjectHE_PS) {
-                            return true;
+                            encoders.add(MediaRecorder.AudioEncoder.HE_AAC);
                         }
                     }
                 }
             }
         }
 
-        return false;
+        //preferences list is in order, pick the first supported one
+        for (EncoderProfile profile : encoderPreference) {
+            if (encoders.contains(profile.encoder)) {
+                return profile;
+            }
+        }
+
+        throw new RuntimeException("No supported audio codecs for recording");
     }
 }

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -19,6 +19,7 @@ import androidx.core.app.NotificationCompat;
 import org.commcare.CommCareNoficationManager;
 import org.commcare.activities.DispatchActivity;
 import org.commcare.dalvik.R;
+import org.commcare.preferences.DeveloperPreferences;
 import org.javarosa.core.services.locale.Localization;
 
 import static org.commcare.utils.NotificationIdentifiers.RECORDING_NOTIFICATION_ID;
@@ -53,7 +54,8 @@ public class AudioRecordingService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         String fileName = intent.getExtras().getString(RECORDING_FILENAME_EXTRA_KEY);
         if (recorder == null) {
-            recorder = audioRecordingHelper.setupRecorder(fileName);
+            recorder = audioRecordingHelper.setupRecorder(fileName,
+                    DeveloperPreferences.getAudioQualityProfile());
         }
         recorder.start();
         return START_NOT_STICKY;

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -37,6 +37,8 @@ import org.commcare.CommCareApplication;
 import org.commcare.CommCareNoficationManager;
 import org.commcare.activities.DispatchActivity;
 import org.commcare.dalvik.R;
+import org.commcare.preferences.DeveloperPreferences;
+import org.commcare.preferences.PrefValues;
 import org.commcare.util.LogTypes;
 import org.commcare.utils.MediaUtil;
 import org.commcare.utils.NotificationUtil;
@@ -69,7 +71,8 @@ public class RecordingFragment extends DialogFragment {
     private static final String MIMETYPE_AUDIO_AAC = "audio/mp4a-latm";
 
     private String fileName;
-    private static final String FILE_EXT = ".mp3";
+    private static final String FILE_EXT_LEGACY = ".mp3";
+    private static final String FILE_EXT_BALANCED = ".m4a";
 
     private LinearLayout layout;
     private ImageButton toggleRecording;
@@ -116,7 +119,13 @@ public class RecordingFragment extends DialogFragment {
     }
 
     private void initAudioFile() {
-        fileName = CommCareApplication.instance().getAndroidFsTemp() + new Date().getTime() + FILE_EXT;
+        String extension;
+        if (DeveloperPreferences.getAudioQualityProfile().equals(PrefValues.AUDIO_QUALITY_BALANCED)) {
+            extension = FILE_EXT_BALANCED;
+        } else {
+            extension = FILE_EXT_LEGACY;
+        }
+        fileName = CommCareApplication.instance().getAndroidFsTemp() + new Date().getTime() + extension;
     }
 
     private void reloadSavedRecording() {


### PR DESCRIPTION
## Product Description
Adds an app-specific preference to control the quality of Audio Recordings in the app, including a new "Balanced" recording profile which decreases voice distortion.

## Technical Summary
[Motivation and change scope / spec](https://docs.google.com/document/d/1dsozUHyEIMFrfg3zXFM6MIAkl-1bp9Y16KkNFSgOATs/edit?tab=t.g3ve57aqbc5o#bookmark=id.jipsfzcxkt0g)

Our previous audio recording configuration was hyper-focused on minimizing file size at the cost of fairly significant distortion of voice waveforms. We want to use those recordings for processing, so this change lets apps pick a recording mode which accepts more background noise and slightly higher file sizes.

New recording settings are gated by the new app preference (`cc-audio-quality-profile` set to `balanced`):
  * Output audio files receive an `m4a` extension (Note: Technically this is not correct for the Opus encoded files, but shifting the extension adds significant complexity, and audio tools are extremely tolerant for containers and encoders). 
  * Sets an explicit 24k bitrate for all modes
  * Shifts to the `VOICE_RECOGNITION` audio source, which maintains voice waveforms more cleanly than the processing heavy `VOICE_COMMUNICATIONS` source.
  * Uses a preference order of encoders: Opus, HE_AAC, then AAC based on availability.

Existing audio recording settings (or apps where the new preference is set to 'default' or 'smallest') will be unaffected by the change.

## Safety Assurance

### Safety story
I confirmed all codepaths by manually testing on a real Android device and simulating the lack of availability of individual codecs or Android versions. 

I confirmed that the existing recording formats aren't affected by the new preference, and remain `.mp3` files with their existing encoding.

This change affects a very limited set of users (people using audio recording) and very limited codepaths, making it appropriate and acceptable for a point release.

In a minor release, we should move the setting to a public one and add this to the HQ available app preferences.

### Automated test coverage
This code is very close to the device, so there is poor existing coverage.

## Labels and Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
