### PR TITLE
QA-8603 Lock PersonalID Profile Screens To Portrait

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -611,6 +611,7 @@
         <activity
             android:name="org.commcare.personalId.profile.PersonalIdProfileActivity"
             android:exported="false"
+            android:screenOrientation="portrait"
             android:theme="@style/CommonTheme.NoActionBar"/>
 
         <service

--- a/docs/personalid/manage_profile.md
+++ b/docs/personalid/manage_profile.md
@@ -9,7 +9,7 @@ screen lets them change name, email, and photo.
 ## Structure
 
 * **`PersonalIdProfileActivity`** — single-activity host for the profile nav graph. Every
-  destination shows a back arrow (no top-level destinations).
+  destination shows a back arrow (no top-level destinations). Locked to portrait mode.
 * **`PersonalIdProfileFragment`** — read-only view plus the Forget PersonalID action.
 * **`PersonalIdProfileEditFragment`** / **`PersonalIdProfileEditViewModel`** — the edit form.
   Form state lives in a `SavedStateHandle` so typed values survive rotation, process death, and


### PR DESCRIPTION
### [QA-8603](https://dimagi.atlassian.net/browse/QA-8603)

## Product Description

The Manage Profile screens no longer rotate to landscape.

## Technical Summary

This one is straightforward

## Safety Assurance

### Safety story

What gives confidence:

- I built the change and verified on a device that the Profile and Edit Profile screens stay portrait when the device is rotated.
- Manifest-only, single-attribute change scoped to one activity. No code paths altered.
- Mirrors the portrait lock already in place on `PersonalIdActivity` and `ConnectActivity`.

Risks to review:

- The lock applies to the whole profile nav graph, including email verification (OTP), not only the two screens in the ticket.
- Users who rotate deliberately for a wider keyboard lose that option on these screens. Design accepted this, given the surrounding PersonalID surfaces are already portrait-only.
- Manifest orientation attributes are not covered by automated tests, so a future regression here would only surface through manual QA.

[QA-8603]: https://dimagi.atlassian.net/browse/QA-8603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ