### PR TITLE
Adds back forget personal ID to Login and setup screens

### DIFF
--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -130,6 +130,7 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
     public static final int MENU_OFFLINE_INSTALL = Menu.FIRST;
     private static final int MENU_SMS = Menu.FIRST + 2;
     private static final int MENU_INSTALL_FROM_LIST = Menu.FIRST + 3;
+    private static final int MENU_PERSONAL_ID_FORGET = Menu.FIRST + 4;
 
     private static final int MENU_REFRESH_OPPORTUNITIES = Menu.FIRST + 5;
 
@@ -497,6 +498,7 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
         menuIdToAnalyticsParam = createMenuItemToAnalyticsParamMapping();
         menu.add(0, MENU_OFFLINE_INSTALL, 0, getString(R.string.menu_archive)).setIcon(android.R.drawable.ic_menu_upload);
         menu.add(0, MENU_INSTALL_FROM_LIST, 2, getString(R.string.menu_app_list_install));
+        menu.add(0, MENU_PERSONAL_ID_FORGET, 3, getString(R.string.personalid_profile_forget_account));
         menu.add(0, MENU_REFRESH_OPPORTUNITIES, 4, getString(R.string.connect_refresh_opportunities));
         return true;
     }
@@ -504,6 +506,10 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
+        MenuItem forgetItem = menu.findItem(MENU_PERSONAL_ID_FORGET);
+        if (forgetItem != null) {
+            forgetItem.setVisible(!fromManager && !fromExternal && PersonalIdManager.getInstance().isloggedIn());
+        }
         MenuItem refreshItem = menu.findItem(MENU_REFRESH_OPPORTUNITIES);
         if (refreshItem != null) {
             boolean showRefreshMenu = !fromExternal &&
@@ -639,6 +645,10 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
                 i = new Intent(getApplicationContext(), InstallFromListActivity.class);
                 startActivityForResult(i, GET_APPS_FROM_HQ);
                 break;
+            case MENU_PERSONAL_ID_FORGET:
+                PersonalIdManager.getInstance().forgetUser(AnalyticsParamValue.PERSONAL_ID_FORGOT_USER_SETUP_PAGE);
+                updateConnectButton();
+                break;
             case MENU_REFRESH_OPPORTUNITIES:
                 refreshOpportunities();
                 break;
@@ -651,7 +661,8 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
     private Map<Integer, String> createMenuItemToAnalyticsParamMapping() {
         return Map.of(
                 MENU_OFFLINE_INSTALL, AnalyticsParamValue.CC_SETUP_MENU_OFFLINE_INSTALL,
-                MENU_INSTALL_FROM_LIST, AnalyticsParamValue.CC_SETUP_MENU_INSTALL_FROM_LIST
+                MENU_INSTALL_FROM_LIST, AnalyticsParamValue.CC_SETUP_MENU_INSTALL_FROM_LIST,
+                MENU_PERSONAL_ID_FORGET, AnalyticsParamValue.CC_SETUP_MENU_PERSONAL_ID_FORGET
         );
     }
 

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -98,6 +98,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
     private static final int MENU_FORGOT_PIN = Menu.FIRST + 3;
     private static final int MENU_APP_MANAGER = Menu.FIRST + 4;
     private static final int MENU_PERSONAL_ID_SIGN_IN = Menu.FIRST + 5;
+    private static final int MENU_PERSONAL_ID_FORGET = Menu.FIRST + 6;
     public static final String NOTIFICATION_MESSAGE_LOGIN = "login_message";
     public static final String KEY_LAST_APP = "id-last-seated-app";
     public static final String KEY_ENTERED_USER = "entered-username";
@@ -669,6 +670,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         menu.add(0, MENU_FORGOT_PIN, 1, Localization.get("login.menu.password.mode"));
         menu.add(0, MENU_APP_MANAGER, 1, Localization.get("login.menu.app.manager"));
         menu.add(0, MENU_PERSONAL_ID_SIGN_IN, 1, getString(R.string.personalid_signup));
+        menu.add(0, MENU_PERSONAL_ID_FORGET, 1, getString(R.string.personalid_profile_forget_account));
         return true;
     }
 
@@ -679,6 +681,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         menu.findItem(MENU_FORGOT_PIN).setVisible(uiController.getLoginMode() == LoginMode.PIN);
         menu.findItem(MENU_PERSONAL_ID_SIGN_IN).setVisible(
                 !personalIdManager.isloggedIn() && personalIdManager.checkDeviceCompability());
+        menu.findItem(MENU_PERSONAL_ID_FORGET).setVisible(personalIdManager.isloggedIn());
         return true;
     }
 
@@ -713,6 +716,12 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
             case MENU_PERSONAL_ID_SIGN_IN:
                 registerPersonalIdUser();
                 return true;
+            case MENU_PERSONAL_ID_FORGET:
+                personalIdManager.forgetUser(AnalyticsParamValue.PERSONAL_ID_FORGOT_USER_LOGIN_PAGE);
+                uiController.setPasswordOrPin("");
+                setConnectAppState(Unmanaged);
+                uiController.refreshView();
+                return true;
             default:
                 return super.onOptionsItemSelected(item);
         }
@@ -725,7 +734,8 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
                 MENU_ACQUIRE_PERMISSIONS, AnalyticsParamValue.LOGIN_MENU_ACQUIRE_PERMISSIONS,
                 MENU_FORGOT_PIN, AnalyticsParamValue.LOGIN_MENU_FORGOT_PIN,
                 MENU_APP_MANAGER, AnalyticsParamValue.LOGIN_MENU_APP_MANAGER,
-                MENU_PERSONAL_ID_SIGN_IN, AnalyticsParamValue.LOGIN_MENU_PERSONAL_ID_SIGN_IN
+                MENU_PERSONAL_ID_SIGN_IN, AnalyticsParamValue.LOGIN_MENU_PERSONAL_ID_SIGN_IN,
+                MENU_PERSONAL_ID_FORGET, AnalyticsParamValue.LOGIN_MENU_PERSONAL_ID_FORGET
         );
     }
 

--- a/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
+++ b/app/src/org/commcare/google/services/analytics/AnalyticsParamValue.java
@@ -34,12 +34,15 @@ public class AnalyticsParamValue {
     public static final String ITEM_UPDATE_CC_PLATFORM = "update_commcare_platform";
     public static final String CC_SETUP_MENU_OFFLINE_INSTALL = "cc_setup_menu_offline_install";
     public static final String CC_SETUP_MENU_INSTALL_FROM_LIST = "cc_setup_menu_install_from_list";
+    public static final String CC_SETUP_MENU_PERSONAL_ID_FORGET =
+            "cc_setup_menu_personal_id_forget";
     public static final String LOGIN_MENU_PRACTICE_MODE = "login_menu_practice_mode";
     public static final String LOGIN_MENU_ABOUT_COMMCARE = "login_menu_about_commcare";
     public static final String LOGIN_MENU_ACQUIRE_PERMISSIONS = "login_menu_acquire_permissions";
     public static final String LOGIN_MENU_FORGOT_PIN = "login_menu_forgot_pin";
     public static final String LOGIN_MENU_APP_MANAGER = "login_menu_app_manager";
     public static final String LOGIN_MENU_PERSONAL_ID_SIGN_IN = "login_menu_personal_id_sign_in";
+    public static final String LOGIN_MENU_PERSONAL_ID_FORGET = "login_menu_personal_id_forget";
     public static final String CONNECT_MESSAGING_CHANNEL_MENU_UNSUBSCRIBE =
             "connect_messaging_channel_menu_unsubscribe";
     public static final String CONNECT_MESSAGING_CHANNEL_MENU_RESUBSCRIBE =
@@ -167,6 +170,10 @@ public class AnalyticsParamValue {
     public static final String USER_TRIGGERED = "user_triggered";
     public static final String SYSTEM_TRIGGERED = "system_triggered";
 
+    public static final String PERSONAL_ID_FORGOT_USER_LOGIN_PAGE =
+            "user_initiated_from_login_page";
+    public static final String PERSONAL_ID_FORGOT_USER_SETUP_PAGE =
+            "user_initiated_from_setup_page";
     public static final String PERSONAL_ID_FORGOT_USER_PROFILE_PAGE =
             "user_initiated_from_profile_page";
     public static final String PERSONAL_ID_FORGOT_USER_DB_ERROR = "global_connect_error";


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/QA-8636

Adds back the button to Forget Personal ID to Login And setup screens. This is done in order to facilitate signing out from Personal ID without user having to Unlock the Personal ID account. 

A long term fix here would be to make the "Forget Personal ID" in Manage Profile accessible without user having to do the Biometric Unlock. 

[Slack Thread](https://dimagi.slack.com/archives/C09J9M8RTJ5/p1786454704382779)


## Technical Summary

This mostly reverts [the commit here](https://github.com/dimagi/commcare-android/pull/3793/changes/9a91755cd112d1a93c43278a879d885d17cee071)

## Safety Assurance

### Safety story


Tested the Forget button at both places


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
