### PR TITLE
QA-8592 Include Keyboard Insets In Edge-To-Edge Padding

### DIFF
--- a/app/src/org/commcare/utils/AndroidUtil.java
+++ b/app/src/org/commcare/utils/AndroidUtil.java
@@ -78,7 +78,7 @@ public class AndroidUtil {
 
     /**
      * Attaches a WindowInsetsListener to the root view of the activity for devices running Android 15+. This
-     * listener applies padding to the view based on the system window insets.
+     * listener applies padding to the view based on the system window insets, including the keyboard.
      *
      * @param activity   The activity to which the listener is attached.
      * @param rootViewId The ID of the root view in the activity's layout.
@@ -89,11 +89,13 @@ public class AndroidUtil {
 
         if (activityRootView != null) {
             ViewCompat.setOnApplyWindowInsetsListener(activityRootView, (view, insets) -> {
-                Insets systemBars = insets.getInsets(
-                        WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+                Insets obstructions = insets.getInsets(
+                        WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
+                                | WindowInsetsCompat.Type.ime());
 
-                // Apply padding so content doesn't overlap with system bars
-                view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+                // Apply padding so content doesn't overlap with system bars or the keyboard. Edge-to-edge
+                // enforcement makes adjustResize a no-op, so this is what makes room for the IME.
+                view.setPadding(obstructions.left, obstructions.top, obstructions.right, obstructions.bottom);
                 return insets;
             });
         }


### PR DESCRIPTION
### [QA-8592](https://dimagi.atlassian.net/browse/QA-8592)

## Product Description

On Android 15+, the keyboard no longer covers input fields and Continue buttons. The reported cases are the PersonalID Phone Number and Backup Code screens, which now make room for the IME and scroll again instead of requiring the user to dismiss the keyboard.

## Technical Summary

`attachWindowInsetsListener` is the only thing making room for system UI on API 35+, and a recent refactor from the deprecated `getSystemWindowInsets()` to typed insets dropped the IME: `getSystemWindowInsets()` is `systemBars() | displayCutout() | ime()` (see `InsetsState#calculateInsets`), and only the first two were carried over. That is also why this only reproduces on Android 15 — `CommonBaseActivity` gates the listener on API 35+, so Android 14 still gets normal framework handling.

Declaring `windowSoftInputMode="adjustResize"` on the affected activities would not help. Under edge-to-edge enforcement at targetSdk 35 it is inert — measured on an API 36 emulator, `LoginActivity` already declares it and its ScrollView stayed at 2127px with the keyboard both open and closed.

## Safety Assurance

### Safety story

What gives confidence:

- Reproduced the original overlap on an Android 15+ emulator without the fix, then confirmed the screens make room for the keyboard and scroll with it applied.
- Measured the underlying mechanism directly: the content ScrollView goes from 2127px to 1218px when the IME opens, where it previously stayed at 2127px.
- The change restores the inset set that shipped in 2.63, so this is a return to known-good behavior rather than new behavior.
- One-line scope, confined to a single helper.

Risks to review:

- This affects every API 35+ activity that extends `CommonBaseActivity`, not only the two screens in the ticket. That is intended — they all lost IME padding the same way — but it is a wider blast radius than the ticket suggests.
- Adding IME padding on top of a window the framework also pans would double-shift content. The only `adjustPan` activity is `CommCareFormDumpActivity`, whose layout has no text input, so there is nothing to trigger it.

[QA-8592]: https://dimagi.atlassian.net/browse/QA-8592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ