### PR TITLE
CCCT-2655 Add Missing Connect Endpoints To Coroutine Network Stack

### DIFF
--- a/app/src/org/commcare/connect/network/ConnectApiService.kt
+++ b/app/src/org/commcare/connect/network/ConnectApiService.kt
@@ -1,10 +1,15 @@
 package org.commcare.connect.network
 
 import okhttp3.ResponseBody
+import org.commcare.connect.network.connect.models.ConfirmPaymentsRequest
 import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.HeaderMap
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface ConnectApiService {
@@ -26,5 +31,28 @@ interface ConnectApiService {
         @Header("Authorization") authorization: String,
         @Path("id") jobId: String,
         @HeaderMap headers: Map<String, String>,
+    ): Response<ResponseBody>
+
+    @FormUrlEncoded
+    @POST(ApiEndPoints.connectStartLearningURL)
+    suspend fun startLearnApp(
+        @Header("Authorization") auth: String,
+        @HeaderMap headers: Map<String, String>,
+        @Field("opportunity") opportunityId: String,
+    ): Response<ResponseBody>
+
+    @POST(ApiEndPoints.connectClaimJobURL)
+    suspend fun claimJob(
+        @Header("Authorization") auth: String,
+        @Path("id") jobUUID: String,
+        @HeaderMap headers: Map<String, String>,
+        @Body body: Map<String, String>,
+    ): Response<ResponseBody>
+
+    @POST(ApiEndPoints.PAYMENT_CONFIRMAITONS)
+    suspend fun confirmPayments(
+        @Header("Authorization") auth: String,
+        @HeaderMap headers: Map<String, String>,
+        @Body body: ConfirmPaymentsRequest,
     ): Response<ResponseBody>
 }

--- a/app/src/org/commcare/connect/network/connect/ConnectNetworkClient.kt
+++ b/app/src/org/commcare/connect/network/connect/ConnectNetworkClient.kt
@@ -10,8 +10,11 @@ import org.commcare.connect.network.ConnectNetworkHelper
 import org.commcare.connect.network.base.BaseApiClient
 import org.commcare.connect.network.base.BaseApiHandler.PersonalIdOrConnectApiErrorCodes
 import org.commcare.connect.network.base.ConnectApiException
+import org.commcare.connect.network.connect.models.ConfirmPaymentsRequest
+import org.commcare.connect.network.connect.models.ConnectPaymentConfirmationModel
 import org.commcare.connect.network.connect.models.DeliveryAppProgressResponseModel
 import org.commcare.connect.network.connect.models.LearningAppProgressResponseModel
+import org.commcare.connect.network.connect.models.PaymentConfirmationBody
 import org.commcare.connect.network.connect.parser.ConnectOpportunitiesParser
 import org.commcare.connect.network.connect.parser.DeliveryAppProgressResponseParser
 import org.commcare.connect.network.connect.parser.LearningAppProgressResponseParser
@@ -73,6 +76,49 @@ class ConnectNetworkClient
                 user = user,
                 apiCall = { auth -> apiService.getDeliveryProgress(auth, job.jobUUID, versionHeaders()) },
                 parse = { code, stream -> DeliveryAppProgressResponseParser<DeliveryAppProgressResponseModel>().parse(code, stream, job) },
+            )
+
+        suspend fun startLearnApp(
+            user: ConnectUserRecord,
+            jobUUID: String,
+        ): Result<Unit> =
+            executeApiCall(
+                user = user,
+                apiCall = { auth -> apiService.startLearnApp(auth, versionHeaders(), jobUUID) },
+                parse = { _, _ -> Unit },
+            )
+
+        suspend fun claimJob(
+            user: ConnectUserRecord,
+            jobUUID: String,
+        ): Result<Unit> =
+            executeApiCall(
+                user = user,
+                apiCall = { auth -> apiService.claimJob(auth, jobUUID, versionHeaders(), emptyMap()) },
+                parse = { _, _ -> Unit },
+            )
+
+        suspend fun confirmPayments(
+            user: ConnectUserRecord,
+            paymentConfirmations: List<ConnectPaymentConfirmationModel>,
+        ): Result<Unit> =
+            executeApiCall(
+                user = user,
+                apiCall = { auth ->
+                    apiService.confirmPayments(auth, versionHeaders(), getConfirmPaymentsRequest(paymentConfirmations))
+                },
+                parse = { _, _ -> Unit },
+            )
+
+        private fun getConfirmPaymentsRequest(paymentConfirmations: List<ConnectPaymentConfirmationModel>) =
+            ConfirmPaymentsRequest(
+                payments =
+                    paymentConfirmations.map { confirmation ->
+                        PaymentConfirmationBody(
+                            id = confirmation.payment.paymentUUID,
+                            confirmed = if (confirmation.toConfirm) "true" else "false",
+                        )
+                    },
             )
 
         private suspend fun <T> executeApiCall(

--- a/app/src/org/commcare/connect/network/connect/models/ConnectRequestModels.kt
+++ b/app/src/org/commcare/connect/network/connect/models/ConnectRequestModels.kt
@@ -1,0 +1,12 @@
+package org.commcare.connect.network.connect.models
+
+import com.google.gson.annotations.SerializedName
+
+data class ConfirmPaymentsRequest(
+    @SerializedName("payments") val payments: List<PaymentConfirmationBody>,
+)
+
+data class PaymentConfirmationBody(
+    @SerializedName("id") val id: String,
+    @SerializedName("confirmed") val confirmed: String,
+)

--- a/app/src/org/commcare/connect/repository/ConnectRepository.kt
+++ b/app/src/org/commcare/connect/repository/ConnectRepository.kt
@@ -95,20 +95,13 @@ class ConnectRepository
                 mapToEmit = { _ -> getCompositeJob(CommCareApplication.instance(), job.jobUUID) },
             )
 
-        fun startLearning(
-            user: ConnectUserRecord,
-            jobUUID: String,
-        ): Flow<DataState<Unit>> = networkOnlyFlow { networkClient.startLearnApp(user, jobUUID) }
+        fun startLearning(jobUUID: String): Flow<DataState<Unit>> =
+            networkOnlyFlow { networkClient.startLearnApp(getConnectUser(), jobUUID) }
 
-        fun claimJob(
-            user: ConnectUserRecord,
-            jobUUID: String,
-        ): Flow<DataState<Unit>> = networkOnlyFlow { networkClient.claimJob(user, jobUUID) }
+        fun claimJob(jobUUID: String): Flow<DataState<Unit>> = networkOnlyFlow { networkClient.claimJob(getConnectUser(), jobUUID) }
 
-        fun confirmPayments(
-            user: ConnectUserRecord,
-            paymentConfirmations: List<ConnectPaymentConfirmationModel>,
-        ): Flow<DataState<Unit>> = networkOnlyFlow { networkClient.confirmPayments(user, paymentConfirmations) }
+        fun confirmPayments(paymentConfirmations: List<ConnectPaymentConfirmationModel>): Flow<DataState<Unit>> =
+            networkOnlyFlow { networkClient.confirmPayments(getConnectUser(), paymentConfirmations) }
 
         /**
          * Emits Cached first,then Loading, then Success or Error after network call.
@@ -156,18 +149,15 @@ class ConnectRepository
                     .onFailure { emit(DataState.Error.from(it)) }
             }.flowOn(Dispatchers.IO)
 
-        private suspend fun fetchOpportunitiesFromNetwork(): Result<List<ConnectJobRecord>> {
-            val user = requireNotNull(ConnectUserDatabaseUtil.getUser(CommCareApplication.instance())) { "No Connect user found" }
-            return networkClient.getConnectOpportunities(user)
-        }
+        private fun getConnectUser(): ConnectUserRecord =
+            requireNotNull(ConnectUserDatabaseUtil.getUser(CommCareApplication.instance())) { "No Connect user found" }
 
-        private suspend fun fetchLearningProgressFromNetwork(job: ConnectJobRecord): Result<LearningAppProgressResponseModel> {
-            val user = requireNotNull(ConnectUserDatabaseUtil.getUser(CommCareApplication.instance())) { "No Connect user found" }
-            return networkClient.getLearningProgress(user, job)
-        }
+        private suspend fun fetchOpportunitiesFromNetwork(): Result<List<ConnectJobRecord>> =
+            networkClient.getConnectOpportunities(getConnectUser())
 
-        private suspend fun fetchDeliveryProgressFromNetwork(job: ConnectJobRecord): Result<DeliveryAppProgressResponseModel> {
-            val user = requireNotNull(ConnectUserDatabaseUtil.getUser(CommCareApplication.instance())) { "No Connect user found" }
-            return networkClient.getDeliveryProgress(user, job)
-        }
+        private suspend fun fetchLearningProgressFromNetwork(job: ConnectJobRecord): Result<LearningAppProgressResponseModel> =
+            networkClient.getLearningProgress(getConnectUser(), job)
+
+        private suspend fun fetchDeliveryProgressFromNetwork(job: ConnectJobRecord): Result<DeliveryAppProgressResponseModel> =
+            networkClient.getDeliveryProgress(getConnectUser(), job)
     }

--- a/app/src/org/commcare/connect/repository/ConnectRepository.kt
+++ b/app/src/org/commcare/connect/repository/ConnectRepository.kt
@@ -8,10 +8,12 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import org.commcare.CommCareApplication
 import org.commcare.android.database.connect.models.ConnectJobRecord
+import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.connect.database.ConnectJobUtils.getCompositeJob
 import org.commcare.connect.database.ConnectJobUtils.getCompositeJobs
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.connect.network.connect.ConnectNetworkClient
+import org.commcare.connect.network.connect.models.ConnectPaymentConfirmationModel
 import org.commcare.connect.network.connect.models.DeliveryAppProgressResponseModel
 import org.commcare.connect.network.connect.models.LearningAppProgressResponseModel
 import org.commcare.connect.network.connect.models.applyToJob
@@ -93,6 +95,21 @@ class ConnectRepository
                 mapToEmit = { _ -> getCompositeJob(CommCareApplication.instance(), job.jobUUID) },
             )
 
+        fun startLearning(
+            user: ConnectUserRecord,
+            jobUUID: String,
+        ): Flow<DataState<Unit>> = networkOnlyFlow { networkClient.startLearnApp(user, jobUUID) }
+
+        fun claimJob(
+            user: ConnectUserRecord,
+            jobUUID: String,
+        ): Flow<DataState<Unit>> = networkOnlyFlow { networkClient.claimJob(user, jobUUID) }
+
+        fun confirmPayments(
+            user: ConnectUserRecord,
+            paymentConfirmations: List<ConnectPaymentConfirmationModel>,
+        ): Flow<DataState<Unit>> = networkOnlyFlow { networkClient.confirmPayments(user, paymentConfirmations) }
+
         /**
          * Emits Cached first,then Loading, then Success or Error after network call.
          * DB writes go in [onNetworkSuccess], re-read in [mapToEmit].
@@ -129,6 +146,14 @@ class ConnectRepository
                 result
                     .onSuccess { data -> emit(DataState.Success(mapToEmit(data))) }
                     .onFailure { throwable -> emit(DataState.Error.from(throwable)) }
+            }.flowOn(Dispatchers.IO)
+
+        private fun <T> networkOnlyFlow(networkCall: suspend () -> Result<T>): Flow<DataState<T>> =
+            flow {
+                emit(DataState.Loading)
+                networkCall()
+                    .onSuccess { emit(DataState.Success(it)) }
+                    .onFailure { emit(DataState.Error.from(it)) }
             }.flowOn(Dispatchers.IO)
 
         private suspend fun fetchOpportunitiesFromNetwork(): Result<List<ConnectJobRecord>> {

--- a/app/unit-tests/src/org/commcare/connect/network/connect/ConnectNetworkClientTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/connect/ConnectNetworkClientTest.kt
@@ -5,17 +5,22 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.runBlocking
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.commcare.CommCareTestApplication
+import org.commcare.android.database.connect.models.ConnectJobPaymentRecord
 import org.commcare.android.database.connect.models.ConnectJobRecord
 import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.connect.network.ConnectApiService
 import org.commcare.connect.network.base.BaseApiHandler.PersonalIdOrConnectApiErrorCodes
 import org.commcare.connect.network.base.ConnectApiException
+import org.commcare.connect.network.connect.models.ConfirmPaymentsRequest
+import org.commcare.connect.network.connect.models.ConnectPaymentConfirmationModel
+import org.commcare.connect.network.connect.models.PaymentConfirmationBody
 import org.commcare.connect.network.getAuthorizationHeader
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -218,10 +223,12 @@ class ConnectNetworkClientTest {
     @Test
     fun testStartLearnApp_success_returnsSuccess() =
         runBlocking {
-            coEvery { mockApiService.startLearnApp(any(), any(), any()) } returns
+            val opportunityIdSlot = slot<String>()
+            coEvery { mockApiService.startLearnApp(any(), any(), capture(opportunityIdSlot)) } returns
                 Response.success("".toResponseBody("application/json".toMediaType()))
             val result = client.startLearnApp(mockUser, "test-uuid")
             assertTrue(result.isSuccess)
+            assertEquals("test-uuid", opportunityIdSlot.captured)
         }
 
     @Test
@@ -240,69 +247,110 @@ class ConnectNetworkClientTest {
     @Test
     fun testStartLearnApp_http401_returnsFailedAuth() =
         runBlocking {
+            val opportunityIdSlot = slot<String>()
             val errorBody = "".toResponseBody("application/json".toMediaType())
-            coEvery { mockApiService.startLearnApp(any(), any(), any()) } returns Response.error(401, errorBody)
+            coEvery { mockApiService.startLearnApp(any(), any(), capture(opportunityIdSlot)) } returns Response.error(401, errorBody)
             val result = client.startLearnApp(mockUser, "test-uuid")
             assertTrue(result.isFailure)
             assertEquals(
                 PersonalIdOrConnectApiErrorCodes.FAILED_AUTH_ERROR,
                 (result.exceptionOrNull() as ConnectApiException).errorCode,
             )
+            assertEquals("test-uuid", opportunityIdSlot.captured)
         }
 
     @Test
     fun testClaimJob_success_returnsSuccess() =
         runBlocking {
-            coEvery { mockApiService.claimJob(any(), any(), any(), any()) } returns
+            val jobUuidSlot = slot<String>()
+            val bodySlot = slot<Map<String, String>>()
+            coEvery { mockApiService.claimJob(any(), capture(jobUuidSlot), any(), capture(bodySlot)) } returns
                 Response.success("".toResponseBody("application/json".toMediaType()))
             val result = client.claimJob(mockUser, "test-uuid")
             assertTrue(result.isSuccess)
+            assertEquals("test-uuid", jobUuidSlot.captured)
+            assertTrue(bodySlot.captured.isEmpty())
         }
 
     @Test
     fun testClaimJob_http403_returnsForbidden() =
         runBlocking {
+            val jobUuidSlot = slot<String>()
+            val bodySlot = slot<Map<String, String>>()
             val errorBody = "".toResponseBody("application/json".toMediaType())
-            coEvery { mockApiService.claimJob(any(), any(), any(), any()) } returns Response.error(403, errorBody)
+            coEvery { mockApiService.claimJob(any(), capture(jobUuidSlot), any(), capture(bodySlot)) } returns
+                Response.error(403, errorBody)
             val result = client.claimJob(mockUser, "test-uuid")
             assertTrue(result.isFailure)
             assertEquals(
                 PersonalIdOrConnectApiErrorCodes.FORBIDDEN_ERROR,
                 (result.exceptionOrNull() as ConnectApiException).errorCode,
             )
+            assertEquals("test-uuid", jobUuidSlot.captured)
+            assertTrue(bodySlot.captured.isEmpty())
         }
 
     @Test
     fun testClaimJob_networkException_returnsNetworkError() =
         runBlocking {
-            coEvery { mockApiService.claimJob(any(), any(), any(), any()) } throws IOException("timeout")
+            val jobUuidSlot = slot<String>()
+            val bodySlot = slot<Map<String, String>>()
+            coEvery { mockApiService.claimJob(any(), capture(jobUuidSlot), any(), capture(bodySlot)) } throws IOException("timeout")
             val result = client.claimJob(mockUser, "test-uuid")
             assertTrue(result.isFailure)
             assertEquals(
                 PersonalIdOrConnectApiErrorCodes.NETWORK_ERROR,
                 (result.exceptionOrNull() as ConnectApiException).errorCode,
             )
+            assertEquals("test-uuid", jobUuidSlot.captured)
+            assertTrue(bodySlot.captured.isEmpty())
         }
 
     @Test
     fun testConfirmPayments_success_returnsSuccess() =
         runBlocking {
-            coEvery { mockApiService.confirmPayments(any(), any(), any()) } returns
+            val requestSlot = slot<ConfirmPaymentsRequest>()
+            coEvery { mockApiService.confirmPayments(any(), any(), capture(requestSlot)) } returns
                 Response.success("".toResponseBody("application/json".toMediaType()))
-            val result = client.confirmPayments(mockUser, emptyList())
+            val mockPayment1 = mockk<ConnectJobPaymentRecord>()
+            every { mockPayment1.paymentUUID } returns "pay-1"
+            val mockPayment2 = mockk<ConnectJobPaymentRecord>()
+            every { mockPayment2.paymentUUID } returns "pay-2"
+            val confirmations =
+                listOf(
+                    ConnectPaymentConfirmationModel(mockPayment1, true),
+                    ConnectPaymentConfirmationModel(mockPayment2, false),
+                )
+            val result = client.confirmPayments(mockUser, confirmations)
             assertTrue(result.isSuccess)
+            assertEquals(2, requestSlot.captured.payments.size)
+            assertEquals(PaymentConfirmationBody("pay-1", "true"), requestSlot.captured.payments[0])
+            assertEquals(PaymentConfirmationBody("pay-2", "false"), requestSlot.captured.payments[1])
         }
 
     @Test
     fun testConfirmPayments_http500_returnsServerError() =
         runBlocking {
+            val requestSlot = slot<ConfirmPaymentsRequest>()
             val errorBody = "".toResponseBody("application/json".toMediaType())
-            coEvery { mockApiService.confirmPayments(any(), any(), any()) } returns Response.error(500, errorBody)
-            val result = client.confirmPayments(mockUser, emptyList())
+            coEvery { mockApiService.confirmPayments(any(), any(), capture(requestSlot)) } returns Response.error(500, errorBody)
+            val mockPayment1 = mockk<ConnectJobPaymentRecord>()
+            every { mockPayment1.paymentUUID } returns "pay-1"
+            val mockPayment2 = mockk<ConnectJobPaymentRecord>()
+            every { mockPayment2.paymentUUID } returns "pay-2"
+            val confirmations =
+                listOf(
+                    ConnectPaymentConfirmationModel(mockPayment1, true),
+                    ConnectPaymentConfirmationModel(mockPayment2, false),
+                )
+            val result = client.confirmPayments(mockUser, confirmations)
             assertTrue(result.isFailure)
             assertEquals(
                 PersonalIdOrConnectApiErrorCodes.SERVER_ERROR,
                 (result.exceptionOrNull() as ConnectApiException).errorCode,
             )
+            assertEquals(2, requestSlot.captured.payments.size)
+            assertEquals(PaymentConfirmationBody("pay-1", "true"), requestSlot.captured.payments[0])
+            assertEquals(PaymentConfirmationBody("pay-2", "false"), requestSlot.captured.payments[1])
         }
 }

--- a/app/unit-tests/src/org/commcare/connect/network/connect/ConnectNetworkClientTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/connect/ConnectNetworkClientTest.kt
@@ -214,4 +214,95 @@ class ConnectNetworkClientTest {
             val result = client.getDeliveryProgress(mockUser, mockJob)
             assertTrue(result.isSuccess)
         }
+
+    @Test
+    fun testStartLearnApp_success_returnsSuccess() =
+        runBlocking {
+            coEvery { mockApiService.startLearnApp(any(), any(), any()) } returns
+                Response.success("".toResponseBody("application/json".toMediaType()))
+            val result = client.startLearnApp(mockUser, "test-uuid")
+            assertTrue(result.isSuccess)
+        }
+
+    @Test
+    fun testStartLearnApp_authHeaderFailure_returnsFailure() =
+        runBlocking {
+            coEvery { getAuthorizationHeader(any()) } returns
+                Result.failure(ConnectApiException(PersonalIdOrConnectApiErrorCodes.TOKEN_UNAVAILABLE_ERROR))
+            val result = client.startLearnApp(mockUser, "test-uuid")
+            assertTrue(result.isFailure)
+            assertEquals(
+                PersonalIdOrConnectApiErrorCodes.TOKEN_UNAVAILABLE_ERROR,
+                (result.exceptionOrNull() as ConnectApiException).errorCode,
+            )
+        }
+
+    @Test
+    fun testStartLearnApp_http401_returnsFailedAuth() =
+        runBlocking {
+            val errorBody = "".toResponseBody("application/json".toMediaType())
+            coEvery { mockApiService.startLearnApp(any(), any(), any()) } returns Response.error(401, errorBody)
+            val result = client.startLearnApp(mockUser, "test-uuid")
+            assertTrue(result.isFailure)
+            assertEquals(
+                PersonalIdOrConnectApiErrorCodes.FAILED_AUTH_ERROR,
+                (result.exceptionOrNull() as ConnectApiException).errorCode,
+            )
+        }
+
+    @Test
+    fun testClaimJob_success_returnsSuccess() =
+        runBlocking {
+            coEvery { mockApiService.claimJob(any(), any(), any(), any()) } returns
+                Response.success("".toResponseBody("application/json".toMediaType()))
+            val result = client.claimJob(mockUser, "test-uuid")
+            assertTrue(result.isSuccess)
+        }
+
+    @Test
+    fun testClaimJob_http403_returnsForbidden() =
+        runBlocking {
+            val errorBody = "".toResponseBody("application/json".toMediaType())
+            coEvery { mockApiService.claimJob(any(), any(), any(), any()) } returns Response.error(403, errorBody)
+            val result = client.claimJob(mockUser, "test-uuid")
+            assertTrue(result.isFailure)
+            assertEquals(
+                PersonalIdOrConnectApiErrorCodes.FORBIDDEN_ERROR,
+                (result.exceptionOrNull() as ConnectApiException).errorCode,
+            )
+        }
+
+    @Test
+    fun testClaimJob_networkException_returnsNetworkError() =
+        runBlocking {
+            coEvery { mockApiService.claimJob(any(), any(), any(), any()) } throws IOException("timeout")
+            val result = client.claimJob(mockUser, "test-uuid")
+            assertTrue(result.isFailure)
+            assertEquals(
+                PersonalIdOrConnectApiErrorCodes.NETWORK_ERROR,
+                (result.exceptionOrNull() as ConnectApiException).errorCode,
+            )
+        }
+
+    @Test
+    fun testConfirmPayments_success_returnsSuccess() =
+        runBlocking {
+            coEvery { mockApiService.confirmPayments(any(), any(), any()) } returns
+                Response.success("".toResponseBody("application/json".toMediaType()))
+            val result = client.confirmPayments(mockUser, emptyList())
+            assertTrue(result.isSuccess)
+        }
+
+    @Test
+    fun testConfirmPayments_http500_returnsServerError() =
+        runBlocking {
+            val errorBody = "".toResponseBody("application/json".toMediaType())
+            coEvery { mockApiService.confirmPayments(any(), any(), any()) } returns Response.error(500, errorBody)
+            val result = client.confirmPayments(mockUser, emptyList())
+            assertTrue(result.isFailure)
+            assertEquals(
+                PersonalIdOrConnectApiErrorCodes.SERVER_ERROR,
+                (result.exceptionOrNull() as ConnectApiException).errorCode,
+            )
+        }
 }

--- a/app/unit-tests/src/org/commcare/connect/repository/ConnectRepositoryTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/repository/ConnectRepositoryTest.kt
@@ -269,7 +269,7 @@ class ConnectRepositoryTest {
         runBlocking {
             coEvery { mockNetworkClient.startLearnApp(any(), any()) } returns Result.success(Unit)
 
-            val emissions = repository.startLearning(mockUser, "test-uuid").toList()
+            val emissions = repository.startLearning("test-uuid").toList()
 
             assertEquals(2, emissions.size)
             assertTrue(emissions[0] is DataState.Loading)
@@ -282,7 +282,7 @@ class ConnectRepositoryTest {
             coEvery { mockNetworkClient.startLearnApp(any(), any()) } returns
                 Result.failure(Exception("Network error"))
 
-            val emissions = repository.startLearning(mockUser, "test-uuid").toList()
+            val emissions = repository.startLearning("test-uuid").toList()
 
             assertEquals(2, emissions.size)
             assertTrue(emissions[0] is DataState.Loading)
@@ -294,7 +294,7 @@ class ConnectRepositoryTest {
         runBlocking {
             coEvery { mockNetworkClient.claimJob(any(), any()) } returns Result.success(Unit)
 
-            val emissions = repository.claimJob(mockUser, "test-uuid").toList()
+            val emissions = repository.claimJob("test-uuid").toList()
 
             assertEquals(2, emissions.size)
             assertTrue(emissions[0] is DataState.Loading)
@@ -307,7 +307,7 @@ class ConnectRepositoryTest {
             coEvery { mockNetworkClient.claimJob(any(), any()) } returns
                 Result.failure(Exception("Network error"))
 
-            val emissions = repository.claimJob(mockUser, "test-uuid").toList()
+            val emissions = repository.claimJob("test-uuid").toList()
 
             assertEquals(2, emissions.size)
             assertTrue(emissions[0] is DataState.Loading)
@@ -319,7 +319,7 @@ class ConnectRepositoryTest {
         runBlocking {
             coEvery { mockNetworkClient.confirmPayments(any(), any()) } returns Result.success(Unit)
 
-            val emissions = repository.confirmPayments(mockUser, emptyList()).toList()
+            val emissions = repository.confirmPayments(emptyList()).toList()
 
             assertEquals(2, emissions.size)
             assertTrue(emissions[0] is DataState.Loading)
@@ -332,7 +332,7 @@ class ConnectRepositoryTest {
             coEvery { mockNetworkClient.confirmPayments(any(), any()) } returns
                 Result.failure(Exception("Network error"))
 
-            val emissions = repository.confirmPayments(mockUser, emptyList()).toList()
+            val emissions = repository.confirmPayments(emptyList()).toList()
 
             assertEquals(2, emissions.size)
             assertTrue(emissions[0] is DataState.Loading)

--- a/app/unit-tests/src/org/commcare/connect/repository/ConnectRepositoryTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/repository/ConnectRepositoryTest.kt
@@ -263,4 +263,79 @@ class ConnectRepositoryTest {
             assertTrue(emissions[1] is DataState.Loading)
             assertTrue(emissions[2] is DataState.Error)
         }
+
+    @Test
+    fun testStartLearning_success_emitsLoadingThenSuccess() =
+        runBlocking {
+            coEvery { mockNetworkClient.startLearnApp(any(), any()) } returns Result.success(Unit)
+
+            val emissions = repository.startLearning(mockUser, "test-uuid").toList()
+
+            assertEquals(2, emissions.size)
+            assertTrue(emissions[0] is DataState.Loading)
+            assertTrue(emissions[1] is DataState.Success)
+        }
+
+    @Test
+    fun testStartLearning_failure_emitsLoadingThenError() =
+        runBlocking {
+            coEvery { mockNetworkClient.startLearnApp(any(), any()) } returns
+                Result.failure(Exception("Network error"))
+
+            val emissions = repository.startLearning(mockUser, "test-uuid").toList()
+
+            assertEquals(2, emissions.size)
+            assertTrue(emissions[0] is DataState.Loading)
+            assertTrue(emissions[1] is DataState.Error)
+        }
+
+    @Test
+    fun testClaimJob_success_emitsLoadingThenSuccess() =
+        runBlocking {
+            coEvery { mockNetworkClient.claimJob(any(), any()) } returns Result.success(Unit)
+
+            val emissions = repository.claimJob(mockUser, "test-uuid").toList()
+
+            assertEquals(2, emissions.size)
+            assertTrue(emissions[0] is DataState.Loading)
+            assertTrue(emissions[1] is DataState.Success)
+        }
+
+    @Test
+    fun testClaimJob_failure_emitsLoadingThenError() =
+        runBlocking {
+            coEvery { mockNetworkClient.claimJob(any(), any()) } returns
+                Result.failure(Exception("Network error"))
+
+            val emissions = repository.claimJob(mockUser, "test-uuid").toList()
+
+            assertEquals(2, emissions.size)
+            assertTrue(emissions[0] is DataState.Loading)
+            assertTrue(emissions[1] is DataState.Error)
+        }
+
+    @Test
+    fun testConfirmPayments_success_emitsLoadingThenSuccess() =
+        runBlocking {
+            coEvery { mockNetworkClient.confirmPayments(any(), any()) } returns Result.success(Unit)
+
+            val emissions = repository.confirmPayments(mockUser, emptyList()).toList()
+
+            assertEquals(2, emissions.size)
+            assertTrue(emissions[0] is DataState.Loading)
+            assertTrue(emissions[1] is DataState.Success)
+        }
+
+    @Test
+    fun testConfirmPayments_failure_emitsLoadingThenError() =
+        runBlocking {
+            coEvery { mockNetworkClient.confirmPayments(any(), any()) } returns
+                Result.failure(Exception("Network error"))
+
+            val emissions = repository.confirmPayments(mockUser, emptyList()).toList()
+
+            assertEquals(2, emissions.size)
+            assertTrue(emissions[0] is DataState.Loading)
+            assertTrue(emissions[1] is DataState.Error)
+        }
 }


### PR DESCRIPTION
### [CCCT-2655](https://dimagi.atlassian.net/browse/CCCT-2655)

## Technical Summary

Part 1 of a two-part migration away from the callback-based `ConnectApiHandler`/`ApiConnect`/`ConnectApiClient` stack. Adds three missing endpoints (`startLearnApp`, `claimJob`, `confirmPayments`) to the existing coroutine-based `ConnectNetworkClient` → `ConnectRepository` chain, without touching call sites or removing old code. Part 2 will migrate call sites and delete the old stack.

## Safety Assurance

### Safety story

**What gives confidence:**
- Purely additive — no existing code paths are modified. The new methods are not called from anywhere yet.
- New unit tests cover all three methods in both `ConnectNetworkClient` and `ConnectRepository`.
- The new methods follow the same `executeApiCall` pattern already used and tested by existing endpoints.

**Risks to review:**
- I reviewed the diff only; no device testing was done, as the changes are no-op in production until Part 2 wires them up.

### Automated test coverage

- `ConnectNetworkClientTest`: tests for `startLearnApp`, `claimJob`, `confirmPayments` (success + failure paths)
- `ConnectRepositoryTest`: tests for `startLearning`, `claimJob`, `confirmPayments` (success + failure paths)

[CCCT-2655]: https://dimagi.atlassian.net/browse/CCCT-2655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ