### PR TITLE
QA-8604 Surface PersonalID Biometric Unlock Errors

### DIFF
--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -21,13 +21,6 @@ import kotlin.time.Duration.Companion.minutes
 private val SESSION_UNLOCK_THRESHOLD_MS = 10.minutes.inWholeMilliseconds
 internal const val BIOMETRIC_INVALIDATION_KEY = "biometric-invalidation-key"
 
-private val PROMPT_DISMISSED_ERRORS =
-    setOf(
-        BiometricPrompt.ERROR_NEGATIVE_BUTTON,
-        BiometricPrompt.ERROR_USER_CANCELED,
-        BiometricPrompt.ERROR_CANCELED,
-    )
-
 /** Middleware to manage Personal ID unlock prompts with session-based bypass logic. */
 object PersonalIdUnlocker {
     @VisibleForTesting
@@ -86,8 +79,19 @@ object PersonalIdUnlocker {
                     errString: CharSequence,
                 ) {
                     callback.connectActivityComplete(false)
-                    if (errorCode !in PROMPT_DISMISSED_ERRORS) {
-                        Toast.makeText(activity, errString, Toast.LENGTH_LONG).show()
+                    val fingerprintConfigured =
+                        BiometricsHelper.isFingerprintConfigured(
+                            activity,
+                            bioManager,
+                        )
+
+                    getBiometricErrorStringRes(fingerprintConfigured, errorCode)?.let { messageRes ->
+                        Toast
+                            .makeText(
+                                activity,
+                                activity.getString(messageRes),
+                                Toast.LENGTH_LONG,
+                            ).show()
                     }
                 }
 
@@ -129,6 +133,30 @@ object PersonalIdUnlocker {
                     }
                 Toast.makeText(activity, activity.getString(messageRes), Toast.LENGTH_LONG).show()
             }
+        }
+    }
+
+    private fun getBiometricErrorStringRes(
+        fingerprintConfigured: Boolean,
+        errorCode: Int,
+    ): Int? {
+        val promptDismissedErrors =
+            setOf(
+                BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+                BiometricPrompt.ERROR_USER_CANCELED,
+                BiometricPrompt.ERROR_CANCELED,
+            )
+
+        return when {
+            errorCode in promptDismissedErrors -> null
+            errorCode == BiometricPrompt.ERROR_LOCKOUT_PERMANENT ->
+                R.string.personalid_biometric_error_lockout_permanent
+            errorCode == BiometricPrompt.ERROR_TIMEOUT ->
+                R.string.personalid_biometric_error_timeout
+            fingerprintConfigured ->
+                R.string.personalid_biometric_error_lockout
+            else ->
+                R.string.personalid_configuration_process_biometric_unavailable_message
         }
     }
 

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -155,18 +155,12 @@ object PersonalIdUnlocker {
 
         return when {
             errorCode in promptDismissedErrors -> null
-            errorCode == BiometricPrompt.ERROR_LOCKOUT ->
-                R.string.personalid_biometric_error_lockout
-            errorCode == BiometricPrompt.ERROR_LOCKOUT_PERMANENT ->
-                R.string.personalid_biometric_error_lockout_permanent
-            errorCode == BiometricPrompt.ERROR_TIMEOUT ->
-                R.string.personalid_biometric_error_timeout
-            fingerprintConfigured && errorCode in plausibleLockoutErrors ->
-                R.string.personalid_biometric_error_lockout
-            !fingerprintConfigured ->
-                R.string.personalid_configuration_process_biometric_unavailable_message
-            else ->
-                R.string.personalid_authentication_failed
+            errorCode == BiometricPrompt.ERROR_LOCKOUT -> R.string.personalid_biometric_error_lockout
+            errorCode == BiometricPrompt.ERROR_LOCKOUT_PERMANENT -> R.string.personalid_biometric_error_lockout_permanent
+            errorCode == BiometricPrompt.ERROR_TIMEOUT -> R.string.personalid_biometric_error_timeout
+            fingerprintConfigured && errorCode in plausibleLockoutErrors -> R.string.personalid_biometric_error_lockout
+            !fingerprintConfigured -> R.string.personalid_configuration_process_biometric_unavailable_message
+            else -> R.string.personalid_authentication_failed
         }
     }
 

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -21,6 +21,13 @@ import kotlin.time.Duration.Companion.minutes
 private val SESSION_UNLOCK_THRESHOLD_MS = 10.minutes.inWholeMilliseconds
 internal const val BIOMETRIC_INVALIDATION_KEY = "biometric-invalidation-key"
 
+private val PROMPT_DISMISSED_ERRORS =
+    setOf(
+        BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+        BiometricPrompt.ERROR_USER_CANCELED,
+        BiometricPrompt.ERROR_CANCELED,
+    )
+
 /** Middleware to manage Personal ID unlock prompts with session-based bypass logic. */
 object PersonalIdUnlocker {
     @VisibleForTesting
@@ -77,7 +84,12 @@ object PersonalIdUnlocker {
                 override fun onAuthenticationError(
                     errorCode: Int,
                     errString: CharSequence,
-                ) = callback.connectActivityComplete(false)
+                ) {
+                    callback.connectActivityComplete(false)
+                    if (errorCode !in PROMPT_DISMISSED_ERRORS) {
+                        Toast.makeText(activity, errString, Toast.LENGTH_LONG).show()
+                    }
+                }
 
                 override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
                     lastUnlockTime = SystemClock.elapsedRealtime()
@@ -109,12 +121,13 @@ object PersonalIdUnlocker {
                     "No unlock method available when trying to unlock PersonalId",
                     Exception("No unlock option"),
                 )
-                Toast
-                    .makeText(
-                        activity,
-                        activity.getString(R.string.connect_unlock_unavailable),
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                val messageRes =
+                    if (BiometricsHelper.isPinConfigured(activity, bioManager)) {
+                        R.string.personalid_configuration_process_biometric_unavailable_message
+                    } else {
+                        R.string.connect_unlock_unavailable
+                    }
+                Toast.makeText(activity, activity.getString(messageRes), Toast.LENGTH_LONG).show()
             }
         }
     }

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -147,16 +147,26 @@ object PersonalIdUnlocker {
                 BiometricPrompt.ERROR_CANCELED,
             )
 
+        val plausibleLockoutErrors =
+            setOf(
+                BiometricPrompt.ERROR_NO_BIOMETRICS,
+                BiometricPrompt.ERROR_HW_UNAVAILABLE,
+            )
+
         return when {
             errorCode in promptDismissedErrors -> null
+            errorCode == BiometricPrompt.ERROR_LOCKOUT ->
+                R.string.personalid_biometric_error_lockout
             errorCode == BiometricPrompt.ERROR_LOCKOUT_PERMANENT ->
                 R.string.personalid_biometric_error_lockout_permanent
             errorCode == BiometricPrompt.ERROR_TIMEOUT ->
                 R.string.personalid_biometric_error_timeout
-            fingerprintConfigured ->
+            fingerprintConfigured && errorCode in plausibleLockoutErrors ->
                 R.string.personalid_biometric_error_lockout
-            else ->
+            !fingerprintConfigured ->
                 R.string.personalid_configuration_process_biometric_unavailable_message
+            else ->
+                R.string.personalid_authentication_failed
         }
     }
 

--- a/app/src/org/commcare/utils/BiometricsHelper.java
+++ b/app/src/org/commcare/utils/BiometricsHelper.java
@@ -171,6 +171,9 @@ public class BiometricsHelper {
             case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> {
                 return ConfigurationStatus.NoHardware;
             }
+            case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> {
+                return ConfigurationStatus.NotAvailable;
+            }
             case BiometricManager.BIOMETRIC_STATUS_UNKNOWN,
                  BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED,
                  BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED-> {


### PR DESCRIPTION
### [QA-8604](https://dimagi.atlassian.net/browse/QA-8604)

## Product Description

I improved the error messaging for failed PersonalID unlocks. Too many wrong fingerprint scans previously left the user on a screen where nothing happened, and a device with no enrolled fingerprint was told to configure a screen lock it already had.

_**Before**_ these changes:

https://github.com/user-attachments/assets/9dc89701-fe84-4fd2-ba57-4b41868e6282

_**After**_ these changes

https://github.com/user-attachments/assets/5b0d60dd-be3b-434a-a2e9-e22d5cb993a3

## Technical Summary

Android is unreliable about naming the cause: during a fingerprint lockout it reports the *unenrolled face sensor* instead, so the prompt's own error text tells users to set up face unlock. The message is therefore chosen from the fingerprint's enrolled state rather than from the framework's error code or string.

The `required_lock` policy is deliberately unchanged. It is the account's registration-time minimum device security (self-signups default to biometric), and the intended handling of an unusable registered biometric is backup-code recovery ([CCCT-1882](https://dimagi.atlassian.net/browse/CCCT-1882)) — so QA's expectation that the device PIN be accepted is answered with an accurate message, not a fallback. Flagging in case there are strong objections.

## Safety Assurance

### Safety story

What gives confidence:

- I verified the behaviour on a test device before and after the change, from a fresh install through PersonalID registration and app linking (recordings above).
- Reproducing the lockout with logcat is how the face-unlock misreport was caught, so the message now keys off the fingerprint's enrolled state rather than the framework's error code.
- Scope is two failure paths in the unlock prompt; the success path, session-bypass logic, and authenticator policy are untouched.
- All messages reuse strings already shipped and translated.

Risks to review:

- Which path Android takes when the fingerprint is unusable depends on what `canAuthenticate` reports, and that varies by OS version and OEM — worth confirming on the reporter's Android 15 device, since it reaches a different branch than the one tested here.
- No automated coverage, so both branches rest on manual verification.

[QA-8604]: https://dimagi.atlassian.net/browse/QA-8604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CCCT-1882]: https://dimagi.atlassian.net/browse/CCCT-1882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
