### PR TITLE
CCCT-2540 Add Open Conversation Button To Connect Job Tile

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -57,6 +57,7 @@ These are published publicly on Playstore, Github Releases and CommCare Forums
 #### What's New
 
 - [Manage Profile] PersonalID users can now view and edit their profile details from the new Manage Profile screen.
+- [Open Conversation] Connect job tile now shows an "Open Conversation" button for delivering jobs with a pending OCS messaging task.
 
 #### Internal Release Notes
 - Deprecated PersonalID support for devices on Android OS less than Android 9.

--- a/app/res/layout/view_progress_job_card.xml
+++ b/app/res/layout/view_progress_job_card.xml
@@ -59,6 +59,25 @@
 
         </androidx.cardview.widget.CardView>
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/acb_open_conversation"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/connect_open_conversation_button_text"
+            android:textColor="@android:color/white"
+            android:textSize="14sp"
+            android:background="@drawable/bg_rounded_corner_lavender_70"
+            android:drawableStart="@drawable/nav_drawer_message_icon"
+            android:drawableEnd="@drawable/connect_right_arrow"
+            android:drawablePadding="8dp"
+            android:padding="16dp"
+            android:layout_marginTop="12dp"
+            android:gravity="center"
+            android:stateListAnimator="@null"
+            app:layout_constraintTop_toBottomOf="@id/cv_relearn_tasks_pending"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
         <TextView
             android:id="@+id/tv_view_more"
             android:layout_width="0dp"
@@ -122,7 +141,7 @@
             android:textColor="@color/connect_subtext_color"
             android:textSize="12sp"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/cv_relearn_tasks_pending" />
+            app:layout_constraintTop_toBottomOf="@+id/acb_open_conversation" />
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/guideline3"

--- a/app/res/layout/view_progress_job_card.xml
+++ b/app/res/layout/view_progress_job_card.xml
@@ -73,6 +73,7 @@
             android:padding="16dp"
             android:layout_marginTop="12dp"
             android:gravity="center"
+            android:visibility="gone"
             android:stateListAnimator="@null"
             app:layout_constraintTop_toBottomOf="@id/cv_relearn_tasks_pending"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -356,6 +356,7 @@
     <string name="connect_progress_warning_max_reached_multi">Has alcanzado el número máximo de visitas para %s.</string>
     <string name="connect_progress_warning_daily_max_reached_multi">Has alcanzado tu límite diario de %s.</string>
     <string name="connect_progress_warning_relearn_tasks_pending">Complete las tareas asignadas para continuar prestando servicios.</string>
+    <string name="connect_open_conversation_button_text">Abrir conversación</string>
     <string name="connect_progress_relearn_tasks_completed">Se han completado todas las tareas requeridas. Puedes continuar con las actividades de entrega.</string>
     <string name="connect_download_learn">Descargar la aplicación Aprender</string>
     <string name="connect_downloading_learn">Descargando la aplicación Aprender</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -353,6 +353,7 @@ License.
     <string name="connect_progress_warning_max_reached_multi">Vous avez atteint le nombre maximum de visites pour %s.</string>
     <string name="connect_progress_warning_daily_max_reached_multi">Vous avez atteint votre limite quotidienne de %s.</string>
     <string name="connect_progress_warning_relearn_tasks_pending">Complétez les tâches assignées pour continuer à fournir des services.</string>
+    <string name="connect_open_conversation_button_text">Ouvrir la conversation</string>
     <string name="connect_progress_relearn_tasks_completed">Toutes les tâches requises ont été complétées. Vous pouvez continuer avec les activités de livraison.</string>
     <string name="connect_download_learn">Téléchargez l\'application Apprendre</string>
     <string name="connect_downloading_learn">Téléchargement de l\'application Learn</string>

--- a/app/res/values-ha/strings.xml
+++ b/app/res/values-ha/strings.xml
@@ -191,6 +191,7 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="connect_progress_warning_max_reached_multi">Kun kai matsakaicin adadin ziyara na %s.</string>
     <string name="connect_progress_warning_daily_max_reached_multi">Kun kai iyakar %s na yau da kullun.</string>
     <string name="connect_progress_warning_relearn_tasks_pending">Kammala ayyukan da aka ba ka don ci gaba da bayar da hidimomi.</string>
+    <string name="connect_open_conversation_button_text">Buɗe Tattaunawa</string>
     <string name="connect_progress_relearn_tasks_completed">An kammala duk ayyukan da ake bukata. Kuna iya ci gaba da ayyukan isarwa.</string>
     <string name="connect_download_learn">Sauke Manhajar Koyi</string>
     <string name="connect_downloading_learn">Sauke Manhajar Koyo</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -353,6 +353,7 @@ License.
     <string name="connect_progress_warning_max_reached_multi">आप %s के लिए अधिकतम विज़िट तक पहुँच गए हैं।</string>
     <string name="connect_progress_warning_daily_max_reached_multi">आप %s के लिए अपनी दैनिक सीमा तक पहुँच गए हैं।</string>
     <string name="connect_progress_warning_relearn_tasks_pending">सेवाएँ प्रदान करना जारी रखने के लिए सौंपे गए कार्य पूरे करें।</string>
+    <string name="connect_open_conversation_button_text">बातचीत खोलें</string>
     <string name="connect_progress_relearn_tasks_completed">सभी आवश्यक कार्य पूरे हो गए हैं। आप वितरण गतिविधियों के साथ जारी रख सकते हैं।</string>
     <string name="connect_download_learn">लर्न ऐप डाउनलोड करें</string>
     <string name="connect_downloading_learn">Learn ऐप डाउनलोड हो रहा है</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -242,6 +242,7 @@
     <string name="connect_job_delivery_preview_subtitle">Baigę mokymosi vertinimą, pereisite prie pristatymo</string>
     <string name="connect_job_info_view_opportunity">Peržiūrėti galimybę</string>
     <string name="connect_progress_warning_relearn_tasks_pending">Užbaikite paskirtas užduotis, kad galėtumėte toliau teikti paslaugas.</string>
+    <string name="connect_open_conversation_button_text">Atidaryti pokalbį</string>
     <string name="connect_progress_relearn_tasks_completed">Visos reikalingos užduotys atliktos. Galite tęsti pristatymo veiklą.</string>
     <string name="connect_last_synced">Paskutinė sinchronizacija: %s</string>
     <string name="connect_sync_successful">Paskutinė sinchronizacija: Ką tik</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -232,6 +232,7 @@
     <string name="connect_job_delivery_preview_subtitle">Når du har fullført opplæringsvurderingen, vil du gå over til levering</string>
     <string name="connect_job_info_view_opportunity">Se mulighet</string>
     <string name="connect_progress_warning_relearn_tasks_pending">Fullfør tildelte oppgaver for å fortsette å levere tjenester.</string>
+    <string name="connect_open_conversation_button_text">Åpne samtale</string>
     <string name="connect_progress_relearn_tasks_completed">Alle nødvendige oppgaver er fullført. Du kan fortsette med leveringsaktiviteter.</string>
     <string name="connect_last_synced">Sist synkronisert: %s</string>
     <string name="connect_sync_successful">Sist synkronisert: Akkurat nå</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -363,6 +363,7 @@
     <string name="connect_progress_warning_max_reached_multi">Você atingiu o número máximo de visitas para %s. </string>
     <string name="connect_progress_warning_daily_max_reached_multi">Atingiu o seu limite diário para %s.</string>
     <string name="connect_progress_warning_relearn_tasks_pending">Complete as tarefas atribuídas para continuar a prestar serviços.</string>
+    <string name="connect_open_conversation_button_text">Abrir conversa</string>
     <string name="connect_progress_relearn_tasks_completed">Todas as tarefas necessárias foram concluídas. Pode continuar com as atividades de entrega.</string>
     <string name="connect_download_learn">Baixe o Aplicativo Aprenda</string>
     <string name="connect_downloading_learn">Descarregamento da aplicação Learn</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -355,6 +355,7 @@
     <string name="connect_progress_warning_max_reached_multi">Umefikia idadi ya juu zaidi ya kutembelewa kwa %s.</string>
     <string name="connect_progress_warning_daily_max_reached_multi">Umefikia kikomo chako cha kila siku kwa %s.</string>
     <string name="connect_progress_warning_relearn_tasks_pending">Kamilisha kazi zilizopewa ili kuendelea kutoa huduma.</string>
+    <string name="connect_open_conversation_button_text">Fungua Mazungumzo</string>
     <string name="connect_progress_relearn_tasks_completed">Kazi zote zinazohitajika zimekamilika. Unaweza kuendelea na shughuli za uwasilishaji.</string>
     <string name="connect_download_learn">Pakua Programu ya Jifunze</string>
     <string name="connect_downloading_learn">Inapakua Programu ya Jifunze</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -351,6 +351,7 @@
     <string name="connect_progress_warning_max_reached_multi">ን %s ዝለዓለ ቁፅሪ ምብፃሕ በፂሕካ ኣለኻ። </string>
     <string name="connect_progress_warning_daily_max_reached_multi">ንመዓልታዊ ገደብ %s በፂሕካ ኣለኻ።</string>
     <string name="connect_progress_warning_relearn_tasks_pending">ኣገልግሎት ምሃብ ንምቕጻል ዝተመደቡ ዕማማት ኣጠናቕቑ።</string>
+    <string name="connect_open_conversation_button_text">ዘተ ክፈት</string>
     <string name="connect_progress_relearn_tasks_completed">ኩሎም ዝድለዩ ስራሕቲ ተዛዚሞም ኣለዉ። ምስ ናይ ኣወሃህባ ንጥፈታት ክትቅጽል ትኽእል ኢኻ።</string>
     <string name="connect_download_learn">Download ተማሃሩ ኣፕ</string>
     <string name="connect_downloading_learn">ምውራድ ( Downloading ) ናይ ትምህርቲ ኣፕ ( App )</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -541,6 +541,7 @@
     <string name="connect_progress_warning_max_reached_multi">You have reached the maximum number of visits for %s. </string>
     <string name="connect_progress_warning_daily_max_reached_multi">You have reached your daily limit for %s.</string>
     <string name="connect_progress_warning_relearn_tasks_pending">Complete assigned tasks to continue delivering services.</string>
+    <string name="connect_open_conversation_button_text">Open Conversation</string>
     <string name="connect_progress_relearn_tasks_completed">All required tasks have been completed. You may continue with delivery activities.</string>
     <string name="connect_download_learn">Download Learn App</string>
     <string name="connect_downloading_learn">Downloading Learn App</string>

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -271,7 +271,7 @@ public class StandardHomeActivity
             }
             case MESSAGING -> {
                 if(personalIdManagedLogin) {
-                    ConnectNavHelper.INSTANCE.goToMessaging(this);
+                    ConnectNavHelper.INSTANCE.goToMessaging(this, null);
                     closeDrawer();
                 } else {
                     navigateToMessaging();

--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 import androidx.annotation.ColorRes;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.AppCompatButton;
 import androidx.cardview.widget.CardView;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -22,15 +23,19 @@ import org.commcare.adapters.HomeScreenAdapter;
 import org.commcare.android.database.connect.models.ConnectAppRecord;
 import org.commcare.android.database.connect.models.ConnectDeliveryPaymentSummaryInfo;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
+import org.commcare.android.database.connect.models.ConnectTaskRecord;
 import org.commcare.connect.ConnectDateUtils;
 import org.commcare.connect.ConnectJobHelper;
+import org.commcare.connect.ConnectNavHelper;
 import org.commcare.connect.database.ConnectJobUtils;
+import org.commcare.connect.database.ConnectTaskUtils;
 import org.commcare.dalvik.R;
 import org.commcare.interfaces.CommCareActivityUIController;
+import org.commcare.personalId.UnlockPolicy;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.preferences.HiddenPreferences;
-import org.commcare.connect.database.ConnectTaskUtils;
 import org.commcare.suite.model.Profile;
+import org.javarosa.core.services.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +54,7 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
     private View viewJobCard;
     private CardView connectMessageCard;
     private ImageView connectMessageWarningIcon;
+    private AppCompatButton acbOpenConversation;
     private ConnectProgressJobSummaryAdapter connectProgressJobSummaryAdapter;
 
     private HomeScreenAdapter adapter;
@@ -85,6 +91,7 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
         viewJobCard = activity.findViewById(R.id.viewJobCard);
         connectMessageCard = activity.findViewById(R.id.cvConnectMessage);
         connectMessageWarningIcon = activity.findViewById(R.id.ivConnectMessageWarningIcon);
+        acbOpenConversation = viewJobCard.findViewById(R.id.acb_open_conversation);
         connectProgressJobSummaryAdapter = new ConnectProgressJobSummaryAdapter(new ArrayList<>());
         RecyclerView recyclerView = viewJobCard.findViewById(R.id.rdDeliveryTypeList);
         recyclerView.setLayoutManager(new LinearLayoutManager(activity));
@@ -134,6 +141,40 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
             cvRelearnTasksPending.setVisibility(View.GONE);
             tvJobTime.setVisibility(View.GONE);
             hoursTitle.setVisibility(View.GONE);
+        }
+        setOpenConversationButtonVisibility(job);
+    }
+
+    private void setOpenConversationButtonVisibility(ConnectJobRecord job) {
+        if (job.getStatus() == STATUS_DELIVERING) {
+            ConnectTaskRecord messagingTask =
+                    ConnectTaskUtils.getPendingTaskOfType(
+                            activity,
+                            job.getJobUUID(),
+                            ConnectTaskRecord.TYPE_OCS
+                    );
+            if (messagingTask == null) {
+                acbOpenConversation.setVisibility(View.GONE);
+            } else if (messagingTask.getConnectChannelId().isEmpty()) {
+                Logger.exception(
+                        "Invalid messaging task",
+                        new Throwable("Messaging task has no channel id: " + messagingTask.getTaskId())
+                );
+                acbOpenConversation.setVisibility(View.GONE);
+            } else {
+                acbOpenConversation.setVisibility(View.VISIBLE);
+                acbOpenConversation.setOnClickListener(v ->
+                        ConnectNavHelper.INSTANCE.unlockAndGoToMessaging(
+                                activity,
+                                UnlockPolicy.SESSION_WITH_TIME_THRESHOLD,
+                                messagingTask.getConnectChannelId(),
+                                (success, error) -> {
+                                }
+                        )
+                );
+            }
+        } else {
+            acbOpenConversation.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -35,7 +35,6 @@ import org.commcare.personalId.UnlockPolicy;
 import org.commcare.preferences.DeveloperPreferences;
 import org.commcare.preferences.HiddenPreferences;
 import org.commcare.suite.model.Profile;
-import org.javarosa.core.services.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -146,35 +145,20 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
     }
 
     private void setOpenConversationButtonVisibility(ConnectJobRecord job) {
-        if (job.getStatus() == STATUS_DELIVERING) {
-            ConnectTaskRecord messagingTask =
-                    ConnectTaskUtils.getPendingTaskOfType(
-                            activity,
-                            job.getJobUUID(),
-                            ConnectTaskRecord.TYPE_OCS
-                    );
-            if (messagingTask == null) {
-                acbOpenConversation.setVisibility(View.GONE);
-            } else if (messagingTask.getConnectChannelId().isEmpty()) {
-                Logger.exception(
-                        "Invalid messaging task",
-                        new Throwable("Messaging task has no channel id: " + messagingTask.getTaskId())
-                );
-                acbOpenConversation.setVisibility(View.GONE);
-            } else {
-                acbOpenConversation.setVisibility(View.VISIBLE);
-                acbOpenConversation.setOnClickListener(v ->
-                        ConnectNavHelper.INSTANCE.unlockAndGoToMessaging(
-                                activity,
-                                UnlockPolicy.SESSION_WITH_TIME_THRESHOLD,
-                                messagingTask.getConnectChannelId(),
-                                (success, error) -> {
-                                }
-                        )
-                );
-            }
-        } else {
+        ConnectTaskRecord messagingTask = ConnectTaskUtils.getValidPendingOcsTask(activity, job);
+        if (messagingTask == null) {
             acbOpenConversation.setVisibility(View.GONE);
+        } else {
+            acbOpenConversation.setVisibility(View.VISIBLE);
+            acbOpenConversation.setOnClickListener(v ->
+                    ConnectNavHelper.INSTANCE.unlockAndGoToMessaging(
+                            activity,
+                            UnlockPolicy.SESSION_WITH_TIME_THRESHOLD,
+                            messagingTask.getConnectChannelId(),
+                            (success, error) -> {
+                            }
+                    )
+            );
         }
     }
 

--- a/app/src/org/commcare/activities/connect/ConnectMessagingActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectMessagingActivity.java
@@ -143,11 +143,6 @@ public class ConnectMessagingActivity extends NavigationHostCommCareActivity<Con
                     ConnectMessagingMessageRecord.META_MESSAGE_CHANNEL_ID);
         }
 
-        if (TextUtils.isEmpty(channelId)) {
-            showFailureMessage(getString(R.string.connect_messaging_pn_wrong_channel));
-            return;
-        }
-
         boolean redirect = CCC_MESSAGE.equals(action) || !TextUtils.isEmpty(channelId);
         if (redirect) {
             unlockAndNavigateToChannel(channelId);
@@ -155,7 +150,10 @@ public class ConnectMessagingActivity extends NavigationHostCommCareActivity<Con
     }
 
     private void unlockAndNavigateToChannel(String channelId) {
-        Objects.requireNonNull(channelId);
+        if (TextUtils.isEmpty(channelId)) {
+            showFailureMessage(getString(R.string.connect_messaging_pn_wrong_channel));
+            return;
+        }
         PersonalIdUnlocker.INSTANCE.unlock(this, UnlockPolicy.SESSION_WITH_TIME_THRESHOLD, success -> {
             if (success) {
                 String notificationId = getIntent().getStringExtra(NOTIFICATION_ID);

--- a/app/src/org/commcare/activities/connect/ConnectMessagingActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectMessagingActivity.java
@@ -24,6 +24,8 @@ import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogController;
 
+import java.util.Objects;
+
 import static org.commcare.connect.ConnectConstants.CCC_MESSAGE;
 import static org.commcare.connect.ConnectConstants.NETWORK_ACTIVITY_MESSAGING_CHANNEL_ID;
 import static org.commcare.connect.ConnectConstants.NOTIFICATION_ID;
@@ -127,6 +129,8 @@ public class ConnectMessagingActivity extends NavigationHostCommCareActivity<Con
 
     private void handleRedirectIfAny() {
         String action = getIntent().getStringExtra(REDIRECT_ACTION);
+        String channelId = getIntent().getStringExtra(CHANNEL_ID);
+
         if (CCC_MESSAGE.equals(action)) {
             PersonalIdManager.getInstance().init(this);
             FirebaseAnalyticsUtil.reportNotificationEvent(
@@ -135,25 +139,35 @@ public class ConnectMessagingActivity extends NavigationHostCommCareActivity<Con
                     getNotificationActionFromIntent(getIntent()),
                     getIntent().getStringExtra(NOTIFICATION_ID)
             );
-            PersonalIdUnlocker.INSTANCE.unlock(this, UnlockPolicy.SESSION_WITH_TIME_THRESHOLD, success -> {
-                if (success) {
-                    String channelId = getIntent().getStringExtra(
-                            ConnectMessagingMessageRecord.META_MESSAGE_CHANNEL_ID);
-                    String notificationId = getIntent().getStringExtra(NOTIFICATION_ID);
-                    if (!TextUtils.isEmpty(notificationId)) {
-                        NotificationRecordDatabaseHelper.INSTANCE
-                                .updateReadStatus(this, notificationId, true);
-                    }
-                    if (TextUtils.isEmpty(channelId)) {
-                        showFailureMessage(getString(R.string.connect_messaging_pn_wrong_channel));
-                    } else {
-                        handleChannelForValidity(channelId);
-                    }
-                } else {
-                    finish();
-                }
-            });
+            channelId = getIntent().getStringExtra(
+                    ConnectMessagingMessageRecord.META_MESSAGE_CHANNEL_ID);
         }
+
+        if (TextUtils.isEmpty(channelId)) {
+            showFailureMessage(getString(R.string.connect_messaging_pn_wrong_channel));
+            return;
+        }
+
+        boolean redirect = CCC_MESSAGE.equals(action) || !TextUtils.isEmpty(channelId);
+        if (redirect) {
+            unlockAndNavigateToChannel(channelId);
+        }
+    }
+
+    private void unlockAndNavigateToChannel(String channelId) {
+        Objects.requireNonNull(channelId);
+        PersonalIdUnlocker.INSTANCE.unlock(this, UnlockPolicy.SESSION_WITH_TIME_THRESHOLD, success -> {
+            if (success) {
+                String notificationId = getIntent().getStringExtra(NOTIFICATION_ID);
+                if (!TextUtils.isEmpty(notificationId)) {
+                    NotificationRecordDatabaseHelper.INSTANCE
+                            .updateReadStatus(this, notificationId, true);
+                }
+                handleChannelForValidity(channelId);
+            } else {
+                finish();
+            }
+        });
     }
 
     private void handleChannelForValidity(String channelId) {

--- a/app/src/org/commcare/android/database/connect/models/ConnectTaskRecord.kt
+++ b/app/src/org/commcare/android/database/connect/models/ConnectTaskRecord.kt
@@ -57,6 +57,11 @@ class ConnectTaskRecord :
 
     companion object {
         const val STORAGE_KEY = "connect_tasks"
+
+        const val STATUS_ASSIGNED = "assigned"
+        const val STATUS_COMPLETED = "completed"
+        const val TYPE_OCS = "ocs"
+
         const val META_JOB_UUID = "opportunity_id"
         const val META_TASK_ID = "task_id"
         const val META_NAME = "name"

--- a/app/src/org/commcare/connect/ConnectNavHelper.kt
+++ b/app/src/org/commcare/connect/ConnectNavHelper.kt
@@ -45,7 +45,7 @@ object ConnectNavHelper {
         channelId: String? = null,
     ) {
         val i = Intent(context, ConnectMessagingActivity::class.java)
-        if (channelId != null) {
+        if (!channelId.isNullOrEmpty()) {
             i.putExtra(ConnectMessagingActivity.CHANNEL_ID, channelId)
         }
         context.startActivity(i)

--- a/app/src/org/commcare/connect/ConnectNavHelper.kt
+++ b/app/src/org/commcare/connect/ConnectNavHelper.kt
@@ -34,13 +34,20 @@ object ConnectNavHelper {
     fun unlockAndGoToMessaging(
         activity: CommCareActivity<*>,
         policy: UnlockPolicy = UnlockPolicy.SESSION_WITH_TIME_THRESHOLD,
+        channelId: String? = null,
         listener: ConnectActivityCompleteListener,
     ) {
-        unlockAndGoTo(activity, policy, listener, ::goToMessaging)
+        unlockAndGoTo(activity, policy, listener) { context -> goToMessaging(context, channelId) }
     }
 
-    fun goToMessaging(context: Context) {
+    fun goToMessaging(
+        context: Context,
+        channelId: String? = null,
+    ) {
         val i = Intent(context, ConnectMessagingActivity::class.java)
+        if (channelId != null) {
+            i.putExtra(ConnectMessagingActivity.CHANNEL_ID, channelId)
+        }
         context.startActivity(i)
     }
 

--- a/app/src/org/commcare/connect/database/ConnectTaskUtils.kt
+++ b/app/src/org/commcare/connect/database/ConnectTaskUtils.kt
@@ -50,7 +50,7 @@ object ConnectTaskUtils {
         }
 
         ConnectJobUtils.getJobPreferences(jobUUID).apply {
-            setRelearnTaskPending(incoming.any { it.status == "assigned" })
+            setRelearnTaskPending(incoming.any { it.status == ConnectTaskRecord.STATUS_ASSIGNED })
             resetRelearnTasksCompletedTime()
             if (changed) {
                 updateTaskModifiedTime()
@@ -69,7 +69,7 @@ object ConnectTaskUtils {
     ): Boolean {
         val tasks = getTasksForJob(context, jobUUID, null)
         if (tasks.isNotEmpty()) {
-            return tasks.any { it.status == "assigned" }
+            return tasks.any { it.status == ConnectTaskRecord.STATUS_ASSIGNED }
         }
         return ConnectJobUtils.getJobPreferences(jobUUID).isRelearnTaskPending()
     }
@@ -86,7 +86,8 @@ object ConnectTaskUtils {
         context: Context,
         jobUUID: String,
         type: String,
-    ): ConnectTaskRecord? = getTasksForJob(context, jobUUID, null).find { it.type == type && it.status == "assigned" }
+    ): ConnectTaskRecord? =
+        getTasksForJob(context, jobUUID, null).find { it.type == type && it.status == ConnectTaskRecord.STATUS_ASSIGNED }
 
     @JvmStatic
     fun shouldShowTasksCompletedMessage(
@@ -119,7 +120,7 @@ object ConnectTaskUtils {
     ): ConnectTaskRecord? {
         val tasks = getTasksForJob(context, jobUUID, null)
         if (tasks.isNotEmpty()) {
-            return tasks.filter { it.status == "completed" }.maxByOrNull { it.dateModified }
+            return tasks.filter { it.status == ConnectTaskRecord.STATUS_COMPLETED }.maxByOrNull { it.dateModified }
         }
         val prefs = ConnectJobUtils.getJobPreferences(jobUUID)
         val completedTimeMs = prefs.getRelearnTasksCompletedTimeMs()

--- a/app/src/org/commcare/connect/database/ConnectTaskUtils.kt
+++ b/app/src/org/commcare/connect/database/ConnectTaskUtils.kt
@@ -8,6 +8,7 @@ import org.commcare.models.database.SqlStorage
 import org.commcare.preferences.ConnectJobPreferences
 import org.commcare.utils.SyncDetailCalculations
 import org.javarosa.core.model.utils.DateUtils
+import org.javarosa.core.services.Logger
 import java.util.Date
 
 /**
@@ -88,6 +89,23 @@ object ConnectTaskUtils {
         type: String,
     ): ConnectTaskRecord? =
         getTasksForJob(context, jobUUID, null).find { it.type == type && it.status == ConnectTaskRecord.STATUS_ASSIGNED }
+
+    @JvmStatic
+    fun getValidPendingOcsTask(
+        context: Context,
+        job: ConnectJobRecord,
+    ): ConnectTaskRecord? {
+        if (job.status != ConnectJobRecord.STATUS_DELIVERING) return null
+        val task = getPendingTaskOfType(context, job.jobUUID, ConnectTaskRecord.TYPE_OCS) ?: return null
+        if (task.connectChannelId.isEmpty()) {
+            Logger.exception(
+                "Invalid messaging task",
+                Throwable("Messaging task has no channel id: ${task.taskId}"),
+            )
+            return null
+        }
+        return task
+    }
 
     @JvmStatic
     fun shouldShowTasksCompletedMessage(

--- a/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
+++ b/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
@@ -83,7 +83,6 @@ public class ConnectMessageFragment extends Fragment {
         channelId = args.getChannelId();
 
         channel = ConnectMessagingDatabaseHelper.getMessagingChannel(requireContext(), channelId);
-        requireActivity().setTitle(channel.getChannelName());
 
         handleSendButtonListener();
         setChatAdapter();
@@ -167,6 +166,7 @@ public class ConnectMessageFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
+        requireActivity().setTitle(channel.getChannelName());
         activeChannel = channelId;
 
         LocalBroadcastManager.getInstance(requireContext()).registerReceiver(updateReceiver,

--- a/app/unit-tests/src/org/commcare/connect/database/ConnectTaskUtilsTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/database/ConnectTaskUtilsTest.kt
@@ -10,7 +10,10 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.commcare.CommCareTestApplication
 import org.commcare.android.database.connect.models.ConnectJobRecord
+import org.commcare.android.database.connect.models.ConnectJobRecord.STATUS_DELIVERING
 import org.commcare.android.database.connect.models.ConnectTaskRecord
+import org.commcare.android.database.connect.models.ConnectTaskRecord.Companion.STATUS_ASSIGNED
+import org.commcare.android.database.connect.models.ConnectTaskRecord.Companion.STATUS_COMPLETED
 import org.commcare.connect.ConnectJobHelper
 import org.commcare.preferences.ConnectJobPreferences
 import org.commcare.utils.SyncDetailCalculations
@@ -50,7 +53,7 @@ class ConnectTaskUtilsTest {
 
     private fun makeTask(
         taskId: String = "task-1",
-        status: String = "assigned",
+        status: String = STATUS_ASSIGNED,
         type: String = "learning",
         dateModified: Date = Date(),
         dueDate: Date = Date(0),
@@ -64,7 +67,7 @@ class ConnectTaskUtilsTest {
         this.name = "Task $taskId"
     }
 
-    private fun makeJob(jobStatus: Int = ConnectJobRecord.STATUS_DELIVERING) =
+    private fun makeJob(jobStatus: Int = STATUS_DELIVERING) =
         mockk<ConnectJobRecord> {
             every { jobUUID } returns this@ConnectTaskUtilsTest.jobUUID
             every { status } returns jobStatus
@@ -102,8 +105,8 @@ class ConnectTaskUtilsTest {
     @Test
     fun `storeTasks does not rewrite an unchanged existing task`() {
         val sharedDate = Date()
-        seedTask(makeTask(taskId = "task-1", status = "assigned", dateModified = sharedDate))
-        val incoming = makeTask(taskId = "task-1", status = "assigned", dateModified = sharedDate)
+        seedTask(makeTask(taskId = "task-1", status = STATUS_ASSIGNED, dateModified = sharedDate))
+        val incoming = makeTask(taskId = "task-1", status = STATUS_ASSIGNED, dateModified = sharedDate)
 
         ConnectTaskUtils.storeTasks(context, listOf(incoming), jobUUID)
 
@@ -113,19 +116,19 @@ class ConnectTaskUtilsTest {
 
     @Test
     fun `storeTasks updates existing task whose mutable field changed`() {
-        seedTask(makeTask(taskId = "task-1", status = "assigned"))
-        val incoming = makeTask(taskId = "task-1", status = "completed")
+        seedTask(makeTask(taskId = "task-1", status = STATUS_ASSIGNED))
+        val incoming = makeTask(taskId = "task-1", status = STATUS_COMPLETED)
 
         ConnectTaskUtils.storeTasks(context, listOf(incoming), jobUUID)
 
-        assertEquals("completed", queryTasks().first().status)
+        assertEquals(STATUS_COMPLETED, queryTasks().first().status)
     }
 
     @Test
     fun `storeTasks updates task modified time when a task changed`() {
-        seedTask(makeTask(taskId = "task-1", status = "assigned"))
+        seedTask(makeTask(taskId = "task-1", status = STATUS_ASSIGNED))
 
-        ConnectTaskUtils.storeTasks(context, listOf(makeTask(taskId = "task-1", status = "completed")), jobUUID)
+        ConnectTaskUtils.storeTasks(context, listOf(makeTask(taskId = "task-1", status = STATUS_COMPLETED)), jobUUID)
 
         assertNotEquals(ConnectJobPreferences.TIMESTAMP_NOT_SET, prefs().getTaskModifiedTime())
     }
@@ -133,23 +136,23 @@ class ConnectTaskUtilsTest {
     @Test
     fun `storeTasks does not update task modified time when nothing changed`() {
         val sharedDate = Date()
-        seedTask(makeTask(taskId = "task-1", status = "assigned", dateModified = sharedDate))
+        seedTask(makeTask(taskId = "task-1", status = STATUS_ASSIGNED, dateModified = sharedDate))
 
-        ConnectTaskUtils.storeTasks(context, listOf(makeTask(taskId = "task-1", status = "assigned", dateModified = sharedDate)), jobUUID)
+        ConnectTaskUtils.storeTasks(context, listOf(makeTask(taskId = "task-1", status = STATUS_ASSIGNED, dateModified = sharedDate)), jobUUID)
 
         assertEquals(ConnectJobPreferences.TIMESTAMP_NOT_SET, prefs().getTaskModifiedTime())
     }
 
     @Test
     fun `storeTasks sets relearn task pending true when any incoming task is assigned`() {
-        ConnectTaskUtils.storeTasks(context, listOf(makeTask(status = "assigned")), jobUUID)
+        ConnectTaskUtils.storeTasks(context, listOf(makeTask(status = STATUS_ASSIGNED)), jobUUID)
 
         assertTrue(prefs().isRelearnTaskPending())
     }
 
     @Test
     fun `storeTasks sets relearn task pending false when no incoming tasks are assigned`() {
-        ConnectTaskUtils.storeTasks(context, listOf(makeTask(status = "completed")), jobUUID)
+        ConnectTaskUtils.storeTasks(context, listOf(makeTask(status = STATUS_COMPLETED)), jobUUID)
 
         assertFalse(prefs().isRelearnTaskPending())
     }
@@ -196,14 +199,14 @@ class ConnectTaskUtilsTest {
 
     @Test
     fun `hasPendingTask returns true when DB has an assigned task`() {
-        seedTask(makeTask(status = "assigned"))
+        seedTask(makeTask(status = STATUS_ASSIGNED))
 
         assertTrue(ConnectTaskUtils.hasPendingTask(context, jobUUID))
     }
 
     @Test
     fun `hasPendingTask returns false when DB has only completed tasks`() {
-        seedTask(makeTask(status = "completed"))
+        seedTask(makeTask(status = STATUS_COMPLETED))
 
         assertFalse(ConnectTaskUtils.hasPendingTask(context, jobUUID))
     }
@@ -226,7 +229,7 @@ class ConnectTaskUtilsTest {
 
     @Test
     fun `getPendingTaskOfType returns task matching type and assigned status`() {
-        seedTask(makeTask(taskId = "t1", status = "assigned", type = "learning"))
+        seedTask(makeTask(taskId = "t1", status = STATUS_ASSIGNED, type = "learning"))
 
         val result = ConnectTaskUtils.getPendingTaskOfType(context, jobUUID, "learning")
         assertEquals("t1", result?.taskId)
@@ -234,21 +237,21 @@ class ConnectTaskUtilsTest {
 
     @Test
     fun `getPendingTaskOfType returns null when type does not match`() {
-        seedTask(makeTask(status = "assigned", type = "delivery"))
+        seedTask(makeTask(status = STATUS_ASSIGNED, type = "delivery"))
 
         assertNull(ConnectTaskUtils.getPendingTaskOfType(context, jobUUID, "learning"))
     }
 
     @Test
     fun `getPendingTaskOfType returns null when type matches but status is not assigned`() {
-        seedTask(makeTask(status = "completed", type = "learning"))
+        seedTask(makeTask(status = STATUS_COMPLETED, type = "learning"))
 
         assertNull(ConnectTaskUtils.getPendingTaskOfType(context, jobUUID, "learning"))
     }
 
     @Test
     fun `hasPendingTaskOfType returns true when matching assigned task exists`() {
-        seedTask(makeTask(status = "assigned", type = "learning"))
+        seedTask(makeTask(status = STATUS_ASSIGNED, type = "learning"))
 
         assertTrue(ConnectTaskUtils.hasPendingTaskOfType(context, jobUUID, "learning"))
     }
@@ -264,7 +267,7 @@ class ConnectTaskUtilsTest {
 
     @Test
     fun `shouldShowTasksCompletedMessage returns false when there is a pending task`() {
-        seedTask(makeTask(status = "assigned"))
+        seedTask(makeTask(status = STATUS_ASSIGNED))
 
         assertFalse(ConnectTaskUtils.shouldShowTasksCompletedMessage(context, makeJob()))
     }
@@ -276,22 +279,22 @@ class ConnectTaskUtilsTest {
 
     @Test
     fun `shouldShowTasksCompletedMessage returns true when task completed within 6h and job is DELIVERING`() {
-        seedTask(makeTask(status = "completed", dateModified = Date()))
+        seedTask(makeTask(status = STATUS_COMPLETED, dateModified = Date()))
 
-        assertTrue(ConnectTaskUtils.shouldShowTasksCompletedMessage(context, makeJob(ConnectJobRecord.STATUS_DELIVERING)))
+        assertTrue(ConnectTaskUtils.shouldShowTasksCompletedMessage(context, makeJob(STATUS_DELIVERING)))
     }
 
     @Test
     fun `shouldShowTasksCompletedMessage returns false when task completed more than 6h ago`() {
         val sevenHoursAgo = Date(System.currentTimeMillis() - 7 * 60 * 60 * 1000L)
-        seedTask(makeTask(status = "completed", dateModified = sevenHoursAgo))
+        seedTask(makeTask(status = STATUS_COMPLETED, dateModified = sevenHoursAgo))
 
         assertFalse(ConnectTaskUtils.shouldShowTasksCompletedMessage(context, makeJob()))
     }
 
     @Test
     fun `shouldShowTasksCompletedMessage returns false when completed within 6h but job not DELIVERING`() {
-        seedTask(makeTask(status = "completed", dateModified = Date()))
+        seedTask(makeTask(status = STATUS_COMPLETED, dateModified = Date()))
 
         assertFalse(ConnectTaskUtils.shouldShowTasksCompletedMessage(context, makeJob(ConnectJobRecord.STATUS_LEARNING)))
     }
@@ -343,8 +346,8 @@ class ConnectTaskUtilsTest {
     @Test
     fun `isLastTaskUpdateLaterThanLastSync returns false when task was modified before last sync`() {
         // Trigger a real task change so taskModifiedTime = ~now
-        seedTask(makeTask(taskId = "task-1", status = "assigned"))
-        ConnectTaskUtils.storeTasks(context, listOf(makeTask(taskId = "task-1", status = "completed")), jobUUID)
+        seedTask(makeTask(taskId = "task-1", status = STATUS_ASSIGNED))
+        ConnectTaskUtils.storeTasks(context, listOf(makeTask(taskId = "task-1", status = STATUS_COMPLETED)), jobUUID)
 
         // Mock last sync as happening after the task update
         mockkObject(ConnectJobHelper)
@@ -361,8 +364,8 @@ class ConnectTaskUtilsTest {
         mockkStatic(SyncDetailCalculations::class)
         every { ConnectJobHelper.getJobForSeatedApp(context) } returns makeJob()
         every { SyncDetailCalculations.getLastSyncTime() } returns 0L
-        seedTask(makeTask(taskId = "task-1", status = "assigned"))
-        ConnectTaskUtils.storeTasks(context, listOf(makeTask(taskId = "task-1", status = "completed")), jobUUID)
+        seedTask(makeTask(taskId = "task-1", status = STATUS_ASSIGNED))
+        ConnectTaskUtils.storeTasks(context, listOf(makeTask(taskId = "task-1", status = STATUS_COMPLETED)), jobUUID)
 
         assertTrue(ConnectTaskUtils.isLastTaskUpdateLaterThanLastSync(context))
     }

--- a/app/unit-tests/src/org/commcare/connect/database/ConnectTaskUtilsTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/database/ConnectTaskUtilsTest.kt
@@ -138,7 +138,11 @@ class ConnectTaskUtilsTest {
         val sharedDate = Date()
         seedTask(makeTask(taskId = "task-1", status = STATUS_ASSIGNED, dateModified = sharedDate))
 
-        ConnectTaskUtils.storeTasks(context, listOf(makeTask(taskId = "task-1", status = STATUS_ASSIGNED, dateModified = sharedDate)), jobUUID)
+        ConnectTaskUtils.storeTasks(
+            context,
+            listOf(makeTask(taskId = "task-1", status = STATUS_ASSIGNED, dateModified = sharedDate)),
+            jobUUID,
+        )
 
         assertEquals(ConnectJobPreferences.TIMESTAMP_NOT_SET, prefs().getTaskModifiedTime())
     }


### PR DESCRIPTION
### [CCCT-2540](https://dimagi.atlassian.net/browse/CCCT-2540)

## Product Description

Adds an "Open Conversation" button to the Connect job tile on the home screen. The button appears when a job is in DELIVERING status and has a pending OCS messaging task with an assigned channel. Tapping it triggers a PersonalID unlock (if required) and navigates directly to the messaging channel.

https://github.com/user-attachments/assets/cf7d29dc-e8e2-486e-b89e-47050d6853ed

## Safety Assurance

### Safety story

**Confidence:**
- I manually exercised the Open Conversation button flow (unlock + channel navigation) and the existing Messaging nav drawer flow on a device — both behaved correctly.

### Automated test coverage

`ConnectTaskUtilsTest` updated to use the new constants — existing test cases cover `getPendingTaskOfType`, `hasPendingTask`, and `storeTasks` paths affected by the refactor. No new test cases added for the UI wiring.

🐟 -> 🐟 

[CCCT-2540]: https://dimagi.atlassian.net/browse/CCCT-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ