### PR TITLE
Extract ConnectDatabaseSchemaManager And Add Connect DB Test Hook

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -82,7 +82,10 @@ import org.commcare.models.database.IDatabase;
 import org.commcare.models.database.MigrationException;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.app.DatabaseAppOpenHelper;
+import org.commcare.models.database.connect.DatabaseConnectOpenHelper;
 import org.commcare.models.database.global.DatabaseGlobalOpenHelper;
+import org.commcare.models.database.user.UserSandboxUtils;
+import org.commcare.connect.database.ConnectDatabaseUtils;
 import org.commcare.models.database.user.DatabaseUserOpenHelper;
 import org.commcare.models.database.user.models.CommCareEntityStorageCache;
 import org.commcare.models.legacy.LegacyInstallUtils;
@@ -1243,6 +1246,15 @@ public class CommCareApplication extends Application implements LifecycleEventOb
                 Logger.log(LogTypes.TYPE_MAINTENANCE, "CommCare has been closed");
                 break;
         }
+    }
+
+    public IDatabase getConnectDbOpenHelper(Context context) {
+        byte[] passphrase = ConnectDatabaseUtils.getConnectDbPassphrase(context);
+        if (passphrase == null || passphrase.length == 0) {
+            throw new IllegalStateException("Attempting to access Connect DB without a passphrase");
+        }
+        return new EncryptedDatabaseAdapter(new DatabaseConnectOpenHelper(
+                context, UserSandboxUtils.getSqlCipherEncodedKey(passphrase)));
     }
 
     public IDatabase getGlobalDbOpenHelper() {

--- a/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
@@ -8,12 +8,11 @@ import org.commcare.android.database.global.models.GlobalErrorRecord;
 import org.commcare.connect.PersonalIdManager;
 import org.commcare.connect.network.SsoToken;
 import org.commcare.google.services.analytics.AnalyticsParamValue;
+import org.commcare.CommCareApplication;
 import org.commcare.models.database.AndroidDbHelper;
-import org.commcare.models.database.EncryptedDatabaseAdapter;
 import org.commcare.models.database.IDatabase;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.connect.DatabaseConnectOpenHelper;
-import org.commcare.models.database.user.UserSandboxUtils;
 import org.commcare.modern.database.Table;
 import org.commcare.utils.GlobalErrorUtil;
 import org.commcare.utils.GlobalErrors;
@@ -52,13 +51,7 @@ public class ConnectDatabaseHelper {
                 synchronized (connectDbHandleLock) {
                     if (connectDatabase == null || !connectDatabase.isOpen()) {
                         try {
-                            byte[] passphrase = ConnectDatabaseUtils.getConnectDbPassphrase(context);
-                            if (passphrase == null || passphrase.length == 0) {
-                                throw new IllegalStateException("Attempting to access Connect DB without a passphrase");
-                            }
-
-                            connectDatabase = new EncryptedDatabaseAdapter(new DatabaseConnectOpenHelper(
-                                    this.c, UserSandboxUtils.getSqlCipherEncodedKey(passphrase)));
+                            connectDatabase = CommCareApplication.instance().getConnectDbOpenHelper(context);
                         } catch (Exception e) {
                             //Flag the DB as broken if we hit an error opening it (usually means corrupted or bad encryption)
                             dbBroken = true;

--- a/app/src/org/commcare/models/database/connect/ConnectDatabaseSchemaManager.kt
+++ b/app/src/org/commcare/models/database/connect/ConnectDatabaseSchemaManager.kt
@@ -1,0 +1,86 @@
+package org.commcare.models.database.connect
+
+import org.commcare.android.database.connect.models.ConnectAppRecord
+import org.commcare.android.database.connect.models.ConnectJobAssessmentRecord
+import org.commcare.android.database.connect.models.ConnectJobDeliveryFlagRecord
+import org.commcare.android.database.connect.models.ConnectJobDeliveryRecord
+import org.commcare.android.database.connect.models.ConnectJobLearningRecord
+import org.commcare.android.database.connect.models.ConnectJobPaymentRecord
+import org.commcare.android.database.connect.models.ConnectJobRecord
+import org.commcare.android.database.connect.models.ConnectLearnModuleSummaryRecord
+import org.commcare.android.database.connect.models.ConnectLinkedAppRecord
+import org.commcare.android.database.connect.models.ConnectMessagingChannelRecord
+import org.commcare.android.database.connect.models.ConnectMessagingMessageRecord
+import org.commcare.android.database.connect.models.ConnectPaymentUnitRecord
+import org.commcare.android.database.connect.models.ConnectReleaseToggleRecord
+import org.commcare.android.database.connect.models.ConnectUserRecord
+import org.commcare.android.database.connect.models.PersonalIdWorkHistory
+import org.commcare.android.database.connect.models.PushNotificationRecord
+import org.commcare.models.database.DbUtil
+import org.commcare.models.database.IDatabase
+import org.commcare.modern.database.TableBuilder
+
+object ConnectDatabaseSchemaManager {
+    const val DB_NAME = "database_connect"
+
+    /**
+     * V.2  - Added ConnectJobRecord, ConnectAppInfo, and ConnectLearningModuleInfo tables
+     * V.3  - Added date_claimed to ConnectJobRecord; reason to ConnectJobDeliveryRecord
+     * V.4  - Added confirmed/confirmedDate to ConnectJobPaymentRecord; link offer info to ConnectLinkedAppRecord
+     * V.5  - Added projectStartDate and isActive to ConnectJobRecord
+     * V.6  - Added pin, secondaryPhoneVerified, and registrationDate to ConnectUserRecord
+     * V.7  - Added ConnectPaymentUnitRecord table
+     * V.8  - Added is_user_suspended to ConnectJobRecord
+     * V.9  - Added using_local_passphrase to ConnectLinkedAppRecord
+     * V.10 - Added last_accessed to ConnectLinkedAppRecord
+     * V.11 - Added daily start and finish times to ConnectJobRecord
+     * V.12 - Added ConnectMessagingChannelRecord and ConnectMessagingMessageRecord tables
+     * V.13 - Added ConnectJobDeliveryFlagRecord table
+     * V.14 - Added photo and isDemo to ConnectUserRecord
+     * V.16 - Added personal_id_credential table
+     * V.17 - Added has_connect_access to ConnectUserRecord
+     * V.18 - Added new columns to personal_id_credential table
+     * V.19 - Added push_notification_history table
+     * V.20 - Added acknowledged to push_notification_history
+     * V.21 - Added ConnectReleaseToggleRecord table
+     * V.22 - Added UUID field to ConnectAppRecord, ConnectLearnModuleSummaryRecord,
+     *         ConnectJobLearningRecord, ConnectJobDeliveryRecord, ConnectJobAssessmentRecord,
+     *         ConnectPaymentUnitRecord, ConnectJobRecord, ConnectJobPaymentRecord, PushNotificationRecord
+     * V.23 - Added slugUUID to ConnectJobDeliveryRecord
+     * V.24 - Added key and opportunityStatus to PushNotificationRecord
+     * V.25 - Added sessionEndpointId and requireAppSync to PushNotificationRecord
+     * V.26 - Added email to ConnectUserRecord
+     */
+    const val DB_VERSION_CONNECT = 26
+
+    @JvmStatic
+    fun initializeSchema(database: IDatabase) {
+        database.beginTransaction()
+        try {
+            database.execSQL(TableBuilder(ConnectUserRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectLinkedAppRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectJobRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectAppRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectLearnModuleSummaryRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectJobLearningRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectJobAssessmentRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectJobDeliveryRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectJobPaymentRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectPaymentUnitRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectMessagingChannelRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectMessagingMessageRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(ConnectJobDeliveryFlagRecord::class.java).tableCreateString)
+            database.execSQL(TableBuilder(PersonalIdWorkHistory::class.java).tableCreateString)
+            database.execSQL(TableBuilder(PushNotificationRecord::class.java).tableCreateString)
+            database.execSQL(
+                TableBuilder(ConnectReleaseToggleRecord::class.java)
+                    .apply { setUnique(ConnectReleaseToggleRecord.META_SLUG) }
+                    .tableCreateString,
+            )
+            DbUtil.createNumbersTable(database)
+            database.setTransactionSuccessful()
+        } finally {
+            database.endTransaction()
+        }
+    }
+}

--- a/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
+++ b/app/src/org/commcare/models/database/connect/DatabaseConnectOpenHelper.java
@@ -7,32 +7,17 @@ import net.zetetic.database.sqlcipher.SQLiteDatabase;
 import net.zetetic.database.sqlcipher.SQLiteOpenHelper;
 
 import org.commcare.CommCareApplication;
-import org.commcare.android.database.connect.models.ConnectAppRecord;
-import org.commcare.android.database.connect.models.ConnectJobAssessmentRecord;
-import org.commcare.android.database.connect.models.ConnectJobDeliveryFlagRecord;
-import org.commcare.android.database.connect.models.ConnectJobDeliveryRecord;
-import org.commcare.android.database.connect.models.ConnectJobLearningRecord;
-import org.commcare.android.database.connect.models.ConnectJobPaymentRecord;
-import org.commcare.android.database.connect.models.ConnectJobRecord;
-import org.commcare.android.database.connect.models.ConnectLearnModuleSummaryRecord;
-import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
-import org.commcare.android.database.connect.models.ConnectMessagingChannelRecord;
-import org.commcare.android.database.connect.models.ConnectMessagingMessageRecord;
-import org.commcare.android.database.connect.models.ConnectPaymentUnitRecord;
-import org.commcare.android.database.connect.models.ConnectReleaseToggleRecord;
-import org.commcare.android.database.connect.models.ConnectUserRecord;
-import org.commcare.android.database.connect.models.PersonalIdWorkHistory;
-import org.commcare.android.database.connect.models.PushNotificationRecord;
 import org.commcare.logging.DataChangeLog;
 import org.commcare.logging.DataChangeLogger;
 import org.commcare.models.database.DbUtil;
 import org.commcare.models.database.EncryptedDatabaseAdapter;
-import org.commcare.models.database.IDatabase;
-import org.commcare.modern.database.TableBuilder;
 import org.commcare.utils.CrashUtil;
 import org.javarosa.core.services.Logger;
 
 import java.io.File;
+
+import static org.commcare.models.database.connect.ConnectDatabaseSchemaManager.DB_NAME;
+import static org.commcare.models.database.connect.ConnectDatabaseSchemaManager.DB_VERSION_CONNECT;
 
 /**
  * The helper for opening/updating the Connect (encrypted) db space for CommCare.
@@ -40,50 +25,18 @@ import java.io.File;
  * @author dviggiano
  */
 public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
-    /**
-     * V.2 - Added ConnectJobRecord, ConnectAppInfo, and ConnectLearningModuleInfo tables
-     * V.3 - Added date_claimed column to ConnectJobRecord,
-     *          and reason column to ConnectJobDeliveryRecord
-     * V.4 - Added confirmed and confirmedDate fields to ConnectJobPaymentRecord
-     *          Added link offer info to ConnectLinkedAppRecord
-     * V.5 - Added projectStartDate and isActive to ConnectJobRecord
-     * V.6 - Added pin,secondaryPhoneVerified, and registrationDate fields to ConnectUserRecord
-     * V.7 - Added ConnectPaymentUnitRecord table
-     * V.8 - Added is_user_suspended to ConnectJobRecord
-     * V.9 - Added using_local_passphrase to ConnectLinkedAppRecord
-     * V.10 - Added last_accessed column to ConnectLinkedAppRecord
-     * V.11 - Added daily start and finish times to ConnectJobRecord
-     * V.12 - Added ConnectMessagingChannelRecord table and ConnectMessagingMessageRecord table
-     * V.13 - Added ConnectJobDeliveryFlagRecord table
-     * V.14 - Added a photo and isDemo field to ConnectUserRecord
-     * V.16 - Added  personal_id_credential table
-     * V.17 - Added a new column has_connect_access to ConnectUserRecord
-     * V.18 - Added new columns to personal_id_credential table (previously the table was unused)
-     * V.19 - Added push_notification_history
-     * V.20 - Added acknowledged column in push_notification_history
-     * V.21 - Added ConnectReleaseToggleRecord table
-     * V.22 - Added a new field UUID for ConnectAppRecord, ConnectLearnModuleSummaryRecord, ConnectJobLearningRecord, ConnectJobDeliveryRecord
-     *          ConnectJobAssessmentRecord, ConnectPaymentUnitRecord, ConnectJobRecord, ConnectJobPaymentRecord and PushNotificationRecord
-     * V.23 - Added a field slugUUID (reference to payment unit uuid) in ConnectJobDeliveryRecord
-     * V.24 - Added key (kind of action for ccc_generic_opportunity) and opportunityStatus (values will be learn/delivery)) in PushNotificationRecord record
-     * V.25 - Added sessionEndpointId and requireAppSync in PushNotificationRecord
-     * V.26 - Added email column to ConnectUserRecord
-     */
-    private static final int CONNECT_DB_VERSION = 26;
-
-    private static final String CONNECT_DB_LOCATOR = "database_connect";
 
     private final Context mContext;
     private final String key;
 
     public DatabaseConnectOpenHelper(Context context, String key) {
-        super(context, CONNECT_DB_LOCATOR, key, null, CONNECT_DB_VERSION, 0, null, null, false);
+        super(context, DB_NAME, key, null, DB_VERSION_CONNECT, 0, null, null, false);
         this.mContext = context;
         this.key = key;
     }
 
     private static File getDbFile() {
-        return CommCareApplication.instance().getDatabasePath(CONNECT_DB_LOCATOR);
+        return CommCareApplication.instance().getDatabasePath(DB_NAME);
     }
 
     public static boolean dbExists() {
@@ -96,66 +49,7 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase db) {
-        IDatabase database = new EncryptedDatabaseAdapter(db);
-        database.beginTransaction();
-        try {
-            TableBuilder builder = new TableBuilder(ConnectUserRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectLinkedAppRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectJobRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectAppRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectLearnModuleSummaryRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectJobLearningRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectJobAssessmentRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectJobDeliveryRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectJobPaymentRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectPaymentUnitRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectMessagingChannelRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectMessagingMessageRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectJobDeliveryFlagRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(PersonalIdWorkHistory.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(PushNotificationRecord.class);
-            database.execSQL(builder.getTableCreateString());
-
-            builder = new TableBuilder(ConnectReleaseToggleRecord.class);
-            builder.setUnique(ConnectReleaseToggleRecord.META_SLUG);
-            database.execSQL(builder.getTableCreateString());
-
-            DbUtil.createNumbersTable(database);
-
-            database.setVersion(CONNECT_DB_VERSION);
-
-            database.setTransactionSuccessful();
-        } finally {
-            database.endTransaction();
-        }
+        ConnectDatabaseSchemaManager.initializeSchema(new EncryptedDatabaseAdapter(db));
     }
 
     @Override
@@ -164,11 +58,10 @@ public class DatabaseConnectOpenHelper extends SQLiteOpenHelper {
             return super.getWritableDatabase();
         } catch (SQLiteException sqle) {
             Logger.exception("Opening database failed", sqle);
-            DbUtil.trySqlCipherDbUpdate(key, mContext, CONNECT_DB_LOCATOR);
+            DbUtil.trySqlCipherDbUpdate(key, mContext, DB_NAME);
             try {
                 return super.getWritableDatabase();
             } catch (SQLiteException e) {
-                // Handle the exception, log the error, or inform the user
                 CrashUtil.log(e.getMessage());
                 throw e;
             }

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -27,6 +27,7 @@ import org.commcare.models.database.HybridFileBackedSqlStorage;
 import org.commcare.models.database.HybridFileBackedSqlStorageMock;
 import org.commcare.models.database.UnencryptedDatabaseAdapter;
 import org.commcare.models.database.app.DatabaseAppOpenHelperMock;
+import org.commcare.models.database.connect.DatabaseConnectOpenHelperMock;
 import org.commcare.models.database.global.DatabaseGlobalOpenHelperMock;
 import org.commcare.models.database.user.DatabaseUserOpenHelperMock;
 import org.commcare.models.encryption.ByteEncrypter;
@@ -338,6 +339,11 @@ public class CommCareTestApplication extends CommCareApplication implements Test
 
     public void setSkipWorkManager() {
         skipWorkManager = true;
+    }
+
+    @Override
+    public IDatabase getConnectDbOpenHelper(Context context) {
+        return new UnencryptedDatabaseAdapter(new DatabaseConnectOpenHelperMock(this));
     }
 
     @Override

--- a/app/unit-tests/src/org/commcare/models/database/connect/DatabaseConnectOpenHelperMock.kt
+++ b/app/unit-tests/src/org/commcare/models/database/connect/DatabaseConnectOpenHelperMock.kt
@@ -1,0 +1,20 @@
+package org.commcare.models.database.connect
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import org.commcare.models.database.UnencryptedDatabaseAdapter
+
+class DatabaseConnectOpenHelperMock(
+    context: Context,
+) : SQLiteOpenHelper(context, null, null, ConnectDatabaseSchemaManager.DB_VERSION_CONNECT) {
+    override fun onCreate(db: SQLiteDatabase) {
+        ConnectDatabaseSchemaManager.initializeSchema(UnencryptedDatabaseAdapter(db))
+    }
+
+    override fun onUpgrade(
+        db: SQLiteDatabase,
+        oldVersion: Int,
+        newVersion: Int,
+    ): Unit = throw UnsupportedOperationException("DatabaseConnectOpenHelperMock does not support onUpgrade")
+}


### PR DESCRIPTION
## Product Description

No user-visible changes. This is a pure internal infrastructure refactor. 

## Technical Summary

Mirrors the pattern used by `AppDatabaseSchemaManager` / `DatabaseGlobalOpenHelper` for the Connect DB. 

This became a blocker for the [other PR ](https://github.com/dimagi/commcare-android/pull/3785) I am working on, as [most tests started failing](https://github.com/dimagi/commcare-android/actions/runs/28661027509/job/85001397602?pr=3785) when trying to access the `getConnectStorage" method as a result of new task parsing code. The 2 approaches I had to resolve it is to mock the DB for every test or to provide a test app wide mock. I chose the later and it also helps ConnectDB aligns better with the pattern we follow for other databases in the app. This will also remove any need of mocking the DB in unit tests getting us closer to more integrated testing. 

## Safety Assurance

### Safety story

**What gives confidence:**

- Correctness relies entirely on the refactor being a structural rename with no logic changes
- I would imagine the set of unit tests plus integrations tests is siffucient to flag any issues caused by the refactor here. 
- Verified basic functionality like Personal ID signup and Opportunity screens locally

### Automated test coverage

`CommCareTestApplication.getConnectDbOpenHelper` is exercised by any Robolectric test that opens the Connect DB. The schema manager is validated indirectly by those tests succeeding against the in-memory DB.


Review 🐟  by 🐟 