### PR TITLE
CCCT-2517 Fix Start Learning Navigation

### DIFF
--- a/app/src/org/commcare/connect/database/ConnectJobUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectJobUtils.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.os.Build;
 import android.text.TextUtils;
 
+import org.commcare.CommCareApplication;
 import org.commcare.android.database.connect.models.ConnectAppRecord;
 import org.commcare.android.database.connect.models.ConnectJobAssessmentRecord;
 import org.commcare.android.database.connect.models.ConnectJobDeliveryFlagRecord;
@@ -32,7 +33,8 @@ import java.util.Vector;
 
 public class ConnectJobUtils {
 
-    public static void upsertJob(Context context, ConnectJobRecord job) {
+    public static void upsertJob(ConnectJobRecord job) {
+        Context context = CommCareApplication.instance();
         List<ConnectJobRecord> list = new ArrayList<>();
         list.add(job);
         new JobStoreManager(context).storeJobs(context, list, false);

--- a/app/src/org/commcare/connect/network/connect/models/DeliveryAppProgressResponseModel.kt
+++ b/app/src/org/commcare/connect/network/connect/models/DeliveryAppProgressResponseModel.kt
@@ -18,7 +18,7 @@ fun DeliveryAppProgressResponseModel.applyToJob(
     context: Context,
 ) {
     if (updatedJob) {
-        ConnectJobUtils.upsertJob(context, job)
+        ConnectJobUtils.upsertJob(job)
     }
     if (hasDeliveries) {
         ConnectJobUtils.storeDeliveries(context, job.deliveries, job.jobUUID, true)

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryDetailsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryDetailsFragment.java
@@ -121,7 +121,7 @@ public class ConnectDeliveryDetailsFragment extends ConnectJobFragment<FragmentC
 
     private void proceedAfterJobClaimed(Button button, ConnectJobRecord job, boolean installed) {
         job.setStatus(ConnectJobRecord.STATUS_DELIVERING);
-        ConnectJobUtils.upsertJob(getContext(), job);
+        ConnectJobUtils.upsertJob(job);
         CommCareApplication.instance().closeUserSession();
 
         NavDirections directions = installed

--- a/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
@@ -1,5 +1,6 @@
 package org.commcare.fragments.connect;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -116,6 +117,7 @@ public class ConnectJobIntroFragment extends ConnectJobFragment<FragmentConnectJ
     }
 
     private void startLearning() {
+        Context appContext = requireContext().getApplicationContext();
         ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(getContext());
 
         new ConnectApiHandler<Boolean>() {
@@ -143,7 +145,7 @@ public class ConnectJobIntroFragment extends ConnectJobFragment<FragmentConnectJ
                 reportApiCall(success);
 
                 job.setStatus(ConnectJobRecord.STATUS_LEARNING);
-                ConnectJobUtils.upsertJob(getContext(), job);
+                ConnectJobUtils.upsertJob(appContext, job);
 
                 if (!isAdded() || ConnectJobIntroFragment.this.getView() == null) {
                     return;

--- a/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
@@ -1,6 +1,5 @@
 package org.commcare.fragments.connect;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -117,7 +116,6 @@ public class ConnectJobIntroFragment extends ConnectJobFragment<FragmentConnectJ
     }
 
     private void startLearning() {
-        Context appContext = requireContext().getApplicationContext();
         ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(getContext());
 
         new ConnectApiHandler<Boolean>() {
@@ -145,7 +143,7 @@ public class ConnectJobIntroFragment extends ConnectJobFragment<FragmentConnectJ
                 reportApiCall(success);
 
                 job.setStatus(ConnectJobRecord.STATUS_LEARNING);
-                ConnectJobUtils.upsertJob(appContext, job);
+                ConnectJobUtils.upsertJob(job);
 
                 if (!isAdded() || ConnectJobIntroFragment.this.getView() == null) {
                     return;

--- a/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobIntroFragment.java
@@ -122,7 +122,7 @@ public class ConnectJobIntroFragment extends ConnectJobFragment<FragmentConnectJ
             @Override
             public void onFailure(@NonNull PersonalIdOrConnectApiErrorCodes errorCode, @Nullable Throwable t) {
                 reportApiCall(false);
-                if (!isAdded() || getView() == null) {
+                if (!isAdded() || ConnectJobIntroFragment.this.getView() == null) {
                     return;
                 }
 
@@ -140,15 +140,16 @@ public class ConnectJobIntroFragment extends ConnectJobFragment<FragmentConnectJ
 
             @Override
             public void onSuccess(Boolean success) {
-                hideError();
                 reportApiCall(success);
 
                 job.setStatus(ConnectJobRecord.STATUS_LEARNING);
                 ConnectJobUtils.upsertJob(getContext(), job);
 
-                if (!isAdded() || getView() == null) {
+                if (!isAdded() || ConnectJobIntroFragment.this.getView() == null) {
                     return;
                 }
+
+                hideError();
 
                 String appId = job.getLearnAppInfo().getAppId();
                 boolean appInstalled = AppUtils.isAppInstalled(appId);


### PR DESCRIPTION
### [CCCT-2517](https://dimagi.atlassian.net/browse/CCCT-2517)

## Product Description

Tapping Start on a new Connect opportunity's introduction screen now proceeds to learning (downloading the learn app, or launching it if already installed) instead of silently doing nothing.

## Technical Summary

The guard in the start-learning callbacks called an unqualified `getView()`, which resolved to `BaseApiHandler`'s Kotlin `view` property (always null here) rather than `Fragment.getView()`, so every callback early-returned. Qualifying it to the fragment restores the guard, and `hideError()` moved below it. `ConnectJobUtils.upsertJob` now sources the application context itself, so persistence no longer depends on the fragment's lifecycle.

## Safety Assurance

### Safety story

What gives confidence:
- Built on a device and confirmed tapping Start navigates to the downloading screen.
- Scoped to the start-learning callbacks and the shared `upsertJob` helper.

Risks to review:
- No automated coverage; verified manually.
- Re-enables navigation/launch/error paths that had been silently dead since CI-766.
- `upsertJob` no longer takes a `Context` param; its other two callers were updated.

[CCCT-2517]: https://dimagi.atlassian.net/browse/CCCT-2517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ