### PR TITLE
QA-8593 Reject Emails With A Single-Character Top-Level Domain

### DIFF
--- a/app/src/org/commcare/utils/StringUtils.java
+++ b/app/src/org/commcare/utils/StringUtils.java
@@ -68,12 +68,12 @@ public class StringUtils {
     }
 
     /**
-     * The final domain label, mirroring the server-side validator: 2-63 characters with no
-     * leading or trailing hyphen. {@link Patterns#EMAIL_ADDRESS} on its own accepts
-     * single-character top-level domains that the server rejects.
+     * Requires a final domain label of two or more characters with no edge hyphens, which
+     * {@link Patterns#EMAIL_ADDRESS} does not — it accepts the single-character top-level domains
+     * the server rejects. Maximum label length stays with Patterns, at 26 characters.
      */
     private static final Pattern EMAIL_TOP_LEVEL_DOMAIN =
-            Pattern.compile("\\.[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9]$");
+            Pattern.compile("\\.[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$");
 
     /**
      * Validates an email address against {@link Patterns#EMAIL_ADDRESS} and

--- a/app/src/org/commcare/utils/StringUtils.java
+++ b/app/src/org/commcare/utils/StringUtils.java
@@ -8,6 +8,8 @@ import org.commcare.dalvik.R;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.util.NoLocalizedTextException;
 
+import java.util.regex.Pattern;
+
 import androidx.annotation.NonNull;
 
 /**
@@ -66,12 +68,26 @@ public class StringUtils {
     }
 
     /**
-     * Validates an email address against {@link Patterns#EMAIL_ADDRESS}. Returns false for
-     * null, empty, or whitespace-only input.
+     * The final domain label, mirroring the server-side validator: 2-63 characters with no
+     * leading or trailing hyphen. {@link Patterns#EMAIL_ADDRESS} on its own accepts
+     * single-character top-level domains that the server rejects.
+     */
+    private static final Pattern EMAIL_TOP_LEVEL_DOMAIN =
+            Pattern.compile("\\.[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9]$");
+
+    /**
+     * Validates an email address against {@link Patterns#EMAIL_ADDRESS} and
+     * {@link #EMAIL_TOP_LEVEL_DOMAIN}. Returns false for null, empty, or whitespace-only input.
      */
     public static boolean isValidEmail(String email) {
-        return email != null && !email.trim().isEmpty()
-                && Patterns.EMAIL_ADDRESS.matcher(email.trim()).matches();
+        if (email == null) {
+            return false;
+        }
+
+        String trimmedEmail = email.trim();
+        return !trimmedEmail.isEmpty()
+                && Patterns.EMAIL_ADDRESS.matcher(trimmedEmail).matches()
+                && EMAIL_TOP_LEVEL_DOMAIN.matcher(trimmedEmail).find();
     }
 
     public static String getLocalizedLevel(String levelCode, Context context) {

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdEmailFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdEmailFragmentTest.kt
@@ -80,6 +80,22 @@ class PersonalIdEmailFragmentTest : BasePersonalIdEmailFragmentTest() {
     }
 
     @Test
+    fun `email with an incomplete top level domain keeps continue button disabled`() {
+        val emailInput = fragment.view?.findViewById<TextInputEditText>(R.id.email_text_value)
+        val continueButton = fragment.view?.findViewById<MaterialButton>(R.id.personalid_email_continue_button)
+
+        activity.runOnUiThread {
+            emailInput?.setText("user@gmail.c")
+        }
+        ShadowLooper.idleMainLooper()
+
+        assertFalse(
+            "Continue button should remain disabled for a single-character top-level domain",
+            continueButton!!.isEnabled,
+        )
+    }
+
+    @Test
     fun `blank email keeps continue button disabled`() {
         val emailInput = fragment.view?.findViewById<TextInputEditText>(R.id.email_text_value)
         val continueButton = fragment.view?.findViewById<MaterialButton>(R.id.personalid_email_continue_button)

--- a/app/unit-tests/src/org/commcare/utils/StringUtilsTest.kt
+++ b/app/unit-tests/src/org/commcare/utils/StringUtilsTest.kt
@@ -58,4 +58,9 @@ class StringUtilsTest {
         assertTrue(StringUtils.isValidEmail("user@gmail.co"))
         assertTrue(StringUtils.isValidEmail("user@g.co"))
     }
+
+    @Test
+    fun `isValidEmail returns true for the longest top level domain in the IANA root`() {
+        assertTrue(StringUtils.isValidEmail("user@example.xn--vermgensberatung-pwb"))
+    }
 }

--- a/app/unit-tests/src/org/commcare/utils/StringUtilsTest.kt
+++ b/app/unit-tests/src/org/commcare/utils/StringUtilsTest.kt
@@ -40,4 +40,22 @@ class StringUtilsTest {
         assertFalse(StringUtils.isValidEmail("@no-local.com"))
         assertFalse(StringUtils.isValidEmail("spaces in@example.com"))
     }
+
+    @Test
+    fun `isValidEmail returns false for single character top level domain`() {
+        assertFalse(StringUtils.isValidEmail("user@gmail.c"))
+        assertFalse(StringUtils.isValidEmail("user@sub.example.x"))
+    }
+
+    @Test
+    fun `isValidEmail returns false when top level domain has a leading or trailing hyphen`() {
+        assertFalse(StringUtils.isValidEmail("user@example.co-"))
+        assertFalse(StringUtils.isValidEmail("user@example.-co"))
+    }
+
+    @Test
+    fun `isValidEmail returns true for two character top level domain`() {
+        assertTrue(StringUtils.isValidEmail("user@gmail.co"))
+        assertTrue(StringUtils.isValidEmail("user@g.co"))
+    }
 }


### PR DESCRIPTION
### [QA-8593](https://dimagi.atlassian.net/browse/QA-8593)

## Product Description

On the PersonalID email screen, an address whose top-level domain is a single character (`abc@gmail.c`) is now rejected inline as an invalid format instead of being submitted for an OTP.

Video showing Manage Profile:

https://github.com/user-attachments/assets/32d845bf-b65d-4955-86d3-af657c44dfc5

Video showing PersonalID setup:

https://github.com/user-attachments/assets/d3c19154-90c0-4df0-91ee-774b208f7cd2


## Technical Summary

These changes mirror the same pattern match checks that happen on Server.

**_Note:_** The ticket's other reported addresses — `abc@gmail.co`, `abc@gma.com`, `abc@gmil.co`, `abc@g.co`, `abc@gma.co` — are deliberately still accepted. A new backlog ticket was made to address typos more generally: [CCCT-2702](https://dimagi.atlassian.net/browse/CCCT-2702).

## Safety Assurance

### Safety story

- I reproduced the crash on a device, and confirmed after the change that Continue stays disabled and the inline invalid-format error shows.
- The change is one validator used by the signup/recovery email screen, the email OTP resend, and the Manage Profile email edit — all three get the stricter rule, and all three already had test coverage that still passes.
- Risk to review: the validator is shared, so anything it now rejects is rejected everywhere.

### Automated test coverage

Thew new cases are now covered by unit tests.

[QA-8593]: https://dimagi.atlassian.net/browse/QA-8593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CCCT-2702]: https://dimagi.atlassian.net/browse/CCCT-2702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ