### PR TITLE
Add generic hook to set application name as CommCareActivity title

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -515,6 +515,10 @@ public abstract class CommCareActivity<R> extends CommonBaseActivity
         return null;
     }
 
+    public boolean usesGenericApplicationTitle() {
+        return false;
+    }
+
     public static String getTopLevelTitleName(Context c) {
         try {
             return Localization.get("app.display.name");

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -616,6 +616,11 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
     }
 
     @Override
+    public boolean usesGenericApplicationTitle() {
+        return true;
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         FirebaseAnalyticsUtil.reportOptionsMenuItemClick(this.getClass(),
                 menuIdToAnalyticsParam.get(item.getItemId()));

--- a/app/src/org/commcare/activities/InstallArchiveActivity.java
+++ b/app/src/org/commcare/activities/InstallArchiveActivity.java
@@ -100,6 +100,11 @@ public class InstallArchiveActivity extends CommCareActivity<InstallArchiveActiv
     }
 
     @Override
+    public boolean usesGenericApplicationTitle() {
+        return true;
+    }
+
+    @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if (requestCode == REQUEST_FILE_LOCATION && resultCode == AppCompatActivity.RESULT_OK) {
             FileUtil.updateFileLocationFromIntent(this, intent, editFileLocation);

--- a/app/src/org/commcare/activities/InstallFromListActivity.java
+++ b/app/src/org/commcare/activities/InstallFromListActivity.java
@@ -258,6 +258,11 @@ public class InstallFromListActivity<T> extends CommCareActivity<T> implements H
         return false;
     }
 
+    @Override
+    public boolean usesGenericApplicationTitle() {
+        return true;
+    }
+
     private String getUsernameForAuth() {
         if (inMobileUserAuthMode) {
             String username = ((EditText)findViewById(R.id.edit_username)).getText().toString();

--- a/app/src/org/commcare/fragments/BreadcrumbBarHelper.java
+++ b/app/src/org/commcare/fragments/BreadcrumbBarHelper.java
@@ -357,7 +357,7 @@ public class BreadcrumbBarHelper {
     }
 
     private static String defaultTitle(String currentTitle, AppCompatActivity activity) {
-        if (activity instanceof CommCareSetupActivity) {
+        if (activity instanceof CommCareActivity<?> ccActivity && ccActivity.usesGenericApplicationTitle()) {
             return activity.getString(R.string.application_name);
         }
         if (currentTitle == null || "".equals(currentTitle)) {


### PR DESCRIPTION
## Product Description

Fixes the title shown in the breadcrumb/action bar for specific activities. Previously, screens like the "Offline Install" and the "Install from list" screen showed the **seated app's** display name (`app.display.name`), which is misleading when performing actions unrelated to the seated app. These screens now show the generic product name (`application_name`, e.g. "CommCare").

## Technical Summary

JIRA ticket: https://dimagi.atlassian.net/browse/QA-8624

- `BreadcrumbBarHelper.defaultTitle()` special-cased `CommCareSetupActivity` with an `instanceof` check to return `R.string.application_name`; 
- Every other activity fell through to `CommCareActivity.getTopLevelTitleName()`, which returns the seated app's display name. 
- Install activities (`InstallArchiveActivity`, `InstallFromListActivity`) are not `CommCareSetupActivity`, so they showed the app name.

**Fix:**
Rather than extend the `instanceof` chain, this adds a small overridable hook:
- `CommCareActivity.usesGenericApplicationTitle()` (defaults `false`).
- `BreadcrumbBarHelper.defaultTitle()` now checks the hook (`instanceof CommCareActivity<?> ccActivity && ccActivity.usesGenericApplicationTitle()`) instead of the hard-coded `CommCareSetupActivity` check.
- Overridden to `true` in `CommCareSetupActivity` (preserving existing behavior), `InstallArchiveActivity`, and `InstallFromListActivity`.

The hook is generic — any `CommCareActivity` that should title itself with the product name can opt in, so this isn't install-specific.

## Safety Assurance

### Safety story

- Successfully tested locally:
  - Confirmed the title shows as the product name on the archive offline install screen, the install-from-list screen, and the setup screen; 
  - Confirmed that ordinary in-form/session screens still show their normal titles.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes, [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes, [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
