### PR TITLE
Log users out from CC app on forgetting PersonalID

### DIFF
--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -193,6 +193,7 @@ public class PersonalIdManager {
         ConnectReleaseTogglesWorker.Companion.cancelPeriodicFetch(CommCareApplication.instance());
         PersonalIdUnlocker.INSTANCE.resetSession();
         PersonalIdUserPreferences.clear();
+        CommCareApplication.instance().closeUserSession();
     }
 
     public AuthInfo.TokenAuth getConnectToken() {


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/QA-8637

Log user out of the current app when clicking the "Forget Personal ID" button on manage profile - 


https://github.com/user-attachments/assets/db1cdbc7-f43d-40fb-b8b7-adcdc348db17


[Slack Thread](https://dimagi.slack.com/archives/C09J9M8RTJ5/p1786561731190729)

## Technical Summary

Just close the user session on App Home. 

The fix doesn't try to see if the logged in app is managed by Personal ID which I think is a fine behaviour at the moment but can be improved upon if required in future. 


## Safety Assurance

### Safety story

Small change with existing usage , Tested locally, 


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
