### PR TITLE
QA-8617 Dispatch Activity Results To The AndroidX Registry

### DIFF
--- a/app/src/org/commcare/activities/SessionAwareHelper.java
+++ b/app/src/org/commcare/activities/SessionAwareHelper.java
@@ -45,8 +45,12 @@ public class SessionAwareHelper {
                                                  int requestCode, int resultCode, Intent intent) {
         boolean redirectedToLogin =
                 SessionRegistrationHelper.handleSessionExpiration(a);
-        if (!redirectedToLogin) {
-            sessionAware.onActivityResultSessionSafe(requestCode, resultCode, intent);
+        if (redirectedToLogin) {
+            return;
         }
+        if (a.getActivityResultRegistry().dispatchResult(requestCode, resultCode, intent)) {
+            return;
+        }
+        sessionAware.onActivityResultSessionSafe(requestCode, resultCode, intent);
     }
 }

--- a/docs/personalid/photo_management.md
+++ b/docs/personalid/photo_management.md
@@ -39,6 +39,9 @@ endpoint, stored locally, and reflected in the drawer header.
     (e.g. the drawer's warning icon).
   * Re-reads the `ConnectUserRecord` from the database at upload time rather than caching
     it, so it always reflects the currently signed-in user.
+  * Relies on the host activity letting the AndroidX activity-result registry see results;
+    `SessionAwareHelper` dispatches to the registry before falling back to CommCare's legacy
+    request-code handling, which is what makes the flow work on the app home screen.
 
 * **`BaseDrawerController`** (`navdrawer/BaseDrawerController.kt`)
   * Wires the drawer's user image tap to the updater's `initiatePhotoUpdate()`.


### PR DESCRIPTION
### [QA-8617](https://dimagi.atlassian.net/browse/QA-8617)

## Product Description

Backing out of the profile-photo camera opened from the app home screen's nav drawer now returns to the home screen, instead of pushing the user forward into session navigation.

This also fixes another issue: Photos captured from that drawer also now actually upload — previously the result never reached the photo uploader.

## Technical Summary

`SessionAwareCommCareActivity.onActivityResult` never called `super`, which is the only place `ComponentActivity` hands results to the AndroidX result registry. So `registerForActivityResult` callbacks were dead on every session-aware activity, and the registry's request code fell out the bottom of `HomeScreenBaseActivity`'s `switch` into `startNextSessionStepSafe()` — the stray forward navigation QA saw. The dispatch went into `SessionAwareHelper` rather than the activity override so the session-expiration check keeps its existing precedence over the callback, and it uses `dispatchResult` directly rather than `super` because only `dispatchResult` reports whether the result was consumed.

## Safety Assurance

### Safety story

What gives confidence:

- I manually verified both paths on device: backing out of the camera from the home-screen drawer stays on the home screen, and a successful capture uploads and updates the drawer photo.
- No collision is possible between the two code spaces: the registry allocates request codes in `[0x00010000, MAX_INT]`, and every request code in the repo is ≤ 8000 (session-aware constants are 0–10). Legacy results still fall through to `onActivityResultSessionSafe` unchanged.
- The only registry launcher hosted by a session-aware activity is the drawer photo updater. The PersonalID and Connect fragment launchers sit under `NavigationHostCommCareActivity`, outside this path, and `LoginActivity` / `CommCareSetupActivity` already called `super`, so their drawer photo flow was already working.

Risks to review:

- This sits in a base class on the result path of every session-aware activity, so scope of impact is wide even though the behavioral delta is narrow.
- Results the registry consumes no longer reach `onActivityResultSessionSafe`. On the home screen that also means `sessionNavigationProceedingAfterOnResume` is no longer set, so `onResumeSessionSafe` refreshes the home screen rather than suppressing the refresh — intended here, but it is a behavior change.
- Fragments that use the legacy `Fragment.startActivityForResult` get codes encoded as `((index+1) << 16) | code`, landing in the same numeric range as registry codes. Those results already never reached fragments in these activities and still do not; a false hit would require the registry to have randomly drawn that exact value while pending.

### Automated test coverage

None added — verified manually instead, at the author's request. The touched path has no existing unit coverage.

[QA-8617]: https://dimagi.atlassian.net/browse/QA-8617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ