### PR TITLE
QA-8611 QA-8610 Update Delivery Progress Tabs In Place On Sync

### DIFF
--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressDeliveryFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressDeliveryFragment.java
@@ -54,6 +54,8 @@ public class ConnectDeliveryProgressDeliveryFragment extends ConnectJobFragment<
     }
 
     public void updateProgressSummary() {
+        reloadActiveJob();
+
         int completed = job.getCompletedVisits();
         int total = job.getMaxVisits();
         int percent = total > 0 ? (100 * completed / total) : 100;

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -97,11 +97,11 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
         observeDataState(
                 viewModel.getDeliveryProgress(),
                 cached -> {
-                    job = cached;
+                    setActiveJob(cached);
                     onDeliveryProgressUpdated();
                 },
                 success -> {
-                    job = success;
+                    setActiveJob(success);
                     onDeliveryProgressUpdated();
                 }
         );
@@ -366,9 +366,11 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
 
     private static class ViewStateAdapter extends FragmentStateAdapter {
         private final List<Fragment> fragments;
+        private final FragmentManager fragmentManager;
 
         public ViewStateAdapter(@NonNull FragmentManager fm, @NonNull Lifecycle lifecycle) {
             super(fm, lifecycle);
+            fragmentManager = fm;
             fragments = new ArrayList<>();
             fragments.add(ConnectDeliveryProgressDeliveryFragment.newInstance());
             fragments.add(ConnectResultsSummaryListFragment.newInstance());
@@ -386,7 +388,7 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
         }
 
         public void refresh() {
-            for (Fragment fragment : fragments) {
+            for (Fragment fragment : fragmentManager.getFragments()) {
                 if (fragment instanceof ConnectDeliveryProgressDeliveryFragment deliveryFragment
                         && deliveryFragment.getView() != null) {
                     deliveryFragment.updateProgressSummary();

--- a/app/src/org/commcare/fragments/connect/ConnectJobFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobFragment.java
@@ -17,7 +17,16 @@ public abstract class ConnectJobFragment<T extends ViewBinding> extends BaseConn
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        job = ((ConnectActivity)requireActivity()).getActiveJob();
+        reloadActiveJob();
+    }
+
+    protected void setActiveJob(ConnectJobRecord updatedJob) {
+        job = updatedJob;
+        ((ConnectActivity) requireActivity()).setActiveJob(updatedJob);
+    }
+
+    protected void reloadActiveJob() {
+        job = ((ConnectActivity) requireActivity()).getActiveJob();
         Objects.requireNonNull(job);
     }
 

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
@@ -90,11 +90,11 @@ public class ConnectLearningProgressFragment extends ConnectJobFragment<Fragment
         observeDataState(
                 viewModel.getLearningProgress(),
                 cached -> {
-                    job = cached;
+                    setActiveJob(cached);
                     updateLearningUI();
                 },
                 success -> {
-                    job = success;
+                    setActiveJob(success);
                     updateLearningUI();
                 }
         );

--- a/app/src/org/commcare/fragments/connect/ConnectResultsSummaryListFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectResultsSummaryListFragment.java
@@ -48,6 +48,7 @@ public class ConnectResultsSummaryListFragment extends ConnectJobFragment<Fragme
     @Override
     public @NotNull View onCreateView(@NotNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = super.onCreateView(inflater, container, savedInstanceState);
+        reloadActiveJob();
         setupRecyclerView();
         updateSummaryView();
         return view;
@@ -60,11 +61,11 @@ public class ConnectResultsSummaryListFragment extends ConnectJobFragment<Fragme
     }
 
     public void updateView() {
+        reloadActiveJob();
         updateSummaryView();
 
         if (adapter != null) {
-            adapter.rebuildPaymentsDisplayList();
-            adapter.notifyDataSetChanged();
+            adapter.updateJobForAdapter(job);
         }
     }
 
@@ -88,7 +89,7 @@ public class ConnectResultsSummaryListFragment extends ConnectJobFragment<Fragme
     }
 
     private static class ResultsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
-        private final ConnectJobRecord job;
+        private ConnectJobRecord job;
         private final boolean showPayments;
         private final Context context;
         private final ArrayList<ConnectJobPaymentRecord> payments = new ArrayList<>();
@@ -288,6 +289,12 @@ public class ConnectResultsSummaryListFragment extends ConnectJobFragment<Fragme
 
             payments.addAll(unconfirmedPayments);
             payments.addAll(confirmedPayments);
+        }
+
+        void updateJobForAdapter(ConnectJobRecord updatedJob) {
+            job = updatedJob;
+            rebuildPaymentsDisplayList();
+            notifyDataSetChanged();
         }
 
         void rebuildPaymentsDisplayList() {


### PR DESCRIPTION
### [QA-8611](https://dimagi.atlassian.net/browse/QA-8611) · [QA-8610](https://dimagi.atlassian.net/browse/QA-8610)

## Product Description

Payment details on the Delivery Progress screen now update as soon as a sync completes — a rolled-back payment disappears and a confirmed payment switches to Revert without having to leave the screen and reopen it.

## Technical Summary

The 2.64 offline-first conversion re-reads the job from the DB on every emission, so the parent rebound its own `job` while the tabs and `ConnectActivity` kept the instance they captured — and since the parser mutates whichever instance was passed into the network call, a tab saw fresh data only while it still held that one. Publishing each reload back to `ConnectActivity` restores the pre-2.64 single shared record; `refresh()` iterates the attached child fragments because a ViewPager2 state restore re-adopts the previously added instances rather than the adapter's.

Deliberately left alone: the Progress tab's per-payment-unit report cards still only rebuild from that tab's own sync button. That behaves the same way in 2.63, so it is not part of this regression.

## Safety Assurance

### Safety story

What gives confidence:

- I reproduced both tickets on a device and confirmed each is fixed, including the back-navigation case where the Payment tab previously kept showing pre-sync data after returning from the deliveries list.
- Scope is limited to how Connect job fragments obtain the job record — no data-layer, schema, or network changes.
- The Connect view-model and repository unit tests pass.

Risks to review:

- There is no automated coverage for this path; all verification was manual.
- The Learn progress screen shares the same one-line change, so its record now also propagates to the activity.
- `ConnectActivity.getActiveJob()` is written from more call sites than before. Every writer is the fragment currently displaying that job, but it is worth a second look.

[QA-8611]: https://dimagi.atlassian.net/browse/QA-8611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QA-8610]: https://dimagi.atlassian.net/browse/QA-8610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ