### PR TITLE
Handle Connect DB Not Found Error

### DIFF
--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -588,6 +588,7 @@
     <string name="personalid_biometric_error_lockout_permanent">Demasiados intentos fallidos. Por favor, desbloquee su dispositivo e inténtelo de nuevo.</string>
     <string name="personalid_biometric_error_timeout">La operación biométrica ha expirado. Por favor, póngase en contacto con el soporte técnico si el problema persiste.</string>
     <string name="personalid_biometric_error_cannot_configure">No pudimos configurar los datos biométricos en su dispositivo. Por favor, póngase en contacto con el soporte técnico si el problema persiste.</string>
+    <string name="personalid_no_connect_database_error">No hay ninguna cuenta de PersonalID presente, por favor vuelva a iniciar sesión en su cuenta de PersonalID e inténtelo de nuevo.</string>
 
     <string name="connect_complete_by">La tarea termina el %s</string>
     <string name="connect_expired_on">La tarea terminó el %s</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -587,6 +587,7 @@ License.
     <string name="personalid_biometric_error_lockout_permanent">Trop de tentatives infructueuses. Veuillez déverrouiller votre appareil et réessayer.</string>
     <string name="personalid_biometric_error_timeout">L\'opération biométrique a expiré. Veuillez contacter le support client si le problème persiste.</string>
     <string name="personalid_biometric_error_cannot_configure">Nous n\'avons pas pu configurer la biométrie sur votre appareil. Veuillez contacter le support client si le problème persiste.</string>
+    <string name="personalid_no_connect_database_error">Aucun compte PersonalID n\'est présent, veuillez vous reconnecter à votre compte PersonalID et réessayer.</string>
 
     <string name="connect_complete_by">La tâche se termine le %s</string>
     <string name="connect_expired_on">La tâche s\'est terminée le %s</string>

--- a/app/res/values-ha/strings.xml
+++ b/app/res/values-ha/strings.xml
@@ -420,6 +420,7 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="personalid_biometric_error_lockout_permanent">Gwaje-gwaje da yawa sun gaza. Da fatan za a buɗe na\'urarka ka sake gwadawa.</string>
     <string name="personalid_biometric_error_timeout">Aikin biometric ya ƙare. Da fatan za a tuntuɓi tallafin abokin ciniki idan matsalar ta ci gaba.</string>
     <string name="personalid_biometric_error_cannot_configure">Ba za mu iya saita yanayin halittu a na\'urarka ba. Da fatan za a tuntuɓi tallafin abokin ciniki idan matsalar ta ci gaba.</string>
+    <string name="personalid_no_connect_database_error">Babu asusun PersonalID da ke nan, don Allah sake shiga asusunka na PersonalID kuma a sake gwadawa.</string>
     <string name="connect_complete_by">Aiki yana ƙarewa akan %s</string>
     <string name="connect_expired_on">Aiki ya ƙare a kan %s</string>
     <string name="connect_job_preview_start">Fara</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -584,6 +584,7 @@ License.
     <string name="personalid_biometric_error_lockout_permanent">बहुत अधिक असफल प्रयास। कृपया अपने डिवाइस को अनलॉक करें और पुनः प्रयास करें।</string>
     <string name="personalid_biometric_error_timeout">बायोमेट्रिक ऑपरेशन का समय समाप्त हो गया। यदि समस्या बनी रहती है तो कृपया ग्राहक सहायता से संपर्क करें।</string>
     <string name="personalid_biometric_error_cannot_configure">हम आपके डिवाइस पर बायोमेट्रिक्स कॉन्फ़िगर नहीं कर सके। यदि समस्या बनी रहती है तो कृपया ग्राहक सहायता से संपर्क करें।</string>
+    <string name="personalid_no_connect_database_error">कोई PersonalID खाता मौजूद नहीं है, कृपया अपने PersonalID खाते में फिर से लॉगिन करें और पुनः प्रयास करें।</string>
 
     <string name="connect_complete_by">कार्य %s को समाप्त होती है</string>
     <string name="connect_expired_on">कार्य %s को समाप्त हुई</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -237,6 +237,7 @@
     <string name="personalid_biometric_error_lockout_permanent">Per daug nepavykusių bandymų. Atrakinkite įrenginį ir bandykite dar kartą.</string>
     <string name="personalid_biometric_error_timeout">Baigėsi biometrinės operacijos laikas. Jei problema išlieka, susisiekite su klientų aptarnavimo tarnyba.</string>
     <string name="personalid_biometric_error_cannot_configure">Nepavyko sukonfigūruoti biometrinių duomenų jūsų įrenginyje. Jei problema išlieka, susisiekite su klientų aptarnavimo tarnyba.</string>
+    <string name="personalid_no_connect_database_error">Nėra PersonalID paskyros, prašome iš naujo prisijungti prie savo PersonalID paskyros ir bandyti dar kartą.</string>
     <string name="personalid_work_history_no_records_available">Šiuo metu nėra jokių darbo įrašų. Spustelėkite atnaujinti arba patikrinkite vėliau.</string>
     <string name="pn_no_notification_available">Pranešimų nėra</string>
     <string name="connect_no_jobs">Jūs dar nebuvote pakviestas į jokias galimybes. Kai būsite pakviestas į galimybę, ji atsiras šiame sąraše.</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -227,7 +227,7 @@
     <string name="personalid_biometric_error_lockout_permanent">For mange mislykkede forsøk. Lås opp enheten og prøv igjen.</string>
     <string name="personalid_biometric_error_timeout">Biometrisk operasjon ble tidsavbrutt. Kontakt kundestøtte hvis problemet vedvarer.</string>
     <string name="personalid_biometric_error_cannot_configure">Vi kunne ikke konfigurere biometri på enheten din. Kontakt kundestøtte hvis problemet vedvarer.</string>
-    <string name="personalid_no_connect_database_error">Ingen PersonalID-konto er til stede, vennligst logg inn på nytt til PersonalID-kontoen din og prøv igjen.</string>
+    <string name="personalid_no_connect_database_error">Ingen PersonalID-konto er til stede. Logg inn på PersonalID-kontoen din på nytt, og prøv igjen.</string>
     <string name="personalid_work_history_no_records_available">Ingen arbeidslogger er tilgjengelige for øyeblikket. Klikk på Oppdater, eller kom tilbake senere.</string>
     <string name="pn_no_notification_available">Ingen varsler tilgjengelig</string>
     <string name="connect_no_jobs">Du har ikke blitt invitert til noen muligheter ennå. Når du har blitt invitert til en mulighet, vil den vises i denne listen.</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -227,6 +227,7 @@
     <string name="personalid_biometric_error_lockout_permanent">For mange mislykkede forsøk. Lås opp enheten og prøv igjen.</string>
     <string name="personalid_biometric_error_timeout">Biometrisk operasjon ble tidsavbrutt. Kontakt kundestøtte hvis problemet vedvarer.</string>
     <string name="personalid_biometric_error_cannot_configure">Vi kunne ikke konfigurere biometri på enheten din. Kontakt kundestøtte hvis problemet vedvarer.</string>
+    <string name="personalid_no_connect_database_error">Ingen PersonalID-konto er til stede, vennligst logg inn på nytt til PersonalID-kontoen din og prøv igjen.</string>
     <string name="personalid_work_history_no_records_available">Ingen arbeidslogger er tilgjengelige for øyeblikket. Klikk på Oppdater, eller kom tilbake senere.</string>
     <string name="pn_no_notification_available">Ingen varsler tilgjengelig</string>
     <string name="connect_no_jobs">Du har ikke blitt invitert til noen muligheter ennå. Når du har blitt invitert til en mulighet, vil den vises i denne listen.</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -593,6 +593,7 @@
     <string name="personalid_biometric_error_lockout_permanent">Muitas tentativas falhadas. Por favor, desbloqueie o seu dispositivo e tente novamente.</string>
     <string name="personalid_biometric_error_timeout">A operação biométrica expirou. Por favor, contacte o apoio ao cliente se o problema persistir.</string>
     <string name="personalid_biometric_error_cannot_configure">Não foi possível configurar a biometria no seu dispositivo. Por favor, contacte o apoio ao cliente se o problema persistir.</string>
+    <string name="personalid_no_connect_database_error">Nenhuma conta PersonalID está presente, por favor volte a iniciar sessão na sua conta PersonalID e tente novamente.</string>
 
     <string name="connect_complete_by">A tarefa termina em %s</string>
     <string name="connect_expired_on">A tarefa terminou em %s</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -592,6 +592,7 @@
     <string name="personalid_biometric_error_lockout_permanent">Majaribio mengi mno yameshindikana. Tafadhali fungua kifaa chako na ujaribu tena.</string>
     <string name="personalid_biometric_error_timeout">Muda wa utendakazi wa kibayometri umekwisha. Tafadhali wasiliana na usaidizi kwa wateja ikiwa tatizo litaendelea.</string>
     <string name="personalid_biometric_error_cannot_configure">Hatukuweza kusanidi bayometriki kwenye kifaa chako. Tafadhali wasiliana na usaidizi kwa wateja ikiwa tatizo litaendelea.</string>
+    <string name="personalid_no_connect_database_error">Hakuna akaunti ya PersonalID iliyopo, tafadhali ingia tena katika akaunti yako ya PersonalID na ujaribu tena.</string>
 
     <string name="connect_complete_by">Kazi inaisha tarehe %s</string>
     <string name="connect_expired_on">Kazi iliisha tarehe %s</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -576,6 +576,7 @@
     <string name="personalid_biometric_error_lockout_permanent">በዝሒ ዝፈሸለ ፈተነታት። በጃኻ ንመሳርሒኻ ክፈቶ እሞ እንደገና ፈትን።</string>
     <string name="personalid_biometric_error_timeout">ናይ ባዮሜትሪክ ኦፕሬሽን ግዜኡ ተወዲኡ። እቲ ጸገም እንተቀጺሉ በጃኻ ንደገፍ ዓማዊል ተወከስ።</string>
     <string name="personalid_biometric_error_cannot_configure">ኣብ መሳርሒኻ ባዮሜትሪክ ክንቃኔ ኣይከኣልናን። እቲ ጸገም እንተቀጺሉ በጃኻ ንደገፍ ዓማዊል ተወከስ።</string>
+    <string name="personalid_no_connect_database_error">ናይ PersonalID ሕሳብ የለን፣ በጃኻ ናብ ናይ PersonalID ሕሳብካ እንደገና እቶ ከምኡ\'ውን እንደገና ፈትን።</string>
 
     <string name="connect_complete_by">ዕዮ ኣብ %s ይወዳእ</string>
     <string name="connect_expired_on">ዕዮ ኣብ %s ተወዲኡ</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -843,6 +843,7 @@
     <string name="personalid_biometric_error_lockout_permanent">Too many failed attempts. Please unlock your device and try again.</string>
     <string name="personalid_biometric_error_timeout">Biometric operation timed out. Please contact customer support if the problem persists.</string>
     <string name="personalid_biometric_error_cannot_configure">We couldn’t configure biometrics on your device. Please contact customer support if the problem persists.</string>
+    <string name="personalid_no_connect_database_error">No PersonalID account present, please re-login into your PersonalID account and try again.</string>
 
     <string name="connect_complete_by">Task ends on %s</string>
     <string name="connect_expired_on">Task ended on %s</string>

--- a/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
@@ -53,10 +53,16 @@ public class ConnectDatabaseHelper {
                         try {
                             connectDatabase = CommCareApplication.instance().getConnectDbOpenHelper(context);
                         } catch (Exception e) {
-                            //Flag the DB as broken if we hit an error opening it (usually means corrupted or bad encryption)
-                            dbBroken = true;
-                            Logger.exception("Error opening Connect DB", e);
-                            GlobalErrorUtil.triggerGlobalError(GlobalErrors.PERSONALID_GENERIC_ERROR);
+                            if (!dbExists()) {
+                                ConnectDatabaseNotFoundException dbNotFound = new ConnectDatabaseNotFoundException();
+                                Logger.exception("Error opening Connect DB", dbNotFound);
+                                throw dbNotFound;
+                            } else {
+                                //Flag the DB as broken if we hit an error opening it (usually means corrupted or bad encryption)
+                                dbBroken = true;
+                                Logger.exception("Error opening Connect DB", e);
+                                GlobalErrorUtil.triggerGlobalError(GlobalErrors.PERSONALID_GENERIC_ERROR);
+                            }
                         }
                     }
                     return connectDatabase;

--- a/app/src/org/commcare/connect/database/ConnectDatabaseNotFoundException.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseNotFoundException.java
@@ -1,0 +1,10 @@
+package org.commcare.connect.database;
+
+/**
+ * Exception thrown when the Connect database file does not exist.
+ */
+public class ConnectDatabaseNotFoundException extends RuntimeException {
+    public ConnectDatabaseNotFoundException() {
+        super("Connect database file does not exist");
+    }
+}

--- a/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 public class ConnectDatabaseUtils {
     // the value of the key should not be renamed due to backward compatibility
     private static final String SECRET_NAME = "secret";
-    public static void storeConnectDbPassphrase(@NotNull Context context, byte[] passphrase) {
+    private static void storeConnectDbPassphrase(@NotNull Context context, byte[] passphrase) {
         try {
             if (passphrase == null || passphrase.length == 0) {
                 throw new IllegalArgumentException("Passphrase must not be null or empty");

--- a/app/src/org/commcare/connect/network/IApiCallback.java
+++ b/app/src/org/commcare/connect/network/IApiCallback.java
@@ -14,4 +14,5 @@ public interface IApiCallback {
     void processOldApiError();
     void processTokenUnavailableError();
     void processTokenRequestDeniedError();
+    void noConnectDatabaseError();
 }

--- a/app/src/org/commcare/connect/network/PersonalIdOrConnectApiErrorHandler.java
+++ b/app/src/org/commcare/connect/network/PersonalIdOrConnectApiErrorHandler.java
@@ -67,6 +67,8 @@ public class PersonalIdOrConnectApiErrorHandler {
                 return context.getString(R.string.personalid_network_response_parsing_error);
             case EMAIL_ALREADY_IN_USE_ERROR:
                 return context.getString(R.string.personalid_email_already_in_use);
+            case NO_CONNECT_DATABASE_ERROR:
+                return context.getString(R.string.personalid_no_connect_database_error);
             default:
                 if (t != null) {
                     Logger.exception("Unhandled throwable passed with API error code: " + errorCode, t);

--- a/app/src/org/commcare/connect/network/base/BaseApi.kt
+++ b/app/src/org/commcare/connect/network/base/BaseApi.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import okhttp3.ResponseBody
 import org.commcare.activities.CommCareActivity
 import org.commcare.connect.ConnectConstants
+import org.commcare.connect.database.ConnectDatabaseNotFoundException
 import org.commcare.connect.network.IApiCallback
 import org.commcare.connect.network.NetworkUtils
 import org.commcare.connect.network.NetworkUtils.getErrorCodes
@@ -43,6 +44,8 @@ class BaseApi {
                                 Logger.exception("Error reading response stream", e)
                                 // Handle error when reading the stream
                                 callback.processFailure(response.code(), endPoint, "", e)
+                            } catch (_: ConnectDatabaseNotFoundException){
+                                callback.noConnectDatabaseError()
                             }
                         } else {
                             val stream =

--- a/app/src/org/commcare/connect/network/base/BaseApiCallback.kt
+++ b/app/src/org/commcare/connect/network/base/BaseApiCallback.kt
@@ -98,4 +98,11 @@ abstract class BaseApiCallback<T>(
             null,
         )
     }
+
+    override fun noConnectDatabaseError() {
+        baseApiHandler.stopLoadingAndInformError(
+            PersonalIdOrConnectApiErrorCodes.NO_CONNECT_DATABASE_ERROR,
+            null,
+        )
+    }
 }

--- a/app/src/org/commcare/connect/network/base/BaseApiHandler.kt
+++ b/app/src/org/commcare/connect/network/base/BaseApiHandler.kt
@@ -109,6 +109,10 @@ abstract class BaseApiHandler<T>(
         // The verified email is already tied to another active account.
         EMAIL_ALREADY_IN_USE_ERROR,
 
+        //  We were not able to find any existing database for the user locally
+        // Can typically happen if another process or user cleaned up their account from the phone.
+        NO_CONNECT_DATABASE_ERROR,
+
         ;
 
         fun shouldAllowRetry(): Boolean =


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/QA-8627

## Technical Summary

Decided to do an alternate implementation on https://github.com/dimagi/commcare-android/pull/3860 to save time with PR reviews. 

The main change here is that we are explicitly checking for DB file existance before trying to access the DB and throwing a dedicated exception for different callers to helper. This error message doesn't really end up showing in my testing given the calls that were happening at the time of Forget were all background calls with no mechanism to show error on UI. 

## Safety Assurance

### Safety story

- Tested the Forget flow a few times and could not reproduce the issue anymore. 
- Think the biggest risk here is if there is a code bug that ends up deleting the DB, we won't crash hard but ask user to sign in again. 


### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
