### PR TITLE
Fix GPS Polling Lifecycle Bugs And Track Accuracy Degradation

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,12 @@
 This file is meant as an easy way for us to collate notes and change logs across releases. 
 -->
 
+## CommCare 2.63.2
+
+### QA Notes
+
+- Make sure there are no regressions in automated location capture in a CC form.  
+
 ## CommCare 2.63.1
 
 ### Release Notes

--- a/app/src/org/commcare/activities/FormEntryActivity.java
+++ b/app/src/org/commcare/activities/FormEntryActivity.java
@@ -988,10 +988,6 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
         attemptToUnregisterBroadcastReceiver(mLocationServiceIssueReceiver);
 
         saveInlineVideoState();
-
-        if (isFinishing()) {
-            PollSensorController.INSTANCE.stopLocationPolling();
-        }
         TextToSpeechConverter.INSTANCE.stop();
 
         attemptToUnregisterBroadcastReceiver(pendingSyncAlertBroadcastReceiver);
@@ -1375,6 +1371,7 @@ public class FormEntryActivity extends SaveSessionCommCareActivity<FormEntryActi
 
         if (!isChangingConfigurations()) {
             isFormEntryActive = false;
+            PollSensorController.INSTANCE.stopLocationPolling();
         }
 
         TextToSpeechConverter.INSTANCE.shutDown();

--- a/app/src/org/commcare/android/javarosa/PollSensorController.java
+++ b/app/src/org/commcare/android/javarosa/PollSensorController.java
@@ -60,7 +60,9 @@ public enum PollSensorController implements CommCareLocationListener {
         // LocationManager needs to be dealt with in the main UI thread, so
         // wrap GPS-checking logic in a Handler
         new Handler(Looper.getMainLooper()).post(() -> {
-            // Start requesting GPS updates
+            synchronized (actions) {
+                if (actions.isEmpty()) return;
+            }
             Context context = CommCareApplication.instance();
             mLocationController = CommCareLocationControllerFactory.getLocationController(context, this);
             requestLocationUpdates();

--- a/app/src/org/commcare/android/javarosa/PollSensorController.java
+++ b/app/src/org/commcare/android/javarosa/PollSensorController.java
@@ -93,7 +93,7 @@ public enum PollSensorController implements CommCareLocationListener {
         synchronized (actions) {
             if (location != null) {
                 float newAccuracy = location.getAccuracy();
-                if (newAccuracy > lastAccuracy) {
+                if (lastAccuracy < 30 && (newAccuracy - lastAccuracy) > 50) {
                     FirebaseAnalyticsUtil.reportAccuracyDegradation(newAccuracy - lastAccuracy);
                 }
                 lastAccuracy = newAccuracy;

--- a/app/src/org/commcare/android/javarosa/PollSensorController.java
+++ b/app/src/org/commcare/android/javarosa/PollSensorController.java
@@ -9,6 +9,7 @@ import android.os.Looper;
 import com.google.android.gms.common.api.ResolvableApiException;
 
 import org.commcare.CommCareApplication;
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.location.CommCareLocationController;
 import org.commcare.location.CommCareLocationControllerFactory;
 import org.commcare.location.CommCareLocationListener;
@@ -33,6 +34,7 @@ public enum PollSensorController implements CommCareLocationListener {
     private CommCareLocationController mLocationController;
     private final ArrayList<PollSensorAction> actions = new ArrayList<>();
     private Timer timeoutTimer = new Timer();
+    private float lastAccuracy = Float.MAX_VALUE;
 
     private ResolvableApiException apiException;
     private boolean noProviders;
@@ -90,11 +92,17 @@ public enum PollSensorController implements CommCareLocationListener {
     public void onLocationResult(@NotNull Location location) {
         synchronized (actions) {
             if (location != null) {
+                float newAccuracy = location.getAccuracy();
+                if (newAccuracy > lastAccuracy) {
+                    FirebaseAnalyticsUtil.reportAccuracyDegradation(newAccuracy - lastAccuracy);
+                }
+                lastAccuracy = newAccuracy;
+
                 for (PollSensorAction action : actions) {
                     action.updateReference(location);
                 }
 
-                if (location.getAccuracy() <= HiddenPreferences.getGpsAutoCaptureAccuracy()) {
+                if (newAccuracy <= HiddenPreferences.getGpsAutoCaptureAccuracy()) {
                     stopLocationPolling();
                 }
             }
@@ -145,6 +153,7 @@ public enum PollSensorController implements CommCareLocationListener {
     public void stopLocationPolling() {
         synchronized (actions) {
             actions.clear();
+            lastAccuracy = Float.MAX_VALUE;
         }
         resetTimeoutTimer();
         if (mLocationController != null) {

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -149,6 +149,7 @@ public class AnalyticsParamValue {
 
 
     // Param values for common commcare event
+    public static final String ACCURACY_DEGRADATION = "accuracy_degradation";
     public static final String STAGE_UPDATE_FAILURE = "stage_update_failure";
     public static final String UPDATE_RESET = "update_reset";
     public static final String CORRUPT_APP_STATE = "corrupt_app_state";

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.List;
 
 import static com.google.firebase.analytics.FirebaseAnalytics.Param.METHOD;
+import static com.google.firebase.analytics.FirebaseAnalytics.Param.VALUE;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.CORRUPT_APP_STATE;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.RSA_KEYSTORE_KEY_RETRIEVAL;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.STAGE_UPDATE_FAILURE;
@@ -40,6 +41,7 @@ import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_U
 import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_USAGE_MOST;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_USAGE_OTHER;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_USAGE_PARTIAL;
+import static org.commcare.google.services.analytics.AnalyticsParamValue.ACCURACY_DEGRADATION;
 import static org.commcare.util.LogTypes.TYPE_ERROR_DESIGN;
 
 /**
@@ -472,6 +474,14 @@ public class FirebaseAnalyticsUtil {
                 CCAnalyticsEvent.COMMON_COMMCARE_EVENT,
                 new String[]{FirebaseAnalytics.Param.ITEM_ID, CCAnalyticsParam.REASON},
                 new String[]{STAGE_UPDATE_FAILURE, reason}
+        );
+    }
+
+    public static void reportAccuracyDegradation(Float value) {
+        reportEvent(
+                CCAnalyticsEvent.COMMON_COMMCARE_EVENT,
+                new String[]{FirebaseAnalytics.Param.ITEM_ID, VALUE},
+                new String[]{ACCURACY_DEGRADATION, value.toString()}
         );
     }
 


### PR DESCRIPTION
## Product Description

No User facing changes

https://dimagi.atlassian.net/browse/CCCT-2605

[inspired from the doc](https://docs.google.com/document/d/1Oy68CXCo9KQgBTHuLDrCtkNJp-ViC5c3xqzPq9_sJgw/edit?tab=t.4mrw48u8hau2#heading=h.8hvu5tslm97u). 

## Technical Summary

The PR try to ahieve 2 specific goals - 

1. Handle `PollSensorController` location updates better in conjunction with the Form entry by 

a) moving the call to `stopLocationPolling()` from `onPause(isFinishing=true)` to `onDestroy(!isChangingConfigurations)` so that GPS is always released when the activity is truly destroyed. 

b) Adds an `actions.isEmpty()` guard inside `startLocationPolling()`'s `Handler.post()` lambda. Prevents an orphaned `LocationController` when `stopLocationPolling()` runs between the background-thread call to `startLocationPolling()` and its deferred main-thread execution.

2. Tracks in analytics whenever auto-capture receives a location with accuracy worst than last location, this is to see how common it is for GPS location to get worst in subsequent tries. It uses an exiting catch all `common_commcare_event` to protect against 200 events quota, also this is only a temporary event and we will remove this in 2.64 release.

## Safety Assurance

### Safety story

**Confidence:**
- I tested automated location capture locally and confirmed it still works end-to-end.
- The diff is narrow — three focused changes to `PollSensorController` and one lifecycle hook change in `FormEntryActivity`.
- The race condition fix is provably safe: both `stopLocationPolling()` and the `Handler.post()` lambda execute on the main thread, so the `actions.isEmpty()` check always sees consistent post-stop state.

**Risks:**
- The OS-kill-while-backgrounded path (the primary motivation for the `onDestroy` change) is hard to reproduce reliably and was not directly exercised.


Review commit by commit. 