### PR TITLE
Bump targetSdk to Android 16 and compileSdk to Android 17

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -261,7 +261,7 @@ static def getDate() {
 
 android {
     namespace 'org.commcare.dalvik'
-    compileSdk 36
+    compileSdk 37
     packagingOptions {
         resources {
             excludes += ['META-INF/LICENSE', 'META-INF/LICENSE.txt', 'META-INF/DEPENDENCIES', 'META-INF/NOTICE', 'META-INF/NOTICE.txt']

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -282,7 +282,7 @@ android {
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 35
+        targetSdk 36
 
         applicationId 'org.commcare.dalvik'
         testNamespace 'org.commcare.dalvik.test'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'androidx.exifinterface:exifinterface:1.3.6'
     implementation 'com.google.android.play:integrity:1.6.0'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation('org.robolectric:robolectric:4.8.2') {
+    testImplementation('org.robolectric:robolectric:4.16.1') {
         exclude(group: 'org.bouncycastle', module: 'bcprov-jdk15on')
     }
     testImplementation 'androidx.test:core:1.6.1'

--- a/app/unit-tests/src/org/commcare/activities/camera/CameraOverlayActivityTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/camera/CameraOverlayActivityTest.kt
@@ -1,6 +1,7 @@
 package org.commcare.activities.camera
 
 import android.app.Activity
+import android.content.Context
 import android.net.Uri
 import android.view.View
 import android.widget.ImageView
@@ -14,6 +15,7 @@ import org.commcare.utils.StringUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -25,11 +27,18 @@ import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowToast
+import java.io.ByteArrayOutputStream
 
 @Config(application = CommCareTestApplication::class)
 @RunWith(AndroidJUnit4::class)
 class CameraOverlayActivityTest {
     private val outputUri = "content://org.commcare.dalvik.fileprovider/external/output.jpg"
+
+    @Before
+    fun registerOutputStream() {
+        shadowOf(ApplicationProvider.getApplicationContext<Context>().contentResolver)
+            .registerOutputStreamSupplier(Uri.parse(outputUri)) { ByteArrayOutputStream() }
+    }
 
     private fun buildActivity(withOutputUri: Boolean = true): CameraOverlayActivity {
         val builder =

--- a/app/unit-tests/src/org/commcare/utils/FileUtilTest.kt
+++ b/app/unit-tests/src/org/commcare/utils/FileUtilTest.kt
@@ -38,7 +38,7 @@ class FileUtilTest {
 
         // Unfortunately, MimeTypeMap.getSingleton() inside FileUtils returns a shadow implementation
         // And I'm not sure how to make robolectric use the actual implementation rather than a shadow.
-        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("jpg", "image/jpeg")
+        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypeMapping("jpg", "image/jpeg")
     }
 
     @Test


### PR DESCRIPTION
## Product Description

This PR bumps targetSdk to 36 and compileSdk to 37. Two additional changes were required to support this:
- Bump Robolectric to 4.16.1  - Android 17 removes the android.hardware.fingerprint package. Up to Robolectric 4.16, the shadow class for `FingerprintManager` still references this package, so compilation fails once `compileSdk` is set to `37` and the class can no longer be resolved. Robolectric 4.16.1 excludes this shadow from the generated accessors, so the removed class is never referenced.
- Register an output stream in camera capture tests - from Robolectric 4.10, ContentResolver calls are delegated to the real implementation unless a stream is explicitly registered for the URI, it was a no-op in previous version. Our camera capture tests use a `FileProvider` authority that has no backing provider during tests, so without a registered stream these calls now fail instead of being shadowed.

## Technical Summary
No new user-facing functionality. The user-visible effect is indirect but real: raising `targetSdk` to 36 opts the whole app into Android 16 runtime behaviour changes instead of the compatibility defaults it has been running under. Areas Android 16 changes that CommCare touches:

- Edge-to-edge enforcement — screens that assume the system handles insets for them can render content under the status or navigation bar - Implemented.
- Adaptive layouts on large screens — orientation, resizability, and aspect ratio restrictions are ignored on displays ≥600dp. Addressed in separate PRs.
- Predictive back — `onBackPressed()`/KEYCODE_BACK no longer fire by default - Opted out temporary, migration tracked separately.
- Scheduled job behavior — `ScheduledExecutorService#scheduleAtFixedRate` now replays at most one missed execution instead of all missed executions - used by `AbstractUniversalDateWidget` to handle continuous date increment/decrement while the user long-presses the control. The change doesn't impact the widgets behavior.

## Safety Assurance

### Safety story

- Local smoke testing was successful, as well as instrumentation and unit tests after the Robolectric upgrade.
These changes will next go through regression testing to verify no regressions were introduced.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
