### PR TITLE
CCCT-2531 Add Overlay-Small Camera Reticle For Image Capture

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,18 @@
 This file is meant as an easy way for us to collate notes and change logs across releases. 
 -->
 
+## CommCare 2.63.3
+
+### Release Notes
+
+#### What's New
+
+- Image capture questions support a new 'overlay-small' appearance that shows a rectangular framing guide in the camera preview, helping users consistently frame the subject (e.g. a MUAC arm + tape).
+
+#### Internal Release Notes
+
+### QA Notes
+
 ## CommCare 2.63.2
 
 ### QA Notes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,8 @@ This file is meant as an easy way for us to collate notes and change logs across
 
 ### QA Notes
 
+- **Image reticle overlay:** On a form image-capture question with `appearance="overlay-small"`, verify Take Picture opens the in-app camera with a rectangular framing guide, and the saved photo is the full frame with the guide not drawn on it.
+
 ## CommCare 2.63.2
 
 ### QA Notes

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -559,8 +559,10 @@
         <activity android:name="org.commcare.recovery.measures.ExecuteRecoveryMeasuresActivity"/>
         <activity android:name="org.commcare.activities.PromptCCReinstallActivity"/>
         <activity
-            android:name="org.commcare.fragments.MicroImageActivity"
+            android:name="org.commcare.activities.camera.MicroImageActivity"
             android:screenOrientation="portrait"/>
+        <activity
+            android:name="org.commcare.activities.camera.CameraOverlayActivity"/>
         <!-- Start Collect Manifest -->
 
         <meta-data

--- a/app/assets/locales/android_translatable_strings.txt
+++ b/app/assets/locales/android_translatable_strings.txt
@@ -1009,11 +1009,3 @@ android.package.name.callout.commcare.org.sendussd=Commcare USSD
 android.package.name.org.commcare.dalvik.abha=CommCare ABHA
 
 location.capture.cancelled=Location capture cancelled
-
-microimage.camera.start.failed=Camera failed to start
-microimage.face.detection.mode.failed=Face detection mode failed, switching to manual mode
-microimage.cropping.failed=Image cropping failed, make sure the target is inside the capture area
-microimage.decoding.no.image=Image processing failed. Please try again
-microimage.scalingdown.compression.error=Image compression failed. Please try again
-microimage.manual.face.capture.failed=Manual capture failed, contact CommCare Support if the issue persists
-microimage.camera.permission.denied=Go to settings and enable camera permission to use this feature

--- a/app/res/drawable/bg_camera_shutter_button.xml
+++ b/app/res/drawable/bg_camera_shutter_button.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@android:color/transparent" />
+            <stroke
+                android:width="4dp"
+                android:color="@android:color/white" />
+        </shape>
+    </item>
+
+    <item
+        android:bottom="8dp"
+        android:left="8dp"
+        android:right="8dp"
+        android:top="8dp">
+        <shape android:shape="oval">
+            <solid android:color="@android:color/white" />
+        </shape>
+    </item>
+
+</layer-list>

--- a/app/res/layout-land/camera_overlay_activity.xml
+++ b/app/res/layout-land/camera_overlay_activity.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:viewBindingIgnore="true">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/view_finder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <org.commcare.views.RectangleOverlayView
+        android:id="@+id/rectangle_overlay"
+        app:reticleWidthFractionLandscape="0.40"
+        app:reticleHeightFractionLandscape="0.40"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <ImageView
+        android:id="@+id/camera_shutter_button"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        android:layout_gravity="end|center_vertical"
+        android:layout_marginEnd="32dp"
+        android:background="@drawable/bg_camera_shutter_button"
+        android:clickable="true"
+        android:contentDescription="@string/image_capture_activity_title"
+        android:focusable="true"
+        android:foreground="?attr/selectableItemBackgroundBorderless" />
+
+    <ProgressBar
+        android:id="@+id/capture_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminateTint="@android:color/white"
+        android:visibility="gone" />
+</FrameLayout>

--- a/app/res/layout/camera_overlay_activity.xml
+++ b/app/res/layout/camera_overlay_activity.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:viewBindingIgnore="true">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/view_finder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <org.commcare.views.RectangleOverlayView
+        android:id="@+id/rectangle_overlay"
+        app:reticleWidthFractionPortrait="0.50"
+        app:reticleHeightFractionPortrait="0.20"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <ImageView
+        android:id="@+id/camera_shutter_button"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        android:layout_gravity="bottom|center_horizontal"
+        android:layout_marginBottom="32dp"
+        android:background="@drawable/bg_camera_shutter_button"
+        android:clickable="true"
+        android:contentDescription="@string/image_capture_activity_title"
+        android:focusable="true"
+        android:foreground="?attr/selectableItemBackgroundBorderless" />
+
+    <ProgressBar
+        android:id="@+id/capture_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminateTint="@android:color/white"
+        android:visibility="gone" />
+</FrameLayout>

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -360,6 +360,12 @@
     <string name="choose_a_6_digit_recovery_code">Elige un código de recuperación de 6 dígitos</string>
     <string name="sync">Sincronizar</string>
     <string name="micro_image_activity_title">Capturar foto de rostro</string>
+    <string name="image_capture_activity_title">Tomar foto</string>
+    <string name="image_capture_failed">No se pudo guardar la foto, inténtalo de nuevo</string>
+    <string name="camera_start_failed">La cámara no pudo iniciarse</string>
+    <string name="camera_permission_denied">Ve a ajustes y habilita el permiso de la cámara para usar esta función</string>
+    <string name="microimage_face_detection_mode_failed">Falló el modo de detección de rostros, cambiando a modo manual</string>
+    <string name="microimage_cropping_failed">Falló el recorte de la imagen, asegúrate de que el objetivo esté dentro del área de captura</string>
     <string name="connect_job_info_title">Detalles de la oportunidad</string>
     <string name="connect_job_info_delivery_detail">Detalles de la entrega</string>
     <string name="connect_job_info_review_delivery">Revisar detalles de la entrega</string>
@@ -468,8 +474,8 @@
     <string name="personalid_second_device_login_title">Iniciar sesión en un segundo dispositivo</string>
     <string name="personalid_second_device_login_message">Sesión cerrada en %s, último uso: %s. Solo se puede iniciar sesión con PersonalID en un dispositivo a la vez.</string>
     <string name="personalid_second_device_login_message_no_date">Se ha cerrado la sesión en %s. Solo se puede iniciar sesión con PersonalID en un dispositivo a la vez.</string>
-    <string name="personalid_camera_permission_title">Permiso de cámara</string>
-    <string name="personalid_camera_permission_msg">Para tomar una foto, CommCare necesita permiso para usar la cámara de tu dispositivo.</string>
+    <string name="camera_permission_title">Permiso de cámara</string>
+    <string name="camera_permission_msg">Para tomar una foto, CommCare necesita permiso para usar la cámara de tu dispositivo.</string>
     <string name="personalid_capture_photo">Tomar foto</string>
     <string name="personalid_configuration_locked_account">Su cuenta ha sido bloqueada. Por favor, contacte con el servicio de asistencia.</string>
     <string name="personalid_work_history_title">Mi Historial Laboral</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -357,6 +357,12 @@ License.
     <string name="choose_a_6_digit_recovery_code">Choisissez un code de récupération à 6 chiffres</string>
     <string name="sync">Synchroniser</string>
     <string name="micro_image_activity_title">Capturer Photo Visage</string>
+    <string name="image_capture_activity_title">Prendre une photo</string>
+    <string name="image_capture_failed">Échec de l\'enregistrement de la photo, veuillez réessayer</string>
+    <string name="camera_start_failed">Le démarrage de la caméra a échoué</string>
+    <string name="camera_permission_denied">Accédez aux paramètres et activez l\'autorisation de la caméra pour utiliser cette fonctionnalité</string>
+    <string name="microimage_face_detection_mode_failed">Le mode de détection des visages a échoué, passage en mode manuel</string>
+    <string name="microimage_cropping_failed">Le recadrage de l\'image a échoué, assurez-vous que la cible se trouve dans la zone de capture</string>
     <string name="connect_job_info_title">Détails de l\'opportunité</string>
     <string name="connect_job_info_delivery_detail">Détails de livraison</string>
     <string name="connect_job_info_review_delivery">Vérifiez les détails de livraison</string>
@@ -468,8 +474,8 @@ License.
     <string name="personalid_second_device_login_title">Connexion sur un deuxième appareil</string>
     <string name="personalid_second_device_login_message">Vous avez été déconnecté(e) de %s, dernière utilisation le %s. L\'identifiant PersonalID ne peut être utilisé que sur un seul appareil à la fois.</string>
     <string name="personalid_second_device_login_message_no_date">Vous avez été déconnecté(e) de %s. L\'identifiant PersonalID ne peut être utilisé que sur un seul appareil à la fois.</string>
-    <string name="personalid_camera_permission_title">Autorisation pour la caméra</string>
-    <string name="personalid_camera_permission_msg">Afin de prendre une photo, CommCare a besoin de l\'autorisation d\'utiliser l\'appareil photo de votre appareil.</string>
+    <string name="camera_permission_title">Autorisation pour la caméra</string>
+    <string name="camera_permission_msg">Afin de prendre une photo, CommCare a besoin de l\'autorisation d\'utiliser l\'appareil photo de votre appareil.</string>
     <string name="personalid_capture_photo">Prendre une photo</string>
     <string name="personalid_work_history_title">Mon Historique de Travail</string>
     <string name="personalid_work_history">Historique de Travail</string>

--- a/app/res/values-ha/strings.xml
+++ b/app/res/values-ha/strings.xml
@@ -195,6 +195,12 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="choose_a_6_digit_recovery_code">Zaɓi Lambar Ajiyar Bayanai Mai Lambobi 6</string>
     <string name="sync">Daidaita</string>
     <string name="micro_image_activity_title">Ɗaukar Hoton Fuska</string>
+    <string name="image_capture_activity_title">Ɗauki Hoto</string>
+    <string name="image_capture_failed">An kasa ajiye hoto, don Allah a sake gwadawa</string>
+    <string name="camera_start_failed">Kyamara ta kasa farawa</string>
+    <string name="camera_permission_denied">Je zuwa saituna kuma kunna izinin kyamara don amfani da wannan fasalin</string>
+    <string name="microimage_face_detection_mode_failed">Yanayin gano fuska ya kasa, ana canzawa zuwa yanayin hannu</string>
+    <string name="microimage_cropping_failed">Yankan hoto ya kasa, tabbatar da cewa abin da ake nufi yana cikin yankin ɗaukar hoto</string>
     <string name="connect_job_info_title">Cikakkun Bayanan Dama</string>
     <string name="connect_job_info_delivery_detail">Cikakkun Bayanan Isarwa</string>
     <string name="connect_job_info_review_delivery">Yi bitar cikakkun bayanai game da isar da kaya</string>
@@ -308,8 +314,8 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="personalid_second_device_login_title">Shiga a Na\'ura ta Biyu</string>
     <string name="personalid_second_device_login_message">An fita daga %s, an yi amfani da %s na ƙarshe. PersonalID za a iya shiga kawai akan na\'ura ɗaya a lokaci guda.</string>
     <string name="personalid_second_device_login_message_no_date">An fita daga %s. Ana iya shiga PersonalID akan na\'ura ɗaya kawai a lokaci guda.</string>
-    <string name="personalid_camera_permission_title">Izini don kyamara</string>
-    <string name="personalid_camera_permission_msg">Domin ɗaukar hoto, CommCare yana buƙatar izinin amfani da kyamarar na\'urarka.</string>
+    <string name="camera_permission_title">Izini don kyamara</string>
+    <string name="camera_permission_msg">Domin ɗaukar hoto, CommCare yana buƙatar izinin amfani da kyamarar na\'urarka.</string>
     <string name="personalid_capture_photo">Ɗauki Hoto</string>
     <string name="personalid_work_history_title">Tarihin Aikina</string>
     <string name="personalid_work_history">Tarihin Aiki</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -357,6 +357,12 @@ License.
     <string name="choose_a_6_digit_recovery_code">6 अंकों का रिकवरी कोड चुनें</string>
     <string name="sync">सिंक करें</string>
     <string name="micro_image_activity_title">चेहरे की फ़ोटो कैप्चर करें</string>
+    <string name="image_capture_activity_title">फ़ोटो लें</string>
+    <string name="image_capture_failed">फ़ोटो सहेजने में विफल, कृपया पुनः प्रयास करें</string>
+    <string name="camera_start_failed">कैमरा शुरू होने में विफल</string>
+    <string name="camera_permission_denied">इस सुविधा का उपयोग करने के लिए सेटिंग्स में जाएँ और कैमरा अनुमति सक्षम करें</string>
+    <string name="microimage_face_detection_mode_failed">चेहरा पहचान मोड विफल, मैन्युअल मोड पर स्विच किया जा रहा है</string>
+    <string name="microimage_cropping_failed">छवि क्रॉपिंग विफल, सुनिश्चित करें कि लक्ष्य कैप्चर क्षेत्र के अंदर है</string>
     <string name="connect_job_info_title">अवसर विवरण</string>
     <string name="connect_job_info_delivery_detail">वितरण विवरण</string>
     <string name="connect_job_info_review_delivery">वितरण विवरण की समीक्षा करें</string>
@@ -464,8 +470,8 @@ License.
     <string name="personalid_second_device_login_title">दूसरे डिवाइस पर लॉग इन करें</string>
     <string name="personalid_second_device_login_message">%s से लॉग आउट किया गया, आखिरी बार %s इस्तेमाल किया गया था। PersonalID से एक समय में सिर्फ़ एक डिवाइस पर लॉग इन किया जा सकता है।</string>
     <string name="personalid_second_device_login_message_no_date">%s से लॉग आउट कर दिया गया है। PersonalID से एक समय में सिर्फ़ एक डिवाइस पर ही लॉग इन किया जा सकता है।</string>
-    <string name="personalid_camera_permission_title">कैमरे के लिए अनुमति</string>
-    <string name="personalid_camera_permission_msg">तस्वीर लेने के लिए, CommCare को आपके डिवाइस के कैमरे का उपयोग करने की अनुमति चाहिए।</string>
+    <string name="camera_permission_title">कैमरे के लिए अनुमति</string>
+    <string name="camera_permission_msg">तस्वीर लेने के लिए, CommCare को आपके डिवाइस के कैमरे का उपयोग करने की अनुमति चाहिए।</string>
     <string name="personalid_capture_photo">तस्वीर लें</string>
     <string name="personalid_configuration_locked_account">आपका खाता लॉक कर दिया गया है। कृपया सहायता से संपर्क करें</string>
     <string name="personalid_work_history_title">मेरा कार्य इतिहास</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -195,4 +195,10 @@
     <string name="connect_offline">Neprisijungęs</string>
     <string name="connect_never">Niekada</string>
     <string name="cannot_navigate_during_form_save">Negalima palikti puslapio, kol išsaugoma forma</string>
+    <string name="image_capture_activity_title">Fotografuoti</string>
+    <string name="image_capture_failed">Nepavyko išsaugoti nuotraukos, bandykite dar kartą</string>
+    <string name="camera_start_failed">Nepavyko paleisti kameros</string>
+    <string name="camera_permission_denied">Eikite į nustatymus ir įjunkite kameros leidimą, kad galėtumėte naudoti šią funkciją</string>
+    <string name="microimage_face_detection_mode_failed">Veido aptikimo režimas nepavyko, perjungiama į rankinį režimą</string>
+    <string name="microimage_cropping_failed">Nepavyko apkarpyti vaizdo, įsitikinkite, kad objektas yra fiksavimo srityje</string>
 </resources>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -185,4 +185,10 @@
     <string name="connect_offline">Frakoblet</string>
     <string name="connect_never">Aldri</string>
     <string name="cannot_navigate_during_form_save">Kan ikke forlate siden mens skjemaet lagres</string>
+    <string name="image_capture_activity_title">Ta bilde</string>
+    <string name="image_capture_failed">Kunne ikke lagre bildet, prøv igjen</string>
+    <string name="camera_start_failed">Kameraet kunne ikke startes</string>
+    <string name="camera_permission_denied">Gå til innstillinger og aktiver kameratillatelse for å bruke denne funksjonen</string>
+    <string name="microimage_face_detection_mode_failed">Ansiktsgjenkjenningsmodus mislyktes, bytter til manuell modus</string>
+    <string name="microimage_cropping_failed">Beskjæring av bildet mislyktes, sørg for at målet er innenfor fangstområdet</string>
 </resources>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -374,6 +374,12 @@
     <string name="choose_a_6_digit_recovery_code">Escolha um código de recuperação de 6 dígitos</string>
     <string name="sync">Sincronizar</string>
     <string name="micro_image_activity_title">Capturar Imagem Facial</string>
+    <string name="image_capture_activity_title">Tirar foto</string>
+    <string name="image_capture_failed">Falha ao guardar a foto, por favor tente novamente</string>
+    <string name="camera_start_failed">A câmara falhou ao iniciar</string>
+    <string name="camera_permission_denied">Vá às definições e ative a permissão da câmara para usar esta funcionalidade</string>
+    <string name="microimage_face_detection_mode_failed">O modo de deteção de rostos falhou, a mudar para o modo manual</string>
+    <string name="microimage_cropping_failed">O recorte da imagem falhou, certifique-se de que o alvo está dentro da área de captura</string>
     <string name="connect_job_info_title">Detalhes de oportunidade</string>
     <string name="connect_job_info_delivery_detail">Detalhes da entrega</string>
     <string name="connect_job_info_review_delivery">Revise os detalhes da entrega</string>
@@ -475,8 +481,8 @@
     <string name="personalid_second_device_login_title">Iniciar sessão no segundo dispositivo</string>
     <string name="personalid_second_device_login_message">Sessão encerrada em %s, último acesso em %s. O PersonalID só pode ser utilizado num dispositivo de cada vez.</string>
     <string name="personalid_second_device_login_message_no_date">Sessão encerrada de %s. O PersonalID só pode ser acedido num dispositivo de cada vez.</string>
-    <string name="personalid_camera_permission_title">Permissão para câmara</string>
-    <string name="personalid_camera_permission_msg">Para tirar uma fotografia, o CommCare precisa de permissão para utilizar a câmara do seu dispositivo.</string>
+    <string name="camera_permission_title">Permissão para câmara</string>
+    <string name="camera_permission_msg">Para tirar uma fotografia, o CommCare precisa de permissão para utilizar a câmara do seu dispositivo.</string>
     <string name="personalid_capture_photo">Capturar foto</string>
     <string name="personalid_work_history_title">Meu Histórico de Trabalho</string>
     <string name="personalid_work_history">Histórico de Trabalho</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -359,6 +359,12 @@
     <string name="choose_a_6_digit_recovery_code">Chagua Msimbo wa Urejeshaji wa Dijiti 6</string>
     <string name="sync">Sawazisha</string>
     <string name="micro_image_activity_title">Piga Picha ya Uso</string>
+    <string name="image_capture_activity_title">Piga Picha</string>
+    <string name="image_capture_failed">Imeshindwa kuhifadhi picha, tafadhali jaribu tena</string>
+    <string name="camera_start_failed">Kamera imeshindwa kuanza</string>
+    <string name="camera_permission_denied">Nenda kwenye mipangilio na uwashe ruhusa ya kamera ili kutumia kipengele hiki</string>
+    <string name="microimage_face_detection_mode_failed">Hali ya utambuzi wa uso imeshindwa, inabadilisha hadi hali ya mikono</string>
+    <string name="microimage_cropping_failed">Upunguzaji wa picha umeshindwa, hakikisha lengo liko ndani ya eneo la kunasa</string>
     <string name="connect_job_info_title">Maelezo ya Fursa</string>
     <string name="connect_job_info_delivery_detail">Maelezo ya Uwasilishaji</string>
     <string name="connect_job_info_review_delivery">Kagua maelezo ya utoaji</string>
@@ -474,8 +480,8 @@
     <string name="personalid_second_device_login_title">Ingia kwenye Kifaa cha Pili</string>
     <string name="personalid_second_device_login_message">Imetoka kwenye %s, imetumika mara ya mwisho %s. PersonalID kinaweza kuingia kwenye kifaa kimoja tu kwa wakati mmoja.</string>
     <string name="personalid_second_device_login_message_no_date">Umetoka kwenye %s. PersonalID kinaweza kuingia kwenye kifaa kimoja tu kwa wakati mmoja.</string>
-    <string name="personalid_camera_permission_title">Ruhusa ya kamera</string>
-    <string name="personalid_camera_permission_msg">Ili kupiga picha, CommCare inahitaji ruhusa ya kutumia kamera ya kifaa chako.</string>
+    <string name="camera_permission_title">Ruhusa ya kamera</string>
+    <string name="camera_permission_msg">Ili kupiga picha, CommCare inahitaji ruhusa ya kutumia kamera ya kifaa chako.</string>
     <string name="personalid_capture_photo">Piga Picha</string>
     <string name="personalid_work_history_title">Historia Yangu ya Kazi</string>
     <string name="personalid_work_history">Historia ya Kazi</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -361,6 +361,12 @@
     <string name="choose_a_6_digit_recovery_code">6 ኣሃዝ ዘለዎ ሓድሽ ኮድ ምረጽ</string>
     <string name="sync">ምትእስሳር</string>
     <string name="micro_image_activity_title">ስእሊ ገጽ ምቕራጽ</string>
+    <string name="image_capture_activity_title">ስእሊ ውሰድ</string>
+    <string name="image_capture_failed">ስእሊ ምዕቓብ ኣይተኻእለን፡ በጃኻ ደጊምካ ፈትን</string>
+    <string name="camera_start_failed">ካሜራ ክጅምር ኣይከኣለን</string>
+    <string name="camera_permission_denied">ናብ ቅንብራት ኪድ እሞ ነዚ ባህሪ ንምጥቃም ፍቓድ ካሜራ ኣንቅሕ</string>
+    <string name="microimage_face_detection_mode_failed">ኩነታት ምልላይ ገጽ ኣይሰርሐን፡ ናብ ኢደ-ሰብ ኩነታት ይቕይር ኣሎ</string>
+    <string name="microimage_cropping_failed">ምቁራጽ ስእሊ ኣይተኻእለን፡ ዕላማ ኣብ ውሽጢ ቦታ ምቅራጽ ከምዘሎ ኣረጋግጽ</string>
     <string name="connect_job_info_title">ዝርዝር ዕድል</string>
     <string name="connect_job_info_delivery_detail">ዝርዝር (ኣተገባብራ)ኣወሃህባ</string>
     <string name="connect_job_info_review_delivery">ዝርዝር ኣወሃህባ ዳህሳስ ከልስ</string>
@@ -460,8 +466,8 @@
     <string name="personalid_second_device_login_title">ኣብ ካልኣይ መሳርሒ እቶ</string>
     <string name="personalid_second_device_login_message">ካብ %s ወጺኡ፣ ንመወዳእታ ግዜ ዝተጠቕመሉ %s። PersonalID ኣብ ሓደ እዋን ኣብ ሓደ መሳርሒ ጥራይ እዩ ክኣቱ ዝኽእል።</string>
     <string name="personalid_second_device_login_message_no_date">ካብ %s ወጺኡ። PersonalID ኣብ ሓደ እዋን ኣብ ሓደ መሳርሒ ጥራይ እዩ ክኣቱ ዝኽእል።</string>
-    <string name="personalid_camera_permission_title">ፍቓድ ንካሜራ</string>
-    <string name="personalid_camera_permission_msg">ስእሊ ንምውሳድ፡ ኮምኬር ናይ መሳርሒኻ ካሜራ ንኽጥቀም ፍቓድ የድልዮ።</string>
+    <string name="camera_permission_title">ፍቓድ ንካሜራ</string>
+    <string name="camera_permission_msg">ስእሊ ንምውሳድ፡ ኮምኬር ናይ መሳርሒኻ ካሜራ ንኽጥቀም ፍቓድ የድልዮ።</string>
     <string name="personalid_capture_photo">ስእሊ ምቕራጽ</string>
     <string name="personalid_work_history_title">ታሪኽ ስራሐይ</string>
     <string name="personalid_work_history">ታሪኽ ስራሕ</string>

--- a/app/res/values/attrs.xml
+++ b/app/res/values/attrs.xml
@@ -143,4 +143,16 @@
         <attr name="progressBackgroundColor" format="color" />
         <attr name="strokeWidth" format="dimension" />
     </declare-styleable>
+
+    <declare-styleable name="RectangleOverlayView">
+        <attr name="reticleScrimColor" format="color" />
+        <attr name="reticleStrokeColor" format="color" />
+        <attr name="reticleOutlineColor" format="color" />
+        <attr name="reticleStrokeWidth" format="dimension" />
+        <attr name="reticleOutlineWidth" format="dimension" />
+        <attr name="reticleWidthFractionPortrait" format="float" />
+        <attr name="reticleHeightFractionPortrait" format="float" />
+        <attr name="reticleWidthFractionLandscape" format="float" />
+        <attr name="reticleHeightFractionLandscape" format="float" />
+    </declare-styleable>
 </resources>

--- a/app/res/values/colors.xml
+++ b/app/res/values/colors.xml
@@ -194,4 +194,6 @@
     <color name="shimmer_grey_0">#00E6E7EB</color>
     <color name="shimmer_grey_20">#33E6E7EB</color>
     <color name="shimmer_grey_60">#99E6E7EB</color>
+    <color name="black_60">#99000000</color>
+    <color name="black_80">#CC000000</color>
 </resources>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -130,6 +130,8 @@
     <dimen name="connect_message_input_corner_radius">50dp</dimen>
     <dimen name="connect_message_input_stroke_width">0.5dp</dimen>
     <dimen name="connect_message_corner_radius">16dp</dimen>
+    <dimen name="reticle_stroke_width">3dp</dimen>
+    <dimen name="reticle_outline_width">1dp</dimen>
 
     <dimen name="corner_radius_small_5dp">5dp</dimen>
     <dimen name="nav_drawer_width">264dp</dimen>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -554,6 +554,12 @@
     </string-array>
 
     <string name="micro_image_activity_title">Capture Face Picture</string>
+    <string name="image_capture_activity_title" cc:translatable="true">Take Photo</string>
+    <string name="image_capture_failed" cc:translatable="true">Failed to save photo, please try again</string>
+    <string name="camera_start_failed" cc:translatable="true">Camera failed to start</string>
+    <string name="camera_permission_denied" cc:translatable="true">Go to settings and enable camera permission to use this feature</string>
+    <string name="microimage_face_detection_mode_failed" cc:translatable="true">Face detection mode failed, switching to manual mode</string>
+    <string name="microimage_cropping_failed" cc:translatable="true">Image cropping failed, make sure the target is inside the capture area</string>
 
     <string name="connect_job_info_title">Opportunity Details</string>
     <string name="connect_job_info_delivery_detail">Delivery Details</string>
@@ -635,8 +641,8 @@
     <string name="personalid_error_message_login_different_device">Please continue on the new device, or configure your account again.</string>
     <string name="personalid_reconfigure">Reconfigure</string>
     <string name="personalid_dismiss">Dismiss</string>
-    <string name="personalid_camera_permission_title">Permission for camera</string>
-    <string name="personalid_camera_permission_msg">In order to take a picture, CommCare needs permission to use your device camera.</string>
+    <string name="camera_permission_title">Permission for camera</string>
+    <string name="camera_permission_msg">In order to take a picture, CommCare needs permission to use your device camera.</string>
     <string name="personalid_capture_photo">Capture Photo</string>
     <string name="personalid_incorrect_otp">You have entered the wrong 6-digit passcode. Please try again.</string>
     <string name="personalid_too_many_otp_attempts">You have made too many attempts to send OTP. Please wait and try again whenever the resend button is visible.</string>

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -283,4 +283,12 @@
         <item name="android:track">@drawable/switch_track</item>
     </style>
 
+    <style name="Widget.CommCare.RectangleOverlayView" parent="">
+        <item name="reticleScrimColor">@color/black_60</item>
+        <item name="reticleOutlineColor">@color/black_80</item>
+        <item name="reticleStrokeColor">@color/white</item>
+        <item name="reticleStrokeWidth">@dimen/reticle_stroke_width</item>
+        <item name="reticleOutlineWidth">@dimen/reticle_outline_width</item>
+    </style>
+
 </resources>

--- a/app/src/org/commcare/activities/camera/BaseCameraActivity.kt
+++ b/app/src/org/commcare/activities/camera/BaseCameraActivity.kt
@@ -1,0 +1,203 @@
+package org.commcare.activities.camera
+
+import android.Manifest
+import android.os.Bundle
+import android.util.Size
+import android.view.MenuItem
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.LayoutRes
+import androidx.annotation.StringRes
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.Preview
+import androidx.camera.core.UseCase
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import org.commcare.activities.CommonBaseActivity
+import org.commcare.dalvik.R
+import org.commcare.interfaces.RuntimePermissionRequester
+import org.commcare.utils.Permissions
+import org.commcare.utils.StringUtils
+import org.commcare.views.dialogs.DialogCreationHelpers
+import org.javarosa.core.services.Logger
+import java.util.concurrent.ExecutionException
+
+/**
+ * Base activity for CameraX-backed screens. Handles the camera permission flow, provider
+ * acquisition, and lifecycle binding of a preview plus a capture use case.
+ *
+ * Subclasses supply the layout, title, camera selector, target resolution, and the
+ * concrete capture use case (e.g. image capture or analysis).
+ */
+abstract class BaseCameraActivity :
+    CommonBaseActivity(),
+    RuntimePermissionRequester {
+    @JvmField
+    protected var cameraView: PreviewView? = null
+
+    private val cameraPermissionRequestLauncher =
+        registerForActivityResult(
+            ActivityResultContracts.RequestPermission(),
+        ) { isGranted ->
+            if (isGranted) {
+                startCamera()
+            } else {
+                logErrorAndExit(
+                    "Error acquiring camera permission",
+                    StringUtils.getStringRobust(this, R.string.camera_permission_denied),
+                    null,
+                )
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(getContentLayout())
+        cameraView = getCameraView()
+        supportActionBar?.apply {
+            title = StringUtils.getStringRobust(this@BaseCameraActivity, getTitleRes())
+            setDisplayHomeAsUpEnabled(true)
+        }
+        onCameraViewReady()
+        checkForCameraPermission()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressedDispatcher.onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    private fun checkForCameraPermission() {
+        if (Permissions.missingAppPermission(this, Manifest.permission.CAMERA)) {
+            if (Permissions.shouldShowPermissionRationale(this, Manifest.permission.CAMERA)) {
+                val dialog =
+                    DialogCreationHelpers.buildPermissionRequestDialog(
+                        this,
+                        this,
+                        -1, // actually not required due to launcher activity
+                        StringUtils.getStringRobust(this, R.string.camera_permission_title),
+                        StringUtils.getStringRobust(this, R.string.camera_permission_msg),
+                    )
+                dialog.showNonPersistentDialog(this)
+            } else {
+                requestNeededPermissions(-1)
+            }
+        } else {
+            startCamera()
+        }
+    }
+
+    override fun requestNeededPermissions(requestCode: Int) {
+        cameraPermissionRequestLauncher.launch(Manifest.permission.CAMERA)
+    }
+
+    protected fun startCamera() {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
+        cameraProviderFuture.addListener({
+            if (isFinishing || isDestroyed) {
+                return@addListener
+            }
+            try {
+                val cameraProvider = cameraProviderFuture.get()
+                bindUseCases(cameraProvider)
+            } catch (e: Exception) {
+                when (e) {
+                    is ExecutionException, is InterruptedException -> {
+                        logErrorAndExit(
+                            "Error acquiring camera provider",
+                            StringUtils.getStringRobust(this, R.string.camera_start_failed),
+                            e,
+                        )
+                    }
+
+                    is IllegalStateException, is IllegalArgumentException -> {
+                        logErrorAndExit(
+                            "Error binding camera use cases",
+                            StringUtils.getStringRobust(this, R.string.camera_start_failed),
+                            e,
+                        )
+                    }
+
+                    else -> {
+                        logErrorAndExit(
+                            "Unknown error occurred while starting camera",
+                            StringUtils.getStringRobust(this, R.string.camera_start_failed),
+                            e,
+                        )
+                    }
+                }
+            }
+        }, ContextCompat.getMainExecutor(this))
+    }
+
+    private fun bindUseCases(cameraProvider: ProcessCameraProvider) {
+        val targetRotation = ContextCompat.getDisplayOrDefault(this).rotation
+        val targetResolution = getTargetResolution()
+
+        val previewBuilder = Preview.Builder().setTargetRotation(targetRotation)
+        targetResolution?.let { previewBuilder.setResolutionSelector(buildResolutionSelector(it)) }
+        val preview = previewBuilder.build()
+        preview.surfaceProvider = cameraView!!.surfaceProvider
+
+        val captureUseCase = buildCaptureUseCase(targetResolution, targetRotation)
+
+        cameraProvider.unbindAll()
+        cameraProvider.bindToLifecycle(this, getCameraSelector(), preview, captureUseCase)
+    }
+
+    /**
+     * Builds a [ResolutionSelector] bound to [targetResolution]. The bound size is normalized to
+     * the sensor's natural landscape orientation, since [ResolutionStrategy] matches against
+     * sensor-oriented sizes rather than rotating to the target rotation like the deprecated
+     * `setTargetResolution`.
+     */
+    protected fun buildResolutionSelector(targetResolution: Size): ResolutionSelector {
+        val boundSize =
+            if (targetResolution.height > targetResolution.width) {
+                Size(targetResolution.height, targetResolution.width)
+            } else {
+                targetResolution
+            }
+        return ResolutionSelector
+            .Builder()
+            .setResolutionStrategy(
+                ResolutionStrategy(boundSize, ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER),
+            ).build()
+    }
+
+    protected fun logErrorAndExit(
+        logMessage: String,
+        userMessage: String,
+        e: Throwable?,
+    ) {
+        Logger.exception(logMessage, e ?: Exception(logMessage))
+        Toast.makeText(this, userMessage, Toast.LENGTH_LONG).show()
+        setResult(RESULT_CANCELED)
+        finish()
+    }
+
+    @LayoutRes
+    protected abstract fun getContentLayout(): Int
+
+    @StringRes
+    protected abstract fun getTitleRes(): Int
+
+    protected abstract fun getCameraView(): PreviewView
+
+    protected abstract fun getCameraSelector(): CameraSelector
+
+    protected abstract fun getTargetResolution(): Size?
+
+    protected abstract fun buildCaptureUseCase(
+        targetResolution: Size?,
+        targetRotation: Int,
+    ): UseCase
+
+    protected open fun onCameraViewReady() {}
+}

--- a/app/src/org/commcare/activities/camera/CameraOverlayActivity.kt
+++ b/app/src/org/commcare/activities/camera/CameraOverlayActivity.kt
@@ -1,0 +1,130 @@
+package org.commcare.activities.camera
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Size
+import android.view.View
+import android.widget.ImageView
+import android.widget.Toast
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.UseCase
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import androidx.core.content.IntentCompat
+import org.commcare.dalvik.R
+import org.commcare.utils.StringUtils
+import org.commcare.utils.closeQuietly
+import org.javarosa.core.services.Logger
+
+/**
+ * Back-camera capture screen that draws a static [org.commcare.views.RectangleOverlayView] reticle
+ * over the preview as a framing guide. Capture is manual via the shutter
+ * button; the full-resolution frame is written to the caller-supplied output URI without cropping,
+ * so the reticle never appears in the saved image.
+ */
+class CameraOverlayActivity : BaseCameraActivity() {
+    private val outputUri: Uri by lazy { intentOutputUri()!! }
+
+    internal var imageCapture: ImageCapture? = null
+    private var isCapturing = false
+
+    override fun getContentLayout(): Int = R.layout.camera_overlay_activity
+
+    override fun getTitleRes(): Int = R.string.image_capture_activity_title
+
+    override fun getCameraView(): PreviewView = findViewById(R.id.view_finder)
+
+    override fun getCameraSelector(): CameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+
+    override fun getTargetResolution(): Size? = null
+
+    override fun onCameraViewReady() {
+        findViewById<ImageView>(R.id.camera_shutter_button).setOnClickListener { captureImage() }
+    }
+
+    override fun buildCaptureUseCase(
+        targetResolution: Size?,
+        targetRotation: Int,
+    ): UseCase {
+        val capture =
+            ImageCapture
+                .Builder()
+                .setCaptureMode(ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY)
+                .setTargetRotation(targetRotation)
+                .build()
+        imageCapture = capture
+        return capture
+    }
+
+    private fun captureImage() {
+        if (isCapturing) {
+            return
+        }
+        val capture = imageCapture ?: return
+        val outputStream =
+            contentResolver.openOutputStream(outputUri) ?: run {
+                handleCaptureError("Unable to open output stream for captured image", null)
+                return
+            }
+        handleCapturingState(true)
+        val outputOptions = ImageCapture.OutputFileOptions.Builder(outputStream).build()
+        capture.takePicture(
+            outputOptions,
+            ContextCompat.getMainExecutor(this),
+            object : ImageCapture.OnImageSavedCallback {
+                override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
+                    outputStream.closeQuietly()
+                    setResult(RESULT_OK)
+                    finish()
+                }
+
+                override fun onError(exception: ImageCaptureException) {
+                    outputStream.closeQuietly()
+                    handleCaptureError("Failed to capture image", exception)
+                }
+            },
+        )
+    }
+
+    /**
+     * Reports a non-fatal capture failure: logs it, toasts the user, and re-enables the shutter so
+     * the capture can be retried without leaving the screen.
+     */
+    private fun handleCaptureError(
+        logMessage: String,
+        e: Throwable?,
+    ) {
+        Logger.exception(logMessage, e ?: Exception(logMessage))
+        Toast.makeText(this, StringUtils.getStringRobust(this, R.string.image_capture_failed), Toast.LENGTH_LONG).show()
+        handleCapturingState(false)
+    }
+
+    private fun handleCapturingState(capturing: Boolean) {
+        isCapturing = capturing
+        findViewById<ImageView>(R.id.camera_shutter_button).apply {
+            isEnabled = !capturing
+            alpha = if (capturing) DISABLED_SHUTTER_ALPHA else 1f
+        }
+        findViewById<View>(R.id.capture_progress).visibility =
+            if (capturing) View.VISIBLE else View.GONE
+    }
+
+    private fun intentOutputUri(): Uri? = IntentCompat.getParcelableExtra(intent, OUTPUT_FILE_URI_EXTRA, Uri::class.java)
+
+    companion object {
+        const val OUTPUT_FILE_URI_EXTRA = "camera_overlay_output_file_uri_extra"
+
+        private const val DISABLED_SHUTTER_ALPHA = 0.5f
+
+        @JvmStatic
+        fun getIntent(
+            context: Context,
+            outputFileUri: Uri,
+        ): Intent =
+            Intent(context, CameraOverlayActivity::class.java)
+                .putExtra(OUTPUT_FILE_URI_EXTRA, outputFileUri)
+    }
+}

--- a/app/src/org/commcare/activities/camera/MicroImageActivity.java
+++ b/app/src/org/commcare/activities/camera/MicroImageActivity.java
@@ -1,20 +1,17 @@
-package org.commcare.fragments;
+package org.commcare.activities.camera;
 
-import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.media.Image;
-import android.os.Bundle;
 import android.util.Base64;
 import android.util.Size;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.Toast;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.mlkit.common.MlKitException;
 import com.google.mlkit.vision.common.InputImage;
 import com.google.mlkit.vision.common.internal.ImageConvertUtils;
@@ -23,42 +20,29 @@ import com.google.mlkit.vision.face.FaceDetection;
 import com.google.mlkit.vision.face.FaceDetector;
 import com.google.mlkit.vision.face.FaceDetectorOptions;
 
-import org.commcare.activities.CommonBaseActivity;
 import org.commcare.dalvik.R;
-import org.commcare.interfaces.RuntimePermissionRequester;
-import org.commcare.util.LogTypes;
 import org.commcare.utils.AndroidUtil;
 import org.commcare.utils.FileUtil;
 import org.commcare.utils.ImageSizeTooLargeException;
 import org.commcare.utils.MediaUtil;
-import org.commcare.utils.Permissions;
+import org.commcare.utils.StringUtils;
 import org.commcare.views.FaceCaptureView;
-import org.commcare.views.dialogs.CommCareAlertDialog;
-import org.commcare.views.dialogs.DialogCreationHelpers;
 import org.javarosa.core.services.Logger;
-import org.javarosa.core.services.locale.Localization;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.camera.core.CameraSelector;
 import androidx.camera.core.ImageAnalysis;
 import androidx.camera.core.ImageCapture;
 import androidx.camera.core.ImageProxy;
-import androidx.camera.core.Preview;
 import androidx.camera.core.UseCase;
-import androidx.camera.lifecycle.ProcessCameraProvider;
 import androidx.camera.view.PreviewView;
 import androidx.core.content.ContextCompat;
 
-public class MicroImageActivity extends CommonBaseActivity implements ImageAnalysis.Analyzer, FaceCaptureView.ImageStabilizedListener, RuntimePermissionRequester {
+public class MicroImageActivity extends BaseCameraActivity implements ImageAnalysis.Analyzer, FaceCaptureView.ImageStabilizedListener {
     public static final String MICRO_IMAGE_BASE_64_RESULT_KEY = "micro_image_base_64_result_key";
     public static final String MICRO_IMAGE_MAX_DIMENSION_PX_EXTRA = "micro_image_max_dimension_px_extra";
     public static final String MICRO_IMAGE_MAX_SIZE_BYTES_EXTRA = "micro_image_max_size_bytes_extra";
@@ -66,37 +50,42 @@ public class MicroImageActivity extends CommonBaseActivity implements ImageAnaly
     private static final int DEFAULT_MICRO_IMAGE_MAX_SIZE_BYTES = 2 * 1024;
     public static final String BASE_64_IMAGE_PREFIX = "data:image/webp;base64,";
 
-    private PreviewView cameraView;
     private FaceCaptureView faceCaptureView;
     private Bitmap inputImage;
     private ImageView cameraShutterButton;
     private boolean isGooglePlayServicesAvailable = false;
 
-    ActivityResultLauncher<String> cameraPermissionRequestLauncher = registerForActivityResult(
-            new ActivityResultContracts.RequestPermission(),
-            isGranted -> {
-                if (isGranted) {
-                    startCamera();
-                } else {
-                    logErrorAndExit("Error acquiring camera permission", "microimage.camera.permission.denied", null);
-                }
-            }
-    );
+    @Override
+    protected int getContentLayout() {
+        return R.layout.micro_image_widget;
+    }
 
     @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.micro_image_widget);
+    protected int getTitleRes() {
+        return R.string.micro_image_activity_title;
+    }
 
+    @NonNull
+    @Override
+    protected PreviewView getCameraView() {
+        return findViewById(R.id.view_finder);
+    }
+
+    @Override
+    protected CameraSelector getCameraSelector() {
+        return CameraSelector.DEFAULT_FRONT_CAMERA;
+    }
+
+    @NonNull
+    @Override
+    protected Size getTargetResolution() {
+        return new Size(faceCaptureView.getImageWidth(), faceCaptureView.getImageHeight());
+    }
+
+    @Override
+    protected void onCameraViewReady() {
         faceCaptureView = findViewById(R.id.face_overlay);
-        cameraView = findViewById(R.id.view_finder);
         cameraShutterButton = findViewById(R.id.camera_shutter_button);
-
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            actionBar.setTitle(R.string.micro_image_activity_title);
-            actionBar.setDisplayHomeAsUpEnabled(true);
-        }
         isGooglePlayServicesAvailable = AndroidUtil.isGooglePlayServicesAvailable(this);
         if (isGooglePlayServicesAvailable) {
             faceCaptureView.setImageStabilizedListener(this);
@@ -104,76 +93,21 @@ public class MicroImageActivity extends CommonBaseActivity implements ImageAnaly
             faceCaptureView.setCaptureMode(FaceCaptureView.CaptureMode.ManualMode);
             cameraShutterButton.setVisibility(View.VISIBLE);
         }
-        checkForCameraPermission();
-    }
-
-    private void checkForCameraPermission() {
-        if (Permissions.missingAppPermission(this, Manifest.permission.CAMERA)) {
-            if (Permissions.shouldShowPermissionRationale(this, Manifest.permission.CAMERA)) {
-                CommCareAlertDialog dialog =
-                        DialogCreationHelpers.buildPermissionRequestDialog(this, this,
-                                -1, // actually not required due to launcher activity
-                                getString(R.string.personalid_camera_permission_title),
-                                getString(R.string.personalid_camera_permission_msg));
-                dialog.showNonPersistentDialog(this);
-            } else {
-                requestNeededPermissions(-1);
-            }
-        } else {
-            startCamera();
-        }
     }
 
     @Override
-    public void requestNeededPermissions(int requestCode) {
-        cameraPermissionRequestLauncher.launch(Manifest.permission.CAMERA);
-    }
-
-    private void startCamera() {
-        ListenableFuture<ProcessCameraProvider> cameraProviderFuture = ProcessCameraProvider.getInstance(this);
-
-        cameraProviderFuture.addListener(() -> {
-            ProcessCameraProvider cameraProvider;
-            try {
-                cameraProvider = cameraProviderFuture.get();
-            } catch (ExecutionException | InterruptedException e) {
-                logErrorAndExit("Error acquiring camera provider", "microimage.camera.start.failed", e);
-                return;
-            }
-            bindUseCases(cameraProvider);
-        }, ContextCompat.getMainExecutor(this));
-    }
-
-    private void bindUseCases(ProcessCameraProvider cameraProvider) {
-        int targetRotation = getWindowManager().getDefaultDisplay().getRotation();
-        Size targetResolution = new Size(faceCaptureView.getImageWidth(), faceCaptureView.getImageHeight());
-
-        // Preview use case
-        Preview preview = new Preview.Builder()
-                .setTargetResolution(targetResolution)
-                .setTargetRotation(targetRotation)
-                .build();
-        preview.setSurfaceProvider(cameraView.getSurfaceProvider());
-
-        UseCase imageAnalyzerOrCapture;
+    protected UseCase buildCaptureUseCase(Size targetResolution, int targetRotation) {
         if (faceCaptureView.getCaptureMode() == FaceCaptureView.CaptureMode.FaceDetectionMode) {
-            imageAnalyzerOrCapture = buildImageAnalysisUseCase(targetResolution, targetRotation);
+            return buildImageAnalysisUseCase(targetResolution, targetRotation);
         } else {
-            imageAnalyzerOrCapture = buildImageCaptureUseCase(targetResolution);
+            return buildImageCaptureUseCase(targetResolution, targetRotation);
         }
-        CameraSelector cameraSelector = CameraSelector.DEFAULT_FRONT_CAMERA;
-
-        // Unbind any previous use cases before binding new ones
-        cameraProvider.unbindAll();
-
-        // Bind the use cases to the camera
-        cameraProvider.bindToLifecycle(this, cameraSelector, preview, imageAnalyzerOrCapture);
     }
 
     private UseCase buildImageAnalysisUseCase(Size targetResolution, int targetRotation) {
         ImageAnalysis imageAnalyzer = new ImageAnalysis.Builder()
                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                .setTargetResolution(targetResolution)
+                .setResolutionSelector(buildResolutionSelector(targetResolution))
                 .setTargetRotation(targetRotation)
                 .build();
 
@@ -181,20 +115,12 @@ public class MicroImageActivity extends CommonBaseActivity implements ImageAnaly
         return imageAnalyzer;
     }
 
-    private void logErrorAndExit(String logMessage, String userMessageKey, Throwable e) {
-        if (e == null) {
-            Logger.log(LogTypes.TYPE_EXCEPTION, logMessage);
-        } else {
-            Logger.exception(logMessage, e);
-        }
-        Toast.makeText(this, Localization.get(userMessageKey), Toast.LENGTH_LONG).show();
-        setResult(AppCompatActivity.RESULT_CANCELED);
-        finish();
-    }
-
     // Set up image capture use case, for when Google Services is not available
-    private UseCase buildImageCaptureUseCase(Size targetResolution) {
-        ImageCapture imageCapture = new ImageCapture.Builder().setTargetResolution(targetResolution).build();
+    private UseCase buildImageCaptureUseCase(Size targetResolution, int targetRotation) {
+        ImageCapture imageCapture = new ImageCapture.Builder()
+                .setResolutionSelector(buildResolutionSelector(targetResolution))
+                .setTargetRotation(targetRotation)
+                .build();
 
         cameraShutterButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -210,7 +136,7 @@ public class MicroImageActivity extends CommonBaseActivity implements ImageAnaly
                             imageProxy.close();
                             finalizeImageCapture(calcPreviewCaptureArea());
                         } else {
-                            logErrorAndExit("No image found, manual capture failed!", "microimage.camera.start.failed", null);
+                            logErrorAndExit("No image found, manual capture failed!", StringUtils.getStringRobust(MicroImageActivity.this, R.string.camera_start_failed), null);
                         }
                     }
                 });
@@ -249,7 +175,7 @@ public class MicroImageActivity extends CommonBaseActivity implements ImageAnaly
 
     private void handleErrorDuringDetection(Exception e) {
         Logger.exception("Error during face detection ", e);
-        Toast.makeText(this, "microimage.face.detection.mode.failed", Toast.LENGTH_LONG).show();
+        Toast.makeText(this, StringUtils.getStringRobust(this, R.string.microimage_face_detection_mode_failed), Toast.LENGTH_LONG).show();
         switchToManualCaptureMode();
     }
 
@@ -303,7 +229,7 @@ public class MicroImageActivity extends CommonBaseActivity implements ImageAnaly
             String finalImageAsBase64 = BASE_64_IMAGE_PREFIX + Base64.encodeToString(compressedByteArray, Base64.DEFAULT);
             finishWithResul(finalImageAsBase64);
         } catch (IOException | ImageSizeTooLargeException e) {
-            logErrorAndExit(e.getMessage(), "microimage.cropping.failed", e.getCause());
+            logErrorAndExit(e.getMessage(), StringUtils.getStringRobust(this, R.string.microimage_cropping_failed), e.getCause());
         } finally {
             recycleBitmap(croppedBitmap);
             recycleBitmap(scaledBitmap);

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
@@ -1,7 +1,7 @@
 package org.commcare.fragments.personalId;
 
-import static org.commcare.fragments.MicroImageActivity.MICRO_IMAGE_MAX_DIMENSION_PX_EXTRA;
-import static org.commcare.fragments.MicroImageActivity.MICRO_IMAGE_MAX_SIZE_BYTES_EXTRA;
+import static org.commcare.activities.camera.MicroImageActivity.MICRO_IMAGE_MAX_DIMENSION_PX_EXTRA;
+import static org.commcare.activities.camera.MicroImageActivity.MICRO_IMAGE_MAX_SIZE_BYTES_EXTRA;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -28,7 +28,7 @@ import org.commcare.connect.network.PersonalIdOrConnectApiErrorHandler;
 import org.commcare.connect.network.connectId.PersonalIdApiHandler;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.ScreenPersonalidPhotoCaptureBinding;
-import org.commcare.fragments.MicroImageActivity;
+import org.commcare.activities.camera.MicroImageActivity;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.utils.MediaUtil;
 import org.jetbrains.annotations.NotNull;

--- a/app/src/org/commcare/utils/StreamExtensions.kt
+++ b/app/src/org/commcare/utils/StreamExtensions.kt
@@ -1,0 +1,16 @@
+@file:JvmName("StreamExtensions") // This sets the generated class name
+
+package org.commcare.utils
+
+import org.javarosa.core.services.Logger
+import java.io.IOException
+import java.io.OutputStream
+
+/** Closes the stream, logging any [IOException] as a non-fatal instead of throwing. */
+fun OutputStream.closeQuietly() {
+    try {
+        close()
+    } catch (e: IOException) {
+        Logger.exception("Failed to close output stream", e)
+    }
+}

--- a/app/src/org/commcare/utils/TypedArrayExtensions.kt
+++ b/app/src/org/commcare/utils/TypedArrayExtensions.kt
@@ -1,0 +1,8 @@
+@file:JvmName("TypedArrayExtensions") // This sets the generated class name
+
+package org.commcare.utils
+
+import android.content.res.TypedArray
+
+/** Returns the float at [index] if the attribute is present, otherwise null. */
+fun TypedArray.getOptionalFloat(index: Int): Float? = if (hasValue(index)) getFloat(index, 0f) else null

--- a/app/src/org/commcare/views/RectangleOverlayView.kt
+++ b/app/src/org/commcare/views/RectangleOverlayView.kt
@@ -1,0 +1,130 @@
+package org.commcare.views
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.View
+import androidx.core.content.withStyledAttributes
+import org.commcare.dalvik.R
+import org.commcare.utils.getOptionalFloat
+
+/**
+ * Rectangular reticle drawn over the camera preview as a framing guide. Its width and height are
+ * scaled independently as fractions of the screen's width and height, per orientation. Does not
+ * crop or alter the captured frame.
+ */
+class RectangleOverlayView
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : View(context, attrs, defStyleAttr) {
+        private var reticleRect: RectF? = null
+
+        private var configuredWidthFractionPortrait: Float? = null
+        private var configuredHeightFractionPortrait: Float? = null
+        private var configuredWidthFractionLandscape: Float? = null
+        private var configuredHeightFractionLandscape: Float? = null
+
+        private val scrimPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+        private val outlinePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.STROKE }
+        private val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.STROKE }
+
+        init {
+            context.withStyledAttributes(
+                attrs,
+                R.styleable.RectangleOverlayView,
+                defStyleAttr,
+                R.style.Widget_CommCare_RectangleOverlayView,
+            ) {
+                configuredWidthFractionPortrait = getOptionalFloat(R.styleable.RectangleOverlayView_reticleWidthFractionPortrait)
+                configuredHeightFractionPortrait = getOptionalFloat(R.styleable.RectangleOverlayView_reticleHeightFractionPortrait)
+                configuredWidthFractionLandscape = getOptionalFloat(R.styleable.RectangleOverlayView_reticleWidthFractionLandscape)
+                configuredHeightFractionLandscape = getOptionalFloat(R.styleable.RectangleOverlayView_reticleHeightFractionLandscape)
+                val strokeWidthPx = getDimension(R.styleable.RectangleOverlayView_reticleStrokeWidth, 0f)
+                val outlineWidthPx = getDimension(R.styleable.RectangleOverlayView_reticleOutlineWidth, 0f)
+
+                scrimPaint.color = getColor(R.styleable.RectangleOverlayView_reticleScrimColor, 0)
+                outlinePaint.color = getColor(R.styleable.RectangleOverlayView_reticleOutlineColor, 0)
+                outlinePaint.strokeWidth = strokeWidthPx + 2 * outlineWidthPx
+                strokePaint.color = getColor(R.styleable.RectangleOverlayView_reticleStrokeColor, 0)
+                strokePaint.strokeWidth = strokeWidthPx
+            }
+        }
+
+        override fun onSizeChanged(
+            w: Int,
+            h: Int,
+            oldw: Int,
+            oldh: Int,
+        ) {
+            super.onSizeChanged(w, h, oldw, oldh)
+            if (w > 0 && h > 0) {
+                reticleRect = computeReticleRect(w, h)
+            }
+        }
+
+        /**
+         * Centered reticle for a [w] x [h] view. Width scales off [w] and height off [h] using the
+         * configured fractions, each falling back to the orientation default when unset and clamped
+         * up to the orientation minimum.
+         */
+        private fun computeReticleRect(
+            w: Int,
+            h: Int,
+        ): RectF {
+            val landscape = w > h
+            val widthFraction =
+                resolveFraction(
+                    if (landscape) configuredWidthFractionLandscape else configuredWidthFractionPortrait,
+                    if (landscape) LANDSCAPE_WIDTH_DEFAULT else PORTRAIT_WIDTH_DEFAULT,
+                    if (landscape) LANDSCAPE_WIDTH_MIN else PORTRAIT_WIDTH_MIN,
+                )
+            val heightFraction =
+                resolveFraction(
+                    if (landscape) configuredHeightFractionLandscape else configuredHeightFractionPortrait,
+                    if (landscape) LANDSCAPE_HEIGHT_DEFAULT else PORTRAIT_HEIGHT_DEFAULT,
+                    if (landscape) LANDSCAPE_HEIGHT_MIN else PORTRAIT_HEIGHT_MIN,
+                )
+            val reticleWidth = w * widthFraction
+            val reticleHeight = h * heightFraction
+            val left = (w - reticleWidth) / 2f
+            val top = (h - reticleHeight) / 2f
+            return RectF(left, top, left + reticleWidth, top + reticleHeight)
+        }
+
+        private fun resolveFraction(
+            configured: Float?,
+            default: Float,
+            min: Float,
+        ): Float = (configured ?: default).coerceAtLeast(min)
+
+        override fun onDraw(canvas: Canvas) {
+            super.onDraw(canvas)
+            val rect = reticleRect ?: return
+            val viewWidth = width.toFloat()
+            val viewHeight = height.toFloat()
+
+            canvas.drawRect(0f, 0f, viewWidth, rect.top, scrimPaint)
+            canvas.drawRect(0f, rect.bottom, viewWidth, viewHeight, scrimPaint)
+            canvas.drawRect(0f, rect.top, rect.left, rect.bottom, scrimPaint)
+            canvas.drawRect(rect.right, rect.top, viewWidth, rect.bottom, scrimPaint)
+
+            canvas.drawRect(rect, outlinePaint)
+            canvas.drawRect(rect, strokePaint)
+        }
+
+        companion object {
+            private const val PORTRAIT_WIDTH_DEFAULT = 0.90f
+            private const val PORTRAIT_WIDTH_MIN = 0.20f
+            private const val PORTRAIT_HEIGHT_DEFAULT = 0.25f
+            private const val PORTRAIT_HEIGHT_MIN = 0.10f
+            private const val LANDSCAPE_WIDTH_DEFAULT = 0.70f
+            private const val LANDSCAPE_WIDTH_MIN = 0.30f
+            private const val LANDSCAPE_HEIGHT_DEFAULT = 0.50f
+            private const val LANDSCAPE_HEIGHT_MIN = 0.20f
+        }
+    }

--- a/app/src/org/commcare/views/widgets/ImageWidget.java
+++ b/app/src/org/commcare/views/widgets/ImageWidget.java
@@ -21,6 +21,7 @@ import com.google.android.material.button.MaterialButton;
 
 import org.commcare.CommCareApplication;
 import org.commcare.activities.FormEntryActivity;
+import org.commcare.activities.camera.CameraOverlayActivity;
 import org.commcare.activities.components.FormEntryConstants;
 import org.commcare.activities.components.FormEntryInstanceState;
 import org.commcare.activities.components.ImageCaptureProcessing;
@@ -59,6 +60,8 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
 
     public static final Object IMAGE_VIEW_TAG = "image_view_tag";
 
+    private static final String OVERLAY_SMALL = "overlay-small";
+
     private final Button mCaptureButton;
     private final Button mChooseButton;
     private final Button mDiscardButton;
@@ -71,6 +74,7 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
     private final TextView mErrorTextView;
 
     private int mMaxDimen;
+    private final boolean useRectangleOverlay;
     private final PendingCalloutInterface pendingCalloutInterface;
 
     public static File getTempFileForImageCapture() {
@@ -170,8 +174,10 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
         addView(mChooseButton);
         addView(mDiscardButton);
 
-        String acq = mPrompt.getAppearanceHint();
-        if (QuestionWidget.ACQUIREFIELD.equalsIgnoreCase(acq)) {
+        String appearanceHint = mPrompt.getAppearanceHint();
+        boolean acquire = appearanceHint != null && appearanceHint.contains(QuestionWidget.ACQUIREFIELD);
+        useRectangleOverlay = appearanceHint != null && appearanceHint.contains(OVERLAY_SMALL);
+        if (acquire) {
             mChooseButton.setVisibility(View.GONE);
         }
         addView(mErrorTextView);
@@ -257,21 +263,14 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
     }
 
     private void takePicture() {
-        Intent i = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
-        Uri uri = FileUtil.getUriForExternalFile(getContext(), getTempFileForImageCapture());
-
-        // We give the camera an absolute filename/path where to put the
-        // picture because of bug:
-        // http://code.google.com/p/android/issues/detail?id=1480
-        // The bug appears to be fixed in Android 2.0+, but as of feb 2,
-        // 2010, G1 phones only run 1.6. Without specifying the path the
-        // images returned by the camera in 1.6 (and earlier) are ~1/4
-        // the size. boo.
-        i.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
-        i.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        i.setFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        Intent intent;
+        if (useRectangleOverlay) {
+            intent = buildOverlayCaptureIntent();
+        } else {
+            intent = buildSystemCaptureIntent();
+        }
         try {
-            ((AppCompatActivity)getContext()).startActivityForResult(i,
+            ((AppCompatActivity)getContext()).startActivityForResult(intent,
                     FormEntryConstants.IMAGE_CAPTURE);
             pendingCalloutInterface.setPendingCalloutFormIndex(mPrompt.getIndex());
         } catch (ActivityNotFoundException e) {
@@ -280,6 +279,20 @@ public class ImageWidget extends QuestionWidget implements QuestionWidget.MediaC
                             R.string.activity_not_found, "image capture"),
                     Toast.LENGTH_SHORT).show();
         }
+    }
+
+    private Intent buildOverlayCaptureIntent() {
+        Uri uri = FileUtil.getUriForExternalFile(getContext(), getTempFileForImageCapture());
+        return CameraOverlayActivity.getIntent(getContext(), uri);
+    }
+
+    private Intent buildSystemCaptureIntent() {
+        Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
+        Uri uri = FileUtil.getUriForExternalFile(getContext(), getTempFileForImageCapture());
+        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
+        intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        intent.setFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        return intent;
     }
 
     public void clearBinaryAttachment() {

--- a/app/unit-tests/src/org/commcare/activities/camera/CameraOverlayActivityTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/camera/CameraOverlayActivityTest.kt
@@ -1,0 +1,149 @@
+package org.commcare.activities.camera
+
+import android.app.Activity
+import android.net.Uri
+import android.view.View
+import android.widget.ImageView
+import androidx.camera.core.ImageCapture
+import androidx.core.content.IntentCompat
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.commcare.CommCareTestApplication
+import org.commcare.dalvik.R
+import org.commcare.utils.StringUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class CameraOverlayActivityTest {
+    private val outputUri = "content://org.commcare.dalvik.fileprovider/external/output.jpg"
+
+    private fun buildActivity(withOutputUri: Boolean = true): CameraOverlayActivity {
+        val builder =
+            if (withOutputUri) {
+                Robolectric.buildActivity(
+                    CameraOverlayActivity::class.java,
+                    CameraOverlayActivity.getIntent(ApplicationProvider.getApplicationContext(), Uri.parse(outputUri)),
+                )
+            } else {
+                Robolectric.buildActivity(CameraOverlayActivity::class.java)
+            }
+        return builder.create().get()
+    }
+
+    private fun CameraOverlayActivity.shutter() = findViewById<ImageView>(R.id.camera_shutter_button)
+
+    private fun CameraOverlayActivity.progress() = findViewById<View>(R.id.capture_progress)
+
+    @Test
+    fun `getIntent targets CameraOverlayActivity and carries the output uri`() {
+        val uri = Uri.parse(outputUri)
+
+        val intent =
+            CameraOverlayActivity.getIntent(ApplicationProvider.getApplicationContext(), uri)
+
+        assertEquals(CameraOverlayActivity::class.java.name, intent.component!!.className)
+        assertEquals(
+            uri,
+            IntentCompat.getParcelableExtra(intent, CameraOverlayActivity.OUTPUT_FILE_URI_EXTRA, Uri::class.java),
+        )
+    }
+
+    @Test
+    fun `clicking the shutter starts a capture and shows the capturing state`() {
+        val activity = buildActivity()
+        val imageCapture = mock<ImageCapture>()
+        activity.imageCapture = imageCapture
+
+        activity.shutter().performClick()
+
+        verify(imageCapture).takePicture(any(), any(), any())
+        assertFalse("Shutter should be disabled while capturing", activity.shutter().isEnabled)
+        assertEquals(0.5f, activity.shutter().alpha, 0f)
+        assertEquals(View.VISIBLE, activity.progress().visibility)
+    }
+
+    @Test
+    fun `captureImage finishes with RESULT_OK when the image is saved`() {
+        val activity = buildActivity()
+        val imageCapture =
+            mock<ImageCapture> {
+                on { takePicture(any(), any(), any()) } doAnswer {
+                    it.getArgument<ImageCapture.OnImageSavedCallback>(2).onImageSaved(mock())
+                }
+            }
+        activity.imageCapture = imageCapture
+
+        activity.shutter().performClick()
+
+        assertEquals(Activity.RESULT_OK, shadowOf(activity).resultCode)
+        assertTrue("A successful capture should finish the activity", activity.isFinishing)
+    }
+
+    @Test
+    fun `captureImage surfaces a retryable error when ImageCapture reports onError`() {
+        val activity = buildActivity()
+        val imageCapture =
+            mock<ImageCapture> {
+                on { takePicture(any(), any(), any()) } doAnswer {
+                    it.getArgument<ImageCapture.OnImageSavedCallback>(2).onError(mock())
+                }
+            }
+        activity.imageCapture = imageCapture
+
+        activity.shutter().performClick()
+
+        assertEquals(
+            StringUtils.getStringRobust(activity, R.string.image_capture_failed),
+            ShadowToast.getTextOfLatestToast(),
+        )
+        assertTrue("Shutter should be re-enabled after an error so capture can be retried", activity.shutter().isEnabled)
+        assertEquals(View.GONE, activity.progress().visibility)
+        assertFalse("Capture errors are non-fatal; the activity must stay open", activity.isFinishing)
+    }
+
+    @Test
+    fun `clicking the shutter again while a capture is in progress is a no-op`() {
+        val activity = buildActivity()
+        val imageCapture = mock<ImageCapture>()
+        activity.imageCapture = imageCapture
+
+        activity.shutter().performClick()
+        activity.shutter().performClick()
+
+        verify(imageCapture, times(1)).takePicture(any(), any(), any())
+    }
+
+    @Test
+    fun `clicking the shutter does nothing when the camera is not ready`() {
+        val activity = buildActivity()
+        activity.imageCapture = null
+
+        activity.shutter().performClick()
+
+        assertTrue("Shutter stays enabled when capture cannot start", activity.shutter().isEnabled)
+        assertEquals(View.GONE, activity.progress().visibility)
+        assertFalse(activity.isFinishing)
+    }
+
+    @Test(expected = NullPointerException::class)
+    fun `clicking the shutter crashes when the intent carries no output uri`() {
+        val activity = buildActivity(withOutputUri = false)
+        activity.imageCapture = mock()
+
+        activity.shutter().performClick()
+    }
+}


### PR DESCRIPTION
### [CCCT-2531](https://dimagi.atlassian.net/browse/CCCT-2531)

## Product Description

A new `overlay-small` appearance on image-capture questions shows a rectangular framing guide in the camera preview to help users consistently frame the subject (e.g. a MUAC arm + tape).

<img width="200" height="444" alt="Screenshot_20260723_124042" src="https://github.com/user-attachments/assets/52e496b8-467d-424a-b783-c42a9cc6cd12" />

<img width="986" height="400" alt="Screenshot_20260723_124102" src="https://github.com/user-attachments/assets/24f797fd-a7aa-49dd-956f-311602810181" />


## Technical Summary

Ticket: https://dimagi.atlassian.net/browse/CCCT-2531

The reticle is drawn as a view overlay on the preview, not composited into the capture, so the saved photo remains the full unmodified frame.

## Safety Assurance

### Safety story

- I ran the `overlay-small` capture flow on a device and confirmed the saved photo is the full frame with the guide not drawn on it.
- I ran the unit test suite.
- Scope is limited to a new opt-in `appearance` value; existing image-capture behavior is unchanged when it is absent.
- I registered a new PersonalID account and verified the photo-capture step works end to end. (+74262424242)
- I tested form image capture for both, with (rectangular framing guide shown) and without (default capture) the overlay.

### Automated test coverage

`CameraOverlayActivityTest` covers the overlay activity behavior.

### QA Plan

See the QA note under CommCare 2.63.3 in RELEASES.md. QA ticket: https://dimagi.atlassian.net/browse/CCCT-2531

[CCCT-2531]: https://dimagi.atlassian.net/browse/CCCT-2531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ