### PR TITLE
QA-8622 Incorrect Navigation On View Info Click

### DIFF
--- a/app/res/navigation/nav_graph_connect.xml
+++ b/app/res/navigation/nav_graph_connect.xml
@@ -63,8 +63,7 @@
         tools:layout="@layout/fragment_connect_learning_progress">
         <action
             android:id="@+id/action_connect_job_learning_progress_fragment_to_connect_job_detail_bottom_sheet_dialog_fragment"
-            app:destination="@id/connect_job_detail_bottom_sheet_dialog_fragment"
-            app:popUpTo="@id/connect_jobs_list_fragment" />
+            app:destination="@id/connect_job_detail_bottom_sheet_dialog_fragment" />
         <action
             android:id="@+id/action_connect_job_learning_progress_fragment_to_connect_job_delivery_details_fragment"
             app:destination="@id/connect_job_delivery_details_fragment"


### PR DESCRIPTION
### [QA-8622](https://dimagi.atlassian.net/browse/QA-8622)

## Product Description

Tapping **View Info** on the Learn Progress screen now opens the opportunity details dialog over that screen, and dismissing it returns there. Previously the user was dropped back on the opportunities list with the dialog floating on top.

## Technical Summary

The View Info action carried `popUpTo="connect_jobs_list_fragment"`, which destroyed the Learn Progress destination before pushing the dialog. Because the bottom sheet is a floating destination, whatever remained underneath became the visible screen. The `popUpTo` is correct on the sibling actions from Learn Progress — those replace the screen — so only the dialog action was changed; the delivery-side action to the same dialog never had it.

This also explains why the bug looked intermittent in QA. `ConnectActivity` picks the graph's start destination at runtime, so entering from the learn app via `GO_TO_JOB_STATUS` makes Learn Progress the start destination, leaving the jobs list off the back stack entirely and turning the `popUpTo` into a no-op. The behavior QA saw as correct was that accident.

## Safety Assurance

### Safety story

What gives confidence:

- I reproduced the bug, applied the fix, and verified on device that the dialog now opens over Learn Progress; I also confirmed the previously-working entry path from the learn app is unchanged.
- One attribute in one navigation action, with a single call site.
- The dialog only renders and dismisses, and reads its job from activity-scoped state rather than the fragment below it, so retaining that fragment cannot change what it shows.
- The full Connect and fragment unit suites pass (408 tests).

Risks to review:

- Leaving Connect from this screen now takes one additional back press, since the user is genuinely one level deeper than before. `ConnectActivity.onBackPressed` finishes the task only at the start destination, which is unaffected.
- Sync from the overflow menu resolves the primary navigation fragment, which is now Learn Progress rather than the jobs list while the dialog is open. That is the intended target, but it is a behavior change.

[QA-8622]: https://dimagi.atlassian.net/browse/QA-8622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ