### PR TITLE
CCCT-2535 Show Payment Unit Cards On The Delivery Visits Tab

### DIFF
--- a/app/res/layout/connect_delivery_progress_item.xml
+++ b/app/res/layout/connect_delivery_progress_item.xml
@@ -5,25 +5,25 @@
     android:id="@+id/rootView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="10dp"
+    android:layout_margin="@dimen/connect_space_md"
     android:clickable="true"
     android:focusable="true"
     android:foreground="?android:attr/selectableItemBackground"
-    app:cardBackgroundColor="@color/white"
-    app:cardCornerRadius="15dp"
+    app:cardBackgroundColor="?attr/colorSurface"
+    app:cardCornerRadius="@dimen/connect_radius_lg"
     app:cardElevation="10dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:padding="@dimen/connect_space_lg">
 
         <TextView
             android:id="@+id/tvDeliveryTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/black"
-            android:textSize="14sp"
+            android:textColor="?attr/connectOnSurfaceEmphasis"
+            android:textSize="@dimen/connect_text_body"
             android:textStyle="bold"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
@@ -33,8 +33,8 @@
             android:id="@+id/imgApproved"
             android:layout_width="13dp"
             android:layout_height="13dp"
-            android:layout_marginStart="5dp"
-            android:layout_marginTop="10dp"
+            android:layout_marginStart="@dimen/connect_space_xs"
+            android:layout_marginTop="@dimen/connect_space_sm"
             android:contentDescription="@null"
             android:src="@drawable/ic_connect_thumb_up"
             app:layout_constraintStart_toStartOf="parent"
@@ -44,7 +44,7 @@
             android:id="@+id/approvedStats"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="6dp"
+            android:layout_marginStart="@dimen/connect_space_sm"
             android:orientation="vertical"
             app:layout_constraintEnd_toStartOf="@id/centerGuideline"
             app:layout_constraintStart_toEndOf="@id/imgApproved"
@@ -54,17 +54,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/connect_results_summary_approved"
-                android:textColor="@color/connect_grey"
-                android:textSize="11sp"
+                android:textColor="?attr/connectOnSurfaceMuted"
+                android:textSize="@dimen/connect_text_caption"
                 android:textStyle="bold" />
 
             <TextView
                 android:id="@+id/tvApproved"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="3dp"
-                android:textColor="@color/connect_green"
-                android:textSize="12sp"
+                android:layout_marginTop="@dimen/connect_space_xs"
+                android:textColor="?attr/connectStatusPositive"
+                android:textSize="@dimen/connect_text_caption"
                 android:textStyle="bold"
                 tools:text="10" />
 
@@ -72,9 +72,9 @@
                 android:id="@+id/tvDeliveryTotalAmount"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="3dp"
-                android:textColor="@color/connect_green"
-                android:textSize="12sp"
+                android:layout_marginTop="@dimen/connect_space_xs"
+                android:textColor="?attr/connectStatusPositive"
+                android:textSize="@dimen/connect_text_caption"
                 android:textStyle="bold"
                 tools:text="10,000 MWK" />
         </LinearLayout>
@@ -83,7 +83,7 @@
             android:id="@+id/imgRemaining"
             android:layout_width="13dp"
             android:layout_height="13dp"
-            android:layout_marginStart="5dp"
+            android:layout_marginStart="@dimen/connect_space_xs"
             android:contentDescription="@null"
             android:src="@drawable/ic_connect_delivery_check_circle"
             app:layout_constraintStart_toStartOf="@id/centerGuideline"
@@ -93,7 +93,7 @@
             android:id="@+id/remainingStats"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="6dp"
+            android:layout_marginStart="@dimen/connect_space_sm"
             android:orientation="vertical"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/imgRemaining"
@@ -103,17 +103,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/connect_results_summary_remaining"
-                android:textColor="@color/connect_grey"
-                android:textSize="11sp"
+                android:textColor="?attr/connectOnSurfaceMuted"
+                android:textSize="@dimen/connect_text_caption"
                 android:textStyle="bold" />
 
             <TextView
                 android:id="@+id/tvRemaining"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="3dp"
-                android:textColor="@color/connect_blue_color"
-                android:textSize="12sp"
+                android:layout_marginTop="@dimen/connect_space_xs"
+                android:textColor="?attr/colorPrimary"
+                android:textSize="@dimen/connect_text_caption"
                 android:textStyle="bold"
                 tools:text="6 in 3 days" />
         </LinearLayout>
@@ -128,8 +128,8 @@
         <org.commcare.views.connect.LinearProgressBar
             android:id="@+id/linearProgressBar"
             android:layout_width="0dp"
-            android:layout_height="8dp"
-            android:layout_marginTop="10dp"
+            android:layout_height="@dimen/connect_progress_card_bar_height"
+            android:layout_marginTop="@dimen/connect_space_sm"
             app:layout_constraintEnd_toStartOf="@id/progressEndGuideline"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/statsBottomBarrier" />
@@ -138,7 +138,7 @@
             android:id="@+id/imgArrowForward"
             android:layout_width="15dp"
             android:layout_height="15dp"
-            android:layout_marginEnd="10dp"
+            android:layout_marginEnd="@dimen/connect_space_sm"
             android:contentDescription="@null"
             android:src="@drawable/ic_connect_arrow_forward"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/res/layout/connect_delivery_progress_item.xml
+++ b/app/res/layout/connect_delivery_progress_item.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rootView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="10dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?android:attr/selectableItemBackground"
+    app:cardBackgroundColor="@color/white"
+    app:cardCornerRadius="15dp"
+    app:cardElevation="10dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tvDeliveryTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/black"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Household visit" />
+
+        <ImageView
+            android:id="@+id/imgApproved"
+            android:layout_width="13dp"
+            android:layout_height="13dp"
+            android:layout_marginStart="5dp"
+            android:layout_marginTop="10dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_connect_thumb_up"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tvDeliveryTitle" />
+
+        <LinearLayout
+            android:id="@+id/approvedStats"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="6dp"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toStartOf="@id/centerGuideline"
+            app:layout_constraintStart_toEndOf="@id/imgApproved"
+            app:layout_constraintTop_toTopOf="@id/imgApproved">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/connect_results_summary_approved"
+                android:textColor="@color/connect_grey"
+                android:textSize="11sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvApproved"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:textColor="@color/connect_green"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                tools:text="10" />
+
+            <TextView
+                android:id="@+id/tvDeliveryTotalAmount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:textColor="@color/connect_green"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                tools:text="10,000 MWK" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/imgRemaining"
+            android:layout_width="13dp"
+            android:layout_height="13dp"
+            android:layout_marginStart="5dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_connect_delivery_check_circle"
+            app:layout_constraintStart_toStartOf="@id/centerGuideline"
+            app:layout_constraintTop_toTopOf="@id/imgApproved" />
+
+        <LinearLayout
+            android:id="@+id/remainingStats"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="6dp"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/imgRemaining"
+            app:layout_constraintTop_toTopOf="@id/imgRemaining">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/connect_results_summary_remaining"
+                android:textColor="@color/connect_grey"
+                android:textSize="11sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvRemaining"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:textColor="@color/connect_blue_color"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                tools:text="6 in 3 days" />
+        </LinearLayout>
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/statsBottomBarrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="approvedStats, remainingStats" />
+
+        <org.commcare.views.connect.LinearProgressBar
+            android:id="@+id/linearProgressBar"
+            android:layout_width="0dp"
+            android:layout_height="8dp"
+            android:layout_marginTop="10dp"
+            app:layout_constraintEnd_toStartOf="@id/progressEndGuideline"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/statsBottomBarrier" />
+
+        <ImageView
+            android:id="@+id/imgArrowForward"
+            android:layout_width="15dp"
+            android:layout_height="15dp"
+            android:layout_marginEnd="10dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_connect_arrow_forward"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/linearProgressBar" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/centerGuideline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.5" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/progressEndGuideline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.75" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>

--- a/app/res/layout/fragment_connect_delivery_visits.xml
+++ b/app/res/layout/fragment_connect_delivery_visits.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rvDeliveryProgressReport"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/connect_background_color" />
+    android:background="@color/connect_background_color"
+    android:clipToPadding="false"
+    android:paddingVertical="6dp"
+    tools:listitem="@layout/connect_delivery_progress_item" />

--- a/app/res/layout/fragment_connect_delivery_visits.xml
+++ b/app/res/layout/fragment_connect_delivery_visits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/rvDeliveryProgressReport"
+    android:id="@+id/rvPaymentUnits"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/connect_background_color"

--- a/app/res/navigation/nav_graph_connect.xml
+++ b/app/res/navigation/nav_graph_connect.xml
@@ -106,6 +106,9 @@
         <action
             android:id="@+id/action_connect_delivery_home_fragment_to_connect_job_detail_bottom_sheet_dialog_fragment"
             app:destination="@id/connect_job_detail_bottom_sheet_dialog_fragment" />
+        <action
+            android:id="@+id/action_connect_delivery_home_fragment_to_connect_delivery_visits_detail_fragment"
+            app:destination="@id/connect_delivery_visits_detail_fragment" />
     </fragment>
 
     <fragment

--- a/app/src/org/commcare/adapters/ConnectDeliveryPaymentUnitAdapter.kt
+++ b/app/src/org/commcare/adapters/ConnectDeliveryPaymentUnitAdapter.kt
@@ -9,33 +9,33 @@ import org.commcare.dalvik.R
 import org.commcare.dalvik.databinding.ConnectDeliveryProgressItemBinding
 import org.commcare.models.connect.ConnectDeliveryDetails
 
-class ConnectDeliveryProgressReportAdapter(
-    private val onDeliveryClicked: (ConnectDeliveryDetails) -> Unit,
-) : RecyclerView.Adapter<ConnectDeliveryProgressReportAdapter.ProgressBarViewHolder>() {
-    private val deliveryProgressList = mutableListOf<ConnectDeliveryDetails>()
+class ConnectDeliveryPaymentUnitAdapter(
+    private val onPaymentUnitClicked: (ConnectDeliveryDetails) -> Unit,
+) : RecyclerView.Adapter<ConnectDeliveryPaymentUnitAdapter.PaymentUnitViewHolder>() {
+    private val paymentUnits = mutableListOf<ConnectDeliveryDetails>()
 
-    class ProgressBarViewHolder(
+    class PaymentUnitViewHolder(
         val binding: ConnectDeliveryProgressItemBinding,
     ) : RecyclerView.ViewHolder(binding.root)
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ): ProgressBarViewHolder {
+    ): PaymentUnitViewHolder {
         val binding =
             ConnectDeliveryProgressItemBinding.inflate(
                 LayoutInflater.from(parent.context),
                 parent,
                 false,
             )
-        return ProgressBarViewHolder(binding)
+        return PaymentUnitViewHolder(binding)
     }
 
     override fun onBindViewHolder(
-        holder: ProgressBarViewHolder,
+        holder: PaymentUnitViewHolder,
         position: Int,
     ) {
-        val details = deliveryProgressList[position]
+        val details = paymentUnits[position]
         val context = holder.itemView.context
         with(holder.binding) {
             linearProgressBar.setProgress(details.approvedPercentage.toFloat())
@@ -46,7 +46,7 @@ class ConnectDeliveryProgressReportAdapter(
             tvApproved.text = details.approvedCount.toString()
             tvDeliveryTotalAmount.text = details.totalAmount
             tvRemaining.text = remainingText(context, details)
-            rootView.setOnClickListener { onDeliveryClicked(details) }
+            rootView.setOnClickListener { onPaymentUnitClicked(details) }
         }
     }
 
@@ -80,11 +80,11 @@ class ConnectDeliveryProgressReportAdapter(
         }
     }
 
-    override fun getItemCount(): Int = deliveryProgressList.size
+    override fun getItemCount(): Int = paymentUnits.size
 
     fun updateData(newData: List<ConnectDeliveryDetails>) {
-        deliveryProgressList.clear()
-        deliveryProgressList.addAll(newData)
+        paymentUnits.clear()
+        paymentUnits.addAll(newData)
         notifyDataSetChanged()
     }
 }

--- a/app/src/org/commcare/adapters/ConnectDeliveryProgressReportAdapter.kt
+++ b/app/src/org/commcare/adapters/ConnectDeliveryProgressReportAdapter.kt
@@ -1,0 +1,88 @@
+package org.commcare.adapters
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import org.commcare.dalvik.R
+import org.commcare.dalvik.databinding.ConnectDeliveryProgressItemBinding
+import org.commcare.models.connect.ConnectDeliveryDetails
+
+class ConnectDeliveryProgressReportAdapter(
+    private val onDeliveryClicked: (ConnectDeliveryDetails) -> Unit,
+) : RecyclerView.Adapter<ConnectDeliveryProgressReportAdapter.ProgressBarViewHolder>() {
+    private val deliveryProgressList = mutableListOf<ConnectDeliveryDetails>()
+
+    class ProgressBarViewHolder(
+        val binding: ConnectDeliveryProgressItemBinding,
+    ) : RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): ProgressBarViewHolder {
+        val binding =
+            ConnectDeliveryProgressItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false,
+            )
+        return ProgressBarViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(
+        holder: ProgressBarViewHolder,
+        position: Int,
+    ) {
+        val details = deliveryProgressList[position]
+        val context = holder.itemView.context
+        with(holder.binding) {
+            linearProgressBar.setProgress(details.approvedPercentage.toFloat())
+            linearProgressBar.setProgressColor(ContextCompat.getColor(context, R.color.connect_green))
+            tvDeliveryTitle.text = details.deliveryName
+            tvApproved.text = details.approvedCount.toString()
+            tvDeliveryTotalAmount.text = details.totalAmount
+            tvRemaining.text = remainingText(context, details)
+            rootView.setOnClickListener { onDeliveryClicked(details) }
+        }
+    }
+
+    private fun remainingText(
+        context: Context,
+        details: ConnectDeliveryDetails,
+    ): String {
+        if (details.pendingCount <= 0) {
+            return context.getString(R.string.connect_results_summary_visits_done)
+        }
+        return when (details.remainingDays) {
+            0 -> {
+                context.getString(R.string.connect_results_summary_days_over)
+            }
+
+            1 -> {
+                context.getString(R.string.connect_results_summary_remaining_today, details.pendingCount)
+            }
+
+            2 -> {
+                context.getString(R.string.connect_results_summary_remaining_tomorrow, details.pendingCount)
+            }
+
+            else -> {
+                context.getString(
+                    R.string.connect_results_summary_remaining_days,
+                    details.pendingCount,
+                    details.remainingDays,
+                )
+            }
+        }
+    }
+
+    override fun getItemCount(): Int = deliveryProgressList.size
+
+    fun updateData(newData: List<ConnectDeliveryDetails>) {
+        deliveryProgressList.clear()
+        deliveryProgressList.addAll(newData)
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/org/commcare/adapters/ConnectDeliveryProgressReportAdapter.kt
+++ b/app/src/org/commcare/adapters/ConnectDeliveryProgressReportAdapter.kt
@@ -3,8 +3,8 @@ package org.commcare.adapters
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.color.MaterialColors
 import org.commcare.dalvik.R
 import org.commcare.dalvik.databinding.ConnectDeliveryProgressItemBinding
 import org.commcare.models.connect.ConnectDeliveryDetails
@@ -39,7 +39,9 @@ class ConnectDeliveryProgressReportAdapter(
         val context = holder.itemView.context
         with(holder.binding) {
             linearProgressBar.setProgress(details.approvedPercentage.toFloat())
-            linearProgressBar.setProgressColor(ContextCompat.getColor(context, R.color.connect_green))
+            linearProgressBar.setProgressColor(
+                MaterialColors.getColor(holder.itemView, R.attr.connectStatusPositive),
+            )
             tvDeliveryTitle.text = details.deliveryName
             tvApproved.text = details.approvedCount.toString()
             tvDeliveryTotalAmount.text = details.totalAmount

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryVisitsDetailFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryVisitsDetailFragment.java
@@ -29,6 +29,7 @@ import org.commcare.activities.CommonBaseActivity;
 import org.commcare.android.database.connect.models.ConnectJobDeliveryFlagRecord;
 import org.commcare.android.database.connect.models.ConnectJobDeliveryRecord;
 import org.commcare.android.database.connect.models.ConnectJobRecord;
+import org.commcare.android.database.connect.models.ConnectPaymentUnitRecord;
 import org.commcare.connect.ConnectDateUtils;
 import org.commcare.connect.repository.ConnectRepository;
 import org.commcare.connect.viewmodel.ConnectDeliveryHomeViewModel;
@@ -53,7 +54,7 @@ public class ConnectDeliveryVisitsDetailFragment extends ConnectJobFragment<Frag
     };
 
     private String currentFilter = ALL_IDENTIFIER;
-    private String unitName;
+    private String unitUuid;
     private DeliveryAdapter adapter;
     private ConnectDeliveryHomeViewModel viewModel;
 
@@ -65,10 +66,11 @@ public class ConnectDeliveryVisitsDetailFragment extends ConnectJobFragment<Frag
     public @NotNull View onCreateView(@NotNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = super.onCreateView(inflater, container, savedInstanceState);
         if (getArguments() != null) {
-            unitName = ConnectDeliveryVisitsDetailFragmentArgs.fromBundle(getArguments()).getUnitId();
+            unitUuid = ConnectDeliveryVisitsDetailFragmentArgs.fromBundle(getArguments()).getUnitId();
         }
-        if (unitName != null) {
-            ((CommonBaseActivity)requireActivity()).setActionBarTitle(getString(R.string.connect_visit_type_title, unitName));
+        if (unitUuid != null) {
+            ((CommonBaseActivity)requireActivity()).setActionBarTitle(
+                    getString(R.string.connect_visit_type_title, getUnitName()));
             setupMenuProvider();
         }
         viewModel = new ViewModelProvider(
@@ -79,6 +81,15 @@ public class ConnectDeliveryVisitsDetailFragment extends ConnectJobFragment<Frag
         setupFilterControls();
         observeDeliveryProgress();
         return view;
+    }
+
+    private String getUnitName() {
+        for (ConnectPaymentUnitRecord unit : job.getPaymentUnits()) {
+            if (unit.getUnitUUID().equals(unitUuid)) {
+                return unit.getName();
+            }
+        }
+        return "";
     }
 
     private void setupRecyclerView() {
@@ -203,7 +214,7 @@ public class ConnectDeliveryVisitsDetailFragment extends ConnectJobFragment<Frag
     }
 
     private boolean matchesFilter(ConnectJobDeliveryRecord delivery, String filter) {
-        boolean matchesUnit = unitName == null || delivery.getUnitName().equalsIgnoreCase(unitName);
+        boolean matchesUnit = unitUuid == null || unitUuid.equals(delivery.getSlugUUID());
         boolean matchesStatus = filter.equals(ALL_IDENTIFIER) || delivery.getStatus().equalsIgnoreCase(filter);
         return matchesUnit && matchesStatus;
     }

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryVisitsFragment.kt
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryVisitsFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.NavHostFragment
 import androidx.recyclerview.widget.LinearLayoutManager
-import org.commcare.adapters.ConnectDeliveryProgressReportAdapter
+import org.commcare.adapters.ConnectDeliveryPaymentUnitAdapter
 import org.commcare.dalvik.R
 import org.commcare.dalvik.databinding.FragmentConnectDeliveryVisitsBinding
 import org.commcare.fragments.RefreshableTab
@@ -19,7 +19,7 @@ import org.commcare.models.connect.ConnectDeliveryDetails
 class ConnectDeliveryVisitsFragment :
     ConnectJobFragment<FragmentConnectDeliveryVisitsBinding>(),
     RefreshableTab {
-    private val adapter = ConnectDeliveryProgressReportAdapter { navigateToDeliveries(it.unitUUID) }
+    private val adapter = ConnectDeliveryPaymentUnitAdapter { navigateToDeliveries(it.unitUUID) }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -27,8 +27,8 @@ class ConnectDeliveryVisitsFragment :
         savedInstanceState: Bundle?,
     ): View {
         val view = super.onCreateView(inflater, container, savedInstanceState)
-        binding.rvDeliveryProgressReport.layoutManager = LinearLayoutManager(context)
-        binding.rvDeliveryProgressReport.adapter = adapter
+        binding.rvPaymentUnits.layoutManager = LinearLayoutManager(context)
+        binding.rvPaymentUnits.adapter = adapter
         updateView()
         return view
     }

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryVisitsFragment.kt
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryVisitsFragment.kt
@@ -1,16 +1,83 @@
 package org.commcare.fragments.connect
 
-import androidx.fragment.app.Fragment
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.fragment.NavHostFragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import org.commcare.adapters.ConnectDeliveryProgressReportAdapter
 import org.commcare.dalvik.R
+import org.commcare.dalvik.databinding.FragmentConnectDeliveryVisitsBinding
 import org.commcare.fragments.RefreshableTab
+import org.commcare.models.connect.ConnectDeliveryDetails
 
+/**
+ * Visits tab of a delivery opportunity: one card per payment unit, each opening that unit's visit
+ * list.
+ */
 class ConnectDeliveryVisitsFragment :
-    Fragment(R.layout.fragment_connect_delivery_visits),
+    ConnectJobFragment<FragmentConnectDeliveryVisitsBinding>(),
     RefreshableTab {
-    override fun updateView() {
+    private val adapter = ConnectDeliveryProgressReportAdapter { navigateToDeliveries(it.unitUUID) }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val view = super.onCreateView(inflater, container, savedInstanceState)
+        binding.rvDeliveryProgressReport.layoutManager = LinearLayoutManager(context)
+        binding.rvDeliveryProgressReport.adapter = adapter
+        updateView()
+        return view
     }
 
+    override fun updateView() {
+        reloadActiveJob()
+        adapter.updateData(deliveryProgress())
+    }
+
+    private fun deliveryProgress(): List<ConnectDeliveryDetails> {
+        val approvedCounts =
+            job.deliveries
+                .filter { APPROVED_STATUS.equals(it.status, ignoreCase = true) }
+                .groupingBy { it.slugUUID }
+                .eachCount()
+
+        return job.paymentUnits.map { unit ->
+            val approved = approvedCounts[unit.unitUUID] ?: 0
+            ConnectDeliveryDetails(
+                unitUUID = unit.unitUUID,
+                deliveryName = unit.name,
+                approvedCount = approved,
+                pendingCount = unit.maxTotal - approved,
+                totalAmount = job.getMoneyString(approved * unit.amount),
+                remainingDays = job.daysRemaining,
+                approvedPercentage = if (unit.maxTotal > 0) approved.toDouble() / unit.maxTotal * 100 else 0.0,
+            )
+        }
+    }
+
+    private fun navigateToDeliveries(unitUuid: String) {
+        val navController = NavHostFragment.findNavController(this)
+        if (navController.currentDestination?.id != R.id.connect_delivery_home_fragment) {
+            return
+        }
+        navController.navigate(
+            ConnectDeliveryHomeFragmentDirections
+                .actionConnectDeliveryHomeFragmentToConnectDeliveryVisitsDetailFragment(unitUuid),
+        )
+    }
+
+    override fun inflateBinding(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+    ): FragmentConnectDeliveryVisitsBinding = FragmentConnectDeliveryVisitsBinding.inflate(inflater, container, false)
+
     companion object {
+        private const val APPROVED_STATUS = "approved"
+
         fun newInstance() = ConnectDeliveryVisitsFragment()
     }
 }

--- a/app/src/org/commcare/models/connect/ConnectDeliveryDetails.kt
+++ b/app/src/org/commcare/models/connect/ConnectDeliveryDetails.kt
@@ -1,0 +1,11 @@
+package org.commcare.models.connect
+
+data class ConnectDeliveryDetails(
+    val unitUUID: String,
+    val deliveryName: String,
+    val approvedCount: Int,
+    val pendingCount: Int,
+    val totalAmount: String,
+    val remainingDays: Int,
+    val approvedPercentage: Double,
+)

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryVisitsFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryVisitsFragmentTest.kt
@@ -1,0 +1,494 @@
+package org.commcare.fragments.connect
+
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.fragment.NavHostFragment
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.viewpager2.widget.ViewPager2
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.commcare.AppUtils
+import org.commcare.CommCareTestApplication
+import org.commcare.activities.connect.ConnectActivity
+import org.commcare.android.database.connect.models.ConnectJobRecord
+import org.commcare.android.database.connect.models.ConnectUserRecord
+import org.commcare.android.database.connect.models.PersonalIdSessionData
+import org.commcare.android.util.ReflectionUtils
+import org.commcare.connect.ConnectLearnJobTestData
+import org.commcare.connect.MessageManager
+import org.commcare.connect.PersonalIdManager
+import org.commcare.connect.database.ConnectDatabaseHelper
+import org.commcare.connect.database.ConnectJobUtils
+import org.commcare.connect.database.ConnectUserDatabaseUtil
+import org.commcare.connect.network.ConnectMockApiServer
+import org.commcare.connect.repository.ConnectRepository
+import org.commcare.connect.repository.ConnectSyncPreferences
+import org.commcare.dalvik.R
+import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Robolectric tests for [ConnectDeliveryVisitsFragment], driven end to end: the job is seeded into
+ * the real Connect database, deliveries arrive over the real networking stack from
+ * [ConnectMockApiServer], and the payment unit cards are read through the tab they live in — down to
+ * tapping one and asserting the visits it opens.
+ */
+@Config(application = CommCareTestApplication::class, sdk = [Build.VERSION_CODES.Q])
+@RunWith(AndroidJUnit4::class)
+class ConnectDeliveryVisitsFragmentTest {
+    private lateinit var activity: ConnectActivity
+    private lateinit var navHostFragment: NavHostFragment
+    private lateinit var savedStatus: PersonalIdManager.PersonalIdStatus
+    private lateinit var job: ConnectJobRecord
+    private val mockApi = ConnectMockApiServer()
+
+    @Volatile
+    private var deliveryProgressBody: String = "{}"
+
+    private val visitDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US)
+    private val endDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    private val navController: NavController get() = navHostFragment.navController
+    private val appContext get() = ApplicationProvider.getApplicationContext<CommCareTestApplication>()
+
+    /** Each unit's own cap, so a unit can be exhausted without ending the job. */
+    private val perUnitTotal = ConnectLearnJobTestData.MAX_VISITS / ConnectLearnJobTestData.PAYMENT_UNIT_COUNT
+
+    @Before
+    fun setUp() {
+        savedStatus = PersonalIdManager.getInstance().status
+        PersonalIdManager.getInstance().status = PersonalIdManager.PersonalIdStatus.LoggedIn
+        mockApi.start()
+        mockApi.server.dispatcher = pathRoutingDispatcher()
+        ConnectSyncPreferences.getInstance(appContext).clearAll()
+
+        mockkStatic(MessageManager::class)
+        every { MessageManager.retrieveMessages(any(), any()) } returns Unit
+
+        mockkStatic(FirebaseAnalyticsUtil::class)
+        every { FirebaseAnalyticsUtil.reportConnectTabChange(any()) } returns Unit
+        every { FirebaseAnalyticsUtil.getNavControllerPageChangeLoggingListener() } returns
+            object : NavController.OnDestinationChangedListener {
+                override fun onDestinationChanged(
+                    controller: NavController,
+                    destination: NavDestination,
+                    arguments: Bundle?,
+                ) = Unit
+            }
+
+        mockkStatic(AppUtils::class)
+        every { AppUtils.isAppInstalled(any()) } returns false
+
+        seedConnectUser()
+        job = seedDeliveryJob()
+
+        activity =
+            Robolectric
+                .buildActivity(ConnectActivity::class.java)
+                .create()
+                .postCreate(null)
+                .start()
+                .resume()
+                .get()
+        navHostFragment =
+            activity.supportFragmentManager
+                .findFragmentById(R.id.nav_host_fragment_connect) as NavHostFragment
+    }
+
+    @After
+    fun tearDown() {
+        PersonalIdManager.getInstance().status = savedStatus
+        mockApi.shutdown()
+        unmockkAll()
+    }
+
+    @Test
+    fun `a card is shown for each payment unit`() {
+        val cards = cardsOn(launch(progressResponse(deliveries = approvedFor(unit = 1, count = 2))))
+
+        assertEquals(ConnectLearnJobTestData.PAYMENT_UNIT_COUNT, cards.size)
+        assertEquals("Unit 1", cards[0].title())
+        assertEquals("Unit 2", cards[1].title())
+    }
+
+    @Test
+    fun `a card shows its unit's approved count, amount earned and visits remaining`() {
+        val card = cardsOn(launch(progressResponse(deliveries = approvedFor(unit = 1, count = 2))))[0]
+
+        assertEquals("2", card.approved())
+        assertEquals("50 ${ConnectLearnJobTestData.CURRENCY}", card.amount())
+        assertEquals(
+            appContext.getString(
+                R.string.connect_results_summary_remaining_days,
+                perUnitTotal - 2,
+                job.daysRemaining,
+            ),
+            card.remaining(),
+        )
+    }
+
+    @Test
+    fun `each card counts only its own unit's deliveries`() {
+        val cards =
+            cardsOn(
+                launch(
+                    progressResponse(
+                        deliveries =
+                            approvedFor(unit = 1, count = 2) +
+                                approvedFor(unit = 2, count = 3, startId = 50),
+                    ),
+                ),
+            )
+
+        assertEquals("2", cards[0].approved())
+        assertEquals("3", cards[1].approved())
+    }
+
+    @Test
+    fun `only approved deliveries count toward a unit's progress`() {
+        val card =
+            cardsOn(
+                launch(
+                    progressResponse(
+                        deliveries =
+                            approvedFor(unit = 1, count = 2) +
+                                deliveriesFor(unit = 1, count = 4, status = "rejected", startId = 20) +
+                                deliveriesFor(unit = 1, count = 3, status = "pending", startId = 30),
+                    ),
+                ),
+            )[0]
+
+        assertEquals("2", card.approved())
+        assertEquals("50 ${ConnectLearnJobTestData.CURRENCY}", card.amount())
+    }
+
+    @Test
+    fun `the progress bar tracks the unit's share of its target`() {
+        val cards =
+            cardsOn(
+                launch(
+                    progressResponse(
+                        deliveries = approvedFor(unit = 1, count = perUnitTotal / 4),
+                    ),
+                ),
+            )
+
+        assertEquals(25f, cards[0].progress(), 0.01f)
+        assertEquals("a unit with no deliveries sits at zero", 0f, cards[1].progress(), 0.01f)
+    }
+
+    @Test
+    fun `a unit that has met its target reports that all visits are done`() {
+        val cards =
+            cardsOn(launch(progressResponse(deliveries = approvedFor(unit = 1, count = perUnitTotal))))
+
+        assertEquals(
+            appContext.getString(R.string.connect_results_summary_visits_done),
+            cards[0].remaining(),
+        )
+        assertEquals(100f, cards[0].progress(), 0.01f)
+    }
+
+    @Test
+    fun `remaining visits are counted against the last day when the job ends today`() {
+        val cards =
+            cardsOn(
+                launch(
+                    progressResponse(
+                        deliveries = approvedFor(unit = 1, count = 2),
+                        endDate = daysFromToday(0),
+                    ),
+                ),
+            )
+
+        assertEquals(
+            appContext.getString(R.string.connect_results_summary_remaining_today, perUnitTotal - 2),
+            cards[0].remaining(),
+        )
+    }
+
+    @Test
+    fun `a card reports the days are over once the job has ended`() {
+        val cards =
+            cardsOn(
+                launch(
+                    progressResponse(
+                        deliveries = approvedFor(unit = 1, count = 2),
+                        endDate = daysFromToday(-1),
+                    ),
+                ),
+            )
+
+        assertEquals(
+            appContext.getString(R.string.connect_results_summary_days_over),
+            cards[0].remaining(),
+        )
+    }
+
+    @Test
+    fun `tapping a card opens that unit's visits and lists only its own deliveries`() {
+        val visits =
+            launch(
+                progressResponse(
+                    deliveries =
+                        approvedFor(unit = 1, count = 2) +
+                            approvedFor(unit = 2, count = 3, startId = 50),
+                ),
+            )
+        val unitTwoCard = cardsOn(visits)[1]
+
+        activity.runOnUiThread { unitTwoCard.performClick() }
+        ShadowLooper.idleMainLooper()
+        layOutHierarchy()
+
+        assertEquals(
+            R.id.connect_delivery_visits_detail_fragment,
+            navController.currentDestination?.id,
+        )
+        assertEquals(
+            appContext.getString(R.string.connect_visit_type_title, "Unit 2"),
+            activity.supportActionBar?.title,
+        )
+        assertEquals(
+            "only the tapped unit's visits are listed",
+            listOf("Entity 50", "Entity 51", "Entity 52"),
+            visitNames(),
+        )
+    }
+
+    /**
+     * Navigates to the delivery home tabs, answers the delivery-progress request the screen fires on
+     * resume with [responseBody], then selects the Visits tab and returns it once laid out.
+     */
+    private fun launch(responseBody: String): ConnectDeliveryVisitsFragment {
+        deliveryProgressBody = responseBody
+
+        activity.setActiveJob(job)
+        activity.runOnUiThread {
+            navController.navigate(
+                R.id.action_connect_jobs_list_fragment_to_connect_job_delivery_progress_fragment,
+            )
+        }
+        ShadowLooper.idleMainLooper()
+
+        awaitDeliverySync()
+        layOutHierarchy()
+
+        val home =
+            navHostFragment.childFragmentManager.primaryNavigationFragment
+                as ConnectDeliveryHomeFragment
+        home
+            .requireView()
+            .findViewById<ViewPager2>(R.id.connect_delivery_home_view_pager)
+            .setCurrentItem(ConnectDeliveryHomeFragment.TAB_VISITS, false)
+        ShadowLooper.idleMainLooper()
+        layOutHierarchy()
+
+        val visits =
+            home.childFragmentManager.fragments
+                .filterIsInstance<ConnectDeliveryVisitsFragment>()
+                .first()
+
+        // The pass above instantiated the page; this one measures and positions the rows it created,
+        // so the item views exist to assert on.
+        layOutHierarchy()
+        return visits
+    }
+
+    /**
+     * The tab is a [androidx.viewpager2.widget.ViewPager2] page holding a
+     * [RecyclerView], so neither the page nor its rows exist until the tree is measured.
+     */
+    private fun layOutHierarchy() {
+        val root = activity.window.decorView
+        root.measure(
+            View.MeasureSpec.makeMeasureSpec(SCREEN_WIDTH_PX, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(SCREEN_HEIGHT_PX, View.MeasureSpec.EXACTLY),
+        )
+        root.layout(0, 0, SCREEN_WIDTH_PX, SCREEN_HEIGHT_PX)
+        ShadowLooper.idleMainLooper()
+    }
+
+    private fun cardsOn(visits: ConnectDeliveryVisitsFragment): List<View> {
+        val recycler = visits.requireView().findViewById<RecyclerView>(R.id.rvDeliveryProgressReport)
+        return (0 until recycler.childCount).map { recycler.getChildAt(it) }
+    }
+
+    private fun visitNames(): List<String> {
+        val detail =
+            navHostFragment.childFragmentManager.primaryNavigationFragment
+                as ConnectDeliveryVisitsDetailFragment
+        val recycler = detail.requireView().findViewById<RecyclerView>(R.id.delivery_list)
+        return (0 until recycler.childCount).map { index ->
+            recycler
+                .getChildAt(index)
+                .findViewById<TextView>(R.id.delivery_item_name)
+                .text
+                .toString()
+        }
+    }
+
+    private fun View.title(): String = findViewById<TextView>(R.id.tvDeliveryTitle).text.toString()
+
+    private fun View.approved(): String = findViewById<TextView>(R.id.tvApproved).text.toString()
+
+    private fun View.amount(): String = findViewById<TextView>(R.id.tvDeliveryTotalAmount).text.toString()
+
+    private fun View.remaining(): String = findViewById<TextView>(R.id.tvRemaining).text.toString()
+
+    /** [org.commcare.views.connect.LinearProgressBar] draws its progress without exposing it. */
+    private fun View.progress(): Float = ReflectionUtils.readField(findViewById<View>(R.id.linearProgressBar), "progress") as Float
+
+    /**
+     * Answers by path so the opportunity-list sync the start destination fires cannot consume the
+     * tab's response. An empty opportunities body is deliberate: a parsed empty list would prune the
+     * seeded job out of the database.
+     */
+    private fun pathRoutingDispatcher(): Dispatcher =
+        object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val body =
+                    if (request.path?.endsWith(DELIVERY_PROGRESS_PATH) == true) {
+                        deliveryProgressBody
+                    } else {
+                        ""
+                    }
+                return MockResponse().setResponseCode(200).setBody(body)
+            }
+        }
+
+    /**
+     * Waits for the delivery-progress response to be applied — the sync timestamp is written right
+     * after the database write — then drains the main looper so the resulting UI update lands.
+     */
+    private fun awaitDeliverySync() {
+        val syncKey = ConnectRepository.SYNC_KEY_DELIVERY_PREFIX + ConnectLearnJobTestData.JOB_UUID
+        val prefs = ConnectSyncPreferences.getInstance(appContext)
+        val deadline = System.currentTimeMillis() + SYNC_TIMEOUT_MS
+
+        while (prefs.getLastSyncTime(syncKey) == null) {
+            if (System.currentTimeMillis() > deadline) {
+                throw AssertionError("Delivery progress was never synced within ${SYNC_TIMEOUT_MS}ms")
+            }
+            ShadowLooper.idleMainLooper()
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        ShadowLooper.idleMainLooper()
+    }
+
+    private fun progressResponse(
+        deliveries: List<String> = emptyList(),
+        endDate: String? = null,
+    ): String {
+        val fields =
+            buildList {
+                add(""""deliveries": [${deliveries.joinToString(",")}]""")
+                endDate?.let { add(""""end_date": "$it"""") }
+            }
+        return "{${fields.joinToString(",")}}"
+    }
+
+    private fun approvedFor(
+        unit: Int,
+        count: Int,
+        startId: Int = 1,
+    ): List<String> = deliveriesFor(unit, count, status = "approved", startId = startId)
+
+    /** One visit per earlier day, so a unit can reach its total cap without hitting a daily cap. */
+    private fun deliveriesFor(
+        unit: Int,
+        count: Int,
+        status: String,
+        startId: Int = 1,
+    ): List<String> =
+        (0 until count).map { index ->
+            val date = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, -(index + 1)) }.time
+            """
+            {
+                "id": ${startId + index},
+                "visit_date": "${visitDateFormat.format(date)}",
+                "status": "$status",
+                "deliver_unit_name": "Unit $unit",
+                "deliver_unit_slug": "unit-$unit",
+                "entity_id": "entity-${startId + index}",
+                "entity_name": "Entity ${startId + index}",
+                "reason": "",
+                "deliver_unit_slug_id": "unit-$unit"
+            }
+            """.trimIndent()
+        }
+
+    private fun daysFromToday(offset: Int): String =
+        endDateFormat.format(
+            Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, offset) }.time,
+        )
+
+    /**
+     * Writes the opportunity through the real storage layer so the repository's cache read and the
+     * tab both see the same record production would.
+     */
+    private fun seedDeliveryJob(): ConnectJobRecord {
+        val seeded =
+            ConnectLearnJobTestData.job().apply {
+                status = ConnectJobRecord.STATUS_DELIVERING
+            }
+        ConnectJobUtils.storeJobs(appContext, listOf(seeded), true)
+        return ConnectJobUtils.getCompositeJob(appContext, ConnectLearnJobTestData.JOB_UUID)!!
+    }
+
+    /**
+     * Writes a real user carrying a live Connect token so the progress call skips the SSO
+     * round-trip. [ConnectDatabaseHelper.dbExists] has to be stubbed because it probes for the
+     * on-disk connect db, which never exists under the in-memory test open helper.
+     */
+    private fun seedConnectUser() {
+        mockkStatic(ConnectDatabaseHelper::class)
+        every { ConnectDatabaseHelper.dbExists() } returns true
+
+        val user =
+            ConnectUserRecord(
+                "1234567890",
+                "test-user-id",
+                "password",
+                "Test User",
+                "1234",
+                Date(),
+                null,
+                false,
+                PersonalIdSessionData.PIN,
+                true,
+            )
+        user.updateConnectToken("test-token", tomorrow())
+        ConnectUserDatabaseUtil.storeUser(appContext, user)
+    }
+
+    private fun tomorrow(): Date = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 1) }.time
+
+    private companion object {
+        const val DELIVERY_PROGRESS_PATH = "/delivery_progress"
+        const val SYNC_TIMEOUT_MS = 10_000L
+        const val POLL_INTERVAL_MS = 20L
+        const val SCREEN_WIDTH_PX = 1080
+        const val SCREEN_HEIGHT_PX = 1920
+    }
+}

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryVisitsFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryVisitsFragmentTest.kt
@@ -124,7 +124,10 @@ class ConnectDeliveryVisitsFragmentTest {
 
     @Test
     fun `a card is shown for each payment unit`() {
-        val cards = cardsOn(launch(progressResponse(deliveries = approvedFor(unit = 1, count = 2))))
+        val cards =
+            getPaymentUnitCards(
+                launchVisitsTab(deliveryProgressJson(deliveries = approvedDeliveriesFor(unit = 1, count = 2))),
+            )
 
         assertEquals(ConnectLearnJobTestData.PAYMENT_UNIT_COUNT, cards.size)
         assertEquals("Unit 1", cards[0].title())
@@ -133,7 +136,10 @@ class ConnectDeliveryVisitsFragmentTest {
 
     @Test
     fun `a card shows its unit's approved count, amount earned and visits remaining`() {
-        val card = cardsOn(launch(progressResponse(deliveries = approvedFor(unit = 1, count = 2))))[0]
+        val card =
+            getPaymentUnitCards(
+                launchVisitsTab(deliveryProgressJson(deliveries = approvedDeliveriesFor(unit = 1, count = 2))),
+            )[0]
 
         assertEquals("2", card.approved())
         assertEquals("50 ${ConnectLearnJobTestData.CURRENCY}", card.amount())
@@ -150,12 +156,12 @@ class ConnectDeliveryVisitsFragmentTest {
     @Test
     fun `each card counts only its own unit's deliveries`() {
         val cards =
-            cardsOn(
-                launch(
-                    progressResponse(
+            getPaymentUnitCards(
+                launchVisitsTab(
+                    deliveryProgressJson(
                         deliveries =
-                            approvedFor(unit = 1, count = 2) +
-                                approvedFor(unit = 2, count = 3, startId = 50),
+                            approvedDeliveriesFor(unit = 1, count = 2) +
+                                approvedDeliveriesFor(unit = 2, count = 3, startId = 50),
                     ),
                 ),
             )
@@ -167,13 +173,13 @@ class ConnectDeliveryVisitsFragmentTest {
     @Test
     fun `only approved deliveries count toward a unit's progress`() {
         val card =
-            cardsOn(
-                launch(
-                    progressResponse(
+            getPaymentUnitCards(
+                launchVisitsTab(
+                    deliveryProgressJson(
                         deliveries =
-                            approvedFor(unit = 1, count = 2) +
-                                deliveriesFor(unit = 1, count = 4, status = "rejected", startId = 20) +
-                                deliveriesFor(unit = 1, count = 3, status = "pending", startId = 30),
+                            approvedDeliveriesFor(unit = 1, count = 2) +
+                                deliveriesJsonFor(unit = 1, count = 4, status = "rejected", startId = 20) +
+                                deliveriesJsonFor(unit = 1, count = 3, status = "pending", startId = 30),
                     ),
                 ),
             )[0]
@@ -185,10 +191,10 @@ class ConnectDeliveryVisitsFragmentTest {
     @Test
     fun `the progress bar tracks the unit's share of its target`() {
         val cards =
-            cardsOn(
-                launch(
-                    progressResponse(
-                        deliveries = approvedFor(unit = 1, count = perUnitTotal / 4),
+            getPaymentUnitCards(
+                launchVisitsTab(
+                    deliveryProgressJson(
+                        deliveries = approvedDeliveriesFor(unit = 1, count = perUnitTotal / 4),
                     ),
                 ),
             )
@@ -200,7 +206,11 @@ class ConnectDeliveryVisitsFragmentTest {
     @Test
     fun `a unit that has met its target reports that all visits are done`() {
         val cards =
-            cardsOn(launch(progressResponse(deliveries = approvedFor(unit = 1, count = perUnitTotal))))
+            getPaymentUnitCards(
+                launchVisitsTab(
+                    deliveryProgressJson(deliveries = approvedDeliveriesFor(unit = 1, count = perUnitTotal)),
+                ),
+            )
 
         assertEquals(
             appContext.getString(R.string.connect_results_summary_visits_done),
@@ -212,11 +222,11 @@ class ConnectDeliveryVisitsFragmentTest {
     @Test
     fun `remaining visits are counted against the last day when the job ends today`() {
         val cards =
-            cardsOn(
-                launch(
-                    progressResponse(
-                        deliveries = approvedFor(unit = 1, count = 2),
-                        endDate = daysFromToday(0),
+            getPaymentUnitCards(
+                launchVisitsTab(
+                    deliveryProgressJson(
+                        deliveries = approvedDeliveriesFor(unit = 1, count = 2),
+                        endDate = endDateDaysFromToday(0),
                     ),
                 ),
             )
@@ -230,11 +240,11 @@ class ConnectDeliveryVisitsFragmentTest {
     @Test
     fun `a card reports the days are over once the job has ended`() {
         val cards =
-            cardsOn(
-                launch(
-                    progressResponse(
-                        deliveries = approvedFor(unit = 1, count = 2),
-                        endDate = daysFromToday(-1),
+            getPaymentUnitCards(
+                launchVisitsTab(
+                    deliveryProgressJson(
+                        deliveries = approvedDeliveriesFor(unit = 1, count = 2),
+                        endDate = endDateDaysFromToday(-1),
                     ),
                 ),
             )
@@ -248,14 +258,14 @@ class ConnectDeliveryVisitsFragmentTest {
     @Test
     fun `tapping a card opens that unit's visits and lists only its own deliveries`() {
         val visits =
-            launch(
-                progressResponse(
+            launchVisitsTab(
+                deliveryProgressJson(
                     deliveries =
-                        approvedFor(unit = 1, count = 2) +
-                            approvedFor(unit = 2, count = 3, startId = 50),
+                        approvedDeliveriesFor(unit = 1, count = 2) +
+                            approvedDeliveriesFor(unit = 2, count = 3, startId = 50),
                 ),
             )
-        val unitTwoCard = cardsOn(visits)[1]
+        val unitTwoCard = getPaymentUnitCards(visits)[1]
 
         activity.runOnUiThread { unitTwoCard.performClick() }
         ShadowLooper.idleMainLooper()
@@ -272,7 +282,7 @@ class ConnectDeliveryVisitsFragmentTest {
         assertEquals(
             "only the tapped unit's visits are listed",
             listOf("Entity 50", "Entity 51", "Entity 52"),
-            visitNames(),
+            visitNamesOnDetailScreen(),
         )
     }
 
@@ -280,7 +290,7 @@ class ConnectDeliveryVisitsFragmentTest {
      * Navigates to the delivery home tabs, answers the delivery-progress request the screen fires on
      * resume with [responseBody], then selects the Visits tab and returns it once laid out.
      */
-    private fun launch(responseBody: String): ConnectDeliveryVisitsFragment {
+    private fun launchVisitsTab(responseBody: String): ConnectDeliveryVisitsFragment {
         deliveryProgressBody = responseBody
 
         activity.setActiveJob(job)
@@ -329,12 +339,12 @@ class ConnectDeliveryVisitsFragmentTest {
         ShadowLooper.idleMainLooper()
     }
 
-    private fun cardsOn(visits: ConnectDeliveryVisitsFragment): List<View> {
-        val recycler = visits.requireView().findViewById<RecyclerView>(R.id.rvDeliveryProgressReport)
+    private fun getPaymentUnitCards(visits: ConnectDeliveryVisitsFragment): List<View> {
+        val recycler = visits.requireView().findViewById<RecyclerView>(R.id.rvPaymentUnits)
         return (0 until recycler.childCount).map { recycler.getChildAt(it) }
     }
 
-    private fun visitNames(): List<String> {
+    private fun visitNamesOnDetailScreen(): List<String> {
         val detail =
             navHostFragment.childFragmentManager.primaryNavigationFragment
                 as ConnectDeliveryVisitsDetailFragment
@@ -396,7 +406,7 @@ class ConnectDeliveryVisitsFragmentTest {
         ShadowLooper.idleMainLooper()
     }
 
-    private fun progressResponse(
+    private fun deliveryProgressJson(
         deliveries: List<String> = emptyList(),
         endDate: String? = null,
     ): String {
@@ -408,14 +418,14 @@ class ConnectDeliveryVisitsFragmentTest {
         return "{${fields.joinToString(",")}}"
     }
 
-    private fun approvedFor(
+    private fun approvedDeliveriesFor(
         unit: Int,
         count: Int,
         startId: Int = 1,
-    ): List<String> = deliveriesFor(unit, count, status = "approved", startId = startId)
+    ): List<String> = deliveriesJsonFor(unit, count, status = "approved", startId = startId)
 
     /** One visit per earlier day, so a unit can reach its total cap without hitting a daily cap. */
-    private fun deliveriesFor(
+    private fun deliveriesJsonFor(
         unit: Int,
         count: Int,
         status: String,
@@ -438,7 +448,7 @@ class ConnectDeliveryVisitsFragmentTest {
             """.trimIndent()
         }
 
-    private fun daysFromToday(offset: Int): String =
+    private fun endDateDaysFromToday(offset: Int): String =
         endDateFormat.format(
             Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, offset) }.time,
         )


### PR DESCRIPTION
### [CCCT-2535](https://dimagi.atlassian.net/browse/CCCT-2535)


https://github.com/user-attachments/assets/fb6c5ddd-5df0-4782-a0d8-b4f4f75e171c



<img width="200" height="445" alt="Screenshot_20260826_112428" src="https://github.com/user-attachments/assets/f0eec977-c4b1-4feb-8722-355d3a631566" />


Please ignore the bottom spacing for the CTA bar—it will be fixed in a follow-up [task](https://dimagi.atlassian.net/browse/CCCT-2778).


## Product Description

The Visits tab of a delivery opportunity was empty. It now lists a card per payment
unit with that unit's approved visits, amount earned and visits remaining, and tapping
a card opens the visit list filtered to that unit.

## Technical Summary

Restores the previous card layout design.

The identity handed to the detail screen is the payment unit's UUID rather than its
name — two payment units can carry the same name by mistake, a UUID cannot — so that
screen now filters deliveries on `slugUUID`, which is also what the dashboard's own
per-unit counts key on.

## Safety Assurance

### Safety story

What gives confidence:

- I tested this by running it on a device.
- I ran the new test class and the existing `ConnectDeliveryHomeFragmentTest` suite; both
  pass. I also confirmed the new tests fail when the unit filter and the approved-only
  filter are broken, so they are not vacuous.
- Scope is one tab plus one filter predicate. No schema, migration or storage changes.

### Automated test coverage

`ConnectDeliveryVisitsFragmentTest` adds nine Robolectric tests driving the tab end to
end — the job seeded through the real Connect database, deliveries arriving over the real
networking stack from a mock server. They lock down the per-unit figures, that only
approved visits count, each phrasing of the remaining-visits line, and the tap-through
that opens the detail screen listing that unit's visits and no others.


[CCCT-2535]: https://dimagi.atlassian.net/browse/CCCT-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ