### PR TITLE
Disable PersonalId Signup for devices more than sw 600dp

### DIFF
--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -642,7 +642,8 @@ public class PersonalIdManager {
     }
 
     public boolean checkDeviceCompability() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.P;
+        int smallestWidthDp = CommCareApplication.instance().getResources().getConfiguration().smallestScreenWidthDp;
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && smallestWidthDp < 600;
     }
 
     public int getFailureAttempt() {

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -82,6 +82,7 @@ public class PersonalIdManager {
     private static final long PERIODICITY_FOR_HEARTBEAT_IN_HOURS = 4;
     private static final long BACKOFF_DELAY_FOR_HEARTBEAT_RETRY = 5 * 60 * 1000L; // 5 mins
     private static final String CONNECT_HEARTBEAT_REQUEST_NAME = "connect_hearbeat_periodic_request";
+    private static final int MAX_SCREEN_WIDTH_DP_FOR_PERSONAL_ID = 600;
     private BiometricManager biometricManager;
 
     private static volatile PersonalIdManager manager = null;
@@ -643,7 +644,7 @@ public class PersonalIdManager {
 
     public boolean checkDeviceCompability() {
         int smallestWidthDp = CommCareApplication.instance().getResources().getConfiguration().smallestScreenWidthDp;
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && smallestWidthDp < 600;
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && smallestWidthDp < MAX_SCREEN_WIDTH_DP_FOR_PERSONAL_ID;
     }
 
     public int getFailureAttempt() {

--- a/app/unit-tests/src/org/commcare/connect/PersonalIDCompatibilityTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/PersonalIDCompatibilityTest.kt
@@ -1,0 +1,46 @@
+package org.commcare.connect
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.commcare.CommCareTestApplication
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class PersonalIDCompatibilityTest {
+    private val manager = PersonalIdManager.getInstance()
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P], qualifiers = "sw360dp")
+    fun `phone width below 600dp is compatible on API 28+`() {
+        assertTrue(manager.checkDeviceCompability())
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P], qualifiers = "sw599dp")
+    fun `width at 599dp is compatible on API 28+`() {
+        assertTrue(manager.checkDeviceCompability())
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P], qualifiers = "sw600dp")
+    fun `width at exactly 600dp is not compatible`() {
+        assertFalse(manager.checkDeviceCompability())
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P], qualifiers = "sw720dp")
+    fun `tablet width above 600dp is not compatible`() {
+        assertFalse(manager.checkDeviceCompability())
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O], qualifiers = "sw360dp")
+    fun `API below 28 is not compatible regardless of screen width`() {
+        assertFalse(manager.checkDeviceCompability())
+    }
+}


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CCCT-2755


## Safety Assurance

### Safety story

Unit Tests should be sufficient here. 


## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
