### PR TITLE
Remove demo code for semi-circle progress bar.

### DIFF
--- a/app/res/layout/fragment_connect_learning_progress.xml
+++ b/app/res/layout/fragment_connect_learning_progress.xml
@@ -65,18 +65,7 @@
                     android:layout_width="fill_parent"
                     android:layout_height="1dp"
                     android:background="@android:color/darker_gray" />
-
-                <!-- Demo sample of the semi-circle progress bar; hard-coded values. -->
-                <org.commcare.views.connect.SemiCircleProgressBar
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="64dp"
-                    android:layout_marginTop="16dp"
-                    android:layout_marginEnd="64dp"
-                    app:currentValue="17"
-                    app:maxValue="40"
-                    app:descriptionText="total visits completed" />
-
+                
                 <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
[CCCT-2515](https://dimagi.atlassian.net/browse/CCCT-2515)

This PR deletes some demo code that was out in to test the semi-circle progress bar during development of that component.
The demo code was checked in accidentally.

[CCCT-2515]: https://dimagi.atlassian.net/browse/CCCT-2515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ