### PR TITLE
QA-8628 Route Drawer App Switch Through DispatchActivity

### DIFF
--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -112,6 +112,10 @@ public class DispatchActivity extends AppCompatActivity {
         } else if (getIntent().hasExtra(EXTRA_APP_ID)) {
             redirectToLoginAppId = getIntent().getStringExtra(EXTRA_APP_ID);
             forceSingleAppMode = getIntent().getBooleanExtra(EXTRA_FORCE_SINGLE_APP_MODE, true);
+            userTriggeredLogout = getIntent().getBooleanExtra(
+                    LoginActivity.USER_TRIGGERED_LOGOUT,
+                    false
+            );
         }
     }
 

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -109,6 +109,9 @@ public class DispatchActivity extends AppCompatActivity {
             waitingForActivityResultFromLogin = savedInstanceState.getBoolean(
                     KEY_WAITING_FOR_ACTIVITY_RESULT
             );
+        } else if (getIntent().hasExtra(EXTRA_APP_ID)) {
+            redirectToLoginAppId = getIntent().getStringExtra(EXTRA_APP_ID);
+            forceSingleAppMode = getIntent().getBooleanExtra(EXTRA_FORCE_SINGLE_APP_MODE, true);
         }
     }
 

--- a/app/src/org/commcare/activities/DispatchActivity.java
+++ b/app/src/org/commcare/activities/DispatchActivity.java
@@ -85,6 +85,9 @@ public class DispatchActivity extends AppCompatActivity {
     private static final String EXTRA_CONSUMED_KEY = "shortcut_extra_was_consumed";
     private static final String KEY_APP_FILES_CHECK_OCCURRED = "check-for-changed-app-files-occurred";
     private static final String KEY_WAITING_FOR_ACTIVITY_RESULT = "waiting-for-login-activity-result";
+    private static final String KEY_REDIRECT_TO_LOGIN_APP_ID = "redirect-to-login-app-id";
+    private static final String KEY_FORCE_SINGLE_APP_MODE = "force-single-app-mode";
+    private static final String KEY_USER_TRIGGERED_LOGOUT = "user-triggered-logout";
 
     private boolean waitingForActivityResultFromLogin;
 
@@ -109,7 +112,10 @@ public class DispatchActivity extends AppCompatActivity {
             waitingForActivityResultFromLogin = savedInstanceState.getBoolean(
                     KEY_WAITING_FOR_ACTIVITY_RESULT
             );
-        } else if (getIntent().hasExtra(EXTRA_APP_ID)) {
+            redirectToLoginAppId = savedInstanceState.getString(KEY_REDIRECT_TO_LOGIN_APP_ID);
+            forceSingleAppMode = savedInstanceState.getBoolean(KEY_FORCE_SINGLE_APP_MODE, true);
+            userTriggeredLogout = savedInstanceState.getBoolean(KEY_USER_TRIGGERED_LOGOUT);
+        } else if (isAppSwitchRequest()) {
             redirectToLoginAppId = getIntent().getStringExtra(EXTRA_APP_ID);
             forceSingleAppMode = getIntent().getBooleanExtra(EXTRA_FORCE_SINGLE_APP_MODE, true);
             userTriggeredLogout = getIntent().getBooleanExtra(
@@ -117,6 +123,10 @@ public class DispatchActivity extends AppCompatActivity {
                     false
             );
         }
+    }
+
+    private boolean isAppSwitchRequest() {
+        return getIntent().getAction() == null && getIntent().hasExtra(EXTRA_APP_ID);
     }
 
     private Intent checkIfAnyPNIntentPresent() {
@@ -159,6 +169,9 @@ public class DispatchActivity extends AppCompatActivity {
         outState.putBoolean(EXTRA_CONSUMED_KEY, shortcutExtraWasConsumed);
         outState.putBoolean(KEY_APP_FILES_CHECK_OCCURRED, alreadyCheckedForAppFilesChange);
         outState.putBoolean(KEY_WAITING_FOR_ACTIVITY_RESULT, waitingForActivityResultFromLogin);
+        outState.putString(KEY_REDIRECT_TO_LOGIN_APP_ID, redirectToLoginAppId);
+        outState.putBoolean(KEY_FORCE_SINGLE_APP_MODE, forceSingleAppMode);
+        outState.putBoolean(KEY_USER_TRIGGERED_LOGOUT, userTriggeredLogout);
     }
 
     private void checkForChangedCCZ() {

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -253,10 +253,7 @@ public class StandardHomeActivity
                     if(!recordId.equals(currentSeatedId)) {
                         //Navigate to LoginActivity for selected app
                         CommCareApplication.instance().closeUserSession();
-                        Intent i = new Intent();
-                        i.putExtra(EXTRA_APP_ID, recordId);
-                        i.putExtra(EXTRA_FORCE_SINGLE_APP_MODE, false);
-                        setResult(RESULT_OK, i);
+                        requestAppSwitch(recordId);
                         finish();
                     }
                 }
@@ -285,6 +282,19 @@ public class StandardHomeActivity
                     navigateToWorkHistory();
                 }
             }
+        }
+    }
+
+    private void requestAppSwitch(String appId) {
+        Intent intent = new Intent();
+        intent.putExtra(EXTRA_APP_ID, appId);
+        intent.putExtra(EXTRA_FORCE_SINGLE_APP_MODE, false);
+
+        if (getCallingActivity() == null) {
+            intent.setClass(this, DispatchActivity.class);
+            startActivity(intent);
+        } else {
+            setResult(RESULT_OK, intent);
         }
     }
 

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -286,16 +286,11 @@ public class StandardHomeActivity
     }
 
     private void requestAppSwitch(String appId) {
-        Intent intent = new Intent();
+        Intent intent = new Intent(this, DispatchActivity.class);
         intent.putExtra(EXTRA_APP_ID, appId);
         intent.putExtra(EXTRA_FORCE_SINGLE_APP_MODE, false);
-
-        if (getCallingActivity() == null) {
-            intent.setClass(this, DispatchActivity.class);
-            startActivity(intent);
-        } else {
-            setResult(RESULT_OK, intent);
-        }
+        intent.putExtra(LoginActivity.USER_TRIGGERED_LOGOUT, true);
+        startActivity(intent);
     }
 
     @Override

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -253,7 +253,11 @@ public class StandardHomeActivity
                     if(!recordId.equals(currentSeatedId)) {
                         //Navigate to LoginActivity for selected app
                         CommCareApplication.instance().closeUserSession();
-                        requestAppSwitch(recordId);
+                        Intent i = new Intent(this, DispatchActivity.class);
+                        i.putExtra(EXTRA_APP_ID, recordId);
+                        i.putExtra(EXTRA_FORCE_SINGLE_APP_MODE, false);
+                        i.putExtra(LoginActivity.USER_TRIGGERED_LOGOUT, true);
+                        startActivity(i);
                         finish();
                     }
                 }
@@ -283,14 +287,6 @@ public class StandardHomeActivity
                 }
             }
         }
-    }
-
-    private void requestAppSwitch(String appId) {
-        Intent intent = new Intent(this, DispatchActivity.class);
-        intent.putExtra(EXTRA_APP_ID, appId);
-        intent.putExtra(EXTRA_FORCE_SINGLE_APP_MODE, false);
-        intent.putExtra(LoginActivity.USER_TRIGGERED_LOGOUT, true);
-        startActivity(intent);
     }
 
     @Override

--- a/docs/commcare/login-engine.md
+++ b/docs/commcare/login-engine.md
@@ -80,6 +80,7 @@ All `LoginActivity` flows now route through `LoginController`; the legacy `tryLo
 - **Back from the opportunities list after a launch** → exits the app: `ConnectActivity` carries a per-instance flag set at launch (`markAppLaunchedFromConnect`), and a back press on the opportunities-list destination calls `finishAffinity()`. Without a launch (plain browsing) back returns to whatever opened Connect.
 - **View Job Status** (`HomeScreenBaseActivity.userPressedOpportunityStatus`) opens the job-status page in a fresh `ConnectActivity` over the live Home; resuming from it finishes that activity, so the backstack stays stable.
 - **Logout** (`userTriggeredLogout`) uses Home's standard `setResult(RESULT_OK) + finish`: a non-Connect app returns to the login screen; a Connect-launched app reveals the opportunities list with the session closed.
+- **Switching apps from Home's nav drawer** → Home reports the selected app to `DispatchActivity` by result, which only reaches it when Dispatch started Home for result. A Connect-launched Home has no caller, so it starts `DispatchActivity` with `EXTRA_APP_ID` itself. `ConnectActivity` is left in the stack, so back out of the newly selected app still lands on the opportunities list.
 
 ## Adding a new caller
 

--- a/docs/commcare/login-engine.md
+++ b/docs/commcare/login-engine.md
@@ -80,7 +80,7 @@ All `LoginActivity` flows now route through `LoginController`; the legacy `tryLo
 - **Back from the opportunities list after a launch** → exits the app: `ConnectActivity` carries a per-instance flag set at launch (`markAppLaunchedFromConnect`), and a back press on the opportunities-list destination calls `finishAffinity()`. Without a launch (plain browsing) back returns to whatever opened Connect.
 - **View Job Status** (`HomeScreenBaseActivity.userPressedOpportunityStatus`) opens the job-status page in a fresh `ConnectActivity` over the live Home; resuming from it finishes that activity, so the backstack stays stable.
 - **Logout** (`userTriggeredLogout`) uses Home's standard `setResult(RESULT_OK) + finish`: a non-Connect app returns to the login screen; a Connect-launched app reveals the opportunities list with the session closed.
-- **Switching apps from Home's nav drawer** → Home reports the selected app to `DispatchActivity` by result, which only reaches it when Dispatch started Home for result. A Connect-launched Home has no caller, so it starts `DispatchActivity` with `EXTRA_APP_ID` itself. `ConnectActivity` is left in the stack, so back out of the newly selected app still lands on the opportunities list.
+- **Switching apps from Home's nav drawer** → Home starts `DispatchActivity` with `EXTRA_APP_ID` instead of reporting the choice back by result, because a Connect-launched Home has no caller to read that result and a Home reached by `FLAG_ACTIVITY_REORDER_TO_FRONT` has one that no longer sits beneath it. `ConnectActivity` is left in the stack, so backing out of the newly selected app still lands on the opportunities list.
 
 ## Adding a new caller
 


### PR DESCRIPTION
### [QA-8628](https://dimagi.atlassian.net/browse/QA-8628)

## Product Description

Picking a different app from the sidebar now opens that app instead of dropping the user back on the opp list.

Unfortunately, this was an edge case that was missed during implementation of the silent Connect app launch flow. 

I know that this is yet another ugly hacky fix, but this will change with the upcoming app navigation changes for the Connect Redesign, and I think that this may be the best temporary fix so that we can get 2.64 out the door.

There's a video of the issue in the ticket. Here's a video of what it looks like _after_ the fix:

https://github.com/user-attachments/assets/732e8fac-973f-4832-b3ac-b90b5a4e93c1

## Technical Summary

The `setResult` hand-off only lands when `DispatchActivity` started Home for result, which neither a Connect-launched Home nor one brought forward with `FLAG_ACTIVITY_REORDER_TO_FRONT` satisfies — hence routing every switch through the dispatcher. The cost is one extra `DispatchActivity` instance per switch; it draws nothing and finishes on the way back.

No `FLAG_ACTIVITY_CLEAR_TOP`, so `ConnectActivity` stays in the stack and backing out of the newly selected app still lands on the opp list.

The action-less intent check keeps the app id off the launcher, `CommCareSession` and deep link filters this activity exports.

## Safety Assurance

### Safety story

What gives confidence:
- I confirmed with the fix that selecting another app from the drawer opens that app.
- Traditional CommCare users cannot reach this code at all: Home only sets up the new drawer when PersonalID is logged in (`shouldShowDrawerAfterCheck(true)`), and `refreshDrawerContent` hides the app list otherwise, so their app switching stays on the login screen's app picker and the app manager.
- No existing intent to `DispatchActivity` carries `extra_app_id`; external launches use `ccodk_session_endpoint_app_id`. The new read is inert for shortcut, deep-link, push-notification, recovery and session-endpoint launches, and is guarded on `savedInstanceState == null` so a rotation or process death can't replay it.
- `ExternalLaunchTests`, `PersonalIdDrawerVisibilityTest`, `RecoveryMeasuresTest`, `SessionEndpointNotificationTest`, `DemoUserRestoreTest` and `SmsInviteLinkFlowTest` pass.

Risks to review:
- Back-stack shape changes: a switch leaves `Dispatch → ConnectActivity → Dispatch → Login → Home`, and Home no longer reports the switch to the `DispatchActivity` that started it — that instance receives `RESULT_CANCELED` and retires when the chain unwinds. Backing out cascades correctly in my testing, but it is worth a second read.
- `DispatchActivity` is exported. Its intent filters can no longer supply `extra_app_id`, but an explicit action-less intent from another app still can, which would preselect that app on the login screen — bounded by `LoginActivity` rejecting ids that aren't installed usable apps, and the same class of capability as the existing session-endpoint extra.

### Automated test coverage

None added. Existing Robolectric coverage over `DispatchActivity` and the Home drawer was run for regressions.

[QA-8628]: https://dimagi.atlassian.net/browse/QA-8628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


