### PR TITLE
QA-8585 Reduce Camera Overlay Image-Capture Latency

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,14 @@
 This file is meant as an easy way for us to collate notes and change logs across releases. 
 -->
 
+## CommCare 2.63.4
+
+### Release Notes
+
+#### Important Bug Fixes
+
+- Image capture with the camera overlay now has reduced latency.
+
 ## CommCare 2.63.3
 
 ### Release Notes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,10 @@ This file is meant as an easy way for us to collate notes and change logs across
 
 - Image capture with the camera overlay now has reduced latency.
 
+### QA Notes
+
+- The Image-capture question with the overlay-small appearance should capture photos promptly with no noticeable shutter lag while maintaining acceptable image quality.
+
 ## CommCare 2.63.3
 
 ### Release Notes

--- a/app/src/org/commcare/activities/camera/CameraOverlayActivity.kt
+++ b/app/src/org/commcare/activities/camera/CameraOverlayActivity.kt
@@ -52,7 +52,7 @@ class CameraOverlayActivity : BaseCameraActivity() {
         val capture =
             ImageCapture
                 .Builder()
-                .setCaptureMode(ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY)
+                .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
                 .setTargetRotation(targetRotation)
                 .build()
         imageCapture = capture

--- a/app/src/org/commcare/activities/camera/CameraOverlayActivity.kt
+++ b/app/src/org/commcare/activities/camera/CameraOverlayActivity.kt
@@ -22,8 +22,9 @@ import org.javarosa.core.services.Logger
 /**
  * Back-camera capture screen that draws a static [org.commcare.views.RectangleOverlayView] reticle
  * over the preview as a framing guide. Capture is manual via the shutter
- * button; the full-resolution frame is written to the caller-supplied output URI without cropping,
- * so the reticle never appears in the saved image.
+ * button; the captured frame is written to the caller-supplied output URI without cropping,
+ * so the reticle never appears in the saved image. Capture resolution is capped (see
+ * [TARGET_CAPTURE_RESOLUTION]) to keep shutter-to-save latency low on high-megapixel sensors.
  */
 class CameraOverlayActivity : BaseCameraActivity() {
     private val outputUri: Uri by lazy { intentOutputUri()!! }
@@ -39,7 +40,7 @@ class CameraOverlayActivity : BaseCameraActivity() {
 
     override fun getCameraSelector(): CameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
 
-    override fun getTargetResolution(): Size? = null
+    override fun getTargetResolution(): Size = TARGET_CAPTURE_RESOLUTION
 
     override fun onCameraViewReady() {
         findViewById<ImageView>(R.id.camera_shutter_button).setOnClickListener { captureImage() }
@@ -49,12 +50,13 @@ class CameraOverlayActivity : BaseCameraActivity() {
         targetResolution: Size?,
         targetRotation: Int,
     ): UseCase {
-        val capture =
+        val builder =
             ImageCapture
                 .Builder()
                 .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
                 .setTargetRotation(targetRotation)
-                .build()
+        targetResolution?.let { builder.setResolutionSelector(buildResolutionSelector(it)) }
+        val capture = builder.build()
         imageCapture = capture
         return capture
     }
@@ -118,6 +120,10 @@ class CameraOverlayActivity : BaseCameraActivity() {
         const val OUTPUT_FILE_URI_EXTRA = "camera_overlay_output_file_uri_extra"
 
         private const val DISABLED_SHUTTER_ALPHA = 0.5f
+
+        // Caps capture to ~5 MP (4:3, long edge 2560 px) instead of the sensor's full resolution,
+        // which is the dominant shutter-to-save cost on high-megapixel devices.
+        private val TARGET_CAPTURE_RESOLUTION = Size(2560, 1920)
 
         @JvmStatic
         fun getIntent(


### PR DESCRIPTION
### [QA-8585](https://dimagi.atlassian.net/browse/QA-8585)

## Product Description

Photos taken through the camera-overlay image-capture screen now save promptly, removing the multi-second shutter lag seen on some devices.

## Technical Summary

Switched the `ImageCapture` use case to minimize-latency capture mode, which drops the multi-frame quality post-processing responsible for the lag on lower-end hardware. Capture resolution is unchanged.

## Safety Assurance

### Safety story

What gives confidence:
- I installed a build and exercised the overlay-small image-capture flow on a physical device, confirming faster capture while image quality remained acceptable.
- The change is a single capture-mode flag on the `ImageCapture` builder; resolution and all other capture parameters are untouched.

Risks to review:
- Reduced post-capture processing could lower image quality on some devices. Worth confirming captured images stay legible for the intended framing/subject use cases.

### QA Plan

See the CommCare 2.63.4 QA Notes in [RELEASES.md](../RELEASES.md).

[QA-8585]: https://dimagi.atlassian.net/browse/QA-8585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ