### PR TITLE
CCCT-2516 Add Connect CTA Bar View

### DIFF
--- a/app/res/drawable/bg_connect_cta_banner.xml
+++ b/app/res/drawable/bg_connect_cta_banner.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/connect_dark_blue_color" />
+    <corners
+        android:topLeftRadius="@dimen/connect_info_card_corner_radius"
+        android:topRightRadius="@dimen/connect_info_card_corner_radius"
+        android:bottomLeftRadius="0dp"
+        android:bottomRightRadius="0dp" />
+</shape>

--- a/app/res/layout/view_connect_cta_bar.xml
+++ b/app/res/layout/view_connect_cta_bar.xml
@@ -25,7 +25,7 @@
         android:id="@+id/cta_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:cardBackgroundColor="@color/connect_cta_bar_background"
+        app:cardBackgroundColor="@color/connect_light_indigo"
         app:cardCornerRadius="@dimen/connect_info_card_corner_radius"
         app:cardElevation="@dimen/connect_info_card_elevation"
         app:contentPadding="16dp">

--- a/app/res/layout/view_connect_cta_bar.xml
+++ b/app/res/layout/view_connect_cta_bar.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:orientation="vertical"
+    tools:parentTag="android.widget.LinearLayout">
+
+    <TextView
+        android:id="@+id/cta_info_banner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="-15dp"
+        android:background="@drawable/bg_connect_cta_banner"
+        android:gravity="center"
+        android:paddingStart="12dp"
+        android:paddingTop="12dp"
+        android:paddingEnd="12dp"
+        android:paddingBottom="27dp"
+        android:textColor="@color/white"
+        android:visibility="gone"
+        tools:text="Further visits will not count towards progress or payments"
+        tools:visibility="visible" />
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cta_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardBackgroundColor="@color/connect_cta_bar_background"
+        app:cardCornerRadius="@dimen/connect_info_card_corner_radius"
+        app:cardElevation="@dimen/connect_info_card_elevation"
+        app:contentPadding="16dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipChildren="false"
+            android:clipToPadding="false">
+
+            <TextView
+                android:id="@+id/cta_title_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:textColor="@color/connect_dark_blue_color"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toTopOf="@id/cta_subtitle_text"
+                app:layout_constraintEnd_toStartOf="@id/cta_end_barrier"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_chainStyle="packed"
+                tools:text="Continue" />
+
+            <TextView
+                android:id="@+id/cta_subtitle_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginEnd="8dp"
+                android:textColor="@color/connect_secondary_text"
+                android:textSize="14sp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/cta_end_barrier"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/cta_title_text"
+                tools:text="Learning modules"
+                tools:visibility="visible" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/cta_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:elevation="3dp"
+                android:fontFamily="sans-serif"
+                android:paddingStart="40dp"
+                android:paddingEnd="40dp"
+                android:stateListAnimator="@null"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                android:textStyle="normal"
+                app:backgroundTint="@color/connect_dark_blue_color"
+                app:cornerRadius="24dp"
+                app:icon="@drawable/ic_connect_arrow_forward"
+                app:iconGravity="textEnd"
+                app:iconTint="@color/white"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Start" />
+
+            <FrameLayout
+                android:id="@+id/cta_progress_cluster"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="visible">
+
+                <org.commcare.views.connect.CircleProgressBar
+                    android:id="@+id/cta_progress_ring"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    app:progressBackgroundColor="@color/connect_light_grey"
+                    app:progressColor="@color/connect_dark_blue_color"
+                    app:strokeWidth="4dp" />
+
+                <TextView
+                    android:id="@+id/cta_progress_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:textColor="@color/connect_dark_blue_color"
+                    android:textSize="12sp"
+                    tools:text="25%" />
+            </FrameLayout>
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/cta_end_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="start"
+                app:constraint_referenced_ids="cta_button,cta_progress_cluster" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+</merge>

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -186,6 +186,7 @@
     <string name="personalid_welcome_user">¡Bienvenido %s!</string>
     <string name="personalid_choice_or">_____________    O    _____________</string>
     <string name="connect_button_logged_in">Ir al menú Conectar</string>
+    <string name="connect_cta_progress_percent">%1$d%%</string>
     <string name="entity_map_error_message">Se produjo un error en la configuración de la aplicación, por lo que no todos los marcadores del mapa se cargaron correctamente</string>
     <string name="personalid_generic_error">Ocurrió un problema con la base de datos, recupera tu cuenta.</string>
     <string name="connect_registration_title">Comience a usar PersonalID</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -248,6 +248,7 @@ License.
     <string name="personalid_welcome_user">Bienvenue %s !</string>
     <string name="personalid_choice_or">_____________    OU    _____________</string>
     <string name="connect_button_logged_in">Accéder au menu Connecter</string>
+    <string name="connect_cta_progress_percent">%1$d%%</string>
     <string name="entity_map_error_message">Une erreur s\'est produite dans la configuration de l\'application, ce qui a empêché le chargement correct de tous les marqueurs sur la carte</string>
     <string name="personalid_generic_error">Un problème est survenu avec la base de données, veuillez récupérer votre compte.</string>
     <string name="connect_registration_title">Démarrer avec PersonalID</string>

--- a/app/res/values-ha/strings.xml
+++ b/app/res/values-ha/strings.xml
@@ -88,6 +88,7 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="personalid_welcome_user">Barka da zuwa %s!</string>
     <string name="personalid_choice_or">_________ KO _________</string>
     <string name="connect_button_logged_in">Je zuwa menu na Haɗawa</string>
+    <string name="connect_cta_progress_percent">%1$d%%</string>
     <string name="connect_registration_title">Fara da PersonalID</string>
     <string name="connect_consent_message_1">Na karanta kuma na yarda da Dimagi\'s</string>
     <string name="connect_phone_country_code_default">+1</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -248,6 +248,7 @@ License.
     <string name="personalid_welcome_user">स्वागत है %s!</string>
     <string name="personalid_choice_or">_____________    या    _____________</string>
     <string name="connect_button_logged_in">कनेक्ट मेनू पर जाएं</string>
+    <string name="connect_cta_progress_percent">%1$d%%</string>
     <string name="entity_map_error_message">ऐप कॉन्फ़िगरेशन में एक गड़बड़ी थी, जिसकी वजह से मैप पर सभी मार्कर ठीक से लोड नहीं हो रहे हैं।</string>
     <string name="personalid_generic_error">डेटाबेस के साथ कोई समस्या हुई है, कृपया अपना खाता पुनर्प्राप्त करें।</string>
     <string name="connect_registration_title">पर्सनलआईडी के साथ शुरुआत करें</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -112,6 +112,7 @@
     <string name="nav_drawer_open">Atidaryti navigacijos meniu</string>
     <string name="nav_drawer_close">Uždaryti navigacijos meniu</string>
     <string name="connect_message_you">Jūs</string>
+    <string name="connect_cta_progress_percent">%1$d%%</string>
     <string name="connect_message_them">Jie</string>
     <string name="fcm_sync_failed_body_text">Norėdami sužinoti daugiau, spustelėkite čia</string>
     <string name="connect_fetch_learning_progress_error">Nepavyko gauti mokymosi eigos</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -112,6 +112,7 @@
     <string name="nav_drawer_open">Åpne navigasjonsmenyen</string>
     <string name="nav_drawer_close">Lukk navigasjonsmenyen</string>
     <string name="connect_message_you">Du</string>
+    <string name="connect_cta_progress_percent">%1$d%%</string>
     <string name="connect_message_them">Dem</string>
     <string name="fcm_sync_failed_body_text">Klikk her for å vite mer</string>
     <string name="connect_fetch_learning_progress_error">Kunne ikke hente læringsfremdriften</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -251,6 +251,7 @@
     <string name="personalid_welcome_user">Bemvindo %s!</string>
     <string name="personalid_choice_or">OU</string>
     <string name="connect_button_logged_in">Vá para o Conectar menu</string>
+    <string name="connect_cta_progress_percent">%1$d%%</string>
     <string name="entity_map_error_message">Ocorreu um erro na configuração da aplicação, o que fez com que nem todos os marcadores no mapa fossem carregados corretamente</string>
     <string name="personalid_generic_error">Ocorreu um problema. Configure sua conta PersonalID novamente.</string>
     <string name="connect_registration_title">Comece a usar o PersonalID</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -249,6 +249,7 @@
     <string name="personalid_welcome_user">Karibu %s!</string>
     <string name="personalid_choice_or">____________ AU _____________</string>
     <string name="connect_button_logged_in">Nenda kwenye menyu ya Unganisha</string>
+    <string name="connect_cta_progress_percent">%1$d%%</string>
     <string name="entity_map_error_message">Kulikuwa na hitilafu katika usanidi wa programu kutokana na ambayo si alama zote kwenye ramani zimepakiwa ipasavyo</string>
     <string name="personalid_generic_error">Tatizo limetokea, tafadhali sanidi akaunti yako ya PersonalID tena.</string>
     <string name="connect_registration_title">Usajili wa PersonalId</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -239,6 +239,7 @@
     <string name="personalid_welcome_user">እንቋዕ ብደሓን መጻእኩም %s!</string>
     <string name="personalid_choice_or">_____________ ወይ _____________</string>
     <string name="connect_button_logged_in">ናብ Connect መማረፂ ኪድ</string>
+    <string name="connect_cta_progress_percent">%1$d%%</string>
     <string name="entity_map_error_message">ኣብ ውቅር ኣፕ ጌጋ ኣጋጢሙ ብሰንኪ እዚ ድማ ኩሎም ኣብቲ ካርታ ዘለዉ ማርከራት ብትኽክል ኣይጽዓኑን እዮም።</string>
     <string name="personalid_generic_error">ጸገም ኣጋጢሙ፡ በጃኻ PersonalID ኣካውንትካ እንደገና ኣወሃህቦ።</string>
     <string name="connect_registration_title">ብ PersonalID ጀምር</string>

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -172,6 +172,14 @@
         <attr name="navigable" />
     </declare-styleable>
 
+    <declare-styleable name="ConnectCtaBar">
+        <attr name="titleText" />
+        <attr name="subtitleText" />
+        <attr name="buttonText" format="string" />
+        <attr name="infoMessage" format="string" />
+        <attr name="progress" format="integer" />
+    </declare-styleable>
+
     <declare-styleable name="RectangleOverlayView">
         <attr name="reticleScrimColor" format="color" />
         <attr name="reticleStrokeColor" format="color" />

--- a/app/res/values/colors.xml
+++ b/app/res/values/colors.xml
@@ -153,7 +153,7 @@
     <color name="connect_light_green">#E6F5E5</color>
     <color name="connect_red">#EA6944</color>
     <color name="connect_light_grey_transparent">#1AD9D9D9</color>
-    <color name="connect_cta_bar_background">#E8EAF6</color>
+    <color name="connect_light_indigo">#E8EAF6</color>
     <color name="connect_un_fill_progress">#ebecfa</color>
     <color name="connect_delivery_rejected_icon">#EA6944</color>
     <color name="connect_thumb_up">#16A085</color>

--- a/app/res/values/colors.xml
+++ b/app/res/values/colors.xml
@@ -153,6 +153,7 @@
     <color name="connect_light_green">#E6F5E5</color>
     <color name="connect_red">#EA6944</color>
     <color name="connect_light_grey_transparent">#1AD9D9D9</color>
+    <color name="connect_cta_bar_background">#E8EAF6</color>
     <color name="connect_un_fill_progress">#ebecfa</color>
     <color name="connect_delivery_rejected_icon">#EA6944</color>
     <color name="connect_thumb_up">#16A085</color>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -356,6 +356,7 @@
     <!-- PersonalID strings -->
     <string name="personalid_login_via">Via PersonalID (or press here)</string>
     <string name="connect_button_logged_in">Go to Connect menu</string>
+    <string name="connect_cta_progress_percent">%1$d%%</string>
     <string name="connect_registration_title">Get Started with PersonalID</string>
     <string name="connect_registration_subtitle">Enter your Phone Number</string>
 

--- a/app/src/org/commcare/views/connect/ConnectCtaBar.kt
+++ b/app/src/org/commcare/views/connect/ConnectCtaBar.kt
@@ -1,0 +1,91 @@
+package org.commcare.views.connect
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.LinearLayout
+import android.widget.TextView
+import org.commcare.dalvik.R
+import org.commcare.dalvik.databinding.ViewConnectCtaBarBinding
+
+/**
+ * Reusable Connect bottom action bar.
+ *
+ * Shows a [titleText]/[subtitleText] block on the left and, on the right, either a CTA button
+ * (Main state) or a circular percent indicator (In-progress state) depending on [progress]. An
+ * optional [infoMessage] shows a non-dismissible banner above the bar.
+ */
+class ConnectCtaBar
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : LinearLayout(context, attrs, defStyleAttr) {
+        private val binding =
+            ViewConnectCtaBarBinding.inflate(LayoutInflater.from(context), this)
+
+        var titleText: CharSequence?
+            get() = binding.ctaTitleText.text
+            set(value) = bindOptionalText(binding.ctaTitleText, value)
+
+        var subtitleText: CharSequence?
+            get() = binding.ctaSubtitleText.text
+            set(value) = bindOptionalText(binding.ctaSubtitleText, value)
+
+        var buttonText: CharSequence?
+            get() = binding.ctaButton.text
+            set(value) {
+                binding.ctaButton.text = value
+            }
+
+        var progress: Int? = null
+            set(value) {
+                field = value?.coerceIn(0, 100)
+                updateProgressState()
+            }
+
+        var infoMessage: CharSequence?
+            get() = binding.ctaInfoBanner.text
+            set(value) = bindOptionalText(binding.ctaInfoBanner, value)
+
+        init {
+            orientation = VERTICAL
+
+            context.obtainStyledAttributes(attrs, R.styleable.ConnectCtaBar).apply {
+                titleText = getString(R.styleable.ConnectCtaBar_titleText)
+                subtitleText = getString(R.styleable.ConnectCtaBar_subtitleText)
+                buttonText = getString(R.styleable.ConnectCtaBar_buttonText)
+                infoMessage = getString(R.styleable.ConnectCtaBar_infoMessage)
+                progress = getInt(R.styleable.ConnectCtaBar_progress, -1).takeIf { it >= 0 }
+                recycle()
+            }
+        }
+
+        fun setOnCtaClickListener(listener: OnClickListener?) {
+            binding.ctaButton.setOnClickListener(listener)
+        }
+
+        private fun updateProgressState() {
+            val value = progress
+            if (value == null) {
+                binding.ctaButton.visibility = VISIBLE
+                binding.ctaProgressCluster.visibility = GONE
+            } else {
+                binding.ctaButton.visibility = GONE
+                binding.ctaProgressCluster.visibility = VISIBLE
+                binding.ctaProgressRing.setProgress(value.toFloat())
+                binding.ctaProgressText.text =
+                    resources.getString(R.string.connect_cta_progress_percent, value)
+                binding.ctaProgressCluster.contentDescription = binding.ctaProgressText.text
+            }
+        }
+
+        private fun bindOptionalText(
+            view: TextView,
+            value: CharSequence?,
+        ) {
+            view.text = value
+            view.visibility = if (value.isNullOrEmpty()) GONE else VISIBLE
+        }
+    }

--- a/app/unit-tests/src/org/commcare/views/connect/ConnectCtaBarTest.kt
+++ b/app/unit-tests/src/org/commcare/views/connect/ConnectCtaBarTest.kt
@@ -1,0 +1,135 @@
+package org.commcare.views.connect
+
+import android.content.Context
+import android.view.ContextThemeWrapper
+import android.view.View
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.button.MaterialButton
+import org.commcare.CommCareTestApplication
+import org.commcare.dalvik.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class ConnectCtaBarTest {
+    // MaterialButton requires a Theme.MaterialComponents descendant; the bare application context
+    // isn't one, so inflate through the app's Material theme as the hosting activity does in production.
+    private fun themedContext(): Context =
+        ContextThemeWrapper(
+            ApplicationProvider.getApplicationContext(),
+            R.style.CommonTheme,
+        )
+
+    private fun newBar() = ConnectCtaBar(themedContext())
+
+    @Test
+    fun `title and subtitle bind to text views`() {
+        val bar = newBar()
+        bar.titleText = "Continue"
+        bar.subtitleText = "Learning modules"
+
+        assertEquals("Continue", bar.findViewById<TextView>(R.id.cta_title_text).text.toString())
+        val subtitle = bar.findViewById<TextView>(R.id.cta_subtitle_text)
+        assertEquals("Learning modules", subtitle.text.toString())
+        assertEquals(View.VISIBLE, subtitle.visibility)
+    }
+
+    @Test
+    fun `empty subtitle is gone`() {
+        val bar = newBar()
+        bar.subtitleText = null
+        assertEquals(View.GONE, bar.findViewById<TextView>(R.id.cta_subtitle_text).visibility)
+    }
+
+    @Test
+    fun `empty title is gone`() {
+        val bar = newBar()
+        bar.titleText = null
+        assertEquals(View.GONE, bar.findViewById<TextView>(R.id.cta_title_text).visibility)
+    }
+
+    @Test
+    fun `button text binds and click listener fires`() {
+        val bar = newBar()
+        bar.buttonText = "Start"
+        val button = bar.findViewById<MaterialButton>(R.id.cta_button)
+        assertEquals("Start", button.text.toString())
+
+        var clicked = false
+        bar.setOnCtaClickListener { clicked = true }
+        button.performClick()
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun `null progress shows button and hides progress cluster`() {
+        val bar = newBar()
+        bar.progress = null
+        assertEquals(View.VISIBLE, bar.findViewById<View>(R.id.cta_button).visibility)
+        assertEquals(View.GONE, bar.findViewById<View>(R.id.cta_progress_cluster).visibility)
+    }
+
+    @Test
+    fun `progress value shows cluster with percent and hides button`() {
+        val bar = newBar()
+        bar.progress = 25
+        assertEquals(View.GONE, bar.findViewById<View>(R.id.cta_button).visibility)
+        assertEquals(View.VISIBLE, bar.findViewById<View>(R.id.cta_progress_cluster).visibility)
+        assertEquals("25%", bar.findViewById<TextView>(R.id.cta_progress_text).text.toString())
+    }
+
+    @Test
+    fun `progress above max clamps to 100 percent`() {
+        val bar = newBar()
+        bar.progress = 150
+        assertEquals("100%", bar.findViewById<TextView>(R.id.cta_progress_text).text.toString())
+    }
+
+    @Test
+    fun `progress below min clamps to 0 percent`() {
+        val bar = newBar()
+        bar.progress = -5
+        assertEquals("0%", bar.findViewById<TextView>(R.id.cta_progress_text).text.toString())
+    }
+
+    @Test
+    fun `info message shows banner with text`() {
+        val bar = newBar()
+        bar.infoMessage = "Further visits will not count."
+        val banner = bar.findViewById<TextView>(R.id.cta_info_banner)
+        assertEquals(View.VISIBLE, banner.visibility)
+        assertEquals("Further visits will not count.", banner.text.toString())
+    }
+
+    @Test
+    fun `empty info message hides banner`() {
+        val bar = newBar()
+        bar.infoMessage = null
+        assertEquals(View.GONE, bar.findViewById<View>(R.id.cta_info_banner).visibility)
+    }
+
+    @Test
+    fun `attributes inflate content`() {
+        val attrs =
+            Robolectric
+                .buildAttributeSet()
+                .addAttribute(R.attr.titleText, "Continue")
+                .addAttribute(R.attr.subtitleText, "Learning modules")
+                .addAttribute(R.attr.buttonText, "Start")
+                .addAttribute(R.attr.progress, "25")
+                .build()
+        val bar = ConnectCtaBar(themedContext(), attrs)
+
+        assertEquals("Continue", bar.findViewById<TextView>(R.id.cta_title_text).text.toString())
+        assertEquals("Learning modules", bar.findViewById<TextView>(R.id.cta_subtitle_text).text.toString())
+        assertEquals("Start", bar.findViewById<MaterialButton>(R.id.cta_button).text.toString())
+        assertEquals("25%", bar.findViewById<TextView>(R.id.cta_progress_text).text.toString())
+    }
+}


### PR DESCRIPTION
### [CCCT-2516](https://dimagi.atlassian.net/browse/CCCT-2516)

## Product Description

Adds `ConnectCtaBar`, a reusable bottom action bar for Connect screens. It shows a title/subtitle on the left and, on the right, either a CTA button (Main state) or a circular percent indicator (In-progress state). An optional non-dismissible banner can appear above the bar. This PR only introduces the component; it is not yet wired into any screen.

### Screenshots

**Main display**
<img width="270" height="585" alt="CTA1_Main" src="https://github.com/user-attachments/assets/a4088ecc-96a6-4d7c-9714-b8ced3504c84" />




**In-progress (progress circle) with popup message**

<img width="270" height="585" alt="CTA1_ProgressAndMessage" src="https://github.com/user-attachments/assets/18a2591c-53d2-4644-9c4a-80b67f199ff1" />


## Technical Summary

The view extends `LinearLayout` and inflates its layout via a `<merge>` binding. State is driven by public properties (`titleText`, `subtitleText`, `buttonText`, `infoMessage`, `progress`), also settable via XML attributes. Setting `progress` swaps the button for the circular indicator; a null/empty value hides the corresponding element. The progress ring reuses the existing `CircleProgressBar`.

## Safety Assurance

### Safety story

I previewed the layout in Android Studio to check the Main / In-progress / banner states against the Figma, and ran the view in the app to confirm rendering and state switching. The change is purely additive — a new view, its layout, and resources — and is not referenced by any existing screen, so it cannot affect current behavior or existing data. Risk to review: no production code path exercises the component yet, so integration behavior (sizing, click handling within a real screen) is only validated once it is wired in.

### Automated test coverage

`ConnectCtaBarTest` (Robolectric) covers title/subtitle binding and visibility, button text and click dispatch, the null-vs-set `progress` toggle between button and percent cluster, banner visibility for set/empty `infoMessage`, and inflation from XML attributes.


[CCCT-2516]: https://dimagi.atlassian.net/browse/CCCT-2516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ