### PR TITLE
QA-8627 Don't Write Connect Data After Signing Out Of PersonalID (2/2: make Connect storage safe to reach around sign-out)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,7 @@ This file is meant as an easy way for us to collate notes and change logs across
 - Confirm that entering an incorrect verification code still displays the "incorrect code" error and does not silently trigger a new OTP.
 - After signing out of PersonalID, the nav drawer should offer sign-in/register rather than a "Logged out of PersonalID" error asking you to configure the account again. Worth repeating a few times, and while push notifications are actively arriving, since the original failure depended on timing.
 - Confirm signing back in still works and that notifications and messaging behave normally afterward.
+- Signing out while a Connect request is landing should no longer be able to wipe the account and restart the app. Signing out repeatedly with notifications arriving, then signing back in, should behave normally every time.
 
 ## CommCare 2.63.4
 

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -85,6 +85,7 @@ import org.commcare.models.database.app.DatabaseAppOpenHelper;
 import org.commcare.models.database.connect.DatabaseConnectOpenHelper;
 import org.commcare.models.database.global.DatabaseGlobalOpenHelper;
 import org.commcare.models.database.user.UserSandboxUtils;
+import org.commcare.connect.database.ConnectDatabaseUnavailableException;
 import org.commcare.connect.database.ConnectDatabaseUtils;
 import org.commcare.models.database.user.DatabaseUserOpenHelper;
 import org.commcare.models.database.user.models.CommCareEntityStorageCache;
@@ -1251,7 +1252,10 @@ public class CommCareApplication extends Application implements LifecycleEventOb
     public IDatabase getConnectDbOpenHelper(Context context) {
         byte[] passphrase = ConnectDatabaseUtils.getConnectDbPassphrase(context);
         if (passphrase == null || passphrase.length == 0) {
-            throw new IllegalStateException("Attempting to access Connect DB without a passphrase");
+            //Typed so callers can tell "no account to open a DB for" apart from a DB that won't
+            //open, which is a genuinely broken DB
+            throw new ConnectDatabaseUnavailableException(
+                    "Attempting to access Connect DB without a passphrase");
         }
         return new EncryptedDatabaseAdapter(new DatabaseConnectOpenHelper(
                 context, UserSandboxUtils.getSqlCipherEncodedKey(passphrase)));

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -30,6 +30,7 @@ import org.commcare.connect.database.ConnectUserDatabaseUtil;
 import org.commcare.connect.network.ConnectSsoHelper;
 import org.commcare.connect.network.ConnectSsoSyncHelper;
 import org.commcare.connect.network.TokenExceptionHandler;
+import org.commcare.connect.repository.ConnectRequestManager;
 import org.commcare.connect.workers.ConnectHeartbeatWorker;
 import org.commcare.connect.workers.ConnectReleaseTogglesWorker;
 import org.commcare.core.network.AuthInfo;
@@ -182,12 +183,16 @@ public class PersonalIdManager {
         // Cancel periodic push notification retrieval when user logs out
         NotificationsSyncWorkerManager.cancelPeriodicPushNotificationRetrieval(CommCareApplication.instance());
 
+        ConnectReleaseTogglesWorker.Companion.cancelPeriodicFetch(CommCareApplication.instance());
+
+        //Drop in-flight API requests
+        ConnectRequestManager.INSTANCE.cancelAll();
+
         ConnectUserDatabaseUtil.forgetUser();
 
         // remove notification read / unread preferences
         NotificationPrefs.INSTANCE.removeNotificationReadPref(CommCareApplication.instance());
 
-        ConnectReleaseTogglesWorker.Companion.cancelPeriodicFetch(CommCareApplication.instance());
         PersonalIdUnlocker.INSTANCE.resetSession();
         PersonalIdUserPreferences.clear();
     }

--- a/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
+import org.commcare.android.database.global.models.ConnectKeyRecord;
 import org.commcare.android.database.global.models.GlobalErrorRecord;
 import org.commcare.connect.PersonalIdManager;
 import org.commcare.connect.network.SsoToken;
@@ -14,6 +15,7 @@ import org.commcare.models.database.IDatabase;
 import org.commcare.models.database.SqlStorage;
 import org.commcare.models.database.connect.DatabaseConnectOpenHelper;
 import org.commcare.modern.database.Table;
+import org.commcare.util.LogTypes;
 import org.commcare.utils.GlobalErrorUtil;
 import org.commcare.utils.GlobalErrors;
 import org.javarosa.core.services.Logger;
@@ -30,7 +32,8 @@ import java.util.Date;
 public class ConnectDatabaseHelper {
     private static final Object connectDbHandleLock = new Object();
     public static IDatabase connectDatabase;
-    static boolean dbBroken = false;
+    //Written under connectDbHandleLock, but isDbBroken() reads it from other threads
+    private static volatile boolean dbBroken = false;
 
     public static void handleReceivedDbPassphrase(Context context, String passphrase) {
         ConnectDatabaseUtils.storeConnectDbPassphrase(context, passphrase);
@@ -52,6 +55,14 @@ public class ConnectDatabaseHelper {
                     if (connectDatabase == null || !connectDatabase.isOpen()) {
                         try {
                             connectDatabase = CommCareApplication.instance().getConnectDbOpenHelper(context);
+                        } catch (ConnectDatabaseUnavailableException e) {
+                            //There's no account to open a DB for, which is the expected state once
+                            //the user signs out. Don't flag the DB or raise the global error: that
+                            //would wipe the account and restart the process over work that simply
+                            //raced with sign-out
+                            Logger.log(LogTypes.TYPE_MAINTENANCE,
+                                    "Skipping Connect DB access, there is no passphrase to open it");
+                            throw e;
                         } catch (Exception e) {
                             //Flag the DB as broken if we hit an error opening it (usually means corrupted or bad encryption)
                             dbBroken = true;
@@ -63,6 +74,23 @@ public class ConnectDatabaseHelper {
                 }
             }
         });
+    }
+
+    /**
+     * Deletes the Connect DB along with the passphrase used to open it.
+     * <p>
+     * Held under the same lock as {@link #getConnectStorage} so that a storage operation racing
+     * with sign-out either completes against the live DB or sees it already gone. Without the
+     * lock a reader can open a handle partway through, and re-flag the DB as broken after this
+     * has cleared the flag.
+     */
+    static void clearConnectData() {
+        synchronized (connectDbHandleLock) {
+            teardown();
+            DatabaseConnectOpenHelper.deleteDb();
+            CommCareApplication.instance().getGlobalStorage(ConnectKeyRecord.class).removeAll();
+            dbBroken = false;
+        }
     }
 
     public static void teardown() {

--- a/app/src/org/commcare/connect/database/ConnectDatabaseUnavailableException.kt
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseUnavailableException.kt
@@ -1,0 +1,17 @@
+package org.commcare.connect.database
+
+/**
+ * Thrown when Connect storage is accessed with no passphrase to open it, which is the expected state
+ * once the user has signed out of PersonalId.
+ *
+ * Deliberately not a [org.commcare.connect.network.LoginInvalidatedException]: that one is
+ * reserved for a DB that can't be opened despite having a passphrase (corruption or bad
+ * encryption), and reaching the uncaught handler with it wipes the account and restarts the
+ * process. A missing passphrase just means the caller raced with sign-out and its work is no
+ * longer wanted.
+ *
+ * @author dviggiano
+ */
+class ConnectDatabaseUnavailableException(
+    message: String,
+) : RuntimeException(message)

--- a/app/src/org/commcare/connect/database/ConnectUserDatabaseUtil.java
+++ b/app/src/org/commcare/connect/database/ConnectUserDatabaseUtil.java
@@ -2,10 +2,7 @@ package org.commcare.connect.database;
 
 import android.content.Context;
 
-import org.commcare.CommCareApplication;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
-import org.commcare.android.database.global.models.ConnectKeyRecord;
-import org.commcare.models.database.connect.DatabaseConnectOpenHelper;
 
 public class ConnectUserDatabaseUtil {
 
@@ -35,10 +32,7 @@ public class ConnectUserDatabaseUtil {
     }
 
     public static void forgetUser() {
-        DatabaseConnectOpenHelper.deleteDb();
-        CommCareApplication.instance().getGlobalStorage(ConnectKeyRecord.class).removeAll();
-        ConnectDatabaseHelper.dbBroken = false;
-        ConnectDatabaseHelper.teardown();
+        ConnectDatabaseHelper.clearConnectData();
     }
 
     public static boolean hasConnectAccess(Context context) {

--- a/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
+++ b/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
@@ -22,6 +22,7 @@ import org.commcare.connect.ConnectConstants.OPPORTUNITY_STATUS_DELIVERY
 import org.commcare.connect.ConnectConstants.OPPORTUNITY_STATUS_LEARN
 import org.commcare.connect.ConnectConstants.OPPORTUNITY_UUID
 import org.commcare.connect.ConnectJobHelper
+import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectJobUtils
 import org.commcare.connect.database.NotificationRecordDatabaseHelper.getNotificationById
 import org.commcare.dalvik.R
@@ -227,7 +228,11 @@ class NotificationsSyncWorker(
     }
 
     private fun raiseFCMPushNotificationIfApplicable() {
-        if (showNotification && !isNotificationRead() && checkForOpportunityStatus()) {
+        if (PersonalIdManager.getInstance().isloggedIn() &&
+            showNotification &&
+            !isNotificationRead() &&
+            checkForOpportunityStatus()
+        ) {
             FirebaseMessagingUtil.handleNotification(appContext, notificationPayload, null, true)
         }
     }

--- a/app/src/org/commcare/utils/PushNotificationApiHelper.kt
+++ b/app/src/org/commcare/utils/PushNotificationApiHelper.kt
@@ -37,7 +37,9 @@ import org.commcare.connect.network.connectId.parser.NotificationParseResult
 import org.commcare.pn.helper.NotificationBroadcastHelper
 import org.commcare.pn.workers.MessagingChannelsKeySyncWorker
 import org.commcare.preferences.NotificationPrefs
+import org.commcare.util.LogTypes
 import org.commcare.utils.coroutines.DispatcherProvider
+import org.javarosa.core.services.Logger
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -85,20 +87,42 @@ object PushNotificationApiHelper {
 
                     scheduleMessagingChannelsKeySync(context)
                     CoroutineScope(DispatcherProvider.io()).launch {
-                        val (savedNotifications, savedNotificationIds) = processParsedDataIntoDB(context, parseResult)
+                        //  runCatching keeps a storage failure from escaping to the uncaught
+                        //  exception handler, and guarantees the continuation is resumed exactly once
+                        val result =
+                            runCatching {
+                                val (savedNotifications, savedNotificationIds) =
+                                    processParsedDataIntoDB(context, parseResult)
 
-                        // Update notification preferences and send broadcasts
-                        if (savedNotificationIds.isNotEmpty()) {
-                            NotificationPrefs.setNotificationAsUnread(context)
-                        }
-                        if (savedNotificationIds.isNotEmpty() || parseResult.messagingNotificationIds.isNotEmpty()) {
-                            NotificationBroadcastHelper.sendNewNotificationBroadcast(context)
-                        }
+                                // Update notification preferences and send broadcasts
+                                if (savedNotificationIds.isNotEmpty()) {
+                                    NotificationPrefs.setNotificationAsUnread(context)
+                                }
+                                if (savedNotificationIds.isNotEmpty() || parseResult.messagingNotificationIds.isNotEmpty()) {
+                                    NotificationBroadcastHelper.sendNewNotificationBroadcast(context)
+                                }
 
-                        // Acknowledge all notifications (both stored and messaging)
-                        acknowledgeNotificationsReceipt(context, savedNotificationIds + parseResult.messagingNotificationIds)
+                                // Acknowledge all notifications (both stored and messaging)
+                                val acknowledged =
+                                    acknowledgeNotificationsReceipt(
+                                        context,
+                                        savedNotificationIds + parseResult.messagingNotificationIds,
+                                    )
+                                if (!acknowledged) {
+                                    //  Not treated as a failure: the notifications are stored, and the
+                                    //  server will resend the unacknowledged ones on the next sync
+                                    Logger.log(
+                                        LogTypes.TYPE_MAINTENANCE,
+                                        "Failed to acknowledge receipt of retrieved notifications",
+                                    )
+                                }
 
-                        continuation.resume(Result.success(savedNotifications))
+                                savedNotifications
+                            }.onFailure {
+                                Logger.exception("Error storing retrieved notifications", it)
+                            }
+
+                        continuation.resume(result)
                     }
                 }
 
@@ -166,7 +190,7 @@ object PushNotificationApiHelper {
         if (savedNotificationIds.isEmpty()) {
             return true
         }
-        val user = ConnectUserDatabaseUtil.getUser(context)
+        val user = ConnectUserDatabaseUtil.getUser(context) ?: return false
         return suspendCoroutine { continuation ->
             object : PersonalIdApiHandler<Boolean>() {
                 override fun onSuccess(result: Boolean) {

--- a/app/unit-tests/src/org/commcare/connect/database/ConnectDatabaseHelperTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/database/ConnectDatabaseHelperTest.kt
@@ -1,0 +1,97 @@
+package org.commcare.connect.database
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.commcare.CommCareTestApplication
+import org.commcare.android.database.connect.models.ConnectUserRecord
+import org.commcare.connect.network.LoginInvalidatedException
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Covers Connect storage being reached around sign-out, which an in-flight request can still do
+ * because the sign-in check and the storage access aren't atomic.
+ *
+ * The invariant under test is that losing that race stays survivable: it must never flag the DB as
+ * broken or raise [LoginInvalidatedException], because reaching the uncaught handler with that wipes
+ * the account and restarts the process.
+ */
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class ConnectDatabaseHelperTest {
+    private val context: Context = CommCareTestApplication.instance()
+
+    @After
+    fun tearDown() {
+        ConnectUserDatabaseUtil.forgetUser()
+    }
+
+    private fun readUserStorage() =
+        ConnectDatabaseHelper
+            .getConnectStorage(context, ConnectUserRecord::class.java)
+            .getRecordsForValues(emptyArray(), emptyArray())
+
+    @Test
+    fun testForgetUserLeavesNoPassphraseAndNoBrokenFlag() {
+        ConnectUserDatabaseUtil.forgetUser()
+
+        //  the passphrase going away is what tells the storage layer there's no account to open a
+        //  DB for, and it has to land together with the deletion rather than partway through it
+        assertNull(ConnectDatabaseUtils.getKeyRecord())
+        assertFalse(ConnectDatabaseHelper.dbExists())
+        assertFalse(ConnectDatabaseHelper.isDbBroken())
+    }
+
+    @Test
+    fun testGetUserAfterForgetUserReturnsNullWithoutFlaggingDb() {
+        ConnectUserDatabaseUtil.forgetUser()
+
+        //  the ordinary "do I have an account" check treats an absent DB as no account, so it stays
+        //  cheap and side-effect free
+        assertNull(ConnectUserDatabaseUtil.getUser(context))
+        assertFalse(ConnectDatabaseHelper.isDbBroken())
+    }
+
+    @Test
+    fun testStorageReadRacingSignOutNeverInvalidatesLogin() {
+        val readerReady = CountDownLatch(1)
+        val signOutDone = CountDownLatch(1)
+        val fatal = AtomicReference<Throwable?>(null)
+
+        val reader =
+            Thread {
+                readerReady.countDown()
+                //  keep hammering storage across the sign-out so at least one read lands on either
+                //  side of it, and ideally one lands mid-teardown
+                repeat(200) {
+                    try {
+                        readUserStorage()
+                    } catch (expected: ConnectDatabaseUnavailableException) {
+                        //  the read can't succeed once the account is gone, it just has to fail
+                        //  survivably
+                    } catch (t: Throwable) {
+                        if (t is LoginInvalidatedException) {
+                            fatal.compareAndSet(null, t)
+                        }
+                    }
+                }
+                signOutDone.countDown()
+            }
+
+        reader.start()
+        assertTrue(readerReady.await(5, TimeUnit.SECONDS))
+        ConnectUserDatabaseUtil.forgetUser()
+        reader.join(TimeUnit.SECONDS.toMillis(30))
+
+        assertNull("A read racing sign-out invalidated the login", fatal.get())
+        assertFalse("A read racing sign-out flagged the Connect DB as broken", ConnectDatabaseHelper.isDbBroken())
+    }
+}


### PR DESCRIPTION
### [QA-8627](https://dimagi.atlassian.net/browse/QA-8627)

Second of two PRs, stacked on [#3863](https://github.com/dimagi/commcare-android/pull/3863) — **review that one first, and merge it first.** The diff here is only the follow-up work; retarget to `commcare_2.64` once #3863 lands.

## Product Description

Same user-visible symptom as #3863: signing out of PersonalID could leave the nav drawer showing "Logged out of PersonalID — A problem occurred, please configure your PersonalID account again". In the worst case the error also reached the uncaught exception handler as a `LoginInvalidatedException`, which wipes the account and exits the process. This PR removes that outcome entirely.

## Technical Summary

#3863 gates the Connect write sites on `isloggedIn()`. That closes the ordinary paths, but a status check is check-then-act: a caller already past its check when sign-out lands still reaches a deleted DB, and the storage layer treated that as a corrupt DB. So sign-out now drops the work it can, and what still gets through is no longer fatal.

**Drop more of the in-flight work**

- `forgetUser` cancels the periodic release-toggles worker and drops in-flight requests via `ConnectRequestManager.cancelAll()` — which existed for exactly this but was never called — before deleting the DB.
- `NotificationsSyncWorker` no longer raises an FCM notification while signed out.

**Stop treating the lost race as corruption**

- `ConnectUserDatabaseUtil.forgetUser` was racing `connectDbHandleLock` on its own: `deleteDb()` and the passphrase removal ran outside the lock while `teardown()` took it, so a reader could open a handle mid-teardown and re-flag the DB as broken *after* `forgetUser` had just cleared the flag. Moved into `ConnectDatabaseHelper.clearConnectData()`, which holds the lock across teardown, deletion and passphrase removal. Deleting a local DB touches no network, so the critical section stays short enough to hold on the UI thread `forgetUser` already runs on.
- An absent passphrase means there's no account to open a DB for — the expected state after sign-out, not corruption. `getConnectDbOpenHelper` now throws the typed `ConnectDatabaseUnavailableException` instead of a bare `IllegalStateException`, and `getHandle` rethrows it without setting `dbBroken` or raising the global error. Only a DB that won't open *despite having a passphrase* is still treated as broken. Losing the race now degrades to a logged, catchable no-op instead of an account wipe and process restart.
- `dbBroken` is private and volatile; it was package-private and read from threads other than the one writing it.

**Contain the notification path**

The storage/broadcast/acknowledge block in `callPushNotificationApi` is wrapped in `runCatching`: a failure is logged and returned as `Result.failure` rather than escaping to the uncaught exception handler, and the continuation is resumed exactly once either way (previously a throw there left the caller suspended forever). A failed acknowledgement is logged but not treated as a failure — the notifications are stored and the server resends unacknowledged ones on the next sync. `acknowledgeNotificationsReceipt` also returns `false` on a null user instead of NPEing.

## Safety Assurance

### Safety story

What gives me confidence:

- The worst outcome this addresses — `LoginInvalidatedException` reaching the uncaught handler and wiping the account — is now unreachable from a missing passphrase, which is the only way sign-out can produce it.
- `clearConnectData` strictly widens an existing critical section; every operation it performs was already happening, just partly unlocked.
- `ConnectDatabaseHelperTest` asserts the invariant directly, including under real thread interleaving.

Risks to review:

- **`clearConnectData` holds `connectDbHandleLock` across the DB deletion on the UI thread.** Local file I/O with no network in the critical section, and `forgetUser` already ran on that thread, but it is a longer hold than before. Worth a look if anyone knows of a Connect storage call that can block for a long time under that lock.
- **`ConnectRequestManager.cancelAll()` is now called for the first time.** It cancels in-flight deferreds, so a caller awaiting one sees a `CancellationException` at sign-out. That is what the method was written for, but it has never actually run in production.
- **The `runCatching` on the notification path swallows more than the sign-out race.** Any storage failure in `processParsedDataIntoDB` — not just a deleted DB — now becomes a logged `Result.failure` instead of an uncaught exception. That is the intent (a background notification sync should not take down the process), but it makes a genuine storage bug quieter than it used to be. The failure is also logged and returned *after* partial work may have happened; there is no rollback.
- **A missing passphrase is no longer flagged as a broken DB.** If some path can lose the passphrase while an account genuinely exists, that state now degrades quietly instead of prompting recovery. `PERSONALID_DB_STARTUP_ERROR` on a `null` user in `init` still covers the startup case.
- **The concurrency test asserts an invariant, not a schedule.** It reads Connect storage from a background thread across a concurrent `forgetUser` and asserts what must hold under any interleaving — never `LoginInvalidatedException`, never `dbBroken` — rather than trying to hit one specific ordering. It will not reliably reproduce the original failure if the fix regresses in a timing-dependent way.

### Automated test coverage

`ConnectDatabaseHelperTest` adds three cases covering Connect storage reached around sign-out, including the latch-based one described above.

Carried over from #3863: `ConnectReleaseTogglesParserTest` covers the release-toggle guard in both directions. The `runCatching` hardening on the notification path is not directly covered.

[QA-8627]: https://dimagi.atlassian.net/browse/QA-8627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
