### PR TITLE
CCCT-2476 Log Manage Profile Actions To Firebase

### DIFF
--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -233,9 +233,12 @@ public class AnalyticsParamValue {
     public static final String USER_PROMPT_ACTION_SKIP = "skip";
     public static final String USER_PROMPT_ACTION_RETRY = "retry";
     public static final String USER_PROMPT_ACTION_PROCEED_WITHOUT_EMAIL = "proceed_without_email";
+    public static final String USER_PROMPT_ACTION_CANCEL = "cancel";
     public static final String USER_PROMPT_INFO_EXISTING_USER_REMINDER = "existing_user_reminder";
     public static final String USER_PROMPT_INFO_EMAIL_VERIFICATION_FAILURE_RETRY =
             "email_verification_failure_retry";
+    public static final String USER_PROMPT_INFO_MANAGE_PROFILE_EMAIL_UPDATE =
+            "manage_profile_email_update";
 
     // Param values for SMS invite link analytics
     public static final String OPP_INVITE_LINK = "opp_invite_link";

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -171,6 +171,11 @@ public class AnalyticsParamValue {
             "user_initiated_from_profile_page";
     public static final String PERSONAL_ID_FORGOT_USER_DB_ERROR = "global_connect_error";
 
+    // Param values for Manage Profile actions
+    public static final String MANAGE_PROFILE_ACTION_PHOTO_UPDATED = "photo_updated";
+    public static final String MANAGE_PROFILE_ACTION_NAME_UPDATED = "name_updated";
+    public static final String MANAGE_PROFILE_ACTION_CHANGES_DISCARDED = "changes_discarded";
+
     // Param values for PersonalID configuration failure
     public static final String START_CONFIGURATION_INTEGRITY_CHECK_FAILURE =
             "start_configuration_integrity_check_failure";

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -175,6 +175,7 @@ public class AnalyticsParamValue {
     public static final String MANAGE_PROFILE_ACTION_PHOTO_UPDATED = "photo_updated";
     public static final String MANAGE_PROFILE_ACTION_NAME_UPDATED = "name_updated";
     public static final String MANAGE_PROFILE_ACTION_CHANGES_DISCARDED = "changes_discarded";
+    public static final String MANAGE_PROFILE_ACTION_EMAIL_UPDATE_INITIATED = "email_update_initiated";
     public static final String MANAGE_PROFILE_OUTCOME_SUCCESS = "success";
     public static final String MANAGE_PROFILE_OUTCOME_FAILURE = "failure";
 

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -175,6 +175,8 @@ public class AnalyticsParamValue {
     public static final String MANAGE_PROFILE_ACTION_PHOTO_UPDATED = "photo_updated";
     public static final String MANAGE_PROFILE_ACTION_NAME_UPDATED = "name_updated";
     public static final String MANAGE_PROFILE_ACTION_CHANGES_DISCARDED = "changes_discarded";
+    public static final String MANAGE_PROFILE_OUTCOME_SUCCESS = "success";
+    public static final String MANAGE_PROFILE_OUTCOME_FAILURE = "failure";
 
     // Param values for PersonalID configuration failure
     public static final String START_CONFIGURATION_INTEGRITY_CHECK_FAILURE =

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsEvent.java
@@ -34,6 +34,7 @@ public class CCAnalyticsEvent {
     static final String PERSONAL_ID_ACCOUNT_RECOVERED = "personalid_account_recovered";
     static final String PERSONAL_ID_ACCOUNT_FORGOTTEN = "personalid_account_forgotten";
     static final String PERSONAL_ID_INTEGRITY_REPORTED = "personalid_integrity_reported";
+    static final String PERSONAL_ID_MANAGE_PROFILE_ACTION = "personalid_manage_profile_action";
     static final String CCC_TAB_CHANGE = "ccc_tab_change";
     static final String CCC_LAUNCH_APP = "ccc_launch_app";
     static final String CCC_AUTO_LOGIN_FAILED = "ccc_auto_login_failed";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
@@ -55,6 +55,7 @@ public class CCAnalyticsParam {
     static final String CCC_MESSAGING_DESIRED_CONSENT_STATUS = "consent_api_desired_consent_status";
 
     static final String MANAGE_PROFILE_ACTION = "manage_profile_action";
+    static final String MANAGE_PROFILE_OUTCOME = "outcome";
 
     // Param keys for OTP analytics
     public static final String OTP_OUTCOME = "outcome";

--- a/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
+++ b/app/src/org/commcare/google/services/analytics/CCAnalyticsParam.java
@@ -54,6 +54,8 @@ public class CCAnalyticsParam {
     static final String CCC_MESSAGING_CONSENT_API_RESULT = "consent_api_success";
     static final String CCC_MESSAGING_DESIRED_CONSENT_STATUS = "consent_api_desired_consent_status";
 
+    static final String MANAGE_PROFILE_ACTION = "manage_profile_action";
+
     // Param keys for OTP analytics
     public static final String OTP_OUTCOME = "outcome";
     public static final String OTP_EVENT_TYPE = "event_type";

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -671,6 +671,14 @@ public class FirebaseAnalyticsUtil {
         reportEvent(CCAnalyticsEvent.PERSONAL_ID_ACCOUNT_FORGOTTEN, b);
     }
 
+    public static void reportPersonalIdProfileAction(String action) {
+        reportEvent(
+                CCAnalyticsEvent.PERSONAL_ID_MANAGE_PROFILE_ACTION,
+                CCAnalyticsParam.MANAGE_PROFILE_ACTION,
+                action
+        );
+    }
+
     public static void reportLoginClicks() {
         reportEvent(CCAnalyticsEvent.LOGIN_CLICK);
     }

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -671,12 +671,13 @@ public class FirebaseAnalyticsUtil {
         reportEvent(CCAnalyticsEvent.PERSONAL_ID_ACCOUNT_FORGOTTEN, b);
     }
 
-    public static void reportPersonalIdProfileAction(String action) {
-        reportEvent(
-                CCAnalyticsEvent.PERSONAL_ID_MANAGE_PROFILE_ACTION,
-                CCAnalyticsParam.MANAGE_PROFILE_ACTION,
-                action
-        );
+    public static void reportPersonalIdProfileAction(String action, @Nullable String outcome) {
+        Bundle params = new Bundle();
+        params.putString(CCAnalyticsParam.MANAGE_PROFILE_ACTION, action);
+        if (outcome != null) {
+            params.putString(CCAnalyticsParam.MANAGE_PROFILE_OUTCOME, outcome);
+        }
+        reportEvent(CCAnalyticsEvent.PERSONAL_ID_MANAGE_PROFILE_ACTION, params);
     }
 
     public static void reportLoginClicks() {

--- a/app/src/org/commcare/personalId/profile/BasePersonalIdProfileFragment.kt
+++ b/app/src/org/commcare/personalId/profile/BasePersonalIdProfileFragment.kt
@@ -40,6 +40,7 @@ abstract class BasePersonalIdProfileFragment : Fragment() {
         message: String,
         positiveText: String,
         negativeText: String,
+        onNegative: (() -> Unit)? = null,
         onPositive: () -> Unit,
     ) {
         val dialog = StandardAlertDialog(title, message)
@@ -49,6 +50,7 @@ abstract class BasePersonalIdProfileFragment : Fragment() {
         }
         dialog.setNegativeButton(negativeText) { dialogInterface, _ ->
             dialogInterface.dismiss()
+            onNegative?.invoke()
         }
         dialog.makeCancelable()
         dialog.showNonPersistentDialog(requireActivity())

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileEditFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileEditFragment.kt
@@ -206,6 +206,10 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
             sessionData = null,
             tracker = viewModel.emailOtpTracker,
             onSuccess = {
+                FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                    AnalyticsParamValue.MANAGE_PROFILE_ACTION_EMAIL_UPDATE_INITIATED,
+                    AnalyticsParamValue.MANAGE_PROFILE_OUTCOME_SUCCESS,
+                )
                 _binding ?: return@sendEmailOtp
                 findNavController().navigate(
                     PersonalIdProfileEditFragmentDirections.actionProfileEditToEmailVerification(
@@ -216,6 +220,10 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
                 )
             },
             onFailure = { errorCode, throwable ->
+                FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                    AnalyticsParamValue.MANAGE_PROFILE_ACTION_EMAIL_UPDATE_INITIATED,
+                    AnalyticsParamValue.MANAGE_PROFILE_OUTCOME_FAILURE,
+                )
                 _binding ?: return@sendEmailOtp
                 onSaveFailed(errorCode, throwable)
             },

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileEditFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileEditFragment.kt
@@ -39,10 +39,15 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
                     _binding?.let { loadUserPhoto(it.profileHeader.profileUserImage, photoBase64) }
                     FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
                         AnalyticsParamValue.MANAGE_PROFILE_ACTION_PHOTO_UPDATED,
+                        AnalyticsParamValue.MANAGE_PROFILE_OUTCOME_SUCCESS,
                     )
                 },
                 onFailure = { _, _ ->
-                    // No-op for the Profile screen. The app sidebar shows a warning icon in the other flow.
+                    // No UI feedback on the Profile screen; the app sidebar shows a warning icon in the other flow.
+                    FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                        AnalyticsParamValue.MANAGE_PROFILE_ACTION_PHOTO_UPDATED,
+                        AnalyticsParamValue.MANAGE_PROFILE_OUTCOME_FAILURE,
+                    )
                 },
             )
     }
@@ -116,6 +121,7 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
         ) {
             FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
                 AnalyticsParamValue.MANAGE_PROFILE_ACTION_CHANGES_DISCARDED,
+                null,
             )
             findNavController().popBackStack()
         }
@@ -149,7 +155,7 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
         val user = viewModel.user
         object : PersonalIdApiHandler<Boolean>() {
             override fun onSuccess(success: Boolean) {
-                reportSavedProfileDetails()
+                reportProfileSaveOutcome(AnalyticsParamValue.MANAGE_PROFILE_OUTCOME_SUCCESS)
                 viewModel.commitProfileDetails()
                 _binding ?: return
                 onSaved()
@@ -159,16 +165,18 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
                 errorCode: PersonalIdOrConnectApiErrorCodes,
                 t: Throwable?,
             ) {
+                reportProfileSaveOutcome(AnalyticsParamValue.MANAGE_PROFILE_OUTCOME_FAILURE)
                 _binding ?: return
                 onSaveFailed(errorCode, t)
             }
         }.updateProfile(requireActivity(), user.userId, user.password, viewModel.currentName, null, null)
     }
 
-    private fun reportSavedProfileDetails() {
+    private fun reportProfileSaveOutcome(outcome: String) {
         if (viewModel.isNameModified()) {
             FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
                 AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED,
+                outcome,
             )
         }
     }

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileEditFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileEditFragment.kt
@@ -188,7 +188,19 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
             message = getString(R.string.personalid_profile_edit_otp_confirm_message, newEmail),
             positiveText = getString(R.string.personalid_profile_edit_otp_confirm_positive),
             negativeText = getString(R.string.personalid_profile_edit_otp_confirm_negative),
+            onNegative = {
+                FirebaseAnalyticsUtil.reportUserPromptEvent(
+                    AnalyticsParamValue.USER_PROMPT_TYPE_EMAIL,
+                    AnalyticsParamValue.USER_PROMPT_ACTION_CANCEL,
+                    AnalyticsParamValue.USER_PROMPT_INFO_MANAGE_PROFILE_EMAIL_UPDATE,
+                )
+            },
         ) {
+            FirebaseAnalyticsUtil.reportUserPromptEvent(
+                AnalyticsParamValue.USER_PROMPT_TYPE_EMAIL,
+                AnalyticsParamValue.USER_PROMPT_ACTION_ACCEPT,
+                AnalyticsParamValue.USER_PROMPT_INFO_MANAGE_PROFILE_EMAIL_UPDATE,
+            )
             binding.btnSave.isEnabled = false
             if (viewModel.isNameModified()) {
                 saveProfileDetails { sendEmailOtpAndNavigate(newEmail) }

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileEditFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileEditFragment.kt
@@ -16,6 +16,8 @@ import org.commcare.dalvik.R
 import org.commcare.dalvik.databinding.PersonalidProfileEditScreenBinding
 import org.commcare.fragments.personalId.EmailHelper
 import org.commcare.fragments.personalId.EmailWorkFlow
+import org.commcare.google.services.analytics.AnalyticsParamValue
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.personalId.photo.PersonalIdPhotoUpdater
 import org.commcare.views.extensions.onTextChanged
 
@@ -35,6 +37,9 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
                 onSuccess = { photoBase64 ->
                     viewModel.onPhotoUpdated(photoBase64)
                     _binding?.let { loadUserPhoto(it.profileHeader.profileUserImage, photoBase64) }
+                    FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                        AnalyticsParamValue.MANAGE_PROFILE_ACTION_PHOTO_UPDATED,
+                    )
                 },
                 onFailure = { _, _ ->
                     // No-op for the Profile screen. The app sidebar shows a warning icon in the other flow.
@@ -109,6 +114,9 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
             positiveText = getString(R.string.personalid_profile_edit_discard_positive),
             negativeText = getString(R.string.personalid_profile_edit_discard_negative),
         ) {
+            FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                AnalyticsParamValue.MANAGE_PROFILE_ACTION_CHANGES_DISCARDED,
+            )
             findNavController().popBackStack()
         }
     }
@@ -141,6 +149,7 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
         val user = viewModel.user
         object : PersonalIdApiHandler<Boolean>() {
             override fun onSuccess(success: Boolean) {
+                reportSavedProfileDetails()
                 viewModel.commitProfileDetails()
                 _binding ?: return
                 onSaved()
@@ -154,6 +163,14 @@ class PersonalIdProfileEditFragment : BasePersonalIdProfileFragment() {
                 onSaveFailed(errorCode, t)
             }
         }.updateProfile(requireActivity(), user.userId, user.password, viewModel.currentName, null, null)
+    }
+
+    private fun reportSavedProfileDetails() {
+        if (viewModel.isNameModified()) {
+            FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED,
+            )
+        }
     }
 
     private fun showEmailOtpConfirmationDialog() {

--- a/app/unit-tests/src/org/commcare/personalId/profile/BasePersonalIdProfileTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/BasePersonalIdProfileTest.kt
@@ -1,13 +1,16 @@
 package org.commcare.personalId.profile
 
+import android.os.Bundle
 import android.widget.TextView
 import androidx.annotation.IdRes
 import androidx.navigation.NavController
+import androidx.navigation.NavDestination
 import androidx.navigation.fragment.NavHostFragment
 import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.connect.network.PersonalIdMockApiServer
 import org.commcare.dalvik.R
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.junit.After
 import org.junit.Before
 import org.mockito.MockedStatic
@@ -29,6 +32,7 @@ abstract class BasePersonalIdProfileTest {
     protected lateinit var navController: NavController
 
     protected lateinit var connectUserDatabaseUtilMock: MockedStatic<ConnectUserDatabaseUtil>
+    protected lateinit var firebaseAnalyticsUtilMock: MockedStatic<FirebaseAnalyticsUtil>
 
     protected val mockApiServer = PersonalIdMockApiServer(PersonalIdMockApiServer.CallbackMode.MAIN_LOOPER)
     protected val mockWebServer get() = mockApiServer.server
@@ -56,6 +60,13 @@ abstract class BasePersonalIdProfileTest {
         connectUserDatabaseUtilMock
             .`when`<ConnectUserRecord> { ConnectUserDatabaseUtil.getUser(any()) }
             .thenReturn(user)
+        firebaseAnalyticsUtilMock = Mockito.mockStatic(FirebaseAnalyticsUtil::class.java)
+        firebaseAnalyticsUtilMock
+            .`when`<NavController.OnDestinationChangedListener> {
+                FirebaseAnalyticsUtil.getNavControllerPageChangeLoggingListener()
+            }.thenReturn(
+                NavController.OnDestinationChangedListener { _: NavController, _: NavDestination, _: Bundle? -> },
+            )
         mockApiServer.start()
         launchProfileActivity()
     }
@@ -64,6 +75,7 @@ abstract class BasePersonalIdProfileTest {
     fun tearDown() {
         activityController.pause().stop().destroy()
         connectUserDatabaseUtilMock.close()
+        firebaseAnalyticsUtilMock.close()
         mockApiServer.shutdown()
     }
 

--- a/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
@@ -11,6 +11,8 @@ import okhttp3.mockwebserver.MockResponse
 import org.commcare.CommCareTestApplication
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
+import org.commcare.google.services.analytics.AnalyticsParamValue
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.PhoneNumberHelper
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -21,6 +23,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowDialog
 
@@ -157,6 +160,11 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
         connectUserDatabaseUtilMock.verify {
             ConnectUserDatabaseUtil.storeUser(any(), any())
         }
+        firebaseAnalyticsUtilMock.verify {
+            FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED,
+            )
+        }
         assertEquals(
             "Should pop back to the profile screen after a successful save",
             R.id.personalid_profile_fragment,
@@ -202,6 +210,10 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
 
         val request = mockApiServer.takeRequestOrFail()
         assertEquals("/users/send_email_otp", request.path)
+        firebaseAnalyticsUtilMock.verify(
+            { FirebaseAnalyticsUtil.reportPersonalIdProfileAction(AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED) },
+            never(),
+        )
     }
 
     @Test
@@ -227,5 +239,37 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
 
         val otpRequest = mockApiServer.takeRequestOrFail()
         assertEquals("/users/send_email_otp", otpRequest.path)
+    }
+
+    // ========== Discard flow ==========
+
+    @Test
+    fun `confirming the discard dialog reports the discard action and pops back`() {
+        setText(nameField(), "Grace Hopper")
+
+        onUiThread { fragment.requireView().findViewById<Button>(R.id.btn_cancel).performClick() }
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        val confirmButton = dialog.findViewById<Button>(R.id.positive_button)!!
+        onUiThread { confirmButton.performClick() }
+
+        firebaseAnalyticsUtilMock.verify {
+            FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                AnalyticsParamValue.MANAGE_PROFILE_ACTION_CHANGES_DISCARDED,
+            )
+        }
+        assertEquals(
+            "Should pop back to the profile screen after discarding changes",
+            R.id.personalid_profile_fragment,
+            currentDestinationId(),
+        )
+
+        val profileFragment = navHostFragment.childFragmentManager.primaryNavigationFragment!!
+        val displayedName = profileFragment.requireView().findViewById<TextView>(R.id.profile_value_name)
+        assertEquals(
+            "The profile screen should still show the original name after discarding",
+            "Ada Lovelace",
+            displayedName.text.toString(),
+        )
     }
 }

--- a/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
@@ -163,6 +163,7 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
         firebaseAnalyticsUtilMock.verify {
             FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
                 AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED,
+                AnalyticsParamValue.MANAGE_PROFILE_OUTCOME_SUCCESS,
             )
         }
         assertEquals(
@@ -178,6 +179,28 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
             "Grace Hopper",
             displayedName.text.toString(),
         )
+    }
+
+    @Test
+    fun `a failed profile update reports the failure outcome and stays on the edit screen`() {
+        setText(nameField(), "Grace Hopper")
+        mockWebServer.enqueue(MockResponse().setResponseCode(500).setBody("{}"))
+
+        clickSave()
+        mockApiServer.drainHttp()
+
+        firebaseAnalyticsUtilMock.verify {
+            FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED,
+                AnalyticsParamValue.MANAGE_PROFILE_OUTCOME_FAILURE,
+            )
+        }
+        assertEquals(
+            "Should remain on the edit screen after a failed save",
+            R.id.personalid_profile_edit_fragment,
+            currentDestinationId(),
+        )
+        assertTrue("Save button should be re-enabled after a failed save", saveButton().isEnabled)
     }
 
     @Test
@@ -211,7 +234,12 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
         val request = mockApiServer.takeRequestOrFail()
         assertEquals("/users/send_email_otp", request.path)
         firebaseAnalyticsUtilMock.verify(
-            { FirebaseAnalyticsUtil.reportPersonalIdProfileAction(AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED) },
+            {
+                FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                    AnalyticsParamValue.MANAGE_PROFILE_ACTION_NAME_UPDATED,
+                    AnalyticsParamValue.MANAGE_PROFILE_OUTCOME_SUCCESS,
+                )
+            },
             never(),
         )
     }
@@ -256,6 +284,7 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
         firebaseAnalyticsUtilMock.verify {
             FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
                 AnalyticsParamValue.MANAGE_PROFILE_ACTION_CHANGES_DISCARDED,
+                null,
             )
         }
         assertEquals(

--- a/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
@@ -233,6 +233,13 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
 
         val request = mockApiServer.takeRequestOrFail()
         assertEquals("/users/send_email_otp", request.path)
+        firebaseAnalyticsUtilMock.verify {
+            FirebaseAnalyticsUtil.reportUserPromptEvent(
+                AnalyticsParamValue.USER_PROMPT_TYPE_EMAIL,
+                AnalyticsParamValue.USER_PROMPT_ACTION_ACCEPT,
+                AnalyticsParamValue.USER_PROMPT_INFO_MANAGE_PROFILE_EMAIL_UPDATE,
+            )
+        }
         firebaseAnalyticsUtilMock.verify(
             {
                 FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
@@ -265,6 +272,29 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
             "Should remain on the edit screen after a failed OTP send",
             R.id.personalid_profile_edit_fragment,
             currentDestinationId(),
+        )
+    }
+
+    @Test
+    fun `canceling the otp confirmation dialog reports the cancel prompt and sends no request`() {
+        setText(emailField(), "grace@example.com")
+        clickSave()
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        val cancelButton = dialog.findViewById<Button>(R.id.negative_button)!!
+        onUiThread { cancelButton.performClick() }
+
+        firebaseAnalyticsUtilMock.verify {
+            FirebaseAnalyticsUtil.reportUserPromptEvent(
+                AnalyticsParamValue.USER_PROMPT_TYPE_EMAIL,
+                AnalyticsParamValue.USER_PROMPT_ACTION_CANCEL,
+                AnalyticsParamValue.USER_PROMPT_INFO_MANAGE_PROFILE_EMAIL_UPDATE,
+            )
+        }
+        assertEquals(
+            "No request should fire when the email change is canceled",
+            0,
+            mockWebServer.requestCount,
         )
     }
 

--- a/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
@@ -245,6 +245,30 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
     }
 
     @Test
+    fun `a failed email otp send reports the email update initiated failure and stays on the edit screen`() {
+        setText(emailField(), "grace@example.com")
+        clickSave()
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        val confirmButton = dialog.findViewById<Button>(R.id.positive_button)!!
+        mockWebServer.enqueue(MockResponse().setResponseCode(500).setBody("{}"))
+        onUiThread { confirmButton.performClick() }
+        mockApiServer.drainHttp()
+
+        firebaseAnalyticsUtilMock.verify {
+            FirebaseAnalyticsUtil.reportPersonalIdProfileAction(
+                AnalyticsParamValue.MANAGE_PROFILE_ACTION_EMAIL_UPDATE_INITIATED,
+                AnalyticsParamValue.MANAGE_PROFILE_OUTCOME_FAILURE,
+            )
+        }
+        assertEquals(
+            "Should remain on the edit screen after a failed OTP send",
+            R.id.personalid_profile_edit_fragment,
+            currentDestinationId(),
+        )
+    }
+
+    @Test
     fun `saving a simultaneous name and email change commits the name before sending the email otp`() {
         setText(nameField(), "Grace Hopper")
         setText(emailField(), "grace@example.com")


### PR DESCRIPTION
### [CCCT-2476](https://dimagi.atlassian.net/browse/CCCT-2476)

## Technical Summary
The three Manage Profile actions are reported as one event keyed by an action parameter rather than separate events, so they can be filtered together in Firebase. The name-updated action fires only when the name actually changed, so an email-only save is not double-counted.

## Safety Assurance

### Safety story
- I ran the build on my test device and used breakpoints to confirm every meaningful Manage Profile action reaches Firebase, alongside the pre-existing screen-open and email-verification events.
- Change is analytics-only: no user-facing behavior, data model, or control flow is altered.

### Automated test coverage
- Fragment tests assert the name-updated action is logged on a successful name save, is not logged when only the email changes, and that the discard action is logged when the discard dialog is confirmed.

[CCCT-2476]: https://dimagi.atlassian.net/browse/CCCT-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ