### PR TITLE
CCCT-2536 Add ConnectSuccessFailureCard Dismissible Status Card

### DIFF
--- a/app/res/layout/view_connect_success_failure_card.xml
+++ b/app/res/layout/view_connect_success_failure_card.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="20dp">
+
+    <ImageView
+        android:id="@+id/success_failure_card_icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:contentDescription="@null"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/check_update" />
+
+    <TextView
+        android:id="@+id/success_failure_card_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="12dp"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/success_failure_card_close"
+        app:layout_constraintStart_toEndOf="@id/success_failure_card_icon"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="All required tasks have been completed."
+        tools:textColor="@color/connect_green" />
+
+    <ImageView
+        android:id="@+id/success_failure_card_close"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_connect_close"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -173,6 +173,7 @@
     </declare-styleable>
 
     <declare-styleable name="ConnectSuccessFailureCard">
+        <attr name="android:visibility" />
         <attr name="mode" format="enum">
             <enum name="success" value="0" />
             <enum name="failure" value="1" />

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -173,7 +173,6 @@
     </declare-styleable>
 
     <declare-styleable name="ConnectSuccessFailureCard">
-        <attr name="android:visibility" />
         <attr name="mode" format="enum">
             <enum name="success" value="0" />
             <enum name="failure" value="1" />

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -172,6 +172,20 @@
         <attr name="navigable" />
     </declare-styleable>
 
+    <declare-styleable name="ConnectSuccessFailureCard">
+        <attr name="mode" format="enum">
+            <enum name="success" value="0" />
+            <enum name="failure" value="1" />
+        </attr>
+        <attr name="messageText" format="string" />
+        <attr name="cardCornerRadius" />
+        <attr name="cardElevation" />
+        <attr name="successBackgroundColor" format="color" />
+        <attr name="successAccentColor" format="color" />
+        <attr name="failureBackgroundColor" format="color" />
+        <attr name="failureAccentColor" format="color" />
+    </declare-styleable>
+
     <declare-styleable name="RectangleOverlayView">
         <attr name="reticleScrimColor" format="color" />
         <attr name="reticleStrokeColor" format="color" />

--- a/app/res/values/colors.xml
+++ b/app/res/values/colors.xml
@@ -17,6 +17,7 @@
     <color name="translucent_blue_grey">#806884AD</color>
     <color name="green">#87D13E</color>
     <color name="red">#FF0000</color>
+    <color name="pale_coral">#FDECE8</color>
 
     <!-- ODK.Collect colors start here -->
 

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -309,4 +309,13 @@
         <item name="descriptionTextColor">@color/connect_text_color</item>
     </style>
 
+    <style name="Widget.CommCare.ConnectSuccessFailureCard" parent="">
+        <item name="cardCornerRadius">@dimen/connect_info_card_corner_radius</item>
+        <item name="cardElevation">6dp</item>
+        <item name="successBackgroundColor">@color/connect_light_green</item>
+        <item name="successAccentColor">@color/connect_green</item>
+        <item name="failureBackgroundColor">@color/pale_coral</item>
+        <item name="failureAccentColor">@color/connect_red</item>
+    </style>
+
 </resources>

--- a/app/src/org/commcare/views/connect/ConnectSuccessFailureCard.kt
+++ b/app/src/org/commcare/views/connect/ConnectSuccessFailureCard.kt
@@ -80,15 +80,18 @@ class ConnectSuccessFailureCard
                 onDismiss?.invoke()
             }
 
+            context.withStyledAttributes(attrs, intArrayOf(android.R.attr.visibility), defStyleAttr) {
+                if (!hasValue(0)) {
+                    visibility = GONE
+                }
+            }
+
             context.withStyledAttributes(
                 attrs,
                 R.styleable.ConnectSuccessFailureCard,
                 defStyleAttr,
                 R.style.Widget_CommCare_ConnectSuccessFailureCard,
             ) {
-                if (!hasValue(R.styleable.ConnectSuccessFailureCard_android_visibility)) {
-                    visibility = GONE
-                }
                 radius = getDimension(R.styleable.ConnectSuccessFailureCard_cardCornerRadius, radius)
                 cardElevation = getDimension(R.styleable.ConnectSuccessFailureCard_cardElevation, cardElevation)
                 successBackgroundColor = getColor(R.styleable.ConnectSuccessFailureCard_successBackgroundColor, 0)

--- a/app/src/org/commcare/views/connect/ConnectSuccessFailureCard.kt
+++ b/app/src/org/commcare/views/connect/ConnectSuccessFailureCard.kt
@@ -1,0 +1,123 @@
+package org.commcare.views.connect
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.annotation.StringRes
+import androidx.cardview.widget.CardView
+import androidx.core.content.withStyledAttributes
+import androidx.core.widget.ImageViewCompat
+import org.commcare.dalvik.R
+import org.commcare.dalvik.databinding.ViewConnectSuccessFailureCardBinding
+
+/**
+ * Reusable dismissible card that shows a short status message in a [Mode.SUCCESS] or
+ * [Mode.FAILURE] style. Mode drives the background, leading icon, and tint; the message
+ * text is supplied by the caller. The card is hidden by default (unless the XML sets an
+ * explicit `android:visibility`) and revealed via [show]; tapping the close icon hides it
+ * again and invokes the handler passed to [show].
+ */
+class ConnectSuccessFailureCard
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : CardView(context, attrs, defStyleAttr) {
+        enum class Mode { SUCCESS, FAILURE }
+
+        private val binding =
+            ViewConnectSuccessFailureCardBinding.inflate(LayoutInflater.from(context), this, true)
+
+        var mode: Mode? = null
+            set(value) {
+                field = value
+                value?.let { applyMode(it) }
+            }
+
+        var messageText: CharSequence?
+            get() = binding.successFailureCardText.text
+            set(value) {
+                binding.successFailureCardText.text = value
+            }
+
+        private var onDismiss: (() -> Unit)? = null
+
+        /**
+         * Configures the card for [mode] with [message], attaches an optional [onDismiss]
+         * handler for this showing, and makes the card visible.
+         */
+        @JvmOverloads
+        fun show(
+            mode: Mode,
+            message: CharSequence,
+            onDismiss: (() -> Unit)? = null,
+        ) {
+            this.onDismiss = onDismiss
+            this.mode = mode
+            messageText = message
+            visibility = VISIBLE
+        }
+
+        @JvmOverloads
+        fun show(
+            mode: Mode,
+            @StringRes messageRes: Int,
+            onDismiss: (() -> Unit)? = null,
+        ) = show(mode, context.getString(messageRes), onDismiss)
+
+        private var successBackgroundColor = 0
+        private var successAccentColor = 0
+        private var failureBackgroundColor = 0
+        private var failureAccentColor = 0
+
+        init {
+            useCompatPadding = false
+            if (attrs?.getAttributeValue(ANDROID_NAMESPACE, "visibility") == null) {
+                visibility = GONE
+            }
+
+            binding.successFailureCardClose.setOnClickListener {
+                visibility = GONE
+                onDismiss?.invoke()
+            }
+
+            context.withStyledAttributes(
+                attrs,
+                R.styleable.ConnectSuccessFailureCard,
+                defStyleAttr,
+                R.style.Widget_CommCare_ConnectSuccessFailureCard,
+            ) {
+                radius = getDimension(R.styleable.ConnectSuccessFailureCard_cardCornerRadius, radius)
+                cardElevation = getDimension(R.styleable.ConnectSuccessFailureCard_cardElevation, cardElevation)
+                successBackgroundColor = getColor(R.styleable.ConnectSuccessFailureCard_successBackgroundColor, 0)
+                successAccentColor = getColor(R.styleable.ConnectSuccessFailureCard_successAccentColor, 0)
+                failureBackgroundColor = getColor(R.styleable.ConnectSuccessFailureCard_failureBackgroundColor, 0)
+                failureAccentColor = getColor(R.styleable.ConnectSuccessFailureCard_failureAccentColor, 0)
+                if (hasValue(R.styleable.ConnectSuccessFailureCard_mode)) {
+                    mode = Mode.values()[getInt(R.styleable.ConnectSuccessFailureCard_mode, 0)]
+                }
+                getString(R.styleable.ConnectSuccessFailureCard_messageText)?.let { messageText = it }
+            }
+        }
+
+        private fun applyMode(mode: Mode) {
+            val (backgroundColor, iconRes, accent) =
+                when (mode) {
+                    Mode.SUCCESS -> Triple(successBackgroundColor, R.drawable.check_update, successAccentColor)
+                    Mode.FAILURE -> Triple(failureBackgroundColor, R.drawable.ic_connect_warning, failureAccentColor)
+                }
+            val accentTint = ColorStateList.valueOf(accent)
+
+            setCardBackgroundColor(backgroundColor)
+            binding.successFailureCardIcon.setImageResource(iconRes)
+            ImageViewCompat.setImageTintList(binding.successFailureCardIcon, accentTint)
+            binding.successFailureCardText.setTextColor(accent)
+            ImageViewCompat.setImageTintList(binding.successFailureCardClose, accentTint)
+        }
+
+        companion object {
+            private const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
+        }
+    }

--- a/app/src/org/commcare/views/connect/ConnectSuccessFailureCard.kt
+++ b/app/src/org/commcare/views/connect/ConnectSuccessFailureCard.kt
@@ -33,7 +33,7 @@ class ConnectSuccessFailureCard
         var mode: Mode? = null
             set(value) {
                 field = value
-                value?.let { applyMode(it) }
+                value?.let { applyMode(styleFor(it)) }
             }
 
         var messageText: CharSequence?
@@ -74,9 +74,6 @@ class ConnectSuccessFailureCard
 
         init {
             useCompatPadding = false
-            if (attrs?.getAttributeValue(ANDROID_NAMESPACE, "visibility") == null) {
-                visibility = GONE
-            }
 
             binding.successFailureCardClose.setOnClickListener {
                 visibility = GONE
@@ -89,6 +86,9 @@ class ConnectSuccessFailureCard
                 defStyleAttr,
                 R.style.Widget_CommCare_ConnectSuccessFailureCard,
             ) {
+                if (!hasValue(R.styleable.ConnectSuccessFailureCard_android_visibility)) {
+                    visibility = GONE
+                }
                 radius = getDimension(R.styleable.ConnectSuccessFailureCard_cardCornerRadius, radius)
                 cardElevation = getDimension(R.styleable.ConnectSuccessFailureCard_cardElevation, cardElevation)
                 successBackgroundColor = getColor(R.styleable.ConnectSuccessFailureCard_successBackgroundColor, 0)
@@ -96,28 +96,31 @@ class ConnectSuccessFailureCard
                 failureBackgroundColor = getColor(R.styleable.ConnectSuccessFailureCard_failureBackgroundColor, 0)
                 failureAccentColor = getColor(R.styleable.ConnectSuccessFailureCard_failureAccentColor, 0)
                 if (hasValue(R.styleable.ConnectSuccessFailureCard_mode)) {
-                    mode = Mode.values()[getInt(R.styleable.ConnectSuccessFailureCard_mode, 0)]
+                    mode = Mode.entries[getInt(R.styleable.ConnectSuccessFailureCard_mode, 0)]
                 }
                 getString(R.styleable.ConnectSuccessFailureCard_messageText)?.let { messageText = it }
             }
         }
 
-        private fun applyMode(mode: Mode) {
-            val (backgroundColor, iconRes, accent) =
-                when (mode) {
-                    Mode.SUCCESS -> Triple(successBackgroundColor, R.drawable.check_update, successAccentColor)
-                    Mode.FAILURE -> Triple(failureBackgroundColor, R.drawable.ic_connect_warning, failureAccentColor)
-                }
-            val accentTint = ColorStateList.valueOf(accent)
+        private fun styleFor(mode: Mode) =
+            when (mode) {
+                Mode.SUCCESS -> ModeStyle(successBackgroundColor, R.drawable.check_update, successAccentColor)
+                Mode.FAILURE -> ModeStyle(failureBackgroundColor, R.drawable.ic_connect_warning, failureAccentColor)
+            }
 
-            setCardBackgroundColor(backgroundColor)
-            binding.successFailureCardIcon.setImageResource(iconRes)
+        private fun applyMode(style: ModeStyle) {
+            val accentTint = ColorStateList.valueOf(style.accentColor)
+
+            setCardBackgroundColor(style.backgroundColor)
+            binding.successFailureCardIcon.setImageResource(style.iconRes)
             ImageViewCompat.setImageTintList(binding.successFailureCardIcon, accentTint)
-            binding.successFailureCardText.setTextColor(accent)
+            binding.successFailureCardText.setTextColor(style.accentColor)
             ImageViewCompat.setImageTintList(binding.successFailureCardClose, accentTint)
         }
 
-        companion object {
-            private const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
-        }
+        private data class ModeStyle(
+            val backgroundColor: Int,
+            val iconRes: Int,
+            val accentColor: Int,
+        )
     }

--- a/app/unit-tests/src/org/commcare/views/connect/ConnectSuccessFailureCardTest.kt
+++ b/app/unit-tests/src/org/commcare/views/connect/ConnectSuccessFailureCardTest.kt
@@ -59,13 +59,6 @@ class ConnectSuccessFailureCardTest {
     }
 
     @Test
-    fun `card is hidden by default`() {
-        val card = ConnectSuccessFailureCard(context)
-
-        assertEquals(View.GONE, card.visibility)
-    }
-
-    @Test
     fun `honors an explicit visibility declared in xml`() {
         val attrs =
             Robolectric

--- a/app/unit-tests/src/org/commcare/views/connect/ConnectSuccessFailureCardTest.kt
+++ b/app/unit-tests/src/org/commcare/views/connect/ConnectSuccessFailureCardTest.kt
@@ -1,0 +1,149 @@
+package org.commcare.views.connect
+
+import android.content.Context
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.widget.ImageViewCompat
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.commcare.CommCareTestApplication
+import org.commcare.dalvik.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class ConnectSuccessFailureCardTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun successColor() = context.getColor(R.color.connect_green)
+
+    private fun failureColor() = context.getColor(R.color.connect_red)
+
+    private fun ConnectSuccessFailureCard.icon() = findViewById<ImageView>(R.id.success_failure_card_icon)
+
+    private fun ConnectSuccessFailureCard.message() = findViewById<TextView>(R.id.success_failure_card_text)
+
+    private fun ConnectSuccessFailureCard.close() = findViewById<ImageView>(R.id.success_failure_card_close)
+
+    private fun ImageView.tintColor() = ImageViewCompat.getImageTintList(this)!!.defaultColor
+
+    @Test
+    fun `success mode applies success styling`() {
+        val card = ConnectSuccessFailureCard(context)
+
+        card.show(ConnectSuccessFailureCard.Mode.SUCCESS, "done")
+
+        assertEquals(context.getColor(R.color.connect_light_green), card.cardBackgroundColor.defaultColor)
+        assertEquals(successColor(), card.message().currentTextColor)
+        assertEquals(successColor(), card.icon().tintColor())
+        assertEquals(successColor(), card.close().tintColor())
+    }
+
+    @Test
+    fun `failure mode applies failure styling`() {
+        val card = ConnectSuccessFailureCard(context)
+
+        card.show(ConnectSuccessFailureCard.Mode.FAILURE, "done")
+
+        assertEquals(context.getColor(R.color.pale_coral), card.cardBackgroundColor.defaultColor)
+        assertEquals(failureColor(), card.message().currentTextColor)
+        assertEquals(failureColor(), card.icon().tintColor())
+        assertEquals(failureColor(), card.close().tintColor())
+    }
+
+    @Test
+    fun `card is hidden by default`() {
+        val card = ConnectSuccessFailureCard(context)
+
+        assertEquals(View.GONE, card.visibility)
+    }
+
+    @Test
+    fun `honors an explicit visibility declared in xml`() {
+        val attrs =
+            Robolectric
+                .buildAttributeSet()
+                .addAttribute(android.R.attr.visibility, "visible")
+                .build()
+
+        val card = ConnectSuccessFailureCard(context, attrs)
+
+        assertEquals(View.VISIBLE, card.visibility)
+    }
+
+    @Test
+    fun `stays hidden when xml omits visibility`() {
+        val attrs =
+            Robolectric
+                .buildAttributeSet()
+                .addAttribute(android.R.attr.contentDescription, "status")
+                .build()
+
+        val card = ConnectSuccessFailureCard(context, attrs)
+
+        assertEquals(View.GONE, card.visibility)
+    }
+
+    @Test
+    fun `method show configures mode and message and makes the card visible`() {
+        val card = ConnectSuccessFailureCard(context)
+
+        card.show(ConnectSuccessFailureCard.Mode.FAILURE, "Upload failed")
+
+        assertEquals(View.VISIBLE, card.visibility)
+        assertEquals(ConnectSuccessFailureCard.Mode.FAILURE, card.mode)
+        assertEquals("Upload failed", card.message().text.toString())
+        assertEquals(failureColor(), card.message().currentTextColor)
+    }
+
+    @Test
+    fun `method show with a string resource resolves and displays it`() {
+        val card = ConnectSuccessFailureCard(context)
+
+        card.show(ConnectSuccessFailureCard.Mode.SUCCESS, android.R.string.ok)
+
+        assertEquals(View.VISIBLE, card.visibility)
+        assertEquals(context.getString(android.R.string.ok), card.message().text.toString())
+    }
+
+    @Test
+    fun `tapping close hides the card and invokes the show onDismiss handler`() {
+        val card = ConnectSuccessFailureCard(context)
+        var dismissed = false
+        card.show(ConnectSuccessFailureCard.Mode.SUCCESS, "done") { dismissed = true }
+
+        card.close().performClick()
+
+        assertEquals(View.GONE, card.visibility)
+        assertTrue(dismissed)
+    }
+
+    @Test
+    fun `tapping close without an onDismiss handler still hides the card`() {
+        val card = ConnectSuccessFailureCard(context)
+        card.show(ConnectSuccessFailureCard.Mode.SUCCESS, "done")
+
+        card.close().performClick()
+
+        assertEquals(View.GONE, card.visibility)
+    }
+
+    @Test
+    fun `message stays vertically centered and bounded between the icons`() {
+        val card = ConnectSuccessFailureCard(context)
+        val params = card.message().layoutParams as ConstraintLayout.LayoutParams
+
+        assertEquals(0, params.width)
+        assertEquals(ConstraintLayout.LayoutParams.PARENT_ID, params.topToTop)
+        assertEquals(ConstraintLayout.LayoutParams.PARENT_ID, params.bottomToBottom)
+        assertEquals(R.id.success_failure_card_icon, params.startToEnd)
+        assertEquals(R.id.success_failure_card_close, params.endToStart)
+    }
+}


### PR DESCRIPTION
### [CCCT-2536](https://dimagi.atlassian.net/browse/CCCT-2536)

## Product Description
A reusable dismissible status card for Connect showing a short message in a success or failure style. Not yet placed on any screen, so no user-visible change ships in this PR.

## Technical Summary
- Colors and card chrome live in a style read as the `defStyleRes` fallback. 
- The card is code-driven—hidden by default and revealed via the `show(mode, message)` method. This method also scopes the optional dismiss handler, which triggers whenever the user presses the close (X) button.
- It defaults to `GONE` in `init` only when the XML declares no explicit `android:visibility`, so declarative visibility is still honored.


```
Usage
val card = findViewById<ConnectSuccessFailureCard>(R.id.status_card)
  // or ViewBinding: val card = binding.statusCard
  
  // without callback
  card.show(ConnectSuccessFailureCard.Mode.SUCCESS, R.string.tasks_completed)
  card.show(ConnectSuccessFailureCard.Mode.FAILURE, context.getString(R.string.tasks_completed))
  
  // with dismiss callback
  card.show(ConnectSuccessFailureCard.Mode.FAILURE, R.string.download_failed) {
      viewModel.onStatusDismissed()
  }

```
The sandbox activity was created solely to test the card.
<img width="200" height="444" alt="Success" src="https://github.com/user-attachments/assets/7d3ab369-f69c-49c0-a34f-8405d368032b" /> <img width="200" height="444" alt="Failure" src="https://github.com/user-attachments/assets/719d77eb-8244-4daf-8d9a-d545c13e0c83" />



## Safety Assurance

### Safety story
- I exercised both success and failure modes and the ✕ dismiss on a device/emulator via a throwaway sandbox activity (reverted, not part of this PR).
- The 10 Robolectric tests pass.


### Automated test coverage
Robolectric tests cover per-mode styling, the hidden-by-default and XML-visibility-honoring rules, `show()` (mode/message/visibility and string-resource overload), and the dismiss-plus-callback behavior.

[CCCT-2536]: https://dimagi.atlassian.net/browse/CCCT-2536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ