### PR TITLE
Resize Camera Reticle And Rename Overlay Appearance Hint

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -93,7 +93,7 @@ These are published publicly on Playstore, Github Releases and CommCare Forums
 - [Delivery Progress Offline-First] The Connect Delivery Progress page now displays cached delivery data immediately on open, even with no network, and shows inline sync status (success / failure / offline) instead of a blocking loading dialog
 - [SMS Invite Links Open App] Clicking a Connect invite link in an SMS message opens the app and navigates to the opportunity
 - Launching an app from a Connect opportunity now opens it directly with a single loading dialog, instead of briefly flashing the login and app-setup screens
-- Image capture questions support a new `rectangle-overlay` appearance that shows a rectangular framing guide in the camera preview, helping users consistently frame the subject (e.g. a MUAC arm + tape).
+- Image capture questions support a new `overlay-small` appearance that shows a rectangular framing guide in the camera preview, helping users consistently frame the subject (e.g. a MUAC arm + tape).
 
 #### Important Bug Fixes
 
@@ -224,7 +224,7 @@ we would like to communicate to QA as part of the release testing
 
 - Verify tapping payment-unit rows on the Connect delivery progress screen — including rapid double-taps and two-finger simultaneous taps — opens the deliveries list without crashing or double-navigating.
 - Verify backing out of a brand new Connect opportunity's intro screen right after tapping Start Learning (easiest with poor connectivity) does not crash once the request completes.
-- **Image reticle overlay:** On a form image-capture question with `appearance="rectangle-overlay"`, verify Take Picture opens the in-app camera with a rectangular framing guide, and the saved photo is the full frame with the guide not drawn on it.
+- **Image reticle overlay:** On a form image-capture question with `appearance="overlay-small"`, verify Take Picture opens the in-app camera with a rectangular framing guide, and the saved photo is the full frame with the guide not drawn on it.
 
 - **Manage Profile (PersonalID):**
   - **Access:** Signed in to PersonalID, open the side navigation drawer and verify a "Manage Profile" link appears and opens a screen showing name, phone, email, and photo. Verify the link is absent when signed out.

--- a/app/res/layout-land/camera_overlay_activity.xml
+++ b/app/res/layout-land/camera_overlay_activity.xml
@@ -13,8 +13,8 @@
 
     <org.commcare.views.RectangleOverlayView
         android:id="@+id/rectangle_overlay"
-        app:reticleWidthFractionLandscape="0.70"
-        app:reticleHeightFractionLandscape="0.55"
+        app:reticleWidthFractionLandscape="0.40"
+        app:reticleHeightFractionLandscape="0.40"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 

--- a/app/res/layout/camera_overlay_activity.xml
+++ b/app/res/layout/camera_overlay_activity.xml
@@ -13,8 +13,8 @@
 
     <org.commcare.views.RectangleOverlayView
         android:id="@+id/rectangle_overlay"
-        app:reticleWidthFractionPortrait="0.85"
-        app:reticleHeightFractionPortrait="0.30"
+        app:reticleWidthFractionPortrait="0.50"
+        app:reticleHeightFractionPortrait="0.20"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 

--- a/app/src/org/commcare/views/RectangleOverlayView.kt
+++ b/app/src/org/commcare/views/RectangleOverlayView.kt
@@ -119,12 +119,12 @@ class RectangleOverlayView
 
         companion object {
             private const val PORTRAIT_WIDTH_DEFAULT = 0.90f
-            private const val PORTRAIT_WIDTH_MIN = 0.80f
+            private const val PORTRAIT_WIDTH_MIN = 0.20f
             private const val PORTRAIT_HEIGHT_DEFAULT = 0.25f
-            private const val PORTRAIT_HEIGHT_MIN = 0.20f
+            private const val PORTRAIT_HEIGHT_MIN = 0.10f
             private const val LANDSCAPE_WIDTH_DEFAULT = 0.70f
-            private const val LANDSCAPE_WIDTH_MIN = 0.60f
+            private const val LANDSCAPE_WIDTH_MIN = 0.30f
             private const val LANDSCAPE_HEIGHT_DEFAULT = 0.50f
-            private const val LANDSCAPE_HEIGHT_MIN = 0.40f
+            private const val LANDSCAPE_HEIGHT_MIN = 0.20f
         }
     }

--- a/app/src/org/commcare/views/widgets/ImageWidget.java
+++ b/app/src/org/commcare/views/widgets/ImageWidget.java
@@ -60,7 +60,7 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
 
     public static final Object IMAGE_VIEW_TAG = "image_view_tag";
 
-    private static final String RECTANGLE_OVERLAY = "rectangle-overlay";
+    private static final String OVERLAY_SMALL = "overlay-small";
 
     private final Button mCaptureButton;
     private final Button mChooseButton;
@@ -176,7 +176,7 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
 
         String appearanceHint = mPrompt.getAppearanceHint();
         boolean acquire = appearanceHint != null && appearanceHint.contains(QuestionWidget.ACQUIREFIELD);
-        useRectangleOverlay = appearanceHint != null && appearanceHint.contains(RECTANGLE_OVERLAY);
+        useRectangleOverlay = appearanceHint != null && appearanceHint.contains(OVERLAY_SMALL);
         if (acquire) {
             mChooseButton.setVisibility(View.GONE);
         }


### PR DESCRIPTION
## Product Description
Makes the camera capture reticle smaller as per the feedback received at [slack](https://dimagi.slack.com/archives/C09H7D1V1NK/p1783581208852889)

## Technical Summary
The appearance-hint keyword that enables the small overlay is renamed from `rectangle-overlay` to `overlay-small`.
[Doc](https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/2143958321/Media+Capture+Questions#Image-Capture) also updated for the same.

## Safety Assurance

### Safety story
- I ran the change on a device and exercised the camera overlay / image capture flow, confirming the smaller reticle.
- Scope is limited to reticle sizing constants and one appearance-hint keyword.