### PR TITLE
Display Date and Time widget components horizontally in landscape

### DIFF
--- a/app/src/org/commcare/views/widgets/DateTimeWidget.java
+++ b/app/src/org/commcare/views/widgets/DateTimeWidget.java
@@ -1,8 +1,10 @@
 package org.commcare.views.widgets;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.view.Gravity;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.CalendarView;
 import android.widget.DatePicker;
@@ -90,6 +92,8 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
         mPickerContainer.addView(mDatePicker);
         mPickerContainer.addView(mTimePicker);
         addView(mPickerContainer);
+
+        applyOrientationLayout(getResources().getConfiguration().orientation);
     }
 
 
@@ -104,6 +108,26 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
         params.height = LayoutParams.WRAP_CONTENT;
         params.width = LayoutParams.WRAP_CONTENT;
         calendarView.setLayoutParams(params);
+    }
+
+    private void applyOrientationLayout(int orientation) {
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            mPickerContainer.setOrientation(HORIZONTAL);
+            applyChildParams(mDatePicker, 0, 2f);
+            applyChildParams(mTimePicker, 0, 1f);
+        } else {
+            mPickerContainer.setOrientation(VERTICAL);
+            applyChildParams(mDatePicker, LayoutParams.WRAP_CONTENT, 0f);
+            applyChildParams(mTimePicker, LayoutParams.WRAP_CONTENT, 0f);
+        }
+    }
+
+    private void applyChildParams(View child, int width, float weight) {
+        LayoutParams params = (LayoutParams) child.getLayoutParams();
+        params.width = width;
+        params.height = LayoutParams.WRAP_CONTENT;
+        params.weight = weight;
+        child.setLayoutParams(params);
     }
 
     public void setAnswer() {

--- a/app/src/org/commcare/views/widgets/DateTimeWidget.java
+++ b/app/src/org/commcare/views/widgets/DateTimeWidget.java
@@ -6,6 +6,7 @@ import android.view.LayoutInflater;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.CalendarView;
 import android.widget.DatePicker;
+import android.widget.LinearLayout;
 import android.widget.TimePicker;
 import android.widget.TimePicker.OnTimeChangedListener;
 
@@ -30,6 +31,7 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
     private final DatePicker mDatePicker;
     private final TimePicker mTimePicker;
     private final DatePicker.OnDateChangedListener mDateListener;
+    private final LinearLayout mPickerContainer;
 
     public DateTimeWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
@@ -83,10 +85,13 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
         setAnswer();
 
         setGravity(Gravity.LEFT);
-        addView(mDatePicker);
-        addView(mTimePicker);
-
+        mPickerContainer = new LinearLayout(getContext());
+        mPickerContainer.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+        mPickerContainer.addView(mDatePicker);
+        mPickerContainer.addView(mTimePicker);
+        addView(mPickerContainer);
     }
+
 
     /**
      * CalendarView bottom line gets cut off in appcompat theme because it's height is fixed here:
@@ -127,7 +132,6 @@ public class DateTimeWidget extends QuestionWidget implements OnTimeChangedListe
 
         widgetEntryChanged();
     }
-
 
     /**
      * Resets date to today.


### PR DESCRIPTION
## Product Description

This PR changes the layout of the DateTime widget in landscape mode: previously the date and time pickers would be rendered vertically regardless of the orientation, so even when the device was rotated to landscape. They should now be laid out correctly — stacked vertically in portrait and side by side in landscape.

<table>
<tr>
<th>
Porttrait
</th>
<th>
landscape
</th>
</tr>
<tr>
<td>
<img width="200px" src="https://github.com/user-attachments/assets/0b643e48-8f14-46cd-91cc-272b49bded9f" />

</td>
<td>
<img width="350px" src="https://github.com/user-attachments/assets/f6c93cad-b2bf-4a84-8cbd-de03ba679f3c" />

</td>
</tr>
</table>


## Technical Summary
The initial approach was to change the orientation of the parent layout,`QuestionWidget`, from a `vertical` to a `horizontal` `LinearLayout`. However, this layout also contains  the question label, help, and hint views. So changing its orientation was resulting in all components to be laid out in a single row. And since the question label spans the full width, it occupied the entire row, leaving the date and time pickers with no available width.
The solution was to Wrap the two pickers in their own dedicated `LinearLayout` container, added to the `QuestionWidget` root as a single child, so the root's own vertical orientation is left untouched.
- Toggle only that container's orientation based on `Configuration.orientation` 

## Safety Assurance

### Safety story
- Successfully tested locally
- The change is confined to `DateTimeWidget`'s view construction/layout; there are no data-model, storage, or answer-handling changes (answer read/write paths are untouched).

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
