### PR TITLE
CCCT-2476 Log Manage Profile Actions To Firebase

### DIFF
--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -171,6 +171,11 @@ public class AnalyticsParamValue {
             "user_initiated_from_profile_page";
     public static final String PERSONAL_ID_FORGOT_USER_DB_ERROR = "global_connect_error";
 
+    // Param values for Manage Profile actions
+    public static final String MANAGE_PROFILE_ACTION_PHOTO_UPDATED = "photo_updated";
+    public static final String MANAGE_PROFILE_ACTION_NAME_UPDATED = "name_updated";
+    public static final String MANAGE_PROFILE_ACTION_CHANGES_DISCARDED = "changes_discarded";
+
     // Param values for PersonalID configuration failure
     public static final String START_CONFIGURATION_INTEGRITY_CHECK_FAILURE =
             "start_configuration_integrity_check_failure";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -34,6 +34,7 @@ public class CCAnalyticsEvent {
     static final String PERSONAL_ID_ACCOUNT_RECOVERED = "personalid_account_recovered";
     static final String PERSONAL_ID_ACCOUNT_FORGOTTEN = "personalid_account_forgotten";
     static final String PERSONAL_ID_INTEGRITY_REPORTED = "personalid_integrity_reported";
+    static final String PERSONAL_ID_MANAGE_PROFILE_ACTION = "personalid_manage_profile_action";
     static final String CCC_TAB_CHANGE = "ccc_tab_change";
     static final String CCC_LAUNCH_APP = "ccc_launch_app";
     static final String CCC_AUTO_LOGIN_FAILED = "ccc_auto_login_failed";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
@@ -54,6 +54,8 @@ public class CCAnalyticsParam {
     static final String CCC_MESSAGING_CONSENT_API_RESULT = "consent_api_success";
     static final String CCC_MESSAGING_DESIRED_CONSENT_STATUS = "consent_api_desired_consent_status";
 
+    static final String MANAGE_PROFILE_ACTION = "manage_profile_action";
+
     // Param keys for OTP analytics
     public static final String OTP_OUTCOME = "outcome";
     public static final String OTP_EVENT_TYPE = "event_type";

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -671,6 +671,14 @@ public class FirebaseAnalyticsUtil {
         reportEvent(CCAnalyticsEvent.PERSONAL_ID_ACCOUNT_FORGOTTEN, b);
     }
 
+    public static void reportPersonalIdProfileAction(String action) {
+        reportEvent(
+                CCAnalyticsEvent.PERSONAL_ID_MANAGE_PROFILE_ACTION,
+                CCAnalyticsParam.MANAGE_PROFILE_ACTION,
+                action
+        );
+    }
+
     public static void reportLoginClicks() {
         reportEvent(CCAnalyticsEvent.LOGIN_CLICK);
     }

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileEditFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileEditFragment.kt
@@ -16,6 +16,8 @@ import org.commcare.dalvik.R
 import org.commcare.dalvik.databinding.PersonalidProfileEditScreenBinding
 import org.commcare.fragments.personalId.EmailHelper
 import org.commcare.fragments.personalId.EmailWorkFlow
+import org.commcare.google.services.analytics.AnalyticsParamValue
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.personalId.photo.PersonalIdPhotoUpdater
 import org.commcare.views.extensions.onTextChanged
 
@@ -35,6 +37,9 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
                 onSuccess = { photoBase64 ->
                     viewModel.onPhotoUpdated(photoBase64)
                     _binding?.let { loadUserPhoto(it.profileHeader.profileUserImage, photoBase64) }
+                    FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                        AnalyticsParamValue.MANAGE_PROFILE_ACTION_PHOTO_UPDATED,
+                    )
                 },
                 onFailure = { _, _ ->
                     // No-op for the Profile screen. The app sidebar shows a warning icon in the other flow.
@@ -109,6 +114,9 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
             positiveText = getString(R.string.personalid_profile_edit_discard_positive),
             negativeText = getString(R.string.personalid_profile_edit_discard_negative),
         ) {
+            FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                AnalyticsParamValue.MANAGE_PROFILE_ACTION_CHANGES_DISCARDED,
+            )
             findNavController().popBackStack()
         }
     }
@@ -141,6 +149,7 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
         val user = viewModel.user
         object : PersonalIdApiHandler<Boolean>() {
             override fun onSuccess(success: Boolean) {
+                reportSavedProfileDetails()
                 viewModel.commitProfileDetails()
                 _binding ?: return
                 onSaved()
@@ -154,6 +163,14 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
                 onSaveFailed(errorCode, t)
             }
         }.updateProfile(requireActivity(), user.userId, user.password, viewModel.currentName, null, null)
+    }
+
+    private fun reportSavedProfileDetails() {
+        if (viewModel.isNameModified()) {
+            FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED,
+            )
+        }
     }
 
     private fun showEmailOtpConfirmationDialog() {

--- a/app/unit-tests/src/org/commcare/personalId/profile/BasePersonalIdProfileTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/BasePersonalIdProfileTest.kt
@@ -1,13 +1,16 @@
 package org.commcare.personalId.profile
 
+import android.os.Bundle
 import android.widget.TextView
 import androidx.annotation.IdRes
 import androidx.navigation.NavController
+import androidx.navigation.NavDestination
 import androidx.navigation.fragment.NavHostFragment
 import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.connect.network.PersonalIdMockApiServer
 import org.commcare.dalvik.R
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.junit.After
 import org.junit.Before
 import org.mockito.MockedStatic
@@ -29,6 +32,7 @@ abstract class BasePersonalIdProfileTest {
     protected lateinit var navController: NavController
 
     protected lateinit var connectUserDatabaseUtilMock: MockedStatic<ConnectUserDatabaseUtil>
+    protected lateinit var firebaseAnalyticsUtilMock: MockedStatic<FirebaseAnalyticsUtil>
 
     protected val mockApiServer = PersonalIdMockApiServer(PersonalIdMockApiServer.CallbackMode.MAIN_LOOPER)
     protected val mockWebServer get() = mockApiServer.server
@@ -56,6 +60,13 @@ abstract class BasePersonalIdProfileTest {
         connectUserDatabaseUtilMock
             .`when`<ConnectUserRecord> { ConnectUserDatabaseUtil.getUser(any()) }
             .thenReturn(user)
+        firebaseAnalyticsUtilMock = Mockito.mockStatic(FirebaseAnalyticsUtil::class.java)
+        firebaseAnalyticsUtilMock
+            .`when`<NavController.OnDestinationChangedListener> {
+                FirebaseAnalyticsUtil.getNavControllerPageChangeLoggingListener()
+            }.thenReturn(
+                NavController.OnDestinationChangedListener { _: NavController, _: NavDestination, _: Bundle? -> },
+            )
         mockApiServer.start()
         launchProfileActivity()
     }
@@ -64,6 +75,7 @@ abstract class BasePersonalIdProfileTest {
     fun tearDown() {
         activityController.pause().stop().destroy()
         connectUserDatabaseUtilMock.close()
+        firebaseAnalyticsUtilMock.close()
         mockApiServer.shutdown()
     }
 

--- a/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
@@ -11,6 +11,8 @@ import okhttp3.mockwebserver.MockResponse
 import org.commcare.CommCareTestApplication
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
+import org.commcare.google.services.analytics.AnalyticsParamValue
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.PhoneNumberHelper
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -21,6 +23,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowDialog
 
@@ -157,6 +160,11 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
         connectUserDatabaseUtilMock.verify {
             ConnectUserDatabaseUtil.storeUser(any(), any())
         }
+        firebaseAnalyticsUtilMock.verify {
+            FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED,
+            )
+        }
         assertEquals(
             "Should pop back to the profile screen after a successful save",
             R.id.personalid_profile_fragment,
@@ -202,6 +210,10 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
 
         val request = mockApiServer.takeRequestOrFail()
         assertEquals("/users/send_email_otp", request.path)
+        firebaseAnalyticsUtilMock.verify(
+            { FirebaseAnalyticsUtil.reportPersonalIdProfileAction(AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED) },
+            never(),
+        )
     }
 
     @Test
@@ -227,5 +239,37 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
 
         val otpRequest = mockApiServer.takeRequestOrFail()
         assertEquals("/users/send_email_otp", otpRequest.path)
+    }
+
+    // ========== Discard flow ==========
+
+    @Test
+    fun `confirming the discard dialog reports the discard action and pops back`() {
+        setText(nameField(), "Grace Hopper")
+
+        onUiThread { fragment.requireView().findViewById<Button>(R.id.btn_cancel).performClick() }
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        val confirmButton = dialog.findViewById<Button>(R.id.positive_button)!!
+        onUiThread { confirmButton.performClick() }
+
+        firebaseAnalyticsUtilMock.verify {
+            FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                AnalyticsParamValue.MANAGE_PROFILE_ACTION_CHANGES_DISCARDED,
+            )
+        }
+        assertEquals(
+            "Should pop back to the profile screen after discarding changes",
+            R.id.personalid_profile_fragment,
+            currentDestinationId(),
+        )
+
+        val profileFragment = navHostFragment.childFragmentManager.primaryNavigationFragment!!
+        val displayedName = profileFragment.requireView().findViewById<TextView>(R.id.profile_value_name)
+        assertEquals(
+            "The profile screen should still show the original name after discarding",
+            "Ada Lovelace",
+            displayedName.text.toString(),
+        )
     }
 }


### PR DESCRIPTION
### [CCCT-2476](https://dimagi.atlassian.net/browse/CCCT-2476)

## Technical Summary

Adds a single `personal_id_manage_profile_action` Firebase event for the Manage Profile screens, carrying a `manage_profile_action` parameter that distinguishes the actions (`photo_updated`, `name_updated`, `changes_discarded`) instead of one event per action. It is emitted through a new `FirebaseAnalyticsUtil.reportPersonalIdProfileAction` helper following the existing event/param/value convention. Screen opens and email verification are deliberately excluded — they are already captured by the auto `SCREEN_VIEW` and `OTP_REQUESTED` events, so re-logging them here would double-count.

## Safety Assurance

### Safety story

What gives confidence:
- I ran the change on my test device and used a debug breakpoint to confirm each meaningful Manage Profile action is logged to Firebase, and that the existing screen-open and email-verification events still fire.
- Narrow scope: the change only adds analytics reporting; profile save, photo update, and discard behavior are untouched.

Risks to review:
- `name_updated` is reported only when the name actually changed, and the report call runs immediately before the ViewModel commit that resets the modified check. This ordering is a positional dependency, mitigated by the successful-save test that would fail if the two were reordered.

### Automated test coverage

`PersonalIdProfileEditFragmentTest` asserts `name_updated` fires on a successful name save and `changes_discarded` on discard, and asserts `name_updated` is *not* reported on an email-only save; `BasePersonalIdProfileTest` was extended to mock `FirebaseAnalyticsUtil`. The `photo_updated` path is verified by manual on-device testing rather than a unit test, since its camera-result flow isn't reachable in the Robolectric harness.

[CCCT-2476]: https://dimagi.atlassian.net/browse/CCCT-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ