### PR TITLE
Use location with best accuracy for Auto Capture

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -93,6 +93,7 @@ These are published publicly on Playstore, Github Releases and CommCare Forums
 - [SMS Invite Links Open App] Clicking a Connect invite link in an SMS message opens the app and navigates to the opportunity
 - Launching an app from a Connect opportunity now opens it directly with a single loading dialog, instead of briefly flashing the login and app-setup screens
 - Image capture questions support a new `rectangle-overlay` appearance that shows a rectangular framing guide in the camera preview, helping users consistently frame the subject (e.g. a MUAC arm + tape).
+- [Auto Location Capture] We now save the location acquired with the best accuracy in a form session rather than the last one. 
 
 #### Important Bug Fixes
 

--- a/app/src/org/commcare/android/javarosa/PollSensorController.java
+++ b/app/src/org/commcare/android/javarosa/PollSensorController.java
@@ -90,7 +90,7 @@ public enum PollSensorController implements CommCareLocationListener {
     @Override
     public void onLocationResult(@NotNull Location location) {
         synchronized (actions) {
-            float newAccuracy = location.getAccuracy();
+            float newAccuracy = location.hasAccuracy() ? location.getAccuracy() : Float.MAX_VALUE;
             if (newAccuracy < lastAccuracy) {
                 lastAccuracy = newAccuracy;
                 for (PollSensorAction action : actions) {

--- a/app/src/org/commcare/android/javarosa/PollSensorController.java
+++ b/app/src/org/commcare/android/javarosa/PollSensorController.java
@@ -9,7 +9,6 @@ import android.os.Looper;
 import com.google.android.gms.common.api.ResolvableApiException;
 
 import org.commcare.CommCareApplication;
-import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.location.CommCareLocationController;
 import org.commcare.location.CommCareLocationControllerFactory;
 import org.commcare.location.CommCareLocationListener;
@@ -91,20 +90,16 @@ public enum PollSensorController implements CommCareLocationListener {
     @Override
     public void onLocationResult(@NotNull Location location) {
         synchronized (actions) {
-            if (location != null) {
-                float newAccuracy = location.getAccuracy();
-                if (lastAccuracy < 30 && (newAccuracy - lastAccuracy) > 50) {
-                    FirebaseAnalyticsUtil.reportAccuracyDegradation(newAccuracy - lastAccuracy);
-                }
+            float newAccuracy = location.getAccuracy();
+            if (newAccuracy < lastAccuracy) {
                 lastAccuracy = newAccuracy;
-
                 for (PollSensorAction action : actions) {
                     action.updateReference(location);
                 }
+            }
 
-                if (newAccuracy <= HiddenPreferences.getGpsAutoCaptureAccuracy()) {
-                    stopLocationPolling();
-                }
+            if (newAccuracy <= HiddenPreferences.getGpsAutoCaptureAccuracy()) {
+                stopLocationPolling();
             }
         }
     }

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -146,7 +146,6 @@ public class AnalyticsParamValue {
 
 
     // Param values for common commcare event
-    public static final String ACCURACY_DEGRADATION = "accuracy_degradation";
     public static final String STAGE_UPDATE_FAILURE = "stage_update_failure";
     public static final String UPDATE_RESET = "update_reset";
     public static final String CORRUPT_APP_STATE = "corrupt_app_state";

--- a/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
+++ b/app/src/org/commcare/google/services/analytics/FirebaseAnalyticsUtil.java
@@ -43,7 +43,6 @@ import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_U
 import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_USAGE_MOST;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_USAGE_OTHER;
 import static org.commcare.google.services.analytics.AnalyticsParamValue.VIDEO_USAGE_PARTIAL;
-import static org.commcare.google.services.analytics.AnalyticsParamValue.ACCURACY_DEGRADATION;
 import static org.commcare.util.LogTypes.TYPE_ERROR_DESIGN;
 
 /**
@@ -476,14 +475,6 @@ public class FirebaseAnalyticsUtil {
                 CCAnalyticsEvent.COMMON_COMMCARE_EVENT,
                 new String[]{FirebaseAnalytics.Param.ITEM_ID, CCAnalyticsParam.REASON},
                 new String[]{STAGE_UPDATE_FAILURE, reason}
-        );
-    }
-
-    public static void reportAccuracyDegradation(Float value) {
-        reportEvent(
-                CCAnalyticsEvent.COMMON_COMMCARE_EVENT,
-                new String[]{FirebaseAnalytics.Param.ITEM_ID, VALUE},
-                new String[]{ACCURACY_DEGRADATION, value.toString()}
         );
     }
 


### PR DESCRIPTION
## Product Description

Follow up PR for https://dimagi.atlassian.net/browse/CCCT-2605. 

Saves location with best accuracy in auto location capture. 

## Technical Summary

Removed the last analytics event given we had got enough conversation that this is a frequent event - 

<img width="802" height="602" alt="Screenshot 2026-07-17 at 6 06 29 PM" src="https://github.com/user-attachments/assets/48bb1046-d204-4143-8d7b-0d27655fdfa3" />


## Safety Assurance

Minimal change, Tested auto-capture locally and verified the expected behaviour

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
