### PR TITLE
CCCT-2776 Fix Null Pin After Backup Code Account Recovery

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,14 @@
 This file is meant as an easy way for us to collate notes and change logs across releases. 
 -->
 
+## CommCare 2.64.1
+
+### Release Notes
+
+#### Important Bug Fixes
+
+- Fixed an issue where recovering a PersonalID account via backup code could result in the account being stored without a pin, causing authentication to fail after recovery.
+
 ## CommCare 2.63.5
 
 ### Release Notes

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.java
@@ -176,11 +176,10 @@ public class PersonalIdBackupCodeFragment extends BasePersonalIdFragment {
     private void handleBackupCodeSubmission() {
         FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(this.getClass().getSimpleName(), null,
                 PersonalIdWorkflow.CONFIGURATION);
+        personalIdSessionData.setBackupCode(binding.backupCodeView.getCodeValue());
         if (isRecovery) {
             confirmBackupCode();
         } else {
-            personalIdSessionData.setBackupCode(
-                    binding.backupCodeView.getCodeValue());
             if (ReleaseToggleHelper.INSTANCE.isEmailOtpVerificationActive(personalIdSessionData)) {
                 navigateToEmail();
             } else {

--- a/app/src/org/commcare/views/connect/NumericCodeView.java
+++ b/app/src/org/commcare/views/connect/NumericCodeView.java
@@ -55,7 +55,11 @@ public class NumericCodeView extends LinearLayout {
 
         // Read attributes from XML
         if (attrs != null) {
-            try (TypedArray typedArray = getContext().obtainStyledAttributes(attrs, R.styleable.NumericCodeView)) {
+            // Deliberately not try-with-resources: that needs TypedArray.close() (API 31), which leaves this
+            // view uninflatable under Robolectric's default SDK. recycle() is equivalent and available everywhere.
+            @SuppressWarnings("resource")
+            TypedArray typedArray = getContext().obtainStyledAttributes(attrs, R.styleable.NumericCodeView);
+            try {
                 digitCount = typedArray.getInt(R.styleable.NumericCodeView_codeViewDigitCount, digitCount);
                 borderColor = typedArray.getColor(R.styleable.NumericCodeView_codeViewBorderColor, borderColor);
                 errorBorderColor = typedArray.getColor(R.styleable.NumericCodeView_codeViewErrorBorderColor, errorBorderColor);
@@ -65,6 +69,8 @@ public class NumericCodeView extends LinearLayout {
                 errorTextColor = typedArray.getColor(R.styleable.NumericCodeView_codeViewErrorTextColor, errorTextColor);
                 textSize = typedArray.getDimension(R.styleable.NumericCodeView_codeViewTextSize, textSize);
                 passwordMode = typedArray.getBoolean(R.styleable.NumericCodeView_codeViewPasswordMode, false);
+            } finally {
+                typedArray.recycle();
             }
         }
 

--- a/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragmentTest.kt
@@ -1,0 +1,135 @@
+package org.commcare.fragments.personalId
+
+import android.view.KeyEvent
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.annotation.CallSuper
+import androidx.annotation.IdRes
+import com.google.android.material.button.MaterialButton
+import org.commcare.android.database.connect.models.ConnectReleaseToggleRecord
+import org.commcare.android.database.connect.models.PersonalIdSessionData
+import org.commcare.dalvik.R
+import org.commcare.views.connect.NumericCodeView
+import org.json.JSONObject
+import org.junit.After
+import org.robolectric.shadows.ShadowLooper
+
+abstract class BasePersonalIdBackupCodeFragmentTest : BasePersonalIdConfigurationTest<PersonalIdBackupCodeFragment>() {
+    protected lateinit var sessionData: PersonalIdSessionData
+
+    protected fun buildSessionData(
+        accountExists: Boolean = false,
+        photoBase64: String? = null,
+    ): PersonalIdSessionData =
+        PersonalIdSessionData(
+            requiredLock = PersonalIdSessionData.PIN,
+            demoUser = false,
+            token = TEST_SESSION_TOKEN,
+            accountExists = accountExists,
+            userName = TEST_USER_NAME,
+            phoneNumber = TEST_PHONE_NUMBER,
+            photoBase64 = photoBase64,
+        )
+
+    protected fun launchBackupCodeFragment(sessionData: PersonalIdSessionData = buildSessionData()) {
+        this.sessionData = sessionData
+        navigateToFragment(sessionData, R.id.personalid_backup_code)
+        activity.runOnUiThread {
+            installTestNavController(fragment.requireView(), R.id.personalid_backup_code)
+        }
+        ShadowLooper.idleMainLooper()
+    }
+
+    @After
+    @CallSuper
+    override fun tearDown() {
+        activityController.pause().stop().destroy()
+        super.tearDown()
+    }
+
+    // ========== Views ==========
+
+    protected val backupCodeView: NumericCodeView get() = findView(R.id.backup_code_view)
+
+    protected val confirmCodeView: NumericCodeView get() = findView(R.id.confirm_code_view)
+
+    protected val continueButton: MaterialButton get() = findView(R.id.connect_backup_code_button)
+
+    protected val errorMessage: TextView get() = findView(R.id.connect_backup_code_error_message)
+
+    protected val heading: TextView get() = findView(R.id.recovery_code_tilte)
+
+    protected val subtitle: TextView get() = findView(R.id.backup_code_subtitle)
+
+    protected val confirmCodeLabel: TextView get() = findView(R.id.confirm_code_label)
+
+    protected val confirmCodeLayout: View get() = findView(R.id.confirm_code_layout)
+
+    protected val welcomeBackLayout: View get() = findView(R.id.welcome_back_layout)
+
+    protected val welcomeBackText: TextView get() = findView(R.id.welcome_back)
+
+    protected val userPhoto: ImageView get() = findView(R.id.user_photo)
+
+    protected val backupCodeVisibilityToggle: ImageView get() = findView(R.id.backup_code_visibility_toggle)
+
+    protected val confirmCodeVisibilityToggle: ImageView get() = findView(R.id.confirm_code_visibility_toggle)
+
+    protected val notMeButton: TextView get() = findView(R.id.not_me_button)
+
+    private fun <T : View> findView(
+        @IdRes id: Int,
+    ): T = fragment.requireView().findViewById(id)
+
+    // ========== Interactions ==========
+
+    protected fun enterBackupCode(code: String) = enterCode(backupCodeView, code)
+
+    protected fun enterConfirmCode(code: String) = enterCode(confirmCodeView, code)
+
+    private fun enterCode(
+        codeView: NumericCodeView,
+        code: String,
+    ) {
+        activity.runOnUiThread { codeView.setCode(code) }
+        ShadowLooper.idleMainLooper()
+    }
+
+    /** Sends ENTER to the first digit box, which is where [NumericCodeView] hosts its key listener. */
+    protected fun pressEnterOnBackupCode() {
+        activity.runOnUiThread {
+            backupCodeView.getChildAt(0).dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+        }
+        ShadowLooper.idleMainLooper()
+    }
+
+    protected fun clickView(view: View) {
+        activity.runOnUiThread { view.performClick() }
+        ShadowLooper.idleMainLooper()
+    }
+
+    /**
+     * The fragment reads the toggle at submission time, so flipping it on the live session-data
+     * instance takes effect without relaunching the screen.
+     */
+    protected fun activateEmailOtpToggle() {
+        sessionData.featureReleaseToggles =
+            listOf(
+                ConnectReleaseToggleRecord.releaseToggleFromJson(
+                    EMAIL_OTP_VERIFICATION_SLUG,
+                    JSONObject().apply { put("active", true) },
+                ),
+            )
+    }
+
+    companion object {
+        const val TEST_SESSION_TOKEN: String = "test_session_token_abc"
+        const val TEST_USER_NAME: String = "Test User"
+        const val TEST_PHONE_NUMBER: String = "+11234567890"
+        const val TEST_BACKUP_CODE: String = "123456"
+
+        // Matches the slug ReleaseToggleHelper looks up for the email-OTP feature.
+        const val EMAIL_OTP_VERIFICATION_SLUG: String = "email_otp_verification"
+    }
+}

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentRecoveryTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentRecoveryTest.kt
@@ -163,8 +163,7 @@ class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmen
         assertEquals(TEST_PHONE_NUMBER, storedUser.primaryPhone)
         assertEquals(TEST_PHOTO_BASE64, storedUser.photo)
         assertEquals(PersonalIdSessionData.PIN, storedUser.requiredLock)
-        // Recovery never writes the entered code onto the session data, so the stored record has no pin.
-        assertNull(storedUser.pin)
+        assertEquals(TEST_BACKUP_CODE, storedUser.pin)
 
         assertMessageDisplay(
             title = fragment.getString(R.string.connect_recovery_success_title),

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentRecoveryTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentRecoveryTest.kt
@@ -1,0 +1,328 @@
+package org.commcare.fragments.personalId
+
+import android.graphics.drawable.BitmapDrawable
+import android.util.Base64
+import android.view.View
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import okhttp3.mockwebserver.MockResponse
+import org.commcare.CommCareTestApplication
+import org.commcare.android.database.connect.models.ConnectUserRecord
+import org.commcare.android.database.connect.models.PersonalIdSessionData
+import org.commcare.connect.ConnectConstants
+import org.commcare.connect.database.ConnectDatabaseHelper
+import org.commcare.connect.database.ConnectUserDatabaseUtil
+import org.commcare.dalvik.R
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Tests [PersonalIdBackupCodeFragment] in account recovery mode.
+ */
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmentTest() {
+    private lateinit var connectDatabaseHelperMock: MockedStatic<ConnectDatabaseHelper>
+    private lateinit var connectUserDatabaseUtilMock: MockedStatic<ConnectUserDatabaseUtil>
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        launchBackupCodeFragment(buildSessionData(accountExists = true, photoBase64 = TEST_PHOTO_BASE64))
+        // Recovery success writes the account to the DB; stub those statics so no real storage is touched.
+        connectDatabaseHelperMock = Mockito.mockStatic(ConnectDatabaseHelper::class.java)
+        connectUserDatabaseUtilMock = Mockito.mockStatic(ConnectUserDatabaseUtil::class.java)
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        connectUserDatabaseUtilMock.close()
+        connectDatabaseHelperMock.close()
+    }
+
+    // ========== Initial State ==========
+
+    @Test
+    fun `screen uses the confirm-code title`() {
+        assertEquals(fragment.getString(R.string.connect_backup_code_title_confirm), activity.title.toString())
+    }
+
+    @Test
+    fun `heading and subtitle use the recovery copy`() {
+        assertEquals(
+            fragment.getString(R.string.connect_backup_code_message_title),
+            heading.text.toString(),
+        )
+        assertEquals(
+            fragment.getString(R.string.connect_backup_code_message),
+            subtitle.text.toString(),
+        )
+    }
+
+    @Test
+    fun `confirm code field is hidden in recovery mode`() {
+        assertEquals(View.GONE, confirmCodeLabel.visibility)
+        assertEquals(View.GONE, confirmCodeLayout.visibility)
+    }
+
+    @Test
+    fun `welcome back header greets the user by name`() {
+        assertEquals(View.VISIBLE, welcomeBackLayout.visibility)
+        assertEquals(
+            fragment.getString(R.string.personalid_welcome_back_msg, TEST_USER_NAME),
+            welcomeBackText.text.toString(),
+        )
+    }
+
+    @Test
+    fun `the session photo is rendered`() {
+        // The layout's android:src is a vector placeholder, so a BitmapDrawable can only have come
+        // from setImageBitmap(), and the shadow records the bytes the bitmap was decoded from.
+        val renderedPhoto = userPhoto.drawable as? BitmapDrawable
+        assertNotNull("Placeholder should be replaced by a decoded bitmap", renderedPhoto)
+        assertArrayEquals(
+            "Rendered bitmap should be decoded from the session's base64 photo",
+            Base64.decode(TEST_PHOTO_BASE64, Base64.DEFAULT),
+            shadowOf(renderedPhoto!!.bitmap).createdFromBytes,
+        )
+    }
+
+    @Test
+    fun `continue is disabled until the code is complete`() {
+        assertFalse("Continue should be disabled initially", continueButton.isEnabled)
+
+        enterBackupCode("12345")
+
+        assertFalse("Continue should stay disabled with fewer than 6 digits", continueButton.isEnabled)
+
+        enterBackupCode(TEST_BACKUP_CODE)
+
+        // A complete code enables continue and immediately auto-submits, which disables the button
+        // again for the duration of the request. Auto-submit is itself gated on the button being
+        // enabled, so the outgoing request is the observable proof that the complete code enabled it.
+        takeRequestOrFail()
+        assertFalse("Continue should be disabled while the auto-submitted request is in flight", continueButton.isEnabled)
+    }
+
+    // ========== Request ==========
+
+    @Test
+    fun `a complete code posts it to the confirm endpoint and disables continue while in flight`() {
+        // No response is enqueued so the request stays in flight, making the disabled assertion deterministic.
+        enterBackupCode(TEST_BACKUP_CODE)
+
+        val request = takeRequestOrFail()
+        assertEquals("/users/recover/confirm_backup_code", request.path)
+        assertEquals("POST", request.method)
+        assertEquals(TEST_BACKUP_CODE, JSONObject(request.body.readUtf8()).getString("recovery_pin"))
+
+        val authHeader = request.headers["Authorization"]
+        assertNotNull("Authorization header should be present", authHeader)
+        assertTrue(
+            "Authorization header should be a token-auth using the session token",
+            authHeader!!.contains(TEST_SESSION_TOKEN),
+        )
+
+        assertFalse("Continue should be disabled while the request is in flight", continueButton.isEnabled)
+    }
+
+    // ========== Success ==========
+
+    @Test
+    fun `a confirmed code stores the account and navigates to the recovery success screen`() {
+        mockWebServer.enqueue(successResponse())
+
+        enterBackupCode(TEST_BACKUP_CODE)
+        drainHttp()
+
+        connectDatabaseHelperMock.verify {
+            ConnectDatabaseHelper.handleReceivedDbPassphrase(Mockito.any(), Mockito.eq("test-db-key"))
+        }
+
+        val userCaptor = ArgumentCaptor.forClass(ConnectUserRecord::class.java)
+        connectUserDatabaseUtilMock.verify {
+            ConnectUserDatabaseUtil.storeUser(Mockito.any(), userCaptor.capture())
+        }
+        val storedUser = userCaptor.value
+        assertEquals(TEST_USER_NAME, storedUser.name)
+        assertEquals("test-personal-id", storedUser.userId)
+        assertEquals(TEST_PHONE_NUMBER, storedUser.primaryPhone)
+        assertEquals(TEST_PHOTO_BASE64, storedUser.photo)
+        assertEquals(PersonalIdSessionData.PIN, storedUser.requiredLock)
+        // Recovery never writes the entered code onto the session data, so the stored record has no pin.
+        assertNull(storedUser.pin)
+
+        assertMessageDisplay(
+            title = fragment.getString(R.string.connect_recovery_success_title),
+            message = fragment.getString(R.string.connect_recovery_success_message),
+            phase = ConnectConstants.PERSONALID_RECOVERY_SUCCESS,
+        )
+    }
+
+    @Test
+    fun `a confirmed code routes to the email screen when the toggle is active and no email is on file`() {
+        activateEmailOtpToggle()
+        mockWebServer.enqueue(successResponse())
+
+        enterBackupCode(TEST_BACKUP_CODE)
+        drainHttp()
+
+        assertEquals(R.id.personalid_email, navController.currentDestination?.id)
+        assertEquals(
+            EmailWorkFlow.RECOVERY,
+            navController
+                .backStack
+                .last()
+                .arguments
+                ?.getSerializable("workflow"),
+        )
+        connectUserDatabaseUtilMock.verifyNoInteractions()
+    }
+
+    @Test
+    fun `a confirmed code finalizes recovery when the server already has a verified email`() {
+        activateEmailOtpToggle()
+        mockWebServer.enqueue(successResponse(email = "user@example.com"))
+
+        enterBackupCode(TEST_BACKUP_CODE)
+        drainHttp()
+
+        connectUserDatabaseUtilMock.verify {
+            ConnectUserDatabaseUtil.storeUser(Mockito.any(), Mockito.any())
+        }
+        assertMessageDisplay(
+            title = fragment.getString(R.string.connect_recovery_success_title),
+            message = fragment.getString(R.string.connect_recovery_success_message),
+            phase = ConnectConstants.PERSONALID_RECOVERY_SUCCESS,
+        )
+    }
+
+    // ========== Failure ==========
+
+    @Test
+    fun `a wrong code clears the field and navigates to the wrong-code message`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("""{"attempts_left":2}"""))
+
+        enterBackupCode(TEST_BACKUP_CODE)
+        drainHttp()
+
+        assertTrue("Entered code should be cleared for the next attempt", backupCodeView.codeValue.isEmpty())
+        assertMessageDisplay(
+            title = fragment.getString(R.string.connect_backup_fail_title),
+            message = fragment.getString(R.string.personalid_wrong_backup_message, 2),
+            phase = ConnectConstants.PERSONALID_RECOVERY_WRONG_BACKUPCODE,
+        )
+        connectUserDatabaseUtilMock.verifyNoInteractions()
+    }
+
+    @Test
+    fun `a locked account navigates to the configuration-failed screen`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(400).setBody("""{"error_code":"LOCKED_ACCOUNT"}"""))
+
+        enterBackupCode(TEST_BACKUP_CODE)
+        drainHttp()
+
+        assertMessageDisplay(
+            title = fragment.getString(R.string.personalid_configuration_process_failed_title),
+            message = fragment.getString(R.string.personalid_configuration_locked_account),
+            phase = ConnectConstants.PERSONALID_DEVICE_CONFIGURATION_FAILED,
+        )
+    }
+
+    @Test
+    fun `a retryable failure shows the error and re-enables continue`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500).setBody("Internal Server Error"))
+
+        enterBackupCode(TEST_BACKUP_CODE)
+        drainHttp()
+
+        assertEquals(R.id.personalid_backup_code, navController.currentDestination?.id)
+        assertEquals(View.VISIBLE, errorMessage.visibility)
+        assertEquals(
+            fragment.getString(R.string.recovery_network_server_error),
+            errorMessage.text.toString(),
+        )
+        assertTrue("Continue should be re-enabled so the user can retry", continueButton.isEnabled)
+    }
+
+    @Test
+    fun `a non-retryable failure shows the error and leaves continue disabled`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(403).setBody("Forbidden"))
+
+        enterBackupCode(TEST_BACKUP_CODE)
+        drainHttp()
+
+        assertEquals(R.id.personalid_backup_code, navController.currentDestination?.id)
+        assertEquals(View.VISIBLE, errorMessage.visibility)
+        assertEquals(
+            fragment.getString(R.string.network_forbidden_error),
+            errorMessage.text.toString(),
+        )
+        assertFalse("Continue should stay disabled on a non-retryable failure", continueButton.isEnabled)
+    }
+
+    // ========== Mode Switch ==========
+
+    @Test
+    fun `not me switches the screen to set-code mode`() {
+        enterBackupCode("123")
+
+        assertEquals(View.GONE, notMeButton.visibility)
+        clickView(notMeButton)
+
+        assertEquals(false, sessionData.accountExists)
+        assertEquals(View.VISIBLE, confirmCodeLabel.visibility)
+        assertEquals(View.VISIBLE, confirmCodeLayout.visibility)
+        assertEquals(View.GONE, welcomeBackLayout.visibility)
+        assertEquals(
+            fragment.getString(R.string.connect_backup_code_remember, 6),
+            subtitle.text.toString(),
+        )
+        assertTrue("Entered code should be cleared when switching modes", backupCodeView.codeValue.isEmpty())
+    }
+
+    // ========== Helpers ==========
+
+    private fun successResponse(email: String? = null): MockResponse {
+        val body =
+            JSONObject().apply {
+                put("username", "test-personal-id")
+                put("db_key", "test-db-key")
+                put("password", "test-oauth-pwd")
+                if (email != null) put("email", email)
+            }
+        return MockResponse().setResponseCode(200).setBody(body.toString())
+    }
+
+    private fun assertMessageDisplay(
+        title: String,
+        message: String,
+        phase: Int,
+    ) {
+        assertEquals(R.id.personalid_message_display, navController.currentDestination?.id)
+        val args = navController.backStack.last().arguments
+        assertEquals(title, args?.getString("title"))
+        assertEquals(message, args?.getString("message"))
+        assertEquals(phase, args?.getInt("callingClass"))
+        assertEquals(false, args?.getBoolean("isCancellable"))
+    }
+
+    companion object {
+        // Base64 for "photo" — decodable so MediaUtil produces a bitmap.
+        private const val TEST_PHOTO_BASE64 = "cGhvdG8="
+    }
+}

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentTest.kt
@@ -1,0 +1,223 @@
+package org.commcare.fragments.personalId
+
+import android.view.View
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.commcare.CommCareTestApplication
+import org.commcare.dalvik.R
+import org.commcare.personalId.PersonalIdUserPreferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Tests [PersonalIdBackupCodeFragment] in account registration mode.
+ */
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class PersonalIdBackupCodeFragmentTest : BasePersonalIdBackupCodeFragmentTest() {
+    @Before
+    override fun setUp() {
+        super.setUp()
+        launchBackupCodeFragment()
+    }
+
+    // ========== Initial State ==========
+
+    @Test
+    fun `screen uses the set-code title`() {
+        assertEquals(fragment.getString(R.string.connect_backup_code_title_set), activity.title.toString())
+    }
+
+    @Test
+    fun `subtitle states the required code length`() {
+        assertEquals(
+            fragment.getString(R.string.connect_backup_code_remember, 6),
+            subtitle.text.toString(),
+        )
+    }
+
+    @Test
+    fun `confirm code field is shown in set mode`() {
+        assertEquals(View.VISIBLE, confirmCodeLabel.visibility)
+        assertEquals(View.VISIBLE, confirmCodeLayout.visibility)
+    }
+
+    @Test
+    fun `welcome back header is hidden in set mode`() {
+        assertEquals(View.GONE, welcomeBackLayout.visibility)
+    }
+
+    @Test
+    fun `both code fields start empty with continue disabled and no error`() {
+        assertTrue("Backup code should start empty", backupCodeView.codeValue.isEmpty())
+        assertTrue("Confirm code should start empty", confirmCodeView.codeValue.isEmpty())
+        assertFalse("Continue button should be disabled initially", continueButton.isEnabled)
+        assertEquals(View.GONE, errorMessage.visibility)
+    }
+
+    @Test
+    fun `codes are hidden by default`() {
+        assertFalse("Backup code should be masked initially", backupCodeView.isPasswordVisible)
+        assertFalse("Confirm code should be masked initially", confirmCodeView.isPasswordVisible)
+    }
+
+    // ========== Validation ==========
+
+    @Test
+    fun `a complete backup code alone keeps continue disabled and shows no error`() {
+        enterBackupCode(TEST_BACKUP_CODE)
+
+        assertFalse("Continue should stay disabled until the code is confirmed", continueButton.isEnabled)
+        assertEquals("Error should not be shown while the confirm code is incomplete", View.GONE, errorMessage.visibility)
+    }
+
+    @Test
+    fun `a partial backup code keeps continue disabled`() {
+        enterBackupCode("123")
+
+        assertFalse("Continue should stay disabled with fewer than 6 digits", continueButton.isEnabled)
+    }
+
+    @Test
+    fun `a complete but mismatched confirm code shows the mismatch error`() {
+        enterBackupCode(TEST_BACKUP_CODE)
+        enterConfirmCode("654321")
+
+        assertEquals(View.VISIBLE, errorMessage.visibility)
+        assertEquals(
+            fragment.getString(R.string.connect_backup_code_mismatch),
+            errorMessage.text.toString(),
+        )
+        assertFalse("Continue should stay disabled while the codes differ", continueButton.isEnabled)
+    }
+
+    @Test
+    fun `an incomplete confirm code does not show the mismatch error`() {
+        enterBackupCode(TEST_BACKUP_CODE)
+        enterConfirmCode("12")
+
+        assertEquals(View.GONE, errorMessage.visibility)
+        assertFalse(continueButton.isEnabled)
+    }
+
+    @Test
+    fun `shortening a mismatched confirm code clears the error`() {
+        enterBackupCode(TEST_BACKUP_CODE)
+        enterConfirmCode("654321")
+        assertEquals(View.VISIBLE, errorMessage.visibility)
+
+        enterConfirmCode("65432")
+
+        assertEquals(View.GONE, errorMessage.visibility)
+        assertEquals("", errorMessage.text.toString())
+    }
+
+    // ========== Submission ==========
+
+    @Test
+    fun `matching codes store the backup code and navigate to photo capture`() {
+        enterBackupCode(TEST_BACKUP_CODE)
+        enterConfirmCode(TEST_BACKUP_CODE)
+
+        assertEquals(TEST_BACKUP_CODE, sessionData.backupCode)
+        assertEquals(R.id.personalid_photo_capture, navController.currentDestination?.id)
+    }
+
+    @Test
+    fun `no email offer date is recorded when the email toggle is inactive`() {
+        enterBackupCode(TEST_BACKUP_CODE)
+        enterConfirmCode(TEST_BACKUP_CODE)
+
+        assertNull(PersonalIdUserPreferences.getLastEmailOfferDate())
+    }
+
+    @Test
+    fun `matching codes navigate to the email screen when the email toggle is active`() {
+        activateEmailOtpToggle()
+
+        enterBackupCode(TEST_BACKUP_CODE)
+        enterConfirmCode(TEST_BACKUP_CODE)
+
+        assertEquals(TEST_BACKUP_CODE, sessionData.backupCode)
+        assertEquals(R.id.personalid_email, navController.currentDestination?.id)
+        assertEquals(
+            EmailWorkFlow.REGISTRATION,
+            navController.backStack
+                .last()
+                .arguments
+                ?.getSerializable("workflow"),
+        )
+        assertNotNull(
+            "Navigating to the email screen should record the offer date",
+            PersonalIdUserPreferences.getLastEmailOfferDate(),
+        )
+    }
+
+    @Test
+    fun `tapping continue submits when the codes were completed out of order`() {
+        completeCodesWithoutAutoSubmit()
+
+        clickView(continueButton)
+
+        assertEquals(R.id.personalid_photo_capture, navController.currentDestination?.id)
+    }
+
+    @Test
+    fun `pressing enter submits when the codes were completed out of order`() {
+        completeCodesWithoutAutoSubmit()
+
+        pressEnterOnBackupCode()
+
+        assertEquals(R.id.personalid_photo_capture, navController.currentDestination?.id)
+    }
+
+    /**
+     * Filling the confirm field first leaves the screen valid but unsubmitted: the confirm field's
+     * completion listener runs while the button is still disabled, and the backup field's listener
+     * only auto-submits during recovery. That is the only state from which the continue button and
+     * the enter key are reachable in set mode.
+     */
+    private fun completeCodesWithoutAutoSubmit() {
+        enterConfirmCode(TEST_BACKUP_CODE)
+        enterBackupCode(TEST_BACKUP_CODE)
+
+        assertTrue("Continue should be enabled once both codes match", continueButton.isEnabled)
+        assertEquals(
+            "Codes should not have been submitted yet",
+            R.id.personalid_backup_code,
+            navController.currentDestination?.id,
+        )
+    }
+
+    // ========== Visibility Toggles ==========
+
+    @Test
+    fun `backup code visibility toggle flips only the backup code`() {
+        clickView(backupCodeVisibilityToggle)
+
+        assertTrue("Backup code should be revealed", backupCodeView.isPasswordVisible)
+        assertFalse("Confirm code should stay masked", confirmCodeView.isPasswordVisible)
+
+        clickView(backupCodeVisibilityToggle)
+
+        assertFalse("Backup code should be masked again", backupCodeView.isPasswordVisible)
+    }
+
+    @Test
+    fun `confirm code visibility toggle flips only the confirm code`() {
+        clickView(confirmCodeVisibilityToggle)
+
+        assertTrue("Confirm code should be revealed", confirmCodeView.isPasswordVisible)
+        assertFalse("Backup code should stay masked", backupCodeView.isPasswordVisible)
+
+        clickView(confirmCodeVisibilityToggle)
+
+        assertFalse("Confirm code should be masked again", confirmCodeView.isPasswordVisible)
+    }
+}


### PR DESCRIPTION
### [CCCT-2776](https://dimagi.atlassian.net/browse/CCCT-2776)

## Technical Summary

Bug Fix. Review commit by commit - 

[first commit](https://github.com/dimagi/commcare-android/pull/3877/changes/06e6ec7d1dbbdeeb35591f444d47c67b9f5c9396) is a port from master of existing tests around backup code to provide safety to this PR (exact copy from master, and doesn't need to be reviewed) 

[second commit](https://github.com/dimagi/commcare-android/pull/3877/changes/777edf19d037a0af82bf1300b44b4bc7983ef317) does the fix and corrects test for the same. 


## Safety Assurance

### Safety story

**Confidence:**

-  Confirmed locally that pin is now retained after recovery 

### Automated test coverage

Tests are part of the PR and fix

[CCCT-2776]: https://dimagi.atlassian.net/browse/CCCT-2776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ