### PR TITLE
QA-8585 Use Minimize-Latency Capture Mode For Camera Overlay

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,10 @@ This file is meant as an easy way for us to collate notes and change logs across
 
 - Image capture using the in-app camera overlay now captures faster, reducing shutter lag when taking a photo.
 
+### QA Notes
+
+- **Overlay capture speed:** On an `overlay-small` image-capture question, verify Take Picture captures promptly with no noticeable shutter lag, and the saved photo is acceptable quality.
+
 ## CommCare 2.63.3
 
 ### Release Notes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,14 @@
 This file is meant as an easy way for us to collate notes and change logs across releases. 
 -->
 
+## CommCare 2.63.4
+
+### Release Notes
+
+#### Important Bug Fixes
+
+- Image capture using the in-app camera overlay now captures faster, reducing shutter lag when taking a photo.
+
 ## CommCare 2.63.3
 
 ### Release Notes

--- a/app/src/org/commcare/activities/camera/CameraOverlayActivity.kt
+++ b/app/src/org/commcare/activities/camera/CameraOverlayActivity.kt
@@ -52,7 +52,7 @@ class CameraOverlayActivity : BaseCameraActivity() {
         val capture =
             ImageCapture
                 .Builder()
-                .setCaptureMode(ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY)
+                .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
                 .setTargetRotation(targetRotation)
                 .build()
         imageCapture = capture


### PR DESCRIPTION
### [QA-8585](https://dimagi.atlassian.net/browse/QA-8585)

## Product Description

The in-app camera overlay (`overlay-small` image capture) now prioritizes capture **speed over image quality** by switching `ImageCapture` from `CAPTURE_MODE_MAXIMIZE_QUALITY` to `CAPTURE_MODE_MINIMIZE_LATENCY`. Users experience a faster shutter/capture when framing with the reticle.

## Technical Summary

One-line change in `CameraOverlayActivity.kt`: the `ImageCapture.Builder` capture mode is set to `CAPTURE_MODE_MINIMIZE_LATENCY`. Targets the 2.63.4 hotfix line (branch `commcare_2.63`). Release and QA notes for the new `## CommCare 2.63.4` section are included in this PR.

## Safety Assurance

### Safety story

Confidence:
- I tested the camera change locally.
- Minimal blast radius — a single enum value on the overlay capture path; no logic or control-flow change.
- The surrounding camera-overlay code shipped in 2.63.3 and is already in production.

Risks to review:
- Latency-vs-quality tradeoff: captured images may be slightly lower quality than before. Acceptable per the ticket's intent (prefer speed), but worth a visual check during QA.

[QA-8585]: https://dimagi.atlassian.net/browse/QA-8585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ