### PR TITLE
CCCT-2599 Wire ImageWidget Appearance Parsing And Capture Routing

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -65,6 +65,7 @@ These are published publicly on Playstore, Github Releases and CommCare Forums
 - [Delivery Progress Offline-First] The Connect Delivery Progress page now displays cached delivery data immediately on open, even with no network, and shows inline sync status (success / failure / offline) instead of a blocking loading dialog
 - [SMS Invite Links Open App] Clicking a Connect invite link in an SMS message opens the app and navigates to the opportunity
 - Launching an app from a Connect opportunity now opens it directly with a single loading dialog, instead of briefly flashing the login and app-setup screens
+- Image capture questions support a new `rectangle-overlay` appearance that shows a rectangular framing guide in the camera preview, helping users consistently frame the subject (e.g. a MUAC arm + tape).
 
 #### Important Bug Fixes
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -196,6 +196,7 @@ we would like to communicate to QA as part of the release testing
 
 - Verify tapping payment-unit rows on the Connect delivery progress screen — including rapid double-taps and two-finger simultaneous taps — opens the deliveries list without crashing or double-navigating.
 - Verify backing out of a brand new Connect opportunity's intro screen right after tapping Start Learning (easiest with poor connectivity) does not crash once the request completes.
+- **Image reticle overlay:** On a form image-capture question with `appearance="rectangle-overlay"`, verify Take Picture opens the in-app camera with a rectangular framing guide, and the saved photo is the full frame with the guide not drawn on it.
 
 
 ## CommCare 2.63

--- a/app/src/org/commcare/views/widgets/ImageWidget.java
+++ b/app/src/org/commcare/views/widgets/ImageWidget.java
@@ -21,6 +21,7 @@ import com.google.android.material.button.MaterialButton;
 
 import org.commcare.CommCareApplication;
 import org.commcare.activities.FormEntryActivity;
+import org.commcare.activities.camera.CameraOverlayActivity;
 import org.commcare.activities.components.FormEntryConstants;
 import org.commcare.activities.components.FormEntryInstanceState;
 import org.commcare.activities.components.ImageCaptureProcessing;
@@ -59,6 +60,8 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
 
     public static final Object IMAGE_VIEW_TAG = "image_view_tag";
 
+    private static final String RECTANGLE_OVERLAY = "rectangle-overlay";
+
     private final Button mCaptureButton;
     private final Button mChooseButton;
     private final Button mDiscardButton;
@@ -71,6 +74,7 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
     private final TextView mErrorTextView;
 
     private int mMaxDimen;
+    private final boolean useRectangleOverlay;
     private final PendingCalloutInterface pendingCalloutInterface;
 
     public static File getTempFileForImageCapture() {
@@ -170,8 +174,10 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
         addView(mChooseButton);
         addView(mDiscardButton);
 
-        String acq = mPrompt.getAppearanceHint();
-        if (QuestionWidget.ACQUIREFIELD.equalsIgnoreCase(acq)) {
+        String appearanceHint = mPrompt.getAppearanceHint();
+        boolean acquire = appearanceHint != null && appearanceHint.contains(QuestionWidget.ACQUIREFIELD);
+        useRectangleOverlay = appearanceHint != null && appearanceHint.contains(RECTANGLE_OVERLAY);
+        if (acquire) {
             mChooseButton.setVisibility(View.GONE);
         }
         addView(mErrorTextView);
@@ -257,21 +263,14 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
     }
 
     private void takePicture() {
-        Intent i = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
-        Uri uri = FileUtil.getUriForExternalFile(getContext(), getTempFileForImageCapture());
-
-        // We give the camera an absolute filename/path where to put the
-        // picture because of bug:
-        // http://code.google.com/p/android/issues/detail?id=1480
-        // The bug appears to be fixed in Android 2.0+, but as of feb 2,
-        // 2010, G1 phones only run 1.6. Without specifying the path the
-        // images returned by the camera in 1.6 (and earlier) are ~1/4
-        // the size. boo.
-        i.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
-        i.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        i.setFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        Intent intent;
+        if (useRectangleOverlay) {
+            intent = buildOverlayCaptureIntent();
+        } else {
+            intent = buildSystemCaptureIntent();
+        }
         try {
-            ((AppCompatActivity)getContext()).startActivityForResult(i,
+            ((AppCompatActivity)getContext()).startActivityForResult(intent,
                     FormEntryConstants.IMAGE_CAPTURE);
             pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
         } catch (ActivityNotFoundException e) {
@@ -280,6 +279,20 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
                             R.string.activity_not_found, "image capture"),
                     Toast.LENGTH_SHORT).show();
         }
+    }
+
+    private Intent buildOverlayCaptureIntent() {
+        Uri uri = FileUtil.getUriForExternalFile(getContext(), getTempFileForImageCapture());
+        return CameraOverlayActivity.getIntent(getContext(), uri);
+    }
+
+    private Intent buildSystemCaptureIntent() {
+        Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
+        Uri uri = FileUtil.getUriForExternalFile(getContext(), getTempFileForImageCapture());
+        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
+        intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        intent.setFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        return intent;
     }
 
     public void clearBinaryAttachment() {


### PR DESCRIPTION
### [CCCT-2599](https://dimagi.atlassian.net/browse/CCCT-2599)

## Product Description
Image capture questions can now opt into the rectangle framing-guide camera via a new `rectangle-overlay` appearance attribute — on its own, or combined with `acquire`.

[Image capture doc](https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143958321/Media+Capture+Questions#Image-Capture) updated.

## Technical Summary
Wires the `rectangle-overlay` appearance into `ImageWidget`: matches both `acquire` and `rectangle-overlay` by substring (order-independent, so `acquire rectangle-overlay` works either way) and routes Take Picture to `CameraOverlayActivity` when the `rectangle-overlay` hint is present. Reuses the existing temp file + `IMAGE_CAPTURE` request code, so the form's `onActivityResult` pipeline needs no changes.

Stacked on `ccct-2598-camera-overlay-activity` (#3788), which introduces `CameraOverlayActivity`; the base will retarget to master once that merges.

## Safety Assurance

### Safety story
What gives me confidence:
- I tested on a device with a form using `appearance="rectangle-overlay"` and the reticle camera launched correctly.
- Narrow, single-file change; the non-overlay capture path is untouched.

[CCCT-2599]: https://dimagi.atlassian.net/browse/CCCT-2599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ