### PR TITLE
QA-8627 Don't Write Connect Data After Signing Out Of PersonalID (1/2: gate the write sites)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,8 @@ This file is meant as an easy way for us to collate notes and change logs across
 
 - On a device where PersonalID sign-up previously got stuck due to a Firebase OTP error, a pre-invited user will now receive the OTP via Twilio automatically and can complete the sign-up flow.
 - Confirm that entering an incorrect verification code still displays the "incorrect code" error and does not silently trigger a new OTP.
+- After signing out of PersonalID, the nav drawer should offer sign-in/register rather than a "Logged out of PersonalID" error asking you to configure the account again. Worth repeating a few times, and while push notifications are actively arriving, since the original failure depended on timing.
+- Confirm signing back in still works and that notifications and messaging behave normally afterward.
 
 ## CommCare 2.63.4
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,9 +14,6 @@ This file is meant as an easy way for us to collate notes and change logs across
 
 - On a device where PersonalID sign-up previously got stuck due to a Firebase OTP error, a pre-invited user will now receive the OTP via Twilio automatically and can complete the sign-up flow.
 - Confirm that entering an incorrect verification code still displays the "incorrect code" error and does not silently trigger a new OTP.
-- After signing out of PersonalID, the nav drawer should offer sign-in/register rather than a "Logged out of PersonalID" error asking you to configure the account again. Worth repeating a few times, and while push notifications are actively arriving, since the original failure depended on timing.
-- Confirm signing back in still works and that notifications and messaging behave normally afterward.
-- The periodic notification retrieval, Connect heartbeat, and release toggle workers no longer restart from scratch on every biometric unlock, so they keep their existing schedule instead of firing immediately. Confirm notifications, heartbeat, and release toggles still update on a fresh sign-in and continue working across unlocks.
 
 ## CommCare 2.63.4
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,7 @@ This file is meant as an easy way for us to collate notes and change logs across
 - Confirm that entering an incorrect verification code still displays the "incorrect code" error and does not silently trigger a new OTP.
 - After signing out of PersonalID, the nav drawer should offer sign-in/register rather than a "Logged out of PersonalID" error asking you to configure the account again. Worth repeating a few times, and while push notifications are actively arriving, since the original failure depended on timing.
 - Confirm signing back in still works and that notifications and messaging behave normally afterward.
+- The periodic notification retrieval, Connect heartbeat, and release toggle workers no longer restart from scratch on every biometric unlock, so they keep their existing schedule instead of firing immediately. Confirm notifications, heartbeat, and release toggles still update on a fresh sign-in and continue working across unlocks.
 
 ## CommCare 2.63.4
 

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -138,9 +138,12 @@ public class PersonalIdManager {
                     TimeUnit.MILLISECONDS
             ).build();
 
+            // UPDATE rather than REPLACE: REPLACE cancels and re-enqueues, which makes the worker
+            // eligible to run immediately on every unlock. An in-flight run started that way can
+            // land after a subsequent sign-out and write to a deleted Connect DB.
             WorkManager.getInstance(CommCareApplication.instance()).enqueueUniquePeriodicWork(
                     CONNECT_HEARTBEAT_REQUEST_NAME,
-                    ExistingPeriodicWorkPolicy.REPLACE,
+                    ExistingPeriodicWorkPolicy.UPDATE,
                     heartbeatRequest
             );
         }

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -85,7 +85,7 @@ public class PersonalIdManager {
     private BiometricManager biometricManager;
 
     private static volatile PersonalIdManager manager = null;
-    private PersonalIdStatus personalIdSatus = PersonalIdStatus.NotIntroduced;
+    private volatile PersonalIdStatus personalIdSatus = PersonalIdStatus.NotIntroduced;
     private Context parentActivity;
     private int failedPinAttempts = 0;
 
@@ -176,11 +176,13 @@ public class PersonalIdManager {
         if (ConnectDatabaseHelper.dbExists()) {
             FirebaseAnalyticsUtil.reportPersonalIdAccountForgotten(reason);
         }
-        ConnectUserDatabaseUtil.forgetUser();
+
         personalIdSatus = PersonalIdStatus.NotIntroduced;
 
         // Cancel periodic push notification retrieval when user logs out
         NotificationsSyncWorkerManager.cancelPeriodicPushNotificationRetrieval(CommCareApplication.instance());
+
+        ConnectUserDatabaseUtil.forgetUser();
 
         // remove notification read / unread preferences
         NotificationPrefs.INSTANCE.removeNotificationReadPref(CommCareApplication.instance());

--- a/app/src/org/commcare/connect/network/connect/parser/ConnectReleaseTogglesParser.kt
+++ b/app/src/org/commcare/connect/network/connect/parser/ConnectReleaseTogglesParser.kt
@@ -18,7 +18,6 @@ class ConnectReleaseTogglesParser : BaseApiResponseParser<List<ConnectReleaseTog
         val responseJson = JSONObject(responseJsonString)
 
         return ConnectReleaseToggleRecord.releaseTogglesFromJson(responseJson).also {
-            //  the user can sign out while the request is in flight, deleting the DB we store into
             if (PersonalIdManager.getInstance().isloggedIn()) {
                 ConnectAppDatabaseUtil.storeReleaseToggles(anyInputObject as Context, it)
             }

--- a/app/src/org/commcare/connect/network/connect/parser/ConnectReleaseTogglesParser.kt
+++ b/app/src/org/commcare/connect/network/connect/parser/ConnectReleaseTogglesParser.kt
@@ -2,6 +2,7 @@ package org.commcare.connect.network.connect.parser
 
 import android.content.Context
 import org.commcare.android.database.connect.models.ConnectReleaseToggleRecord
+import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectAppDatabaseUtil
 import org.commcare.connect.network.base.BaseApiResponseParser
 import org.json.JSONObject
@@ -17,7 +18,10 @@ class ConnectReleaseTogglesParser : BaseApiResponseParser<List<ConnectReleaseTog
         val responseJson = JSONObject(responseJsonString)
 
         return ConnectReleaseToggleRecord.releaseTogglesFromJson(responseJson).also {
-            ConnectAppDatabaseUtil.storeReleaseToggles(anyInputObject as Context, it)
+            //  the user can sign out while the request is in flight, deleting the DB we store into
+            if (PersonalIdManager.getInstance().isloggedIn()) {
+                ConnectAppDatabaseUtil.storeReleaseToggles(anyInputObject as Context, it)
+            }
         }
     }
 }

--- a/app/src/org/commcare/connect/workers/ConnectReleaseTogglesWorker.kt
+++ b/app/src/org/commcare/connect/workers/ConnectReleaseTogglesWorker.kt
@@ -80,9 +80,11 @@ class ConnectReleaseTogglesWorker(
                     ).setConstraints(getWorkConstraints())
                     .build()
 
+            // UPDATE keeps the existing schedule (so re-scheduling on unlock doesn't trigger an
+            // immediate run) while still picking up any changes to the request itself.
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                 PERIODIC_FETCH_WORK_NAME,
-                ExistingPeriodicWorkPolicy.KEEP,
+                ExistingPeriodicWorkPolicy.UPDATE,
                 workRequest,
             )
         }

--- a/app/src/org/commcare/pn/workermanager/NotificationsSyncWorkerManager.kt
+++ b/app/src/org/commcare/pn/workermanager/NotificationsSyncWorkerManager.kt
@@ -89,9 +89,12 @@ class NotificationsSyncWorkerManager(
                         TimeUnit.MINUTES,
                     ).build()
 
+            // UPDATE rather than REPLACE: REPLACE cancels and re-enqueues, which makes the worker
+            // eligible to run immediately on every unlock. An in-flight run started that way can
+            // land after a subsequent sign-out and write to a deleted Connect DB.
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                 PERIODIC_NOTIFICATION_REQUEST_NAME,
-                ExistingPeriodicWorkPolicy.REPLACE,
+                ExistingPeriodicWorkPolicy.UPDATE,
                 retrievalRequest,
             )
         }

--- a/app/src/org/commcare/pn/workers/MessagingChannelsKeySyncWorker.kt
+++ b/app/src/org/commcare/pn/workers/MessagingChannelsKeySyncWorker.kt
@@ -6,6 +6,7 @@ import androidx.work.WorkerParameters
 import org.commcare.CommCareApplication
 import org.commcare.connect.ConnectActivityCompleteListener
 import org.commcare.connect.MessageManager
+import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectMessagingDatabaseHelper
 import org.commcare.pn.workermanager.NotificationsSyncWorkerManager.Companion.schedulePushNotificationRetrievalWith
 
@@ -14,6 +15,10 @@ class MessagingChannelsKeySyncWorker(
     workerParams: WorkerParameters,
 ) : CoroutineWorker(context, workerParams) {
     override suspend fun doWork(): Result {
+        if (!PersonalIdManager.getInstance().isloggedIn()) {
+            return Result.success()
+        }
+
         val existingChannels = ConnectMessagingDatabaseHelper.getMessagingChannels(context)
         existingChannels?.let {
             existingChannels.filter { it.consented && it.key.isEmpty() }.map {
@@ -26,7 +31,7 @@ class MessagingChannelsKeySyncWorker(
                             success: Boolean,
                             error: String?,
                         ) {
-                            if (success)schedulePushNotificationRetrievalWith(context, 3000)
+                            if (success) schedulePushNotificationRetrievalWith(context, 3000)
                         }
                     },
                 )

--- a/app/src/org/commcare/utils/PushNotificationApiHelper.kt
+++ b/app/src/org/commcare/utils/PushNotificationApiHelper.kt
@@ -27,6 +27,7 @@ import org.commcare.connect.ConnectConstants.OPPORTUNITY_UUID
 import org.commcare.connect.ConnectConstants.PAYMENT_ID
 import org.commcare.connect.ConnectConstants.PAYMENT_UUID
 import org.commcare.connect.ConnectConstants.REDIRECT_ACTION
+import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectMessagingDatabaseHelper
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.connect.database.NotificationRecordDatabaseHelper
@@ -76,6 +77,12 @@ object PushNotificationApiHelper {
 
             object : PersonalIdApiHandler<NotificationParseResult>() {
                 override fun onSuccess(parseResult: NotificationParseResult) {
+                    //  the user can sign out while the request is in flight, deleting the DB we store into
+                    if (!PersonalIdManager.getInstance().isloggedIn()) {
+                        continuation.resume(Result.success(emptyList()))
+                        return
+                    }
+
                     scheduleMessagingChannelsKeySync(context)
                     CoroutineScope(DispatcherProvider.io()).launch {
                         val (savedNotifications, savedNotificationIds) = processParsedDataIntoDB(context, parseResult)

--- a/app/src/org/commcare/utils/PushNotificationApiHelper.kt
+++ b/app/src/org/commcare/utils/PushNotificationApiHelper.kt
@@ -77,7 +77,6 @@ object PushNotificationApiHelper {
 
             object : PersonalIdApiHandler<NotificationParseResult>() {
                 override fun onSuccess(parseResult: NotificationParseResult) {
-                    //  the user can sign out while the request is in flight, deleting the DB we store into
                     if (!PersonalIdManager.getInstance().isloggedIn()) {
                         continuation.resume(Result.success(emptyList()))
                         return

--- a/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
@@ -406,10 +406,16 @@ class PushNotificationActivityTest {
 
     @Test
     fun `clicking a notification does not navigate when the user is not logged in`() {
-        PersonalIdManager.getInstance().status = PersonalIdManager.PersonalIdStatus.Registering
         val record = buildRecord("a", action = ConnectConstants.CCC_DEST_PAYMENTS)
 
-        launchAndClickFirstNotification(record)
+        // Storing a retrieved notification requires a signed-in user, so load first and drop the
+        // login only for the click, which is the gating this test actually covers.
+        launchActivity()
+        completeLoad(listOf(record))
+        assertEquals(View.VISIBLE, recyclerView.visibility)
+        PersonalIdManager.getInstance().status = PersonalIdManager.PersonalIdStatus.Registering
+
+        recyclerView.findViewHolderForAdapterPosition(0)!!.itemView.performClick()
 
         assertNull(shadowOf(activity).nextStartedActivity)
     }

--- a/app/unit-tests/src/org/commcare/connect/network/connectId/parser/ConnectReleaseTogglesParserTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/connectId/parser/ConnectReleaseTogglesParserTest.kt
@@ -5,7 +5,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verify
 import org.commcare.CommCareTestApplication
+import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectAppDatabaseUtil
 import org.commcare.connect.network.connect.parser.ConnectReleaseTogglesParser
 import org.javarosa.core.model.utils.DateUtils
@@ -25,10 +27,12 @@ import java.io.ByteArrayInputStream
 class ConnectReleaseTogglesParserTest {
     private var context: Context = CommCareTestApplication.instance()
     private lateinit var parser: ConnectReleaseTogglesParser
+    private lateinit var savedPersonalIdStatus: PersonalIdManager.PersonalIdStatus
 
     @Before
     fun setUp() {
         parser = ConnectReleaseTogglesParser()
+        savedPersonalIdStatus = PersonalIdManager.getInstance().status
         mockkStatic(ConnectAppDatabaseUtil::class)
 
         // Mock the DB storage call so it doesn't try to access a real DB.
@@ -38,7 +42,28 @@ class ConnectReleaseTogglesParserTest {
     @After
     fun tearDown() {
         unmockkStatic(ConnectAppDatabaseUtil::class)
+        PersonalIdManager.getInstance().status = savedPersonalIdStatus
     }
+
+    private fun setSignedIn(signedIn: Boolean) {
+        PersonalIdManager.getInstance().status =
+            if (signedIn) {
+                PersonalIdManager.PersonalIdStatus.LoggedIn
+            } else {
+                PersonalIdManager.PersonalIdStatus.NotIntroduced
+            }
+    }
+
+    private fun singleToggleJson() =
+        """
+        {
+            "toggles": {
+                "feature_a": {
+                    "active": true
+                }
+            }
+        }
+        """.trimIndent()
 
     @Test
     fun testParseValidResponse() {
@@ -169,6 +194,29 @@ class ConnectReleaseTogglesParserTest {
 
         // Assert
         assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun testTogglesAreStoredWhileSignedIn() {
+        setSignedIn(true)
+        val inputStream = ByteArrayInputStream(singleToggleJson().toByteArray())
+
+        val result = parser.parse(200, inputStream, context)
+
+        assertEquals(1, result.size)
+        verify(exactly = 1) { ConnectAppDatabaseUtil.storeReleaseToggles(context, result) }
+    }
+
+    @Test
+    fun testTogglesAreNotStoredWhenSignedOut() {
+        setSignedIn(false)
+        val inputStream = ByteArrayInputStream(singleToggleJson().toByteArray())
+
+        val result = parser.parse(200, inputStream, context)
+
+        //  the response is still parsed and returned, it just isn't persisted
+        assertEquals(1, result.size)
+        verify(exactly = 0) { ConnectAppDatabaseUtil.storeReleaseToggles(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
### [QA-8627](https://dimagi.atlassian.net/browse/QA-8627)

First of two PRs. This one gates the Connect write sites on the sign-in status; [#3860](https://github.com/dimagi/commcare-android/pull/3860) stacks the storage-layer hardening on top.

## Product Description

Signing out of PersonalID could leave the nav drawer showing "Logged out of PersonalID — A problem occurred, please configure your PersonalID account again", instead of the sign-in and register options. The error persisted for 24 hours or until dismissed. Sign-out now leaves the drawer in the correct signed-out state.

## Technical Summary

The trigger is a stale write: an in-flight Connect request (notification retrieval, release toggles) lands after signing out has deleted the Connect DB and its passphrase. `ConnectDatabaseHelper.getHandle()` then can't open the DB, flags `dbBroken` and raises `PERSONALID_GENERIC_ERROR`, which the exception handler persists as a `GlobalErrorRecord` for the drawer to display.

Connect storage is only valid while signed in, so the callers violating that contract now check before they write:

- `PushNotificationApiHelper.callPushNotificationApi` resumes with an empty list instead of storing retrieved notifications and acknowledging them.
- `ConnectReleaseTogglesParser` still parses the response and returns it, it just doesn't persist it.
- `MessagingChannelsKeySyncWorker` read Connect storage with no check at all, and now bails out.

Two supporting changes are what make those checks mean anything:

- `forgetUser` flips the status to `NotIntroduced` **before** deleting the DB rather than after. Previously a callback landing between the delete and the status change would pass its check and hit a deleted DB. Nothing between the two reads the DB, but the ordering is load-bearing.
- `personalIdSatus` is now `volatile`, since every one of these checks runs on a worker thread while sign-out writes the field from the UI thread.

## Safety Assurance

### Safety story

What gives me confidence:

- The change is additive at each call site — early returns on a state that previously produced the bug. No behavior change while signed in.
- New tests cover the release-toggle guard in both directions, and the existing `PushNotificationActivityTest` suite passes against the new gate.
- The sign-out flow was exercised on device and the drawer shows the sign-in/register state as expected.

Risks to review:

- **A status check is check-then-act, so this narrows the window rather than closing it.** A caller already past its check when sign-out lands still reaches the deleted DB and still produces the banner. That interleaving is what the follow-up PR addresses; this PR covers the ordinary case, which is the whole in-flight duration of a request rather than the microseconds inside `forgetUser`.
- **The race is not directly reproduced by any test.** It needs a response to land inside a narrow window after sign-out. QA's repeated sign-out while notifications are actively arriving is the real check here.
- **Responses arriving while registering or recovering are now dropped too**, not just after sign-out. The Connect DB does exist in that state, so this discards data that could have been stored. Deliberate — the simpler `isloggedIn()` gate was preferred over tracking that case — but it is a real behavior change. `PushNotificationActivityTest`'s click-gating test had to be adjusted for it: it previously loaded notifications while registering, and now loads signed in and drops the login only for the click it actually covers.
- **This is a caller-by-caller fix, so coverage is only as complete as the list of callers.** Guarded here: notification retrieval, release toggles, messaging-channel key sync. The FCM notification raise in `NotificationsSyncWorker` is guarded in the follow-up. **Not guarded anywhere:** `ConnectOpportunitiesParser` (reachable from the same `NotificationsSyncWorker` via `syncOpportunities`) and the remaining `connectId` response parsers. Those can still land post-sign-out. `ConnectOpportunitiesParser` was left out because its tests assert `storeJobs` is always called and would all need updating; worth deciding whether to widen this or track it separately. Note that the follow-up PR makes the consequence non-fatal for all of them, guarded or not.

### Automated test coverage

`ConnectReleaseTogglesParserTest` gains two cases: toggles are stored while signed in, and are parsed but not persisted once signed out — the stale-write path this PR fixes.

The race window itself is not covered; the failure needs a response to arrive inside a narrow window after sign-out, which the existing test harness cannot schedule. The follow-up PR covers the interleaving with a latch-based concurrency test.

[QA-8627]: https://dimagi.atlassian.net/browse/QA-8627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
