### PR TITLE
CI-834 Keep Retrofit Suspend Generic Signatures Under R8 Full Mode

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -112,6 +112,13 @@
 -keepattributes Exceptions
 -dontwarn okio.**
 
+# R8 full mode strips generic signature type arguments that reference classes which
+# aren't kept. Retrofit reads Continuation<Response<T>> off suspend service methods
+# via reflection, so both types must be kept. Retrofit 2.9.0 ships without these
+# rules; they can be dropped once we upgrade to 2.10.0+.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+
 -dontwarn java.lang.invoke.*
 -dontwarn **$$Lambda$*
 


### PR DESCRIPTION
### [CI-834](https://dimagi.atlassian.net/browse/CI-834) _and_ [QA-8596](https://dimagi.atlassian.net/browse/QA-8596)

## Product Description
The Connect opportunity list and delivery progress no longer force-close the app on release builds.

## Technical Summary
R8 full mode drops generic signature type arguments pointing at classes without a keep rule, so `ConnectApiService`'s suspend methods reached Retrofit's reflection as a raw `Continuation` and every call threw `ClassCastException` in `HttpServiceMethod.parseAnnotations`. The `Call`-based interfaces were never affected only because `retrofit2.Call` and `okhttp3.**` are already kept — `Continuation` and `retrofit2.Response` were the two types in those signatures without a rule. Retrofit ships these same rules from 2.10.0 onward; adding them directly keeps the change minimal on a release branch, and the inline comment notes they become redundant after a dependency bump.

Links to the issues in Firebase:
- [Link 1](https://console.firebase.google.com/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/3dd9e5c90876e3cc4267439ee39907e5?time=90d&types=crash&sessionEventKey=6A6897DF01AB00016CAAB4385857AF24_2245991263782967302)
- [Link 2
](https://console.firebase.google.com/project/commcare-a57e4/crashlytics/app/android:org.commcare.dalvik/issues/f0fa24127e1a5109164cbcccafaf1411?time=90d&types=crash&sessionEventKey=6A68984701B2000137CD700E7E0B4222_2245991464520246856)

## Safety Assurance

### Safety story

What gives confidence:

- I reproduced the crash on a device with a minified release build, then installed the same build with these rules and confirmed the opportunity list loads normally. The captured logcat trace matched the Firebase report frame for frame, down to `$Proxy15.getConnectOpportunities`.
- I verified in the DEX before and after that all three suspend methods carry `Continuation<-Response<ResponseBody>>` rather than a bare `Continuation`.
- ProGuard-config-only change; no runtime code is touched. Both rules allow shrinking and obfuscation, so they affect signature retention and nothing else.

Risks to review:

- Debug builds are not minified, so neither local development nor the default test suite exercises this at all. Any verification of this area has to happen on a release build.
- 2.63 is unaffected because it has no suspend service methods, so this is a defect introduced with the offline-first Connect work rather than a change in existing behavior. `master` carries the same latent gap and will pick up the fix on back-merge.

### Automated test coverage
None. The defect exists only in R8 output, and `testBuildType` defaults to `debug` (unminified), so neither unit nor instrumentation tests can reach it. The practical guard is a release-build smoke test of the Connect screens.

[CI-834]: https://dimagi.atlassian.net/browse/CI-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[QA-8596]: https://dimagi.atlassian.net/browse/QA-8596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ