### PR TITLE
Enable lint check for all branches

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,7 +3,6 @@ name: Lint Code Base
 
 on:
   pull_request:
-    branches: [ master ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Product Description

N/A

## Technical Summary

Think it's harmless to run lint for PRs to all branches and allows us to adapt PRs targeting feature branches. 

## Safety Assurance

Tooling change

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
