### PR TITLE
Log non-fatal when form record folder creation fails

### DIFF
--- a/app/src/org/commcare/activities/components/FormEntryInstanceState.java
+++ b/app/src/org/commcare/activities/components/FormEntryInstanceState.java
@@ -117,6 +117,11 @@ public class FormEntryInstanceState {
         String path = mFormRecordDestination + file + "_" + time;
         if (FileUtil.createFolder(path)) {
             mFormRecordPath = path + File.separator + file + "_" + time + ".xml";
+        } else {
+            // TODO: This branch was left unhandled in the original code. We should handle this case more
+            //  gracefully, perhaps by notifying the user and cancelling the form entry process. For now, we log
+            //  a non-fatal exception to help with debugging.
+            Logger.exception("Unable to create form record folder at " + path, new RuntimeException());
         }
     }
 


### PR DESCRIPTION
## Technical Summary

Investigating this production crash:

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.lastIndexOf(java.lang.String)' on a null object reference
       at org.commcare.activities.components.FormEntryInstanceState.getInstanceFolder(FormEntryInstanceState.java:128)
       at org.commcare.activities.FormEntryActivity.updateFormAttachmentCount(FormEntryActivity.java:1188)
       at org.commcare.activities.FormEntryActivity$3.deliverResult(FormEntryActivity.java:1147)
```

Root cause: for a new form, `mFormRecordPath` stays null until `initFormRecordPath()` runs after form load. This method only assigns the path if `FileUtil.createFolder()` succeeds — `File.mkdirs()` returns `false` on failure (storage full, unmounted volume, etc.) without throwing, and the failure branch was unhandled. The path silently stays `null` and `updateFormAttachmentCount()` NPEs one frame later in `getInstanceFolder()`.

This PR adds a non-fatal `Logger.exception` in the failure branch so crash reports capture the actual folder-creation failure (including the path) instead of the opaque downstream NPE.

Not addressed here (left as TODO in the code): gracefully aborting form entry with a user-facing error when the folder can't be created. The downstream NPE can still occur; this change gives us the diagnostics to understand why creation fails before deciding on the right user-facing handling.

## Safety Assurance

### Safety story

The change is additive: a log statement in a previously empty failure branch. The happy path (folder created successfully) is untouched, and no existing data is read or written differently. The only new behavior is a non-fatal exception report when folder creation fails — a state that previously crashed the app moments later anyway.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)