### PR TITLE
Fix channel name for Messaging

### DIFF
--- a/app/src/org/commcare/adapters/ChannelAdapter.java
+++ b/app/src/org/commcare/adapters/ChannelAdapter.java
@@ -84,7 +84,7 @@ public class ChannelAdapter extends RecyclerView.Adapter<ChannelAdapter.ChannelV
                 ConnectMessagingChannelRecord channel,
                 OnChannelClickListener clickListener
         ) {
-            binding.tvChannelName.setText(channel.getChannelName());
+            binding.tvChannelName.setText(channel.getChannelSource());
 
             Date lastDate = channel.getLastMessageDate();
             int unread = channel.getUnreadCount();

--- a/app/src/org/commcare/adapters/ChannelAdapter.java
+++ b/app/src/org/commcare/adapters/ChannelAdapter.java
@@ -84,7 +84,7 @@ public class ChannelAdapter extends RecyclerView.Adapter<ChannelAdapter.ChannelV
                 ConnectMessagingChannelRecord channel,
                 OnChannelClickListener clickListener
         ) {
-            binding.tvChannelName.setText(channel.getChannelSource());
+            binding.tvChannelName.setText(channel.getDisplayName());
 
             Date lastDate = channel.getLastMessageDate();
             int unread = channel.getUnreadCount();

--- a/app/src/org/commcare/android/database/connect/models/ConnectMessagingChannelRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectMessagingChannelRecord.java
@@ -88,6 +88,19 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
         return connectMessagingChannelRecord;
     }
 
+    public static ConnectMessagingChannelRecord fromV27(ConnectMessagingChannelRecordV27 oldRecord) {
+        ConnectMessagingChannelRecord record = new ConnectMessagingChannelRecord();
+        record.channelId = oldRecord.getChannelId();
+        record.channelCreated = oldRecord.getChannelCreated();
+        record.answeredConsent = oldRecord.getAnsweredConsent();
+        record.consented = oldRecord.getConsented();
+        record.channelSource = oldRecord.getChannelSource();
+        record.keyUrl = oldRecord.getKeyUrl();
+        record.key = oldRecord.getKey();
+        record.channelName = "";
+        return record;
+    }
+
     public static ConnectMessagingChannelRecord fromMessagePayload(Map<String, String> payloadData) {
         ConnectMessagingChannelRecord connectMessagingChannelRecord = new ConnectMessagingChannelRecord();
 

--- a/app/src/org/commcare/android/database/connect/models/ConnectMessagingChannelRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectMessagingChannelRecord.java
@@ -10,7 +10,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.Serializable;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -28,7 +27,7 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
     public static final String META_CHANNEL_CREATED = "created";
     public static final String META_ANSWERED_CONSENT = "answered_consent";
     public static final String META_CONSENT = "consent";
-    public static final String META_CHANNEL_NAME = "channel_source";
+    public static final String META_CHANNEL_SOURCE = "channel_source";
     public static final String META_KEY_URL = "key_url";
     public static final String META_KEY = "key";
 
@@ -53,8 +52,8 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
     private boolean consented;
 
     @Persisting(5)
-    @MetaField(META_CHANNEL_NAME)
-    private String channelName;
+    @MetaField(META_CHANNEL_SOURCE)
+    private String channelSource;
 
     @Persisting(6)
     @MetaField(META_KEY_URL)
@@ -73,7 +72,7 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
 
         connectMessagingChannelRecord.channelId = json.getString(META_CHANNEL_ID);
         connectMessagingChannelRecord.consented = json.getBoolean(META_CONSENT);
-        connectMessagingChannelRecord.channelName = json.getString(META_CHANNEL_NAME);
+        connectMessagingChannelRecord.channelSource = json.getString(META_CHANNEL_SOURCE);
         connectMessagingChannelRecord.keyUrl = json.getString(META_KEY_URL);
 
         connectMessagingChannelRecord.channelCreated = new Date();
@@ -88,7 +87,7 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
 
         connectMessagingChannelRecord.channelId = payloadData.get(META_CHANNEL_ID);
         connectMessagingChannelRecord.consented = payloadData.get(META_CONSENT).equals("true");
-        connectMessagingChannelRecord.channelName = payloadData.get(META_CHANNEL_NAME);
+        connectMessagingChannelRecord.channelSource = payloadData.get(META_CHANNEL_SOURCE);
         connectMessagingChannelRecord.keyUrl = payloadData.get(META_KEY_URL);
 
         connectMessagingChannelRecord.channelCreated = new Date();
@@ -130,12 +129,12 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
         this.consented = consented;
     }
 
-    public String getChannelName() {
-        return channelName;
+    public String getChannelSource() {
+        return channelSource;
     }
 
-    public void setChannelName(String channelName) {
-        this.channelName = channelName;
+    public void setChannelSource(String channelSource) {
+        this.channelSource = channelSource;
     }
 
     public String getKeyUrl() {

--- a/app/src/org/commcare/android/database/connect/models/ConnectMessagingChannelRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectMessagingChannelRecord.java
@@ -30,6 +30,7 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
     public static final String META_CHANNEL_SOURCE = "channel_source";
     public static final String META_KEY_URL = "key_url";
     public static final String META_KEY = "key";
+    public static final String META_CHANNEL_NAME = "channel_name";
 
     public ConnectMessagingChannelRecord() {
 
@@ -63,6 +64,10 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
     @MetaField(META_KEY)
     private String key;
 
+    @Persisting(8)
+    @MetaField(META_CHANNEL_NAME)
+    private String channelName;
+
     private SpannableString preview;
 
     private List<ConnectMessagingMessageRecord> messages = new ArrayList<>();
@@ -74,6 +79,7 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
         connectMessagingChannelRecord.consented = json.getBoolean(META_CONSENT);
         connectMessagingChannelRecord.channelSource = json.getString(META_CHANNEL_SOURCE);
         connectMessagingChannelRecord.keyUrl = json.getString(META_KEY_URL);
+        connectMessagingChannelRecord.channelName = json.optString(META_CHANNEL_NAME, "");
 
         connectMessagingChannelRecord.channelCreated = new Date();
         connectMessagingChannelRecord.answeredConsent = false;
@@ -89,6 +95,8 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
         connectMessagingChannelRecord.consented = payloadData.get(META_CONSENT).equals("true");
         connectMessagingChannelRecord.channelSource = payloadData.get(META_CHANNEL_SOURCE);
         connectMessagingChannelRecord.keyUrl = payloadData.get(META_KEY_URL);
+        String channelName = payloadData.get(META_CHANNEL_NAME);
+        connectMessagingChannelRecord.channelName = channelName != null ? channelName : "";
 
         connectMessagingChannelRecord.channelCreated = new Date();
         connectMessagingChannelRecord.answeredConsent = false;
@@ -151,6 +159,18 @@ public class ConnectMessagingChannelRecord extends Persisted implements Serializ
 
     public void setKey(String key) {
         this.key = key;
+    }
+
+    public String getChannelName() {
+        return channelName;
+    }
+
+    public void setChannelName(String channelName) {
+        this.channelName = channelName;
+    }
+
+    public String getDisplayName() {
+        return (channelName != null && !channelName.isEmpty()) ? channelName : channelSource;
     }
 
     public List<ConnectMessagingMessageRecord> getMessages() {

--- a/app/src/org/commcare/android/database/connect/models/ConnectMessagingChannelRecordV27.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectMessagingChannelRecordV27.java
@@ -1,0 +1,71 @@
+package org.commcare.android.database.connect.models;
+
+import org.commcare.android.storage.framework.Persisted;
+import org.commcare.models.framework.Persisting;
+import org.commcare.modern.database.Table;
+import org.commcare.modern.models.MetaField;
+
+import java.util.Date;
+
+@Table(ConnectMessagingChannelRecord.STORAGE_KEY)
+public class ConnectMessagingChannelRecordV27 extends Persisted {
+
+    public ConnectMessagingChannelRecordV27() {
+    }
+
+    @Persisting(1)
+    @MetaField(ConnectMessagingChannelRecord.META_CHANNEL_ID)
+    private String channelId;
+
+    @Persisting(2)
+    @MetaField(ConnectMessagingChannelRecord.META_CHANNEL_CREATED)
+    private Date channelCreated;
+
+    @Persisting(3)
+    @MetaField(ConnectMessagingChannelRecord.META_ANSWERED_CONSENT)
+    private boolean answeredConsent;
+
+    @Persisting(4)
+    @MetaField(ConnectMessagingChannelRecord.META_CONSENT)
+    private boolean consented;
+
+    @Persisting(5)
+    @MetaField(ConnectMessagingChannelRecord.META_CHANNEL_SOURCE)
+    private String channelSource;
+
+    @Persisting(6)
+    @MetaField(ConnectMessagingChannelRecord.META_KEY_URL)
+    private String keyUrl;
+
+    @Persisting(7)
+    @MetaField(ConnectMessagingChannelRecord.META_KEY)
+    private String key;
+
+    public String getChannelId() {
+        return channelId;
+    }
+
+    public Date getChannelCreated() {
+        return channelCreated;
+    }
+
+    public boolean getAnsweredConsent() {
+        return answeredConsent;
+    }
+
+    public boolean getConsented() {
+        return consented;
+    }
+
+    public String getChannelSource() {
+        return channelSource;
+    }
+
+    public String getKeyUrl() {
+        return keyUrl;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
+++ b/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
@@ -83,7 +83,7 @@ public class ConnectMessageFragment extends Fragment {
         channelId = args.getChannelId();
 
         channel = ConnectMessagingDatabaseHelper.getMessagingChannel(requireContext(), channelId);
-        requireActivity().setTitle(channel.getChannelName());
+        requireActivity().setTitle(channel.getChannelSource());
 
         handleSendButtonListener();
         setChatAdapter();
@@ -341,7 +341,7 @@ public class ConnectMessageFragment extends Fragment {
         if (menuItemId == MENU_UNSUBSCRIBE) {
             String titleText = getString(
                     R.string.connect_messaging_unsubscribe_dialog_title,
-                    channel.getChannelName()
+                    channel.getChannelSource()
             );
             String messageText = getString(R.string.connect_messaging_unsubscribe_dialog_body);
             String negativeButtonText =
@@ -377,11 +377,11 @@ public class ConnectMessageFragment extends Fragment {
         } else if (menuItemId == MENU_RESUBSCRIBE) {
             String titleText = getString(
                     R.string.connect_messaging_resubscribe_dialog_title,
-                    channel.getChannelName()
+                    channel.getChannelSource()
             );
             String messageText = getString(
                     R.string.connect_messaging_resubscribe_dialog_body,
-                    channel.getChannelName()
+                    channel.getChannelSource()
             );
             String negativeButtonText =
                     getString(R.string.connect_messaging_resubscribe_dialog_cancel);

--- a/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
+++ b/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
@@ -83,7 +83,7 @@ public class ConnectMessageFragment extends Fragment {
         channelId = args.getChannelId();
 
         channel = ConnectMessagingDatabaseHelper.getMessagingChannel(requireContext(), channelId);
-        requireActivity().setTitle(channel.getChannelSource());
+        requireActivity().setTitle(channel.getDisplayName());
 
         handleSendButtonListener();
         setChatAdapter();
@@ -341,7 +341,7 @@ public class ConnectMessageFragment extends Fragment {
         if (menuItemId == MENU_UNSUBSCRIBE) {
             String titleText = getString(
                     R.string.connect_messaging_unsubscribe_dialog_title,
-                    channel.getChannelSource()
+                    channel.getDisplayName()
             );
             String messageText = getString(R.string.connect_messaging_unsubscribe_dialog_body);
             String negativeButtonText =
@@ -377,11 +377,11 @@ public class ConnectMessageFragment extends Fragment {
         } else if (menuItemId == MENU_RESUBSCRIBE) {
             String titleText = getString(
                     R.string.connect_messaging_resubscribe_dialog_title,
-                    channel.getChannelSource()
+                    channel.getDisplayName()
             );
             String messageText = getString(
                     R.string.connect_messaging_resubscribe_dialog_body,
-                    channel.getChannelSource()
+                    channel.getDisplayName()
             );
             String negativeButtonText =
                     getString(R.string.connect_messaging_resubscribe_dialog_cancel);

--- a/app/src/org/commcare/models/database/connect/ConnectDatabaseSchemaManager.kt
+++ b/app/src/org/commcare/models/database/connect/ConnectDatabaseSchemaManager.kt
@@ -52,8 +52,9 @@ object ConnectDatabaseSchemaManager {
      * V.25 - Added sessionEndpointId and requireAppSync to PushNotificationRecord
      * V.26 - Added email to ConnectUserRecord
      * V.27 - Added connect_tasks table (ConnectTaskRecord) for DB-persisted task tracking
+     * V.28 - Added channel_name to ConnectMessagingChannelRecord
      */
-    const val DB_VERSION_CONNECT = 27
+    const val DB_VERSION_CONNECT = 28
 
     @JvmStatic
     fun initializeSchema(database: IDatabase) {

--- a/app/src/org/commcare/models/database/connect/ConnectDatabaseUpgrader.java
+++ b/app/src/org/commcare/models/database/connect/ConnectDatabaseUpgrader.java
@@ -29,6 +29,7 @@ import org.commcare.android.database.connect.models.ConnectLinkedAppRecordV3;
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecordV8;
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecordV9;
 import org.commcare.android.database.connect.models.ConnectMessagingChannelRecord;
+import org.commcare.android.database.connect.models.ConnectMessagingChannelRecordV27;
 import org.commcare.android.database.connect.models.ConnectMessagingMessageRecord;
 import org.commcare.android.database.connect.models.ConnectPaymentUnitRecord;
 import org.commcare.android.database.connect.models.ConnectPaymentUnitRecordV21;
@@ -189,6 +190,11 @@ public class ConnectDatabaseUpgrader {
         if (oldVersion == 26) {
             upgradeTwentySixTwentySeven(db);
             oldVersion = 27;
+        }
+
+        if (oldVersion == 27) {
+            upgradeTwentySevenTwentyEight(db);
+            oldVersion = 28;
         }
     }
 
@@ -603,7 +609,7 @@ public class ConnectDatabaseUpgrader {
     }
 
     private void upgradeElevenTwelve(IDatabase db) {
-        addTableForNewModel(db, ConnectMessagingChannelRecord.STORAGE_KEY, new ConnectMessagingChannelRecord());
+        addTableForNewModel(db, ConnectMessagingChannelRecord.STORAGE_KEY, new ConnectMessagingChannelRecordV27());
         addTableForNewModel(db, ConnectMessagingMessageRecord.STORAGE_KEY, new ConnectMessagingMessageRecord());
     }
 
@@ -1112,6 +1118,36 @@ public class ConnectDatabaseUpgrader {
 
     private void upgradeTwentySixTwentySeven(IDatabase db) {
         addTableForNewModel(db, ConnectTaskRecord.STORAGE_KEY, new ConnectTaskRecord());
+    }
+
+    private void upgradeTwentySevenTwentyEight(IDatabase db) {
+        db.beginTransaction();
+        try {
+            db.execSQL(DbUtil.addColumnToTable(
+                    ConnectMessagingChannelRecord.STORAGE_KEY,
+                    ConnectMessagingChannelRecord.META_CHANNEL_NAME,
+                    "TEXT"));
+
+            SqlStorage<ConnectMessagingChannelRecordV27> oldStorage = new SqlStorage<>(
+                    ConnectMessagingChannelRecord.STORAGE_KEY,
+                    ConnectMessagingChannelRecordV27.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            SqlStorage<ConnectMessagingChannelRecord> newStorage = new SqlStorage<>(
+                    ConnectMessagingChannelRecord.STORAGE_KEY,
+                    ConnectMessagingChannelRecord.class,
+                    new ConcreteAndroidDbHelper(c, db));
+
+            for (ConnectMessagingChannelRecordV27 oldRecord : oldStorage) {
+                ConnectMessagingChannelRecord newRecord = ConnectMessagingChannelRecord.fromV27(oldRecord);
+                newRecord.setID(oldRecord.getID());
+                newStorage.write(newRecord);
+            }
+
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
     }
 
     private static void addTableForNewModel(IDatabase db, String storageKey,

--- a/app/src/org/commcare/utils/FirebaseMessagingUtil.java
+++ b/app/src/org/commcare/utils/FirebaseMessagingUtil.java
@@ -484,7 +484,7 @@ public class FirebaseMessagingUtil {
 
             notificationTitleId = R.string.connect_messaging_channel_notification_title;
             notificationMessage = context.getString(R.string.connect_messaging_channel_notification_message,
-                    channel.getChannelName());
+                    channel.getChannelSource());
 
             channelId = channel.getChannelId();
         }

--- a/app/src/org/commcare/utils/FirebaseMessagingUtil.java
+++ b/app/src/org/commcare/utils/FirebaseMessagingUtil.java
@@ -484,7 +484,7 @@ public class FirebaseMessagingUtil {
 
             notificationTitleId = R.string.connect_messaging_channel_notification_title;
             notificationMessage = context.getString(R.string.connect_messaging_channel_notification_message,
-                    channel.getChannelSource());
+                    channel.getDisplayName());
 
             channelId = channel.getChannelId();
         }

--- a/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
+++ b/app/unit-tests/src/org/commcare/android/tests/processing/FormStorageTest.java
@@ -423,7 +423,8 @@ public class FormStorageTest {
 
             // Added in 2.64
             "org.commcare.android.database.connect.models.ConnectUserRecordV25",
-            "org.commcare.android.database.connect.models.ConnectTaskRecord"
+            "org.commcare.android.database.connect.models.ConnectTaskRecord",
+            "org.commcare.android.database.connect.models.ConnectMessagingChannelRecordV27"
 
     );
 

--- a/app/unit-tests/src/org/commcare/connect/network/connectId/parser/RetrieveNotificationsResponseParserTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/connectId/parser/RetrieveNotificationsResponseParserTest.kt
@@ -213,7 +213,7 @@ class RetrieveNotificationsResponseParserTest {
         // Create a mock channel with encryption key for decryption
         val mockChannel = mock(ConnectMessagingChannelRecord::class.java)
         `when`(mockChannel.channelId).thenReturn("channel_001")
-        `when`(mockChannel.channelName).thenReturn("Test Channel")
+        `when`(mockChannel.channelSource).thenReturn("Test Channel")
         `when`(mockChannel.key).thenReturn(encryptionKey)
         `when`(mockChannel.consented).thenReturn(true)
 


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CCCT-2509

## Safety Assurance

### Safety story

- Tested DB migration by updating from the old version and verifying that the messages are still visible
-  Tested that channel names still shows up as expected in the channel list and activity titles for the per channel message screen. 
- Tested messaging notifications and verified that the `channel_name` is present there in payload and that mobile parses it correctly


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
