### PR TITLE
Disable mobile data when running offline instrumentation tests

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/androidTests/DemoUserOfflineTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/DemoUserOfflineTest.kt
@@ -23,7 +23,7 @@ class DemoUserOfflineTest: DemoUserTest() {
 
     @Before
     fun setup() {
-        InstrumentationUtility.changeWifi(false)
+        InstrumentationUtility.setNetworkEnabled(false)
         installApp(APP_NAME, CCZ_NAME, true)
     }
 
@@ -35,10 +35,10 @@ class DemoUserOfflineTest: DemoUserTest() {
     @Test
     fun testPracticeMode_withUpdatedApp_offline() {
         // Briefly turn the internet back on to allow us to log in
-        InstrumentationUtility.changeWifi(true)
+        InstrumentationUtility.setNetworkEnabled(true)
         updateApp("test_user_3", "123")
         // Internet back off
-        InstrumentationUtility.changeWifi(false)
+        InstrumentationUtility.setNetworkEnabled(false)
         testPracticeMode_withUpdatedApp()
     }
 

--- a/app/instrumentation-tests/src/org/commcare/androidTests/FormEntryTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/FormEntryTest.kt
@@ -166,7 +166,7 @@ class FormEntryTest: BaseTest() {
         InstrumentationUtility.login("user_with_no_data", "123")
         InstrumentationUtility.logout()
         // Disable wifi
-        InstrumentationUtility.changeWifi(false)
+        InstrumentationUtility.setNetworkEnabled(false)
         // We can still login.
         InstrumentationUtility.login("user_with_no_data", "123")
         // Submit a form.
@@ -187,7 +187,7 @@ class FormEntryTest: BaseTest() {
                 .check(matches(isDisplayed()))
 
         // Enabled wifi.
-        InstrumentationUtility.changeWifi(true)
+        InstrumentationUtility.setNetworkEnabled(true)
 
         // Confirm form is sent on sync.
         onView(withText("Sync with Server"))

--- a/app/instrumentation-tests/src/org/commcare/androidTests/LoginTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/LoginTest.kt
@@ -95,13 +95,13 @@ class LoginTest: BaseTest() {
         InstrumentationUtility.logout()
 
         // Login Offline
-        InstrumentationUtility.changeWifi(false)
+        InstrumentationUtility.setNetworkEnabled(false)
         InstrumentationUtility.login("user_with_no_data", "123")
         verifyAllHomeButtonsPresent(homeButtons)
         InstrumentationUtility.logout()
 
         // login offline with bad password
-        InstrumentationUtility.changeWifi(false)
+        InstrumentationUtility.setNetworkEnabled(false)
         InstrumentationUtility.login("user_with_no_data", "badpass")
         onView(withText("Either the password you entered was incorrect, or CommCare couldn't reach the server"))
                 .check(matches(isDisplayed()))
@@ -111,7 +111,7 @@ class LoginTest: BaseTest() {
         onView(withText("Couldn't Reach Server. Please check your network connection"))
                 .check(matches(isDisplayed()))
 
-        InstrumentationUtility.changeWifi(true)
+        InstrumentationUtility.setNetworkEnabled(true)
         onView(withId(R.id.edit_password))
                 .perform(clearText())
         onView(withId(R.id.login_button))

--- a/app/instrumentation-tests/src/org/commcare/androidTests/ManualQuarantineTest.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/ManualQuarantineTest.kt
@@ -39,7 +39,7 @@ class ManualQuarantineTest : BaseTest() {
         InstrumentationUtility.login("test", "1234")
         // Enable quarantine
         enableFormQuarantine()
-        InstrumentationUtility.changeWifi(false)
+        InstrumentationUtility.setNetworkEnabled(false)
     }
 
     @After
@@ -135,7 +135,7 @@ class ManualQuarantineTest : BaseTest() {
             .perform(click())
         withText("Display Form").isDisplayed()
 
-        InstrumentationUtility.changeWifi(true)
+        InstrumentationUtility.setNetworkEnabled(true)
         InstrumentationUtility.gotoHome()
         onView(withText("Sync with Server"))
             .perform(click())

--- a/app/instrumentation-tests/src/org/commcare/androidTests/MenuTests.kt
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/MenuTests.kt
@@ -201,12 +201,12 @@ class MenuTests : BaseTest() {
             .perform(click())
         onView(withText("No problems were detected."))
             .check(matches(isDisplayed()))
-        InstrumentationUtility.changeWifi(false)
+        InstrumentationUtility.setNetworkEnabled(false)
         onView(withId(R.id.run_connection_test))
             .perform(click())
         onView(withText("You are not connected the Internet. Please run this test again after connecting to Wi-Fi or mobile data."))
             .check(matches(isDisplayed()))
-        InstrumentationUtility.changeWifi(true)
+        InstrumentationUtility.setNetworkEnabled(true)
         InstrumentationUtility.logout()
     }
 

--- a/app/instrumentation-tests/src/org/commcare/utils/InstrumentationUtility.kt
+++ b/app/instrumentation-tests/src/org/commcare/utils/InstrumentationUtility.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.net.wifi.WifiManager
-import android.os.Build
 import android.os.RemoteException
 import android.provider.MediaStore
 import android.view.View
@@ -24,10 +23,8 @@ import androidx.test.espresso.PerformException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.ViewInteraction
-import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
-import androidx.test.espresso.action.ViewActions.repeatedlyUntil
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.action.ViewActions.swipeUp
 import androidx.test.espresso.action.ViewActions.typeText
@@ -37,7 +34,6 @@ import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.matcher.RootMatchers
-import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed

--- a/app/instrumentation-tests/src/org/commcare/utils/InstrumentationUtility.kt
+++ b/app/instrumentation-tests/src/org/commcare/utils/InstrumentationUtility.kt
@@ -328,13 +328,14 @@ object InstrumentationUtility {
     }
 
     /**
-     * This method will toggle the wifi state in mobile.
-     * Starting with Android Q, applications are not allowed to enable/disable Wi-Fi.
+     * This method will toggle the network state in mobile, both Wi-Fi and data. It will wait for the Wi-Fi state
+     * to be changed before returning.
      */
     @JvmStatic
     fun changeWifi(enable: Boolean) {
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         uiDevice.executeShellCommand(if (enable) "svc wifi enable" else "svc wifi disable")
+        uiDevice.executeShellCommand(if (enable) "svc data enable" else "svc data disable")
         waitForWifiState(enable)
     }
 

--- a/app/instrumentation-tests/src/org/commcare/utils/InstrumentationUtility.kt
+++ b/app/instrumentation-tests/src/org/commcare/utils/InstrumentationUtility.kt
@@ -332,11 +332,11 @@ object InstrumentationUtility {
      * to be changed before returning.
      */
     @JvmStatic
-    fun changeWifi(enable: Boolean) {
+    fun setNetworkEnabled(enabled: Boolean) {
         val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        uiDevice.executeShellCommand(if (enable) "svc wifi enable" else "svc wifi disable")
-        uiDevice.executeShellCommand(if (enable) "svc data enable" else "svc data disable")
-        waitForWifiState(enable)
+        uiDevice.executeShellCommand(if (enabled) "svc wifi enable" else "svc wifi disable")
+        uiDevice.executeShellCommand(if (enabled) "svc data enable" else "svc data disable")
+        waitForWifiState(enabled)
     }
 
     private fun waitForWifiState(


### PR DESCRIPTION
## Technical Summary

The instrumentation tests use `InstrumentationUtility.changeWifi(false)` to put the device "offline" (e.g. `DemoUserOfflineTest`, offline login/form-submission, manual quarantine, the menu connection test). But it only ran `svc wifi disable`. And I've noticed that in some instances in BrowserStack a device has an active **mobile data** connection, so these "offline" tests behave incorrectly and fail.

This change:
- Toggles mobile data (`svc data enable/disable`) alongside Wi-Fi, so the helper truly simulates a fully offline device.
- Renames `changeWifi(enable)` -> `setNetworkEnabled(enabled)` to reflect that it now controls all network connectivity rather than just Wi-Fi.
- Updates all call sites and drops imports left unused by the change.

## Safety Assurance

### Safety story
- **Scope is limited to `app/instrumentation-tests`** — no shipped app code, storage, or data is affected, so there is no user-facing blast radius.

### Automated test coverage
- This is test infrastructure. The affected instrumentation tests exercise the helper directly (`DemoUserOfflineTest`, `FormEntryTest` offline submission, `LoginTest` offline login, `ManualQuarantineTest`, `MenuTests` connection test) and should pass with mobile data also disabled.
- Note: `svc data` requires a device/emulator where mobile data is applicable; `waitForWifiState` still only polls the Wi-Fi state.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage? No (test-only change)
- [ ] Does the PR introduce any major changes worth communicating? No
- [x] Risk label is set correctly — **low / trivial (test-only)**
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
