### PR TITLE
QA-8614 Restore Active Job When Connect Activity Is Recreated

### DIFF
--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -62,6 +62,13 @@ public class ConnectActivity extends NavigationHostCommCareActivity<ConnectActiv
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+            String savedJobUuid = savedInstanceState.getString(OPPORTUNITY_UUID);
+            if (!Strings.isNullOrEmpty(savedJobUuid)) {
+                job = ConnectJobUtils.getCompositeJob(this, savedJobUuid);
+            }
+        }
+
         super.onCreate(savedInstanceState);
 
         PersonalIdManager personalIdManager = PersonalIdManager.getInstance();
@@ -102,6 +109,14 @@ public class ConnectActivity extends NavigationHostCommCareActivity<ConnectActiv
     public void onPostCreate(@Nullable Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
         getSupportActionBar().setTitle(getString(R.string.connect_title));
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (job != null) {
+            outState.putString(OPPORTUNITY_UUID, job.getJobUUID());
+        }
     }
 
     private int getStartDestinationId(Bundle startArgs) {

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -132,7 +132,7 @@ public class ConnectActivity extends NavigationHostCommCareActivity<ConnectActiv
     private void initStateFromExtras() {
         redirectionAction = getIntent().getStringExtra(REDIRECT_ACTION);
         opportunityUuid = getIntent().getStringExtra(OPPORTUNITY_UUID);
-        if (!TextUtils.isEmpty(opportunityUuid)) {
+        if (job == null && !TextUtils.isEmpty(opportunityUuid)) {
             job = ConnectJobUtils.getCompositeJob(this, opportunityUuid);
         }
     }

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -64,7 +64,7 @@ public class ConnectActivity extends NavigationHostCommCareActivity<ConnectActiv
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         if (savedInstanceState != null) {
             String savedJobUuid = savedInstanceState.getString(OPPORTUNITY_UUID);
-            if (!Strings.isNullOrEmpty(savedJobUuid)) {
+            if (savedJobUuid != null) {
                 job = ConnectJobUtils.getCompositeJob(this, savedJobUuid);
             }
         }


### PR DESCRIPTION
### [QA-8614](https://dimagi.atlassian.net/browse/QA-8614)

## Product Description

Returning to the Learn or Delivery progress screen after Android has torn down and rebuilt the Connect activity now restores the screen the user was on, instead of crashing out to Connect home.

## Technical Summary

The active job lives only in memory on `ConnectActivity`, so it was gone whenever the activity was rebuilt from saved state. It is now saved as an opportunity UUID and reloaded at the top of `onCreate`, before `super.onCreate()` — the job screens read the active job from their own `onCreate`, which runs while the fragment back stack is being restored inside that `super` call, so the reload has to happen ahead of it.

## Safety Assurance

### Safety story

What gives confidence:

- I reproduced the crash on a physical device on the Learn progress screen, then confirmed the same steps no longer crash with this change: the screen and its back stack are restored intact, with the correct job, and back navigation still returns to the jobs list.
- The change is confined to saving and restoring one value on a single activity; no data model, migration, or network behavior is touched.

Risks to review:

- Restoration is exercised on every rebuild of `ConnectActivity`, so it is worth a look at the notification deep-link entry points, which set the active job from intent extras rather than saved state.
- If the saved opportunity no longer resolves to a record, the job screens still fail fast as they do today; this change does not alter that behavior.

[QA-8614]: https://dimagi.atlassian.net/browse/QA-8614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ