### PR TITLE
SAAS-20177 - Support rotation in the audio recording dialog

### DIFF
--- a/app/res/layout-land/recording_fragment.xml
+++ b/app/res/layout-land/recording_fragment.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Landscape counterpart of layout/recording_fragment.xml. Same ids, laid out as two columns so the
+  record control and the text/actions sit side by side rather than stacking past the bottom of a
+  short screen.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:paddingStart="10dp"
+    android:paddingLeft="10dp"
+    android:paddingTop="10dp"
+    android:paddingEnd="10dp"
+    android:paddingRight="10dp"
+    android:paddingBottom="10dp"
+    tools:viewBindingIgnore="true">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/recording_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="10dp"
+            android:layout_toStartOf="@+id/discardrecording"
+            android:layout_toLeftOf="@+id/discardrecording"
+            android:textColor="@color/grey"
+            android:textSize="@dimen/text_medium" />
+
+        <ImageButton
+            android:id="@+id/discardrecording"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:background="@drawable/icon_close_darkwarm" />
+
+    </RelativeLayout>
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <FrameLayout
+            android:id="@+id/recording_layout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:paddingHorizontal="10dp">
+
+            <ImageButton
+                android:id="@+id/startrecording"
+                android:layout_width="@dimen/audio_recording_button_size"
+                android:layout_height="@dimen/audio_recording_button_size"
+                android:layout_gravity="center"
+                android:background="@drawable/record_start" />
+
+            <ProgressBar
+                android:id="@+id/demo_mpc"
+                android:layout_width="@dimen/audio_recording_progress_size"
+                android:layout_height="@dimen/audio_recording_progress_size"
+                android:layout_gravity="center"
+                android:indeterminateDrawable="@drawable/progress_bar"
+                android:indeterminateDuration="2000"
+                android:visibility="invisible" />
+
+        </FrameLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:paddingHorizontal="10dp">
+
+            <Chronometer
+                android:id="@+id/recording_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="@dimen/audio_recording_timer_text_size"
+                android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/recording_animation_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/standard_spacer_double"
+                android:drawableStart="@drawable/recording_dot"
+                android:drawablePadding="8dp"
+                android:text="@string/recording_in_progress"
+                android:textColor="@color/audio_recording_primary_color"
+                android:textSize="@dimen/text_large"
+                android:textStyle="bold"
+                android:visibility="invisible" />
+
+            <LinearLayout
+                android:id="@+id/recording_action_container"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:visibility="gone"
+                android:orientation="horizontal">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/negative_action_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="15dp"
+                    android:layout_marginLeft="15dp"
+                    android:layout_marginEnd="15dp"
+                    android:layout_marginRight="15dp"
+                    android:layout_marginBottom="10dp"
+                    android:gravity="center"
+                    android:padding="10dp"
+                    style="@style/NegativeButtonStyle"
+                    tools:text="Finish"
+                    android:visibility="gone" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/positive_action_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="15dp"
+                    android:layout_marginLeft="15dp"
+                    android:layout_marginEnd="15dp"
+                    android:layout_marginRight="15dp"
+                    android:layout_marginBottom="10dp"
+                    android:gravity="center"
+                    android:padding="10dp"
+                    android:text="@string/confirm_audio_file_deletion"
+                    android:visibility="gone" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/app/res/layout-land/recording_fragment.xml
+++ b/app/res/layout-land/recording_fragment.xml
@@ -4,141 +4,147 @@
   record control and the text/actions sit side by side rather than stacking past the bottom of a
   short screen.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:gravity="center_horizontal"
-    android:paddingStart="10dp"
-    android:paddingLeft="10dp"
-    android:paddingTop="10dp"
-    android:paddingEnd="10dp"
-    android:paddingRight="10dp"
-    android:paddingBottom="4dp"
     tools:viewBindingIgnore="true">
 
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <TextView
-            android:id="@+id/recording_header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentLeft="true"
-            android:layout_marginStart="10dp"
-            android:layout_marginEnd="10dp"
-            android:layout_toStartOf="@+id/discardrecording"
-            android:layout_toLeftOf="@+id/discardrecording"
-            android:textColor="@color/grey"
-            android:textSize="@dimen/audio_recording_header_text_size" />
-
-        <ImageButton
-            android:id="@+id/discardrecording"
-            android:layout_width="@dimen/audio_recording_close_button_size"
-            android:layout_height="@dimen/audio_recording_close_button_size"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:background="@drawable/icon_close_darkwarm" />
-
-    </RelativeLayout>
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:id="@+id/recording_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="vertical"
+        android:gravity="center_horizontal"
+        android:paddingStart="10dp"
+        android:paddingLeft="10dp"
+        android:paddingTop="10dp"
+        android:paddingEnd="10dp"
+        android:paddingRight="10dp"
+        android:paddingBottom="4dp">
 
-        <FrameLayout
-            android:id="@+id/recording_layout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:paddingHorizontal="10dp">
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/recording_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentLeft="true"
+                android:layout_marginStart="10dp"
+                android:layout_marginEnd="10dp"
+                android:layout_toStartOf="@+id/discardrecording"
+                android:layout_toLeftOf="@+id/discardrecording"
+                android:textColor="@color/grey"
+                android:textSize="@dimen/audio_recording_header_text_size" />
 
             <ImageButton
-                android:id="@+id/startrecording"
-                android:layout_width="@dimen/audio_recording_button_size"
-                android:layout_height="@dimen/audio_recording_button_size"
-                android:layout_gravity="center"
-                android:background="@drawable/record_start" />
+                android:id="@+id/discardrecording"
+                android:layout_width="@dimen/audio_recording_close_button_size"
+                android:layout_height="@dimen/audio_recording_close_button_size"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:background="@drawable/icon_close_darkwarm" />
 
-            <ProgressBar
-                android:id="@+id/demo_mpc"
-                android:layout_width="@dimen/audio_recording_progress_size"
-                android:layout_height="@dimen/audio_recording_progress_size"
-                android:layout_gravity="center"
-                android:indeterminateDrawable="@drawable/progress_bar"
-                android:indeterminateDuration="2000"
-                android:visibility="invisible" />
-
-        </FrameLayout>
-
+        </RelativeLayout>
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:gravity="center_horizontal"
-            android:orientation="vertical"
-            android:paddingHorizontal="10dp">
+            android:orientation="horizontal">
 
-            <Chronometer
-                android:id="@+id/recording_time"
+            <FrameLayout
+                android:id="@+id/recording_layout"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textSize="@dimen/audio_recording_timer_text_size"
-                android:visibility="gone" />
+                android:layout_gravity="center_vertical"
+                android:paddingHorizontal="10dp">
 
-            <TextView
-                android:id="@+id/recording_animation_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/standard_spacer_double"
-                android:drawableStart="@drawable/recording_dot"
-                android:drawablePadding="8dp"
-                android:text="@string/recording_in_progress"
-                android:textColor="@color/audio_recording_primary_color"
-                android:textSize="@dimen/text_large"
-                android:textStyle="bold"
-                android:visibility="invisible" />
+                <ImageButton
+                    android:id="@+id/startrecording"
+                    android:layout_width="@dimen/audio_recording_button_size"
+                    android:layout_height="@dimen/audio_recording_button_size"
+                    android:layout_gravity="center"
+                    android:background="@drawable/record_start" />
+
+                <ProgressBar
+                    android:id="@+id/demo_mpc"
+                    android:layout_width="@dimen/audio_recording_progress_size"
+                    android:layout_height="@dimen/audio_recording_progress_size"
+                    android:layout_gravity="center"
+                    android:indeterminateDrawable="@drawable/progress_bar"
+                    android:indeterminateDuration="2000"
+                    android:visibility="invisible" />
+
+            </FrameLayout>
 
             <LinearLayout
-                android:id="@+id/recording_action_container"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center"
-                android:visibility="gone"
-                android:orientation="horizontal">
+                android:layout_gravity="center_vertical"
+                android:gravity="center_horizontal"
+                android:orientation="vertical"
+                android:paddingHorizontal="10dp">
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/negative_action_button"
+                <Chronometer
+                    android:id="@+id/recording_time"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="15dp"
-                    android:layout_marginLeft="15dp"
-                    android:layout_marginEnd="15dp"
-                    android:layout_marginRight="15dp"
-                    android:layout_marginBottom="10dp"
-                    android:gravity="center"
-                    android:padding="10dp"
-                    style="@style/NegativeButtonStyle"
-                    tools:text="Finish"
+                    android:textSize="@dimen/audio_recording_timer_text_size"
                     android:visibility="gone" />
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/positive_action_button"
+                <TextView
+                    android:id="@+id/recording_animation_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="15dp"
-                    android:layout_marginLeft="15dp"
-                    android:layout_marginEnd="15dp"
-                    android:layout_marginRight="15dp"
-                    android:layout_marginBottom="10dp"
+                    android:layout_marginBottom="@dimen/standard_spacer_double"
+                    android:drawableStart="@drawable/recording_dot"
+                    android:drawablePadding="8dp"
+                    android:text="@string/recording_in_progress"
+                    android:textColor="@color/audio_recording_primary_color"
+                    android:textSize="@dimen/text_large"
+                    android:textStyle="bold"
+                    android:visibility="invisible" />
+
+                <LinearLayout
+                    android:id="@+id/recording_action_container"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:gravity="center"
-                    android:padding="10dp"
-                    android:text="@string/confirm_audio_file_deletion"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/negative_action_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="15dp"
+                        android:layout_marginLeft="15dp"
+                        android:layout_marginEnd="15dp"
+                        android:layout_marginRight="15dp"
+                        android:layout_marginBottom="10dp"
+                        android:gravity="center"
+                        android:padding="10dp"
+                        style="@style/NegativeButtonStyle"
+                        tools:text="Finish"
+                        android:visibility="gone" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/positive_action_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="15dp"
+                        android:layout_marginLeft="15dp"
+                        android:layout_marginEnd="15dp"
+                        android:layout_marginRight="15dp"
+                        android:layout_marginBottom="10dp"
+                        android:gravity="center"
+                        android:padding="10dp"
+                        android:text="@string/confirm_audio_file_deletion"
+                        android:visibility="gone" />
+                </LinearLayout>
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>
-</LinearLayout>
+</ScrollView>

--- a/app/res/layout-land/recording_fragment.xml
+++ b/app/res/layout-land/recording_fragment.xml
@@ -15,7 +15,7 @@
     android:paddingTop="10dp"
     android:paddingEnd="10dp"
     android:paddingRight="10dp"
-    android:paddingBottom="10dp"
+    android:paddingBottom="4dp"
     tools:viewBindingIgnore="true">
 
     <RelativeLayout
@@ -33,12 +33,12 @@
             android:layout_toStartOf="@+id/discardrecording"
             android:layout_toLeftOf="@+id/discardrecording"
             android:textColor="@color/grey"
-            android:textSize="@dimen/text_medium" />
+            android:textSize="@dimen/audio_recording_header_text_size" />
 
         <ImageButton
             android:id="@+id/discardrecording"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
+            android:layout_width="@dimen/audio_recording_close_button_size"
+            android:layout_height="@dimen/audio_recording_close_button_size"
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
             android:background="@drawable/icon_close_darkwarm" />

--- a/app/res/layout/audio_prototype.xml
+++ b/app/res/layout/audio_prototype.xml
@@ -125,8 +125,8 @@
 
             <ImageButton
                 android:id="@+id/capture_button"
-                android:layout_height="160dp"
-                android:layout_width="160dp"
+                android:layout_height="@dimen/audio_recording_button_size"
+                android:layout_width="@dimen/audio_recording_button_size"
                 android:layout_marginEnd="30dp"
                 android:layout_marginStart="30dp"
                 android:src="@drawable/record"
@@ -147,7 +147,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/standard_spacer_large"
             android:text="@string/start_recording"
-            android:textSize="@dimen/font_size_40"
+            android:textSize="@dimen/audio_recording_capture_label_text_size"
             android:textStyle="bold"
             android:textColor="@color/black"
             android:visibility="visible"/>

--- a/app/res/layout/recording_fragment.xml
+++ b/app/res/layout/recording_fragment.xml
@@ -1,122 +1,128 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:layout_gravity="center_horizontal"
-    android:gravity="center_horizontal"
-    android:orientation="vertical"
-    android:paddingStart="10dp"
-    android:paddingLeft="10dp"
-    android:paddingTop="10dp"
-    android:paddingEnd="10dp"
-    android:paddingRight="10dp"
-    android:paddingBottom="4dp"
+    android:layout_height="wrap_content"
     tools:viewBindingIgnore="true">
 
-    <RelativeLayout
+    <LinearLayout
+        android:id="@+id/recording_content"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingStart="10dp"
+        android:paddingLeft="10dp"
+        android:paddingTop="10dp"
+        android:paddingEnd="10dp"
+        android:paddingRight="10dp"
+        android:paddingBottom="4dp">
 
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/recording_header"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentLeft="true"
+                android:layout_margin="10dp"
+                android:textColor="@color/grey"
+                android:textSize="@dimen/audio_recording_header_text_size" />
+
+            <ImageButton
+                android:id="@+id/discardrecording"
+                android:layout_width="@dimen/audio_recording_close_button_size"
+                android:layout_height="@dimen/audio_recording_close_button_size"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:background="@drawable/icon_close_darkwarm" />
+
+        </RelativeLayout>
+
+        <FrameLayout
+            android:id="@+id/recording_layout"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_gravity="center"
+            android:layout_weight=".7">
+
+            <ImageButton
+                android:id="@+id/startrecording"
+                android:layout_width="@dimen/audio_recording_button_size"
+                android:layout_height="@dimen/audio_recording_button_size"
+                android:layout_gravity="center"
+                android:background="@drawable/record_start" />
+
+            <ProgressBar
+                android:id="@+id/demo_mpc"
+                android:layout_width="@dimen/audio_recording_progress_size"
+                android:layout_height="@dimen/audio_recording_progress_size"
+                android:layout_gravity="center"
+                android:indeterminateDrawable="@drawable/progress_bar"
+                android:indeterminateDuration="2000"
+                android:visibility="invisible" />
+
+        </FrameLayout>
+
+        <Chronometer
+            android:id="@+id/recording_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/audio_recording_timer_text_size"
+            android:visibility="gone"
+            android:layout_weight=".1"/>
         <TextView
-            android:id="@+id/recording_header"
+            android:id="@+id/recording_animation_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/standard_spacer_double"
+            android:textStyle="bold"
+            android:textColor="@color/audio_recording_primary_color"
+            android:text="@string/recording_in_progress"
+            android:drawableStart="@drawable/recording_dot"
+            android:textSize="@dimen/text_large"
+            android:drawablePadding="8dp"
+            android:visibility="invisible"/>
+
+        <LinearLayout
+            android:id="@+id/recording_action_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentLeft="true"
-            android:layout_margin="10dp"
-            android:textColor="@color/grey"
-            android:textSize="@dimen/audio_recording_header_text_size" />
-
-        <ImageButton
-            android:id="@+id/discardrecording"
-            android:layout_width="@dimen/audio_recording_close_button_size"
-            android:layout_height="@dimen/audio_recording_close_button_size"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:background="@drawable/icon_close_darkwarm" />
-
-    </RelativeLayout>
-
-    <FrameLayout
-        android:id="@+id/recording_layout"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_gravity="center"
-        android:layout_weight=".7">
-
-        <ImageButton
-            android:id="@+id/startrecording"
-            android:layout_width="@dimen/audio_recording_button_size"
-            android:layout_height="@dimen/audio_recording_button_size"
-            android:layout_gravity="center"
-            android:background="@drawable/record_start" />
-
-        <ProgressBar
-            android:id="@+id/demo_mpc"
-            android:layout_width="@dimen/audio_recording_progress_size"
-            android:layout_height="@dimen/audio_recording_progress_size"
-            android:layout_gravity="center"
-            android:indeterminateDrawable="@drawable/progress_bar"
-            android:indeterminateDuration="2000"
-            android:visibility="invisible" />
-
-    </FrameLayout>
-
-    <Chronometer
-        android:id="@+id/recording_time"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="@dimen/audio_recording_timer_text_size"
-        android:visibility="gone"
-        android:layout_weight=".1"/>
-    <TextView
-        android:id="@+id/recording_animation_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/standard_spacer_double"
-        android:textStyle="bold"
-        android:textColor="@color/audio_recording_primary_color"
-        android:text="@string/recording_in_progress"
-        android:drawableStart="@drawable/recording_dot"
-        android:textSize="@dimen/text_large"
-        android:drawablePadding="8dp"
-        android:visibility="invisible"/>
-
-    <LinearLayout
-        android:id="@+id/recording_action_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:visibility="gone">
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/negative_action_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="10dp"
-            android:layout_marginStart="15dp"
-            android:layout_marginLeft="15dp"
-            android:layout_marginEnd="15dp"
-            android:layout_marginRight="15dp"
-            android:layout_marginBottom="10dp"
             android:gravity="center"
-            tools:text="Finish"
-            style="@style/NegativeButtonStyle"
-            android:visibility="gone" />
+            android:visibility="gone">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/positive_action_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="10dp"
-            android:layout_marginStart="15dp"
-            android:layout_marginLeft="15dp"
-            android:layout_marginEnd="15dp"
-            android:layout_marginRight="15dp"
-            android:layout_marginBottom="10dp"
-            android:gravity="center"
-            android:text="@string/confirm_audio_file_deletion"
-            android:visibility="gone" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/negative_action_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="10dp"
+                android:layout_marginStart="15dp"
+                android:layout_marginLeft="15dp"
+                android:layout_marginEnd="15dp"
+                android:layout_marginRight="15dp"
+                android:layout_marginBottom="10dp"
+                android:gravity="center"
+                tools:text="Finish"
+                style="@style/NegativeButtonStyle"
+                android:visibility="gone" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/positive_action_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="10dp"
+                android:layout_marginStart="15dp"
+                android:layout_marginLeft="15dp"
+                android:layout_marginEnd="15dp"
+                android:layout_marginRight="15dp"
+                android:layout_marginBottom="10dp"
+                android:gravity="center"
+                android:text="@string/confirm_audio_file_deletion"
+                android:visibility="gone" />
+        </LinearLayout>
     </LinearLayout>
-</LinearLayout>
+</ScrollView>

--- a/app/res/layout/recording_fragment.xml
+++ b/app/res/layout/recording_fragment.xml
@@ -11,6 +11,7 @@
     android:paddingTop="10dp"
     android:paddingEnd="10dp"
     android:paddingRight="10dp"
+    android:paddingBottom="4dp"
     tools:viewBindingIgnore="true">
 
     <RelativeLayout
@@ -25,12 +26,12 @@
             android:layout_alignParentLeft="true"
             android:layout_margin="10dp"
             android:textColor="@color/grey"
-            android:textSize="@dimen/text_medium" />
+            android:textSize="@dimen/audio_recording_header_text_size" />
 
         <ImageButton
             android:id="@+id/discardrecording"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
+            android:layout_width="@dimen/audio_recording_close_button_size"
+            android:layout_height="@dimen/audio_recording_close_button_size"
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
             android:background="@drawable/icon_close_darkwarm" />

--- a/app/res/layout/recording_fragment.xml
+++ b/app/res/layout/recording_fragment.xml
@@ -46,15 +46,15 @@
 
         <ImageButton
             android:id="@+id/startrecording"
-            android:layout_width="160dp"
-            android:layout_height="160dp"
+            android:layout_width="@dimen/audio_recording_button_size"
+            android:layout_height="@dimen/audio_recording_button_size"
             android:layout_gravity="center"
             android:background="@drawable/record_start" />
 
         <ProgressBar
             android:id="@+id/demo_mpc"
-            android:layout_width="290dp"
-            android:layout_height="290dp"
+            android:layout_width="@dimen/audio_recording_progress_size"
+            android:layout_height="@dimen/audio_recording_progress_size"
             android:layout_gravity="center"
             android:indeterminateDrawable="@drawable/progress_bar"
             android:indeterminateDuration="2000"
@@ -66,7 +66,7 @@
         android:id="@+id/recording_time"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="@dimen/font_size_xxxxlarge"
+        android:textSize="@dimen/audio_recording_timer_text_size"
         android:visibility="gone"
         android:layout_weight=".1"/>
     <TextView

--- a/app/res/values-sw390dp/dimens.xml
+++ b/app/res/values-sw390dp/dimens.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="audio_recording_button_size">160dp</dimen>
+    <dimen name="audio_recording_progress_size">290dp</dimen>
+    <dimen name="audio_recording_timer_text_size">64sp</dimen>
+    <dimen name="audio_recording_dialog_max_width">600dp</dimen>
+    <dimen name="audio_recording_header_text_size">18sp</dimen>
+    <dimen name="audio_recording_capture_label_text_size">40sp</dimen>
+    <dimen name="audio_recording_close_button_size">50dp</dimen>
+</resources>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -58,7 +58,6 @@
     <dimen name="font_size_xlarge">21sp</dimen>
     <dimen name="font_size_xlarger">23sp</dimen>
     <dimen name="font_size_40">40sp</dimen>
-    <dimen name="font_size_xxxxlarge">64sp</dimen>
     <dimen name="font_size_dp_medium">15dp</dimen>
     <dimen name="font_size_dp_large">18dp</dimen>
     <dimen name="cell_padding_vertical">8dp</dimen>
@@ -148,4 +147,8 @@
     <dimen name="semi_circle_progress_stroke_width">14dp</dimen>
     <dimen name="semi_circle_progress_value_text_size">28sp</dimen>
     <dimen name="semi_circle_progress_description_text_size">16sp</dimen>
+
+    <dimen name="audio_recording_button_size">160dp</dimen>
+    <dimen name="audio_recording_progress_size">290dp</dimen>
+    <dimen name="audio_recording_timer_text_size">64sp</dimen>
 </resources>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -148,8 +148,11 @@
     <dimen name="semi_circle_progress_value_text_size">28sp</dimen>
     <dimen name="semi_circle_progress_description_text_size">16sp</dimen>
 
-    <dimen name="audio_recording_button_size">160dp</dimen>
-    <dimen name="audio_recording_progress_size">290dp</dimen>
-    <dimen name="audio_recording_timer_text_size">64sp</dimen>
-    <dimen name="audio_recording_dialog_max_width">600dp</dimen>
+    <dimen name="audio_recording_button_size">110dp</dimen>
+    <dimen name="audio_recording_progress_size">190dp</dimen>
+    <dimen name="audio_recording_timer_text_size">40sp</dimen>
+    <dimen name="audio_recording_dialog_max_width">420dp</dimen>
+    <dimen name="audio_recording_header_text_size">16sp</dimen>
+    <dimen name="audio_recording_capture_label_text_size">32sp</dimen>
+    <dimen name="audio_recording_close_button_size">40dp</dimen>
 </resources>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -151,4 +151,5 @@
     <dimen name="audio_recording_button_size">160dp</dimen>
     <dimen name="audio_recording_progress_size">290dp</dimen>
     <dimen name="audio_recording_timer_text_size">64sp</dimen>
+    <dimen name="audio_recording_dialog_max_width">600dp</dimen>
 </resources>

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -11,6 +11,7 @@ import android.media.MediaRecorder;
 import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
+import android.os.SystemClock;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -56,6 +57,14 @@ public class AudioRecordingService extends Service {
     private RecordingActionListener actionListener;
     private boolean pauseSupported;
 
+    /**
+     * Base for the elapsed recording time, in the {@link SystemClock#elapsedRealtime()} timebase and in
+     * the form a Chronometer expects: the recording has been running for
+     * {@code elapsedRealtime() - chronometerBase} ms. Pausing advances it by the length of the pause.
+     */
+    private long chronometerBase;
+    /** When elapsed time last stopped advancing, i.e. when the recording was paused or stopped. */
+    private long mLastStopTime;
     private RecordingState state = RecordingState.IDLE;
 
     /**
@@ -114,6 +123,7 @@ public class AudioRecordingService extends Service {
                     DeveloperPreferences.getAudioQualityProfile());
         }
         recorder.start();
+        chronometerBase = SystemClock.elapsedRealtime();
         state = RecordingState.RECORDING;
         // Re-post so the notification reflects pauseSupported, which is only known here (the
         // initial notification is built in onCreate, before this intent is delivered).
@@ -205,9 +215,31 @@ public class AudioRecordingService extends Service {
         return state;
     }
 
+    /**
+     * The value to hand to {@link android.widget.Chronometer#setBase(long)} so that it displays the
+     * elapsed recording time, excluding any time spent paused. Safe to call in any state; before the
+     * recording starts it reads as zero elapsed time.
+     */
+    public long getChronometerBase() {
+        switch (state) {
+            case IDLE:
+                return SystemClock.elapsedRealtime();
+            case PAUSED:
+            case STOPPED:
+                // Keep the display frozen at the moment elapsed time stopped advancing.
+                return chronometerBase + (SystemClock.elapsedRealtime() - mLastStopTime);
+            default:
+                return chronometerBase;
+        }
+    }
+
     @RequiresApi(api = Build.VERSION_CODES.N)
     public void pauseRecording() {
+        if (state != RecordingState.RECORDING) {
+            return;
+        }
         recorder.pause();
+        mLastStopTime = SystemClock.elapsedRealtime();
         state = RecordingState.PAUSED;
         notificationManager.notify(RECORDING_NOTIFICATION_ID,
                 createNotification(false));
@@ -216,12 +248,16 @@ public class AudioRecordingService extends Service {
     @RequiresApi(api = Build.VERSION_CODES.N)
     public void resumeRecording() {
         recorder.resume();
+        chronometerBase += SystemClock.elapsedRealtime() - mLastStopTime;
         state = RecordingState.RECORDING;
         notificationManager.notify(RECORDING_NOTIFICATION_ID,
                 createNotification(true));
     }
 
     public void stopRecording() {
+        if (state == RecordingState.RECORDING) {
+            mLastStopTime = SystemClock.elapsedRealtime();
+        }
         state = RecordingState.STOPPED;
         recorder.stop();
     }

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -65,6 +65,7 @@ public class AudioRecordingService extends Service {
     private long chronometerBase;
     /** When elapsed time last stopped advancing, i.e. when the recording was paused or stopped. */
     private long mLastStopTime;
+    private String fileName;
     private RecordingState state = RecordingState.IDLE;
 
     /**
@@ -116,7 +117,7 @@ public class AudioRecordingService extends Service {
             return START_NOT_STICKY;
         }
 
-        String fileName = intent.getExtras().getString(RECORDING_FILENAME_EXTRA_KEY);
+        fileName = intent.getExtras().getString(RECORDING_FILENAME_EXTRA_KEY);
         pauseSupported = intent.getBooleanExtra(PAUSE_SUPPORTED_EXTRA_KEY, false);
         if (recorder == null) {
             recorder = audioRecordingHelper.setupRecorder(fileName,
@@ -213,6 +214,10 @@ public class AudioRecordingService extends Service {
 
     public RecordingState getState() {
         return state;
+    }
+
+    public String getFileName() {
+        return fileName;
     }
 
     /**

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -55,6 +55,7 @@ public class AudioRecordingService extends Service {
     private NotificationManager notificationManager;
     private AudioRecordingHelper audioRecordingHelper = new AudioRecordingHelper();
     private RecordingActionListener actionListener;
+    private String pendingAction;
     private boolean pauseSupported;
 
     /**
@@ -80,6 +81,25 @@ public class AudioRecordingService extends Service {
 
     public void setRecordingActionListener(RecordingActionListener actionListener) {
         this.actionListener = actionListener;
+        if (actionListener != null && pendingAction != null) {
+            String action = pendingAction;
+            pendingAction = null;
+            dispatchAction(action);
+        }
+    }
+
+    private void dispatchAction(String action) {
+        if (actionListener == null) {
+            // Nothing is bound, which on a configuration change means the UI is mid-rebuild. Hold the
+            // action so it isn't lost, and replay it when the new UI binds.
+            pendingAction = action;
+            return;
+        }
+        switch (action) {
+            case ACTION_SAVE_RECORDING -> actionListener.onSaveRequested();
+            case ACTION_PAUSE_RECORDING -> actionListener.onPauseRequested();
+            case ACTION_RESUME_RECORDING -> actionListener.onResumeRequested();
+        }
     }
 
 
@@ -101,13 +121,7 @@ public class AudioRecordingService extends Service {
         // relay them to the bound fragment instead of (re)starting the recorder.
         String action = intent.getAction();
         if (action != null) {
-            if (actionListener != null) {
-                switch (action) {
-                    case ACTION_SAVE_RECORDING -> actionListener.onSaveRequested();
-                    case ACTION_PAUSE_RECORDING -> actionListener.onPauseRequested();
-                    case ACTION_RESUME_RECORDING -> actionListener.onResumeRequested();
-                }
-            }
+            dispatchAction(action);
             return START_NOT_STICKY;
         }
 

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -28,11 +28,22 @@ import static org.commcare.utils.NotificationIdentifiers.RECORDING_NOTIFICATION_
 /**
  * A foreground service intended to be bound to the RecordingFragment for managing audio recording
  * operations. Due to its persistent notification, the system treats it with higher importance, reducing the
- * likelihood of interruptions during recordings.
+ * likelihood of interruptions during recordings. This service owns the authoritative recording state.
  *
  * @author avazirna
  **/
 public class AudioRecordingService extends Service {
+
+    /**
+     * The lifecycle of a single recording session, from the service's point of view.
+     */
+    public enum RecordingState {
+        IDLE,
+        RECORDING,
+        PAUSED,
+        STOPPED
+    }
+
     private MediaRecorder recorder;
     private final IBinder binder = new AudioRecorderBinder();
     public static final String RECORDING_FILENAME_EXTRA_KEY = "recording-filename-extra-key";
@@ -44,6 +55,8 @@ public class AudioRecordingService extends Service {
     private AudioRecordingHelper audioRecordingHelper = new AudioRecordingHelper();
     private RecordingActionListener actionListener;
     private boolean pauseSupported;
+
+    private RecordingState state = RecordingState.IDLE;
 
     /**
      * Callback used to relay notification action button presses back to the bound
@@ -88,6 +101,12 @@ public class AudioRecordingService extends Service {
             return START_NOT_STICKY;
         }
 
+        // A rebinding UI or second start intent for a session that is already under way must not restart the
+        // recorder
+        if (state != RecordingState.IDLE) {
+            return START_NOT_STICKY;
+        }
+
         String fileName = intent.getExtras().getString(RECORDING_FILENAME_EXTRA_KEY);
         pauseSupported = intent.getBooleanExtra(PAUSE_SUPPORTED_EXTRA_KEY, false);
         if (recorder == null) {
@@ -95,6 +114,7 @@ public class AudioRecordingService extends Service {
                     DeveloperPreferences.getAudioQualityProfile());
         }
         recorder.start();
+        state = RecordingState.RECORDING;
         // Re-post so the notification reflects pauseSupported, which is only known here (the
         // initial notification is built in onCreate, before this intent is delivered).
         notificationManager.notify(RECORDING_NOTIFICATION_ID, createNotification(true));
@@ -108,10 +128,14 @@ public class AudioRecordingService extends Service {
     }
 
     private void resetRecorder() {
-        if (recorder != null) {
-            recorder.release();
-            recorder = null;
+        if (recorder == null) {
+            return;
         }
+        if (state == RecordingState.RECORDING || state == RecordingState.PAUSED) {
+            stopRecording();
+        }
+        recorder.release();
+        recorder = null;
     }
 
     private Notification createNotification(boolean recordingRunning) {
@@ -177,9 +201,14 @@ public class AudioRecordingService extends Service {
         return recorder != null;
     }
 
+    public RecordingState getState() {
+        return state;
+    }
+
     @RequiresApi(api = Build.VERSION_CODES.N)
     public void pauseRecording() {
         recorder.pause();
+        state = RecordingState.PAUSED;
         notificationManager.notify(RECORDING_NOTIFICATION_ID,
                 createNotification(false));
     }
@@ -187,11 +216,13 @@ public class AudioRecordingService extends Service {
     @RequiresApi(api = Build.VERSION_CODES.N)
     public void resumeRecording() {
         recorder.resume();
+        state = RecordingState.RECORDING;
         notificationManager.notify(RECORDING_NOTIFICATION_ID,
                 createNotification(true));
     }
 
     public void stopRecording() {
+        state = RecordingState.STOPPED;
         recorder.stop();
     }
 }

--- a/app/src/org/commcare/views/widgets/AudioRecordingService.java
+++ b/app/src/org/commcare/views/widgets/AudioRecordingService.java
@@ -261,4 +261,12 @@ public class AudioRecordingService extends Service {
         state = RecordingState.STOPPED;
         recorder.stop();
     }
+
+    /**
+     * Ends the session: finalizes the audio file and releases it. Only for terminal actions (save, discard,
+     * cancel) - a UI that is merely being torn down and recreated should unbind and leave the recording running.
+     */
+    public void finishAndRelease() {
+        resetRecorder();
+    }
 }

--- a/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
+++ b/app/src/org/commcare/views/widgets/CommCareAudioWidget.java
@@ -39,10 +39,12 @@ import java.util.TimerTask;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 
 import static android.Manifest.permission.RECORD_AUDIO;
 import static org.commcare.views.widgets.RecordingFragment.APPEARANCE_ATTR_ARG_KEY;
 import static org.commcare.views.widgets.RecordingFragment.AUDIO_FILE_PATH_ARG_KEY;
+import static org.commcare.views.widgets.RecordingFragment.RESULT_REQUEST_KEY_ARG_KEY;
 
 /**
  * An alternative audio widget that records and plays audio natively without
@@ -50,8 +52,7 @@ import static org.commcare.views.widgets.RecordingFragment.AUDIO_FILE_PATH_ARG_K
  *
  * @author Saumya Jain (sjain@dimagi.com)
  */
-public class CommCareAudioWidget extends AudioWidget
-        implements RecordingFragment.RecordingCompletionListener {
+public class CommCareAudioWidget extends AudioWidget {
 
     private LinearLayout layout;
     private ConstraintLayout playbackContainer;
@@ -65,6 +66,8 @@ public class CommCareAudioWidget extends AudioWidget
     private MediaPlayer player;
     private boolean showFileChooser;
     private static final String ACQUIRE_UPLOAD_FIELD = "acquire-or-upload";
+    private static final String RECORDER_FRAGMENT_TAG_PREFIX = "recorder-";
+    private static final String RECORDING_RESULT_REQUEST_KEY_PREFIX = "recording-result-";
     private ImageButton captureButton;
     private LinearLayout recordingContainer;
     private MaterialButton deleteAudio;
@@ -135,6 +138,12 @@ public class CommCareAudioWidget extends AudioWidget
 
         showFileChooser = ACQUIRE_UPLOAD_FIELD.equals(mPrompt.getAppearanceHint());
         chooseButton.setVisibility(showFileChooser ? VISIBLE : GONE);
+
+        listenForRecordingResult();
+        if (getSupportFragmentManager().findFragmentByTag(getRecorderFragmentTag()) != null) {
+            // Rebuilt while the recorder is still open, so re-apply the disable it was launched with.
+            setCaptureButtonEnabled(false);
+        }
     }
 
     @Override
@@ -189,19 +198,50 @@ public class CommCareAudioWidget extends AudioWidget
 
     private void launchAudioRecorder(FormEntryPrompt prompt) {
         RecordingFragment recorder = new RecordingFragment();
-        recorder.setListener(this);
         Bundle args = new Bundle();
         String sourceFilePath = getSourceFilePathToDisplay();
         if (!TextUtils.isEmpty(sourceFilePath)) {
             args.putString(AUDIO_FILE_PATH_ARG_KEY, sourceFilePath);
         }
         args.putString(APPEARANCE_ATTR_ARG_KEY, prompt.getAppearanceHint());
+        args.putString(RESULT_REQUEST_KEY_ARG_KEY, getRecordingResultRequestKey());
         recorder.setArguments(args);
-        recorder.show(((FragmentActivity)getContext()).getSupportFragmentManager(), "Recorder");
+        recorder.show(getSupportFragmentManager(), getRecorderFragmentTag());
     }
 
-    @Override
-    public void onRecordingCompletion(String audioFile) {
+    private String getRecorderFragmentTag() {
+        return RECORDER_FRAGMENT_TAG_PREFIX + mPrompt.getIndex().toString();
+    }
+
+    /**
+     * Keyed by form index so the result reaches this question rather than another audio widget on the
+     * same screen, and so that it still matches once the widget has been rebuilt.
+     */
+    private String getRecordingResultRequestKey() {
+        return RECORDING_RESULT_REQUEST_KEY_PREFIX + mPrompt.getIndex().toString();
+    }
+
+    private FragmentManager getSupportFragmentManager() {
+        return ((FragmentActivity)getContext()).getSupportFragmentManager();
+    }
+
+    /**
+     * Listens on the fragment manager rather than being handed to the dialog, so the result still
+     * arrives when this widget was rebuilt while the dialog was open.
+     */
+    private void listenForRecordingResult() {
+        getSupportFragmentManager().setFragmentResultListener(getRecordingResultRequestKey(),
+                (FragmentActivity)getContext(),
+                (requestKey, result) -> onRecordingResult(result));
+    }
+
+    private void onRecordingResult(Bundle result) {
+        String audioFile = result.getString(RecordingFragment.RESULT_AUDIO_FILE_PATH_KEY);
+        if (audioFile == null) {
+            // Dismissed without recording anything, so just undo the disable done on launch.
+            setCaptureButtonEnabled(true);
+            return;
+        }
         Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Saving recording: " + audioFile);
         if (new File(audioFile).exists()) {
             setBinaryData(audioFile);

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -279,13 +279,13 @@ public class RecordingFragment extends DialogFragment {
         } else {
             requireActivity().startService(serviceIntent);
         }
-        bindAudioRecordingService(serviceIntent);
+        bindAudioRecordingService(serviceIntent, Context.BIND_AUTO_CREATE);
     }
 
-    private void bindAudioRecordingService(Intent serviceIntent) {
-        requireActivity().bindService(serviceIntent, getAudioRecordingServiceConnection(),
-                Context.BIND_AUTO_CREATE);
+    private boolean bindAudioRecordingService(Intent serviceIntent, int flags) {
+        boolean bound = requireActivity().bindService(serviceIntent, getAudioRecordingServiceConnection(), flags);
         audioRecordingServiceBounded = true;
+        return bound;
     }
 
     /**
@@ -296,11 +296,7 @@ public class RecordingFragment extends DialogFragment {
      */
     private boolean rebindToRunningRecording() {
         Intent serviceIntent = new Intent(requireActivity(), AudioRecordingService.class);
-        boolean bound = requireActivity().bindService(serviceIntent,
-                getAudioRecordingServiceConnection(), 0);
-        // Unbinding is required even when the bind fails, so record that we asked.
-        audioRecordingServiceBounded = true;
-        return bound;
+        return bindAudioRecordingService(serviceIntent, 0);
     }
 
     /**

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -15,7 +15,6 @@ import android.media.AudioRecordingConfiguration;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.os.SystemClock;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -95,7 +94,6 @@ public class RecordingFragment extends DialogFragment {
     private Chronometer recordingDuration;
 
     private RecordingCompletionListener listener;
-    private long mLastStopTime;
     private boolean inPausedState = false;
     private boolean savedRecordingExists = false;
     private AudioManager.AudioRecordingCallback audioRecordingCallback;
@@ -283,7 +281,6 @@ public class RecordingFragment extends DialogFragment {
                     registerAudioRecordingConfigurationChangeCallback();
                 }
 
-                recordingDuration.setBase(SystemClock.elapsedRealtime());
                 recordingInProgress();
                 Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording started");
 
@@ -303,6 +300,7 @@ public class RecordingFragment extends DialogFragment {
     }
 
     private void recordingInProgress() {
+        recordingDuration.setBase(audioRecordingService.getChronometerBase());
         recordingDuration.start();
         if (isPauseSupported()) {
             toggleRecording.setBackgroundResource(R.drawable.pause);
@@ -347,10 +345,10 @@ public class RecordingFragment extends DialogFragment {
     private void pauseRecording(boolean pausedByUser) {
         Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording pausing");
         inPausedState = true;
-        recordingDuration.stop();
-        chronoPause();
-
         audioRecordingService.pauseRecording();
+
+        recordingDuration.stop();
+        recordingDuration.setBase(audioRecordingService.getChronometerBase());
         pauseRecordingIndicators();
 
         recordingActionContainer.setVisibility(VISIBLE);
@@ -397,7 +395,6 @@ public class RecordingFragment extends DialogFragment {
     private void resumeRecording() {
         Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording resuming");
         inPausedState = false;
-        chronoResume();
 
         audioRecordingService.resumeRecording();
         recordingInProgress();
@@ -453,21 +450,6 @@ public class RecordingFragment extends DialogFragment {
 
     private static void enableScreenRotation(AppCompatActivity context) {
         context.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
-    }
-
-    private void chronoPause() {
-        recordingDuration.stop();
-        mLastStopTime = SystemClock.elapsedRealtime();
-    }
-
-    private void chronoResume() {
-        if (mLastStopTime == 0) {
-            recordingDuration.setBase(SystemClock.elapsedRealtime());
-        } else {
-            long intervalOnPause = SystemClock.elapsedRealtime() - mLastStopTime;
-            recordingDuration.setBase(recordingDuration.getBase() + intervalOnPause);
-        }
-        recordingDuration.start();
     }
 
     @RequiresApi(api = Build.VERSION_CODES.N)

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -372,8 +372,15 @@ public class RecordingFragment extends DialogFragment {
         this.pausedByUser = pausedByUser;
         audioRecordingService.pauseRecording();
 
+        pausedRecording(pausedByUser);
+        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording paused");
+    }
+
+    private void pausedRecording(boolean pausedByUser) {
         recordingDuration.stop();
         recordingDuration.setBase(audioRecordingService.getChronometerBase());
+        recordingDuration.setVisibility(VISIBLE);
+        recordingProgress.setVisibility(VISIBLE);
         pauseRecordingIndicators();
 
         recordingActionContainer.setVisibility(VISIBLE);
@@ -382,7 +389,6 @@ public class RecordingFragment extends DialogFragment {
         toggleRecording.setOnClickListener(v -> resumeRecording());
         instruction.setText(Localization.get(pausedByUser ? "pause.recording"
                 : "pause.recording.because.no.sound.captured"));
-        Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording paused");
     }
 
     private void pauseRecordingIndicators() {

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -27,6 +27,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
+import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -90,7 +91,7 @@ public class RecordingFragment extends DialogFragment {
     private static final String FILE_EXT_LEGACY = ".mp3";
     private static final String FILE_EXT_BALANCED = ".m4a";
 
-    private LinearLayout layout;
+    private ScrollView layout;
     private FrameLayout recordingContainer;
     private ImageButton toggleRecording;
     private ImageButton discardRecording;
@@ -122,7 +123,7 @@ public class RecordingFragment extends DialogFragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        layout = (LinearLayout) inflater.inflate(R.layout.recording_fragment, container);
+        layout = (ScrollView) inflater.inflate(R.layout.recording_fragment, container);
         prepareButtons();
         prepareText();
         initMediaResources();
@@ -219,7 +220,8 @@ public class RecordingFragment extends DialogFragment {
         window.getDecorView().getWindowVisibleDisplayFrame(displayRectangle);
 
         int maxWidth = getResources().getDimensionPixelSize(R.dimen.audio_recording_dialog_max_width);
-        layout.setMinimumWidth((int) (Math.min(displayRectangle.width() * 0.9f, maxWidth)));
+        layout.findViewById(R.id.recording_content)
+                .setMinimumWidth((int)(Math.min(displayRectangle.width() * 0.9f, maxWidth)));
         getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
     }
 

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -77,6 +77,11 @@ public class RecordingFragment extends DialogFragment {
 
     private static final String MIMETYPE_AUDIO_AAC = "audio/mp4a-latm";
 
+    private static final String FILE_NAME_STATE_KEY = "file-name-state-key";
+    private static final String SESSION_STARTED_STATE_KEY = "session-started-state-key";
+    private static final String SAVED_RECORDING_EXISTS_STATE_KEY = "saved-recording-exists-state-key";
+    private static final String PAUSED_BY_USER_STATE_KEY = "paused-by-user-state-key";
+
     private String fileName;
     private static final String FILE_EXT_LEGACY = ".mp3";
     private static final String FILE_EXT_BALANCED = ".m4a";
@@ -95,7 +100,10 @@ public class RecordingFragment extends DialogFragment {
 
     private RecordingCompletionListener listener;
     private boolean inPausedState = false;
+    private boolean pausedByUser = true;
     private boolean savedRecordingExists = false;
+    /** Whether a recording session has been handed to the service, and so survives this view. */
+    private boolean recordingSessionStarted = false;
     private AudioManager.AudioRecordingCallback audioRecordingCallback;
     private boolean audioRecordingServiceBounded = false;
     private AudioRecordingService audioRecordingService;
@@ -138,6 +146,15 @@ public class RecordingFragment extends DialogFragment {
         } else if (savedInstanceState == null) {
             startRecording();
         }
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(FILE_NAME_STATE_KEY, fileName);
+        outState.putBoolean(SESSION_STARTED_STATE_KEY, recordingSessionStarted);
+        outState.putBoolean(SAVED_RECORDING_EXISTS_STATE_KEY, savedRecordingExists);
+        outState.putBoolean(PAUSED_BY_USER_STATE_KEY, pausedByUser);
     }
 
     private void initMediaResources() {
@@ -233,6 +250,7 @@ public class RecordingFragment extends DialogFragment {
 
         disableScreenRotation((AppCompatActivity) getContext());
         setCancelable(false);
+        recordingSessionStarted = true;
 
         Intent serviceIntent = new Intent(requireActivity(), AudioRecordingService.class);
         serviceIntent.putExtra(RECORDING_FILENAME_EXTRA_KEY, fileName);
@@ -345,6 +363,7 @@ public class RecordingFragment extends DialogFragment {
     private void pauseRecording(boolean pausedByUser) {
         Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording pausing");
         inPausedState = true;
+        this.pausedByUser = pausedByUser;
         audioRecordingService.pauseRecording();
 
         recordingDuration.stop();
@@ -519,9 +538,18 @@ public class RecordingFragment extends DialogFragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        unbindAudioRecordingService();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             unregisterAudioRecordingConfigurationChangeCallback();
+        }
+        // On a configuration change this view is about to be rebuilt, so leave the recording running and
+        // let the new view rebind to it. Any other teardown ends the session for good.
+        boolean endingSession = !requireActivity().isChangingConfigurations();
+        if (endingSession && audioRecordingService != null) {
+            audioRecordingService.finishAndRelease();
+        }
+        unbindAudioRecordingService();
+        if (endingSession) {
+            requireActivity().stopService(new Intent(requireActivity(), AudioRecordingService.class));
         }
     }
 
@@ -531,8 +559,7 @@ public class RecordingFragment extends DialogFragment {
                 audioRecordingService.setRecordingActionListener(null);
             }
             requireActivity().unbindService(audioRecordingServiceConnection);
-            requireActivity()
-                    .stopService(new Intent(requireActivity(), AudioRecordingService.class));
+            audioRecordingServiceBounded = false;
         }
     }
 }

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -131,21 +131,34 @@ public class RecordingFragment extends DialogFragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        Bundle args = getArguments();
-        if (args != null) {
-            fileName = args.getString(AUDIO_FILE_PATH_ARG_KEY);
+        if (savedInstanceState != null) {
+            fileName = savedInstanceState.getString(FILE_NAME_STATE_KEY);
+            recordingSessionStarted = savedInstanceState.getBoolean(SESSION_STARTED_STATE_KEY);
+            savedRecordingExists = savedInstanceState.getBoolean(SAVED_RECORDING_EXISTS_STATE_KEY);
+            pausedByUser = savedInstanceState.getBoolean(PAUSED_BY_USER_STATE_KEY, true);
+        } else {
+            Bundle args = getArguments();
+            if (args != null) {
+                fileName = args.getString(AUDIO_FILE_PATH_ARG_KEY);
+            }
+        }
+
+        if (recordingSessionStarted) {
+            // Recreated mid-session; the service kept recording, so rebind and restore from it rather
+            // than looking at the audio file, which exists but is still being written to.
+            bindAudioRecordingService();
+            return;
+        }
+
+        if (fileName != null && new File(fileName).exists()) {
+            reloadSavedRecording();
+            return;
         }
 
         if (fileName == null) {
             initAudioFile();
         }
-
-        File f = new File(fileName);
-        if (f.exists()) {
-            reloadSavedRecording();
-        } else if (savedInstanceState == null) {
-            startRecording();
-        }
+        startRecording();
     }
 
     @Override
@@ -268,11 +281,23 @@ public class RecordingFragment extends DialogFragment {
                 getAudioRecordingServiceConnection(), Context.BIND_AUTO_CREATE);
     }
 
+    private void bindAudioRecordingService() {
+        Intent serviceIntent = new Intent(requireActivity(), AudioRecordingService.class);
+        bindAudioRecordingService(serviceIntent);
+    }
+
     private ServiceConnection getAudioRecordingServiceConnection() {
         return audioRecordingServiceConnection = new ServiceConnection() {
             @Override
             public void onServiceConnected(ComponentName name, IBinder service) {
                 audioRecordingService = ((AudioRecordingService.AudioRecorderBinder) service).getService();
+
+                // The service is the source of truth for the file and how far along we are, which is how
+                // a view recreated mid-recording picks the session back up.
+                if (audioRecordingService.getFileName() != null) {
+                    fileName = audioRecordingService.getFileName();
+                }
+                restoreViewFromRecordingState();
 
                 // Relay notification action presses back to the recording UI. Invoked on the
                 // main thread from the service; guarded in case the dialog is no longer attached.
@@ -303,13 +328,6 @@ public class RecordingFragment extends DialogFragment {
                     registerAudioRecordingConfigurationChangeCallback();
                 }
 
-                recordingInProgress();
-                // The service is the source of truth for the file and how far along we are, which is how
-                // a view recreated mid-recording picks the session back up.
-                if (audioRecordingService.getFileName() != null) {
-                    fileName = audioRecordingService.getFileName();
-                }
-
                 Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording started");
 
                 // Extend the user extension if about to expire, this is to prevent the session from expiring
@@ -325,6 +343,25 @@ public class RecordingFragment extends DialogFragment {
                 audioRecordingServiceBounded = false;
             }
         };
+    }
+
+    /**
+     * Renders whichever point of the recording the service is at. Called on every bind, so it covers
+     * both starting a fresh recording and picking one back up after the view was recreated.
+     */
+    private void restoreViewFromRecordingState() {
+        switch (audioRecordingService.getState()) {
+            case PAUSED:
+                inPausedState = true;
+                pausedRecording(pausedByUser);
+                break;
+            case STOPPED:
+                // Nothing left to show; the dialog is already on its way out.
+                break;
+            default:
+                // IDLE means the start command hasn't been dispatched yet, but it is on its way.
+                recordingInProgress();
+        }
     }
 
     private void recordingInProgress() {

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -260,8 +260,12 @@ public class RecordingFragment extends DialogFragment {
         } else {
             requireActivity().startService(serviceIntent);
         }
-        requireActivity().bindService(serviceIntent, getAudioRecordingServiceConnection(),
-                Context.BIND_AUTO_CREATE);
+        bindAudioRecordingService(serviceIntent);
+    }
+
+    private void bindAudioRecordingService(Intent serviceIntent) {
+        audioRecordingServiceBounded = requireActivity().bindService(serviceIntent,
+                getAudioRecordingServiceConnection(), Context.BIND_AUTO_CREATE);
     }
 
     private ServiceConnection getAudioRecordingServiceConnection() {

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -149,8 +149,12 @@ public class RecordingFragment extends DialogFragment {
         if (recordingSessionStarted) {
             // Recreated mid-session; the service kept recording, so rebind and restore from it rather
             // than looking at the audio file, which exists but is still being written to.
-            bindAudioRecordingService();
-            return;
+            if (rebindToRunningRecording()) {
+                return;
+            }
+            // The service went down with the process, so there is nothing to pick up.
+            recordingSessionStarted = false;
+            discardUnfinalisedRecording();
         }
 
         if (fileName != null && new File(fileName).exists()) {
@@ -279,13 +283,38 @@ public class RecordingFragment extends DialogFragment {
     }
 
     private void bindAudioRecordingService(Intent serviceIntent) {
-        audioRecordingServiceBounded = requireActivity().bindService(serviceIntent,
-                getAudioRecordingServiceConnection(), Context.BIND_AUTO_CREATE);
+        requireActivity().bindService(serviceIntent, getAudioRecordingServiceConnection(),
+                Context.BIND_AUTO_CREATE);
+        audioRecordingServiceBounded = true;
     }
 
-    private void bindAudioRecordingService() {
+    /**
+     * Attaches to a recording that is already running. Omits BIND_AUTO_CREATE so a session whose service
+     * is gone reports itself as such, rather than spinning up an idle one we would misread as live.
+     *
+     * @return whether there was a running recording to attach to
+     */
+    private boolean rebindToRunningRecording() {
         Intent serviceIntent = new Intent(requireActivity(), AudioRecordingService.class);
-        bindAudioRecordingService(serviceIntent);
+        boolean bound = requireActivity().bindService(serviceIntent,
+                getAudioRecordingServiceConnection(), 0);
+        // Unbinding is required even when the bind fails, so record that we asked.
+        audioRecordingServiceBounded = true;
+        return bound;
+    }
+
+    /**
+     * Drops the file left behind by a session whose service died mid-recording; the recorder never
+     * finalised it, so it won't play.
+     */
+    private void discardUnfinalisedRecording() {
+        if (savedRecordingExists || fileName == null) {
+            return;
+        }
+        if (!new File(fileName).delete()) {
+            Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Failed to delete partial recording file");
+        }
+        fileName = null;
     }
 
     private ServiceConnection getAudioRecordingServiceConnection() {
@@ -579,9 +608,9 @@ public class RecordingFragment extends DialogFragment {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             unregisterAudioRecordingConfigurationChangeCallback();
         }
-        // On a configuration change this view is about to be rebuilt, so leave the recording running and
-        // let the new view rebind to it. Any other teardown ends the session for good.
-        boolean endingSession = !requireActivity().isChangingConfigurations();
+        // A config change, or the system reclaiming a stopped activity, rebuilds this view and the
+        // recording has to outlive it. Only a dismissal or a finishing activity ends the session.
+        boolean endingSession = isRemoving() || requireActivity().isFinishing();
         if (endingSession && audioRecordingService != null) {
             audioRecordingService.finishAndRelease();
         }

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -300,6 +300,12 @@ public class RecordingFragment extends DialogFragment {
                 }
 
                 recordingInProgress();
+                // The service is the source of truth for the file and how far along we are, which is how
+                // a view recreated mid-recording picks the session back up.
+                if (audioRecordingService.getFileName() != null) {
+                    fileName = audioRecordingService.getFileName();
+                }
+
                 Logger.log(LogTypes.TYPE_MEDIA_EVENT, "Recording started");
 
                 // Extend the user extension if about to expire, this is to prevent the session from expiring

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -70,6 +70,10 @@ public class RecordingFragment extends DialogFragment {
 
     public static final String AUDIO_FILE_PATH_ARG_KEY = "audio_file_path";
     public static final String APPEARANCE_ATTR_ARG_KEY = "appearance_attr_key";
+    public static final String RESULT_REQUEST_KEY_ARG_KEY = "result_request_key";
+
+    /** Path the recording ended up at, absent if the dialog was dismissed without changing anything. */
+    public static final String RESULT_AUDIO_FILE_PATH_KEY = "result_audio_file_path";
     private static final CharSequence LONG_APPEARANCE_VALUE = "long";
     private static final String SAVE_TEXT_KEY = "save";
     private static final String CANCEL_TEXT_KEY = "recording.cancel";
@@ -98,7 +102,7 @@ public class RecordingFragment extends DialogFragment {
     private ProgressBar recordingProgress;
     private Chronometer recordingDuration;
 
-    private RecordingCompletionListener listener;
+    private boolean resultDelivered = false;
     private boolean inPausedState = false;
     private boolean pausedByUser = true;
     private boolean savedRecordingExists = false;
@@ -244,9 +248,7 @@ public class RecordingFragment extends DialogFragment {
     private void resetRecordingView() {
         // reset the file path
         initAudioFile();
-        if (listener != null) {
-            listener.onRecordingCompletion(fileName);
-        }
+        deliverResult(fileName);
         dismiss();
     }
 
@@ -485,21 +487,24 @@ public class RecordingFragment extends DialogFragment {
         if (inPausedState) {
             stopRecording(false);
         }
-        if (listener != null) {
-            listener.onRecordingCompletion(fileName);
-        }
+        deliverResult(fileName);
         dismissAllowingStateLoss();
     }
 
     /**
-     * A listener interface for handling post-recording events
+     * Reports the outcome through the fragment result API rather than a listener the caller holds, so
+     * that it still reaches a caller that was rebuilt while this dialog was open.
      */
-    public interface RecordingCompletionListener {
-        void onRecordingCompletion(String audioFile);
-    }
-
-    public void setListener(RecordingCompletionListener listener) {
-        this.listener = listener;
+    private void deliverResult(@Nullable String audioFile) {
+        resultDelivered = true;
+        Bundle args = getArguments();
+        String requestKey = args == null ? null : args.getString(RESULT_REQUEST_KEY_ARG_KEY);
+        if (requestKey == null) {
+            return;
+        }
+        Bundle result = new Bundle();
+        result.putString(RESULT_AUDIO_FILE_PATH_KEY, audioFile);
+        getParentFragmentManager().setFragmentResult(requestKey, result);
     }
 
     @RequiresApi(api = Build.VERSION_CODES.N)
@@ -581,6 +586,11 @@ public class RecordingFragment extends DialogFragment {
         unbindAudioRecordingService();
         if (endingSession) {
             requireActivity().stopService(new Intent(requireActivity(), AudioRecordingService.class));
+            if (!resultDelivered) {
+                // Dismissed without saving; tell the caller so it can drop the state it put up while
+                // this dialog was open.
+                deliverResult(null);
+            }
         }
     }
 

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -213,7 +213,9 @@ public class RecordingFragment extends DialogFragment {
         Rect displayRectangle = new Rect();
         Window window = getActivity().getWindow();
         window.getDecorView().getWindowVisibleDisplayFrame(displayRectangle);
-        layout.setMinimumWidth((int) (displayRectangle.width() * 0.9f));
+
+        int maxWidth = getResources().getDimensionPixelSize(R.dimen.audio_recording_dialog_max_width);
+        layout.setMinimumWidth((int) (Math.min(displayRectangle.width() * 0.9f, maxWidth)));
         getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
     }
 

--- a/app/src/org/commcare/views/widgets/RecordingFragment.java
+++ b/app/src/org/commcare/views/widgets/RecordingFragment.java
@@ -119,7 +119,6 @@ public class RecordingFragment extends DialogFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         layout = (LinearLayout) inflater.inflate(R.layout.recording_fragment, container);
-        disableScreenRotation((AppCompatActivity) getContext());
         prepareButtons();
         prepareText();
         initMediaResources();
@@ -261,7 +260,6 @@ public class RecordingFragment extends DialogFragment {
             }
         }
 
-        disableScreenRotation((AppCompatActivity) getContext());
         setCancelable(false);
         recordingSessionStarted = true;
 
@@ -502,26 +500,6 @@ public class RecordingFragment extends DialogFragment {
 
     public void setListener(RecordingCompletionListener listener) {
         this.listener = listener;
-    }
-
-    @Override
-    public void onDismiss(DialogInterface dialog) {
-        super.onDismiss(dialog);
-        enableScreenRotation((AppCompatActivity) getContext());
-    }
-
-    private static void disableScreenRotation(AppCompatActivity context) {
-        int currentOrientation = context.getResources().getConfiguration().orientation;
-
-        if (currentOrientation == Configuration.ORIENTATION_LANDSCAPE) {
-            context.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
-        } else {
-            context.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
-        }
-    }
-
-    private static void enableScreenRotation(AppCompatActivity context) {
-        context.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
     }
 
     @RequiresApi(api = Build.VERSION_CODES.N)

--- a/app/unit-tests/src/org/commcare/views/widgets/AudioRecordingServiceTest.kt
+++ b/app/unit-tests/src/org/commcare/views/widgets/AudioRecordingServiceTest.kt
@@ -1,0 +1,157 @@
+package org.commcare.views.widgets
+
+import android.content.Intent
+import android.os.Build
+import android.os.SystemClock
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.commcare.CommCareTestApplication
+import org.commcare.preferences.DeveloperPreferences
+import org.commcare.preferences.PrefValues
+import org.commcare.views.widgets.AudioRecordingService.RecordingState
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import java.time.Duration
+
+/**
+ * Covers the recording state the service reports to a UI that rebinds to it, in particular the
+ * elapsed time, which has to exclude any stretch spent paused or stopped however long ago that was.
+ */
+@Config(application = CommCareTestApplication::class, sdk = [Build.VERSION_CODES.N])
+@RunWith(AndroidJUnit4::class)
+class AudioRecordingServiceTest {
+
+    @Before
+    fun stubQualityProfile() {
+        mockkStatic(DeveloperPreferences::class)
+        every { DeveloperPreferences.getAudioQualityProfile() } returns PrefValues.AUDIO_QUALITY_DEFAULT
+    }
+
+    @After
+    fun unstubQualityProfile() {
+        unmockkStatic(DeveloperPreferences::class)
+    }
+
+    private fun startCommandIntent() =
+        Intent(ApplicationProvider.getApplicationContext(), AudioRecordingService::class.java).apply {
+            putExtra(AudioRecordingService.RECORDING_FILENAME_EXTRA_KEY, RECORDING_FILE_NAME)
+            putExtra(AudioRecordingService.PAUSE_SUPPORTED_EXTRA_KEY, true)
+        }
+
+    private fun startedService(intent: Intent = startCommandIntent()): AudioRecordingService =
+        Robolectric.buildService(AudioRecordingService::class.java, intent)
+            .create()
+            .startCommand(0, 0)
+            .get()
+
+    /** What a Chronometer given this base would display, in ms. */
+    private fun AudioRecordingService.elapsed(): Long =
+        SystemClock.elapsedRealtime() - chronometerBase
+
+    private fun advance(seconds: Long) {
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(seconds))
+    }
+
+    @Test
+    fun `elapsed time tracks an uninterrupted recording`() {
+        val service = startedService()
+        assertEquals(RecordingState.RECORDING, service.state)
+
+        advance(5)
+        assertEquals(5000, service.elapsed())
+    }
+
+    @Test
+    fun `elapsed time freezes while paused`() {
+        val service = startedService()
+        advance(5)
+        service.pauseRecording()
+        assertEquals(RecordingState.PAUSED, service.state)
+
+        advance(10)
+        // Still 5s: the pause does not count towards the recording.
+        assertEquals(5000, service.elapsed())
+    }
+
+    @Test
+    fun `elapsed time excludes the pause after resuming`() {
+        val service = startedService()
+        advance(5)
+        service.pauseRecording()
+        advance(10)
+        service.resumeRecording()
+        assertEquals(RecordingState.RECORDING, service.state)
+
+        advance(3)
+        assertEquals(8000, service.elapsed())
+    }
+
+    @Test
+    fun `elapsed time freezes after stopping`() {
+        val service = startedService()
+        advance(5)
+        service.stopRecording()
+        assertEquals(RecordingState.STOPPED, service.state)
+
+        advance(10)
+        // A UI binding well after the stop must still see the recording's real length.
+        assertEquals(5000, service.elapsed())
+    }
+
+    @Test
+    fun `stopping while paused keeps the pause excluded`() {
+        val service = startedService()
+        advance(5)
+        service.pauseRecording()
+        advance(10)
+        service.stopRecording()
+
+        advance(10)
+        // Re-freezing on stop would have counted the 10s pause, reporting 15s for a 5s recording.
+        assertEquals(5000, service.elapsed())
+    }
+
+    @Test
+    fun `repeated stops are ignored`() {
+        val service = startedService()
+        advance(5)
+        service.stopRecording()
+        advance(10)
+        service.stopRecording()
+
+        assertEquals(RecordingState.STOPPED, service.state)
+        assertEquals(5000, service.elapsed())
+    }
+
+    @Test
+    fun `a second start does not restart the recording`() {
+        val intent = startCommandIntent()
+        val service = startedService(intent)
+
+        advance(5)
+        service.onStartCommand(intent, 0, 0)
+
+        // Elapsed time is unchanged, i.e. the recording was not restarted from zero.
+        assertEquals(5000, service.elapsed())
+        assertEquals(RecordingState.RECORDING, service.state)
+    }
+
+    @Test
+    fun `file name is reported for a rebinding UI`() {
+        val service = startedService()
+        assertEquals(RECORDING_FILE_NAME, service.fileName)
+    }
+
+    companion object {
+        private const val RECORDING_FILE_NAME = "/tmp/test-recording.m4a"
+    }
+}


### PR DESCRIPTION
## Product Description

This PR adds support rotation to the audio recording dialog. Previously it locked the screen for the duration of a recording, so a user who turned the device mid-recording either could not, or lost the recording if the dialog was rebuilt for any other reason.

Rotating now keeps the recording running and the elapsed time correct, and the dialog picks the session back up in whatever state it was in — recording or paused. Notification Pause/Resume/Save presses that are triggered while the screen is turning are replayed once the dialog comes back rather than being dropped. 

<table>
<tr>
<td>
Device
</td>
</tr>
<tr>
<td>
<video width="200px" src="https://github.com/user-attachments/assets/75fd57d3-e58d-4bf4-8013-2ebb45d37662"></video>
</td>
</tr>
<tr>
<td>
Tablet
</td>
</tr>
<tr>
<td>




<video width="200px" src="https://github.com/user-attachments/assets/67fbc9a5-1478-48b5-9749-332dbbc4d08b"></video>
</td>
</tr>
</table>

## Technical Summary

Ticket: [SAAS-20177](https://dimagi.atlassian.net/browse/SAAS-20177)

Rotation was previously *prevented* rather than supported, and the code underneath was not recreation-safe. The design moves the authoritative state out of the fragment:
- **`AudioRecordingService` owns the session.** A `RecordingState` enum, the filename, and a `getChronometerBase()` that returns exactly what `Chronometer.setBase()` wants with paused stretches excluded. The fragment renders from the service on every bind, so a fresh recording and a rebuilt view take the same path through `restoreViewFromRecordingState()`.
- **The fragment rebinds rather than restarts.** `onDestroyView` splits on `isChangingConfigurations()` — a configuration change unbinds and leaves the recording running; any other teardown ends the session. `onViewCreated` branches on a persisted `recordingSessionStarted` flag instead of file existence.
- **Notification actions survive the rebuild window.** The service queues an action that arrives while nothing is bound and replays it when the new view binds, after the view state has been restored so the replay sees accurate state.
- **Outcome delivery moved to the fragment result API**, keyed by form index. A listener handed to the dialog cannot survive the widget being rebuilt; `setFragmentResultListener` also holds a result set before the listener registers, which matters because widgets are built only after the form finishes loading. Keying by index replaces a shared `"Recorder"` fragment tag that would have crossed wires between two audio questions on one screen.
- **Orientation handling removed entirely.** The old `enableScreenRotation()` restored `SENSOR`, not the `UNSPECIFIED` that `FormEntryActivityUIController.checkForOrientationRequirements()` expects, so the activity was left in the wrong mode after every recording.

## Safety Assurance

### Safety story

- Tested locally on both a phone and a tablet, with rotation triggered repeatedly at various points. The behavior was successful in all cases.
- Existing recordings are unaffected by these changes: the widget's answer is still a file path — only the delivery mechanism changes (how that path reaches the widget), not what's stored.

### Automated test coverage
Added `AudioRecordingServiceTest.kt` with 8 tests covering the service's state machine and elapsed-time calculations, the areas of this change most likely to fail silently. Tests cover:
- elapsed time across an uninterrupted recording, a pause, a resume, and a stop
- stopping while paused does not re-freeze the base and count the pause
- repeated stops are ignored
- a second start intent does not restart a session already under way
- the filename is reported to a rebinding UI

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SAAS-20177]: https://dimagi.atlassian.net/browse/SAAS-20177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ