### PR TITLE
Rename task type to mode

### DIFF
--- a/app/src/org/commcare/android/database/connect/models/ConnectTaskRecord.kt
+++ b/app/src/org/commcare/android/database/connect/models/ConnectTaskRecord.kt
@@ -40,8 +40,8 @@ class ConnectTaskRecord :
     var connectChannelId: String = ""
 
     @Persisting(7)
-    @MetaField(META_TYPE)
-    var type: String = ""
+    @MetaField(META_MODE)
+    var mode: String = ""
 
     @Persisting(8)
     @MetaField(META_DUE_DATE)
@@ -60,7 +60,7 @@ class ConnectTaskRecord :
 
         const val STATUS_ASSIGNED = "assigned"
         const val STATUS_COMPLETED = "completed"
-        const val TYPE_OCS = "ocs"
+        const val MODE_OCS = "ocs"
 
         const val META_JOB_UUID = "opportunity_id"
         const val META_TASK_ID = "task_id"
@@ -68,7 +68,7 @@ class ConnectTaskRecord :
         const val META_DESCRIPTION = "description"
         const val META_STATUS = "status"
         const val META_CONNECT_CHANNEL_ID = "connect_channel_id"
-        const val META_TYPE = "type"
+        const val META_MODE = "mode"
         const val META_DUE_DATE = "due_date"
         const val META_DATE_CREATED = "date_created"
         const val META_DATE_MODIFIED = "date_modified"
@@ -86,7 +86,7 @@ class ConnectTaskRecord :
             task.description = json.optString("task_description", "")
             task.status = json.getString("status")
             task.connectChannelId = json.optString("connect_channel_id", "")
-            task.type = json.optString("task_type", "")
+            task.mode = json.optString("task_mode", "")
             if (json.hasNonNull("due_date")) {
                 task.dueDate = DateUtils.parseDate(json.getString("due_date"))
             }

--- a/app/src/org/commcare/connect/database/ConnectTaskUtils.kt
+++ b/app/src/org/commcare/connect/database/ConnectTaskUtils.kt
@@ -76,19 +76,19 @@ object ConnectTaskUtils {
     }
 
     @JvmStatic
-    fun hasPendingTaskOfType(
+    fun hasPendingTaskOfMode(
         context: Context,
         jobUUID: String,
-        type: String,
-    ): Boolean = getPendingTaskOfType(context, jobUUID, type) != null
+        mode: String,
+    ): Boolean = getPendingTaskOfMode(context, jobUUID, mode) != null
 
     @JvmStatic
-    fun getPendingTaskOfType(
+    fun getPendingTaskOfMode(
         context: Context,
         jobUUID: String,
-        type: String,
+        mode: String,
     ): ConnectTaskRecord? =
-        getTasksForJob(context, jobUUID, null).find { it.type == type && it.status == ConnectTaskRecord.STATUS_ASSIGNED }
+        getTasksForJob(context, jobUUID, null).find { it.mode == mode && it.status == ConnectTaskRecord.STATUS_ASSIGNED }
 
     @JvmStatic
     fun getValidPendingOcsTask(
@@ -96,7 +96,7 @@ object ConnectTaskUtils {
         job: ConnectJobRecord,
     ): ConnectTaskRecord? {
         if (job.status != ConnectJobRecord.STATUS_DELIVERING) return null
-        val task = getPendingTaskOfType(context, job.jobUUID, ConnectTaskRecord.TYPE_OCS) ?: return null
+        val task = getPendingTaskOfMode(context, job.jobUUID, ConnectTaskRecord.MODE_OCS) ?: return null
         if (task.connectChannelId.isEmpty()) {
             Logger.exception(
                 "Invalid messaging task",

--- a/app/unit-tests/src/org/commcare/connect/database/ConnectTaskUtilsTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/database/ConnectTaskUtilsTest.kt
@@ -54,14 +54,14 @@ class ConnectTaskUtilsTest {
     private fun makeTask(
         taskId: String = "task-1",
         status: String = STATUS_ASSIGNED,
-        type: String = "learning",
+        mode: String = "learning",
         dateModified: Date = Date(),
         dueDate: Date = Date(0),
     ) = ConnectTaskRecord().apply {
         this.jobUUID = this@ConnectTaskUtilsTest.jobUUID
         this.taskId = taskId
         this.status = status
-        this.type = type
+        this.mode = mode
         this.dateModified = dateModified
         this.dueDate = dueDate
         this.name = "Task $taskId"
@@ -228,41 +228,41 @@ class ConnectTaskUtilsTest {
     }
 
     // ===========================
-    // getPendingTaskOfType / hasPendingTaskOfType
+    // getPendingTaskOfMode / hasPendingTaskOfMode
     // ===========================
 
     @Test
-    fun `getPendingTaskOfType returns task matching type and assigned status`() {
-        seedTask(makeTask(taskId = "t1", status = STATUS_ASSIGNED, type = "learning"))
+    fun `getPendingTaskOfMode returns task matching mode and assigned status`() {
+        seedTask(makeTask(taskId = "t1", status = STATUS_ASSIGNED, mode = "learning"))
 
-        val result = ConnectTaskUtils.getPendingTaskOfType(context, jobUUID, "learning")
+        val result = ConnectTaskUtils.getPendingTaskOfMode(context, jobUUID, "learning")
         assertEquals("t1", result?.taskId)
     }
 
     @Test
-    fun `getPendingTaskOfType returns null when type does not match`() {
-        seedTask(makeTask(status = STATUS_ASSIGNED, type = "delivery"))
+    fun `getPendingTaskOfMode returns null when mode does not match`() {
+        seedTask(makeTask(status = STATUS_ASSIGNED, mode = "delivery"))
 
-        assertNull(ConnectTaskUtils.getPendingTaskOfType(context, jobUUID, "learning"))
+        assertNull(ConnectTaskUtils.getPendingTaskOfMode(context, jobUUID, "learning"))
     }
 
     @Test
-    fun `getPendingTaskOfType returns null when type matches but status is not assigned`() {
-        seedTask(makeTask(status = STATUS_COMPLETED, type = "learning"))
+    fun `getPendingTaskOfMode returns null when mode matches but status is not assigned`() {
+        seedTask(makeTask(status = STATUS_COMPLETED, mode = "learning"))
 
-        assertNull(ConnectTaskUtils.getPendingTaskOfType(context, jobUUID, "learning"))
+        assertNull(ConnectTaskUtils.getPendingTaskOfMode(context, jobUUID, "learning"))
     }
 
     @Test
-    fun `hasPendingTaskOfType returns true when matching assigned task exists`() {
-        seedTask(makeTask(status = STATUS_ASSIGNED, type = "learning"))
+    fun `hasPendingTaskOfMode returns true when matching assigned task exists`() {
+        seedTask(makeTask(status = STATUS_ASSIGNED, mode = "learning"))
 
-        assertTrue(ConnectTaskUtils.hasPendingTaskOfType(context, jobUUID, "learning"))
+        assertTrue(ConnectTaskUtils.hasPendingTaskOfMode(context, jobUUID, "learning"))
     }
 
     @Test
-    fun `hasPendingTaskOfType returns false when no tasks in DB`() {
-        assertFalse(ConnectTaskUtils.hasPendingTaskOfType(context, jobUUID, "learning"))
+    fun `hasPendingTaskOfMode returns false when no tasks in DB`() {
+        assertFalse(ConnectTaskUtils.hasPendingTaskOfMode(context, jobUUID, "learning"))
     }
 
     // ===========================

--- a/app/unit-tests/src/org/commcare/connect/network/connect/parser/DeliveryAppProgressResponseParserTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/connect/parser/DeliveryAppProgressResponseParserTest.kt
@@ -7,7 +7,6 @@ import org.commcare.connect.network.connect.models.DeliveryAppProgressResponseMo
 import org.javarosa.core.model.utils.DateUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -282,7 +281,7 @@ class DeliveryAppProgressResponseParserTest {
         val task = result.tasks[0]
         assertEquals("", task.description)
         assertEquals("", task.connectChannelId)
-        assertEquals("", task.type)
+        assertEquals("", task.mode)
         assertNull(task.dueDate)
     }
 


### PR DESCRIPTION
## Product Description

No user visible changes

## Technical Summary

Renaming task_type based on a web change - https://github.com/dimagi/commcare-connect/pull/1353

## Safety Assurance

### Safety story

- SImple rename
- Doesn't need a migration as the original task model is not out yet, debug installers (devs) might need to "Forget Personal ID" and re-sign up. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
