### PR TITLE
Fix edge-to-edge inset handling in Android 15+ devices

### DIFF
--- a/app/src/org/commcare/utils/AndroidUtil.java
+++ b/app/src/org/commcare/utils/AndroidUtil.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
 import androidx.core.view.OnApplyWindowInsetsListener;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
@@ -92,12 +93,10 @@ public class AndroidUtil {
 
         if (activityRootView != null) {
             ViewCompat.setOnApplyWindowInsetsListener(activityRootView, (view, insets) -> {
-                WindowInsets windowInsets = activityRootView.getRootWindowInsets();
-                if (windowInsets != null) {
-                    Insets systemBars = windowInsets.getSystemWindowInsets();
-                    // Apply padding so content doesn't overlap with system bars
-                    view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
-                }
+                Insets systemBars = insets.getSystemWindowInsets();
+
+                // Apply padding so content doesn't overlap with system bars
+                view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
                 return insets;
             });
         }

--- a/app/src/org/commcare/utils/AndroidUtil.java
+++ b/app/src/org/commcare/utils/AndroidUtil.java
@@ -2,12 +2,10 @@ package org.commcare.utils;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.graphics.Insets;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.TypedValue;
 import android.view.View;
-import android.view.WindowInsets;
 import android.widget.Toast;
 
 import com.google.android.gms.common.ConnectionResult;
@@ -16,11 +14,9 @@ import com.google.android.gms.common.GoogleApiAvailability;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
@@ -93,7 +89,8 @@ public class AndroidUtil {
 
         if (activityRootView != null) {
             ViewCompat.setOnApplyWindowInsetsListener(activityRootView, (view, insets) -> {
-                Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+                Insets systemBars = insets.getInsets(
+                        WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
 
                 // Apply padding so content doesn't overlap with system bars
                 view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);

--- a/app/src/org/commcare/utils/AndroidUtil.java
+++ b/app/src/org/commcare/utils/AndroidUtil.java
@@ -91,18 +91,14 @@ public class AndroidUtil {
         View activityRootView = activity.findViewById(rootViewId);
 
         if (activityRootView != null) {
-            ViewCompat.setOnApplyWindowInsetsListener(activityRootView, new OnApplyWindowInsetsListener() {
-                @NonNull
-                @Override
-                public WindowInsetsCompat onApplyWindowInsets(@NonNull View view, @NonNull WindowInsetsCompat insets) {
-                    WindowInsets windowInsets = activityRootView.getRootWindowInsets();
-                    if (windowInsets != null) {
-                        Insets systemBars = windowInsets.getSystemWindowInsets();
-                        // Apply padding so content doesn't overlap with system bars
-                        view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
-                    }
-                    return insets;
+            ViewCompat.setOnApplyWindowInsetsListener(activityRootView, (view, insets) -> {
+                WindowInsets windowInsets = activityRootView.getRootWindowInsets();
+                if (windowInsets != null) {
+                    Insets systemBars = windowInsets.getSystemWindowInsets();
+                    // Apply padding so content doesn't overlap with system bars
+                    view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
                 }
+                return insets;
             });
         }
     }

--- a/app/src/org/commcare/utils/AndroidUtil.java
+++ b/app/src/org/commcare/utils/AndroidUtil.java
@@ -93,7 +93,7 @@ public class AndroidUtil {
 
         if (activityRootView != null) {
             ViewCompat.setOnApplyWindowInsetsListener(activityRootView, (view, insets) -> {
-                Insets systemBars = insets.getSystemWindowInsets();
+                Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
 
                 // Apply padding so content doesn't overlap with system bars
                 view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);

--- a/app/src/org/commcare/utils/AndroidUtil.java
+++ b/app/src/org/commcare/utils/AndroidUtil.java
@@ -93,7 +93,7 @@ public class AndroidUtil {
 
         if (activityRootView != null) {
             ViewCompat.setOnApplyWindowInsetsListener(activityRootView, (view, insets) -> {
-                Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
 
                 // Apply padding so content doesn't overlap with system bars
                 view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);


### PR DESCRIPTION
## Product Description

This PR fixes the way window insets are being retrieved on Android 15+ (edge-to-edge) devices. Instead of obtaining the insets from the root view, it now uses the `WindowInsetsCompat` instance dispatched to the view.
The issue was noted after upgrading `AppCompat` to version `1.7`, where screens using the built-in `ActionBar` started rendering their content beneath the bar due to incorrect inset handling.
<table>
<tr>
<th> Orientation</th>
<th> Before </th>
<th> After </th>
</tr>
<tr>
<th> Portrait</th>
<td>
<img width="200px" src="https://github.com/user-attachments/assets/f8f9c8b9-0fe1-42f0-85d7-446380589efe" /> </td>
<td>
<img width="200px" src="https://github.com/user-attachments/assets/b60c3329-e559-4c64-90ee-dfe68f816b15" /> </td>
</tr>
<tr>
<th> Landscape </th>
<td> 
<img width="200px" src="https://github.com/user-attachments/assets/4cdd9883-e553-4961-b31a-05a735351ff4" />
</td>
<td> 
<img width="200px" src="https://github.com/user-attachments/assets/bc41ba23-11a8-4681-9870-a48191d660ac" /></td>
</tr>
<tr>
<th> Display cutout </th>
<td> 
<img width="200px" src="https://github.com/user-attachments/assets/31a6061a-7637-4081-a9a0-1967bd7cf59e" />
</td>
<td>
<img width="200px" src="https://github.com/user-attachments/assets/c80c58f3-c10d-43b1-9421-e8bda1042dc7" /></td>
</tr>
</table>


## Technical Summary
`AndroidUtil.attachWindowInsetsListener` previously re-fetched insets via `activityRootView.getRootWindowInsets()` and read from `WindowInsets.getSystemWindowInsets()`. This PR:
- Uses the `WindowInsetsCompat` already supplied by the `onApplyWindowInsets` callback parameter (non-null, reflects the current dispatch) instead of re-fetching from the root view.
- Adds `WindowInsetsCompat.Type.displayCutout()` to the inset mask so content is also padded away from display cutouts, not just system bars.

## Safety Assurance

### Safety story
- This change was tested on a device running Android 16 and the views were rendered as expected. Also, this change only affects view padding, no other UI properties or layout behavior are expected to be impacted.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change