### PR TITLE
Make ktlint Conditional On New Vs Existing Kotlin Files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,7 @@ The Gradle ktlint task auto-formats a file and verifies it is clean:
 ```
 When to run it depends on whether the Kotlin file is new or existing:
 - **New Kotlin file** — run ktlint directly before committing.
-- **Existing Kotlin file** — you may run ktlint to *check* for violations, but do NOT auto-apply its formatting. On a small change it often reformats unrelated lines, bloating the diff and confusing reviewers. Fix real lint errors in the lines you actually changed, and ask the author before applying formatting to anything else. The author may prefer to let CI flag formatting initially and apply ktlint once at the end of review.
-
-If any violations remain that cannot be auto-fixed, resolve them manually.
+- **Existing Kotlin file** — you may run ktlint to *check* for violations, but do NOT auto-apply its formatting
 
 ## Test File Locations
 - Unit tests: `app/unit-tests/src/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,16 +49,20 @@ When planning or writing a spec for a new feature, consult [`docs/common-edge-ca
 All the changes below should be part of a separate commit after the main code changes:
 - Clean up any unused code and imports
 - Verify Java code with `checkstyle.xml` and make changes as applicable
-- Run ktlint format and verify: `./gradlew ktlintFile -PfilePath=path/to/file.kt`
+- Run ktlint per the "AI Workflow: ktlint" rules below
 - Run relevant unit tests to ensure no regressions
 - Commit changes
 
 ## AI Workflow: ktlint
-After editing or creating a Kotlin file, always run the Gradle ktlint task:
+The Gradle ktlint task auto-formats a file and verifies it is clean:
 ```bash
 ./gradlew ktlintFile -PfilePath=<relative-path-to-file>
 ```
-This task auto-formats the file and then verifies it is clean. If any violations remain that cannot be auto-fixed, resolve them manually. This should be done before committing.
+When to run it depends on whether the Kotlin file is new or existing:
+- **New Kotlin file** — run ktlint directly before committing.
+- **Existing Kotlin file** — you may run ktlint to *check* for violations, but do NOT auto-apply its formatting. On a small change it often reformats unrelated lines, bloating the diff and confusing reviewers. Fix real lint errors in the lines you actually changed, and ask the author before applying formatting to anything else. The author may prefer to let CI flag formatting initially and apply ktlint once at the end of review.
+
+If any violations remain that cannot be auto-fixed, resolve them manually.
 
 ## Test File Locations
 - Unit tests: `app/unit-tests/src/`


### PR DESCRIPTION
## Technical Summary

Updates the ktlint guidance in `AGENTS.md`: new Kotlin files get ktlint applied directly, while existing files are only checked (not auto-formatted) to avoid reformatting unrelated lines and bloating PR diffs.