### PR TITLE
Remove Unreachable Swiss Server URL From LetsEncryptTest

### DIFF
--- a/app/instrumentation-tests/src/org/commcare/androidTests/LetsEncryptTest.java
+++ b/app/instrumentation-tests/src/org/commcare/androidTests/LetsEncryptTest.java
@@ -32,9 +32,6 @@ public class LetsEncryptTest {
     private static final String GOOGLE_TEST_URL = "https://www.google.com/robots.txt"; // GlobalSign
     private static final String COMMCARE_TEST_URL = "http://www.commcarehq.org/serverup.txt"; // AWS
 
-    // DST Root CA X3 , will shift to ISRG Root X1 on 1 Sep 2021 and can be removed there after
-    private static final String SWISS_TEST_URL = "https://swiss.commcarehq.org/serverup.txt";
-
     private CommCareNetworkService commCareNetworkService;
 
     @Before
@@ -45,7 +42,6 @@ public class LetsEncryptTest {
     @Test
     public void getPassesWithoutException() throws IOException {
         makeGetRequest(ISRG_TEST_URL, 404);
-        makeGetRequest(SWISS_TEST_URL, 200);
         makeGetRequest(COMMCARE_TEST_URL, 200);
         makeGetRequest(GOOGLE_TEST_URL, 200);
     }


### PR DESCRIPTION
## Technical Summary

`LetsEncryptTest` was failing with a `SocketTimeoutException` connecting to `swiss.commcarehq.org:443`. Dimagi no longer maintains that server, so the endpoint is permanently unreachable rather than transiently down and there is nothing to fix on the infrastructure side.

The URL only existed to exercise the DST Root CA X3 chain during the 2021 Let's Encrypt root transition, and the inline comment already marked it removable after that root shifted to ISRG Root X1. The test covers ISRG Root X1 directly via `valid-isrgrootx1.letsencrypt.org`, so deleting the Swiss check loses no certificate-chain coverage.

## Safety Assurance

### Safety story

What gives confidence:
- I ran the connected instrumentation suite and confirmed all tests pass with the Swiss URL removed.
- I confirmed Dimagi no longer maintains the Swiss server, so no reachable replacement endpoint is being dropped.
- Scope is one instrumentation test; no production code is touched.

Risks to review:
- The test still depends on three live external endpoints and asserts HTTP/2 on each, so it remains vulnerable to the same class of failure if any of those hosts change. That exposure is pre-existing and not altered here.

### Automated test coverage

`LetsEncryptTest` continues to verify certificate-chain handling against ISRG Root X1, the AWS-hosted CommCare HQ endpoint, and GlobalSign, so the root-of-trust conditions the test was written to catch are still covered.