### PR TITLE
Ccct 2709 confirm backup code profile

### DIFF
--- a/app/res/drawable/ic_key_round.xml
+++ b/app/res/drawable/ic_key_round.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12.65,10C11.83,7.67 9.61,6 7,6c-3.31,0 -6,2.69 -6,6s2.69,6 6,6c2.61,0 4.83,-1.67 5.65,-4H17v4h4v-4h2v-4H12.65zM7,14c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2z"/>
+</vector>

--- a/app/res/layout/fragment_recovery_code.xml
+++ b/app/res/layout/fragment_recovery_code.xml
@@ -212,23 +212,22 @@
             android:textSize="16sp"
             android:visibility="gone"/>
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
                 <TextView
                     android:id="@+id/not_me_button"
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/personalid_this_is_not_me"
                     android:textColor="@color/cc_brand_color"
+                    android:textSize="12sp"
                     android:layout_marginStart="16dp"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginEnd="16dp"
                     android:clickable="true"
-                    android:layout_marginEnd="10dp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/connect_backup_code_button"
-                    app:layout_constraintBottom_toBottomOf="parent"
                     android:visibility="gone"
                     android:textStyle="bold"/>
 
@@ -237,17 +236,13 @@
                     style="@style/CustomButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
-                    android:layout_marginTop="16dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
+                    android:layout_gravity="end"
+                    android:layout_marginTop="32dp"
                     android:layout_marginEnd="16dp"
                     android:layout_marginBottom="16dp"
                     android:text="@string/personalid_continue_label"
-                    android:drawableRight="@drawable/connect_right_arrow"
-                    />
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                    android:drawableRight="@drawable/connect_right_arrow"/>
+            </LinearLayout>
     </LinearLayout>
     </ScrollView>
 </layout>

--- a/app/res/layout/fragment_recovery_code.xml
+++ b/app/res/layout/fragment_recovery_code.xml
@@ -223,7 +223,7 @@
                     android:layout_height="wrap_content"
                     android:text="@string/personalid_this_is_not_me"
                     android:textColor="@color/cc_brand_color"
-                    android:textSize="12sp"
+                    android:textSize="14sp"
                     android:layout_marginStart="16dp"
                     android:layout_marginTop="16dp"
                     android:layout_marginEnd="16dp"

--- a/app/res/layout/personalid_profile_screen.xml
+++ b/app/res/layout/personalid_profile_screen.xml
@@ -91,20 +91,41 @@
             android:layout_marginTop="16dp"
             android:background="@color/grey_light" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/profile_btn_forget_personalid"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="32dp"
-            android:text="@string/personalid_profile_forget_account"
-            android:textAllCaps="false"
-            android:textColor="@color/white"
             android:layout_gravity="center"
-            android:textSize="14sp"
-            app:backgroundTint="@color/red_700"
-            app:icon="@drawable/ic_personalid_forget_warning"
-            app:iconGravity="textStart"
-            app:iconTint="@null" />
+            android:layout_marginTop="32dp"
+            android:orientation="vertical">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/profile_change_backup_code"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/personalid_profile_change_backup_code"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                android:textSize="14sp"
+                app:backgroundTint="@color/connect_dark_blue_color"
+                app:icon="@drawable/ic_key_round"
+                app:iconGravity="textStart"
+                app:iconTint="@null" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/profile_btn_forget_personalid"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/personalid_profile_forget_account"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                android:textSize="14sp"
+                app:backgroundTint="@color/red_700"
+                app:icon="@drawable/ic_personalid_forget_warning"
+                app:iconGravity="textStart"
+                app:iconTint="@null" />
+
+        </LinearLayout>
 
     </LinearLayout>
 </ScrollView>

--- a/app/res/navigation/nav_graph_personalid_profile.xml
+++ b/app/res/navigation/nav_graph_personalid_profile.xml
@@ -12,6 +12,9 @@
         <action
             android:id="@+id/action_profile_to_profile_edit"
             app:destination="@id/personalid_profile_edit_fragment" />
+        <action
+            android:id="@+id/action_profile_to_profile_backup_code"
+            app:destination="@id/personalid_profile_backup_code_fragment" />
     </fragment>
 
     <fragment
@@ -38,4 +41,22 @@
             android:name="emailOtpRequestCount"
             app:argType="integer" />
     </fragment>
+
+    <fragment
+        android:id="@+id/personalid_profile_backup_code_fragment"
+        android:name="org.commcare.personalId.profile.PersonalIdProfileBackupCodeFragment"
+        android:label="@string/connect_backup_code_title_confirm">
+        <action
+            android:id="@+id/action_profile_backup_code_to_set_new_backup_code"
+            app:destination="@id/personalid_set_new_backup_code_fragment" />
+        <action
+            android:id="@+id/action_profile_backup_code_to_email_verification"
+            app:destination="@id/personalid_email_verification_fragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/personalid_set_new_backup_code_fragment"
+        android:name="org.commcare.personalId.profile.SetNewBackupCodeFragment"
+        android:label="@string/personalid_set_new_backup_code_title" />
+
 </navigation>

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -415,6 +415,10 @@
     <string name="personalid_profile_edit_save">Guardar</string>
     <string name="personalid_profile_edit_cancel">Cancelar</string>
     <string name="personalid_profile_edit_save_success">Tu perfil se ha actualizado correctamente.</string>
+    <string name="personalid_profile_change_backup_code">Cambiar código de respaldo</string>
+    <string name="personalid_forgot_backup_code">¿Olvidaste tu código de respaldo?</string>
+    <string name="personalid_no_email_forgot_backup_code_toast">Por favor, añade una dirección de correo electrónico</string>
+    <string name="personalid_set_new_backup_code_title">Establecer nuevo código de respaldo</string>
     <string name="connect_job_info_delivery_detail">Detalles de la entrega</string>
     <string name="connect_job_info_review_delivery">Revisar detalles de la entrega</string>
     <string name="connect_job_info_visit">%d visitas máximo</string>

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -417,6 +417,7 @@
     <string name="personalid_profile_edit_save_success">Tu perfil se ha actualizado correctamente.</string>
     <string name="personalid_profile_change_backup_code">Cambiar código de respaldo</string>
     <string name="personalid_forgot_backup_code">¿Olvidaste tu código de respaldo?</string>
+    <string name="personalid_backup_code_too_many_attempts">Demasiados intentos. Por favor, inténtalo de nuevo más tarde.</string>
     <string name="personalid_no_email_forgot_backup_code_toast">Por favor, añade una dirección de correo electrónico</string>
     <string name="personalid_set_new_backup_code_title">Establecer nuevo código de respaldo</string>
     <string name="connect_job_info_delivery_detail">Detalles de la entrega</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -412,6 +412,10 @@ License.
     <string name="personalid_profile_edit_save">Enregistrer</string>
     <string name="personalid_profile_edit_cancel">Annuler</string>
     <string name="personalid_profile_edit_save_success">Votre profil a été mis à jour avec succès.</string>
+    <string name="personalid_profile_change_backup_code">Changer le code de sauvegarde</string>
+    <string name="personalid_forgot_backup_code">Vous avez oublié votre code de sauvegarde ?</string>
+    <string name="personalid_no_email_forgot_backup_code_toast">Veuillez ajouter une adresse e-mail</string>
+    <string name="personalid_set_new_backup_code_title">Définir un nouveau code de sauvegarde</string>
     <string name="connect_job_info_delivery_detail">Détails de livraison</string>
     <string name="connect_job_info_review_delivery">Vérifiez les détails de livraison</string>
     <string name="connect_job_info_visit">%d visites maximum</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -414,6 +414,7 @@ License.
     <string name="personalid_profile_edit_save_success">Votre profil a été mis à jour avec succès.</string>
     <string name="personalid_profile_change_backup_code">Changer le code de sauvegarde</string>
     <string name="personalid_forgot_backup_code">Vous avez oublié votre code de sauvegarde ?</string>
+    <string name="personalid_backup_code_too_many_attempts">Trop de tentatives. Veuillez réessayer plus tard.</string>
     <string name="personalid_no_email_forgot_backup_code_toast">Veuillez ajouter une adresse e-mail</string>
     <string name="personalid_set_new_backup_code_title">Définir un nouveau code de sauvegarde</string>
     <string name="connect_job_info_delivery_detail">Détails de livraison</string>

--- a/app/res/values-ha/strings.xml
+++ b/app/res/values-ha/strings.xml
@@ -250,6 +250,10 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="personalid_profile_edit_save">Ajiye</string>
     <string name="personalid_profile_edit_cancel">Soke</string>
     <string name="personalid_profile_edit_save_success">An sabunta bayanan martabarka cikin nasara.</string>
+    <string name="personalid_profile_change_backup_code">Canza lambar sirrin ajiyar bayanai</string>
+    <string name="personalid_forgot_backup_code">Ka manta da lambar sirrin ajiyar bayananka?</string>
+    <string name="personalid_no_email_forgot_backup_code_toast">Da fatan za a ƙara adireshin imel</string>
+    <string name="personalid_set_new_backup_code_title">Saita sabuwar lambar sirrin ajiyar bayanai</string>
     <string name="connect_job_info_delivery_detail">Cikakkun Bayanan Isarwa</string>
     <string name="connect_job_info_review_delivery">Yi bitar cikakkun bayanai game da isar da kaya</string>
     <string name="connect_job_info_visit">Matsakaicin Ziyarar %d</string>

--- a/app/res/values-ha/strings.xml
+++ b/app/res/values-ha/strings.xml
@@ -252,6 +252,7 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="personalid_profile_edit_save_success">An sabunta bayanan martabarka cikin nasara.</string>
     <string name="personalid_profile_change_backup_code">Canza lambar sirrin ajiyar bayanai</string>
     <string name="personalid_forgot_backup_code">Ka manta da lambar sirrin ajiyar bayananka?</string>
+    <string name="personalid_backup_code_too_many_attempts">Yunkuri da yawa. Da fatan za a sake gwadawa daga baya.</string>
     <string name="personalid_no_email_forgot_backup_code_toast">Da fatan za a ƙara adireshin imel</string>
     <string name="personalid_set_new_backup_code_title">Saita sabuwar lambar sirrin ajiyar bayanai</string>
     <string name="connect_job_info_delivery_detail">Cikakkun Bayanan Isarwa</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -412,6 +412,9 @@ License.
     <string name="personalid_profile_edit_save">सहेजें</string>
     <string name="personalid_profile_edit_cancel">रद्द करें</string>
     <string name="personalid_profile_edit_save_success">आपकी प्रोफ़ाइल सफलतापूर्वक अपडेट कर दी गई है।</string>
+    <string name="personalid_profile_change_backup_code">बैकअप कोड बदलें</string>
+    <string name="personalid_forgot_backup_code">अपना बैकअप कोड भूल गए?</string>
+    <string name="personalid_no_email_forgot_backup_code_toast">Please add an email address</string>
     <string name="connect_job_info_delivery_detail">वितरण विवरण</string>
     <string name="connect_job_info_review_delivery">वितरण विवरण की समीक्षा करें</string>
     <string name="connect_job_info_visit">अधिकतम %d विज़िट</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -414,6 +414,7 @@ License.
     <string name="personalid_profile_edit_save_success">आपकी प्रोफ़ाइल सफलतापूर्वक अपडेट कर दी गई है।</string>
     <string name="personalid_profile_change_backup_code">बैकअप कोड बदलें</string>
     <string name="personalid_forgot_backup_code">अपना बैकअप कोड भूल गए?</string>
+        <string name="personalid_backup_code_too_many_attempts">Too many attempts. Please try again later.</string>
     <string name="personalid_no_email_forgot_backup_code_toast">Please add an email address</string>
     <string name="connect_job_info_delivery_detail">वितरण विवरण</string>
     <string name="connect_job_info_review_delivery">वितरण विवरण की समीक्षा करें</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -105,6 +105,7 @@
     <string name="personalid_profile_edit_save_success">Jūsų profilis sėkmingai atnaujintas.</string>
     <string name="personalid_profile_change_backup_code">Keisti atsarginį kodą</string>
     <string name="personalid_forgot_backup_code">Pamiršote savo atsarginį kodą?</string>
+        <string name="personalid_backup_code_too_many_attempts">Too many attempts. Please try again later.</string>
     <string name="personalid_no_email_forgot_backup_code_toast">Please add an email address</string>
     <string name="nav_drawer_signin_register">Prisijungti / Registruotis</string>
     <string name="nav_drawer_help">Pagalba</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -103,6 +103,9 @@
     <string name="personalid_profile_edit_save">Išsaugoti</string>
     <string name="personalid_profile_edit_cancel">Atšaukti</string>
     <string name="personalid_profile_edit_save_success">Jūsų profilis sėkmingai atnaujintas.</string>
+    <string name="personalid_profile_change_backup_code">Keisti atsarginį kodą</string>
+    <string name="personalid_forgot_backup_code">Pamiršote savo atsarginį kodą?</string>
+    <string name="personalid_no_email_forgot_backup_code_toast">Please add an email address</string>
     <string name="nav_drawer_signin_register">Prisijungti / Registruotis</string>
     <string name="nav_drawer_help">Pagalba</string>
     <string name="nav_drawer_not_signed_in_to_personal_id">Neprisijungta prie „PersonalID“</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -105,6 +105,7 @@
     <string name="personalid_profile_edit_save_success">Profilen din er oppdatert.</string>
     <string name="personalid_profile_change_backup_code">Endre sikkerhetskode</string>
     <string name="personalid_forgot_backup_code">Glemt sikkerhetskoden din?</string>
+        <string name="personalid_backup_code_too_many_attempts">Too many attempts. Please try again later.</string>
     <string name="personalid_no_email_forgot_backup_code_toast">Please add an email address</string>
     <string name="nav_drawer_signin_register">Logg inn / Registrer deg</string>
     <string name="nav_drawer_help">Hjelp</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -103,6 +103,9 @@
     <string name="personalid_profile_edit_save">Lagre</string>
     <string name="personalid_profile_edit_cancel">Avbryt</string>
     <string name="personalid_profile_edit_save_success">Profilen din er oppdatert.</string>
+    <string name="personalid_profile_change_backup_code">Endre sikkerhetskode</string>
+    <string name="personalid_forgot_backup_code">Glemt sikkerhetskoden din?</string>
+    <string name="personalid_no_email_forgot_backup_code_toast">Please add an email address</string>
     <string name="nav_drawer_signin_register">Logg inn / Registrer deg</string>
     <string name="nav_drawer_help">Hjelp</string>
     <string name="nav_drawer_not_signed_in_to_personal_id">Du er ikke logget inn med PersonalID</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -430,6 +430,7 @@
     <string name="personalid_profile_edit_save_success">Seu perfil foi atualizado com sucesso.</string>
     <string name="personalid_profile_change_backup_code">Alterar código de backup</string>
     <string name="personalid_forgot_backup_code">Esqueceu o seu código de backup?</string>
+    <string name="personalid_backup_code_too_many_attempts">Muitas tentativas. Por favor, tente novamente mais tarde.</string>
     <string name="personalid_no_email_forgot_backup_code_toast">Por favor, adicione um endereço de e-mail</string>
     <string name="personalid_set_new_backup_code_title">Definir novo código de backup</string>
     <string name="connect_job_info_delivery_detail">Detalhes da entrega</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -428,6 +428,10 @@
     <string name="personalid_profile_edit_save">Salvar</string>
     <string name="personalid_profile_edit_cancel">Cancelar</string>
     <string name="personalid_profile_edit_save_success">Seu perfil foi atualizado com sucesso.</string>
+    <string name="personalid_profile_change_backup_code">Alterar código de backup</string>
+    <string name="personalid_forgot_backup_code">Esqueceu o seu código de backup?</string>
+    <string name="personalid_no_email_forgot_backup_code_toast">Por favor, adicione um endereço de e-mail</string>
+    <string name="personalid_set_new_backup_code_title">Definir novo código de backup</string>
     <string name="connect_job_info_delivery_detail">Detalhes da entrega</string>
     <string name="connect_job_info_review_delivery">Revise os detalhes da entrega</string>
     <string name="connect_job_info_visit">%d máximo de visitas</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -414,6 +414,9 @@
     <string name="personalid_profile_edit_save">Hifadhi</string>
     <string name="personalid_profile_edit_cancel">Ghairi</string>
     <string name="personalid_profile_edit_save_success">Wasifu wako umesasishwa kwa mafanikio.</string>
+    <string name="personalid_profile_change_backup_code">Badilisha nambari ya hifadhi nakala</string>
+    <string name="personalid_forgot_backup_code">Umesahau nambari yako ya hifadhi nakala?</string>
+    <string name="personalid_no_email_forgot_backup_code_toast">Please add an email address</string>
     <string name="connect_job_info_delivery_detail">Maelezo ya Uwasilishaji</string>
     <string name="connect_job_info_review_delivery">Kagua maelezo ya utoaji</string>
     <string name="connect_job_info_visit">%d upeo wa Ziara</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -416,6 +416,7 @@
     <string name="personalid_profile_edit_save_success">Wasifu wako umesasishwa kwa mafanikio.</string>
     <string name="personalid_profile_change_backup_code">Badilisha nambari ya hifadhi nakala</string>
     <string name="personalid_forgot_backup_code">Umesahau nambari yako ya hifadhi nakala?</string>
+        <string name="personalid_backup_code_too_many_attempts">Too many attempts. Please try again later.</string>
     <string name="personalid_no_email_forgot_backup_code_toast">Please add an email address</string>
     <string name="connect_job_info_delivery_detail">Maelezo ya Uwasilishaji</string>
     <string name="connect_job_info_review_delivery">Kagua maelezo ya utoaji</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -415,6 +415,10 @@
     <string name="personalid_profile_edit_save">ኣቐምጥ</string>
     <string name="personalid_profile_edit_cancel">ሰርዝ</string>
     <string name="personalid_profile_edit_save_success">ፕሮፋይልኩም ብዓወት ተሐዲሱ።</string>
+    <string name="personalid_profile_change_backup_code">ናይ ምትካእ ኮድ ቀይር</string>
+    <string name="personalid_forgot_backup_code">ናይ ምትካእ ኮድካ ረሲዕካ?</string>
+    <string name="personalid_no_email_forgot_backup_code_toast">በጃኻ ናይ ኢ-መይል ኣድራሻ ወስኽ</string>
+    <string name="personalid_set_new_backup_code_title">ሓድሽ ናይ ምትካእ ኮድ ኣቐምጥ</string>
     <string name="connect_job_info_delivery_detail">ዝርዝር (ኣተገባብራ)ኣወሃህባ</string>
     <string name="connect_job_info_review_delivery">ዝርዝር ኣወሃህባ ዳህሳስ ከልስ</string>
     <string name="connect_job_info_visit">%d ዝለዓለ ምብጻሕ</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -417,6 +417,7 @@
     <string name="personalid_profile_edit_save_success">ፕሮፋይልኩም ብዓወት ተሐዲሱ።</string>
     <string name="personalid_profile_change_backup_code">ናይ ምትካእ ኮድ ቀይር</string>
     <string name="personalid_forgot_backup_code">ናይ ምትካእ ኮድካ ረሲዕካ?</string>
+    <string name="personalid_backup_code_too_many_attempts">ብዙሕ ፈተናታት። በጃኻ ድሕሪ ሕጂ እንደገና ፈትን።</string>
     <string name="personalid_no_email_forgot_backup_code_toast">በጃኻ ናይ ኢ-መይል ኣድራሻ ወስኽ</string>
     <string name="personalid_set_new_backup_code_title">ሓድሽ ናይ ምትካእ ኮድ ኣቐምጥ</string>
     <string name="connect_job_info_delivery_detail">ዝርዝር (ኣተገባብራ)ኣወሃህባ</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -800,6 +800,7 @@
     <string name="personalid_this_is_not_me"><u>This is not me</u></string>
     <string name="personalid_profile_change_backup_code">Change backup code</string>
     <string name="personalid_forgot_backup_code">Forgot your backup code?</string>
+        <string name="personalid_backup_code_too_many_attempts">Too many attempts. Please try again later.</string>
     <string name="personalid_no_email_forgot_backup_code_toast">Please add an email address</string>
     <string name="personalid_welcome_back_msg">Welcome back %s</string>
     <string name="personalid_wrong_backup_message">You have entered the wrong Backup Code. Please try again. Your account will be locked after %d more incorrect attempts.</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -378,6 +378,7 @@
     <string name="connect_backup_code_message">Enter your 6-digit Backup Code</string>
     <string name="connect_backup_code_remember">Please be sure to remember your backup code! It must be %d digits. Keep it in a safe place as you will need it to access your account again.</string>
     <string name="connect_backup_code_mismatch">The backup codes you enter must match.</string>
+    <string name="personalid_set_new_backup_code_title">Set New Backup Code</string>
 
     <string name="connect_backup_fail_title">Wrong Backup Code</string>
     <string name="personalid_network_response_parsing_error">Error parsing data from server. Please contact customer support.</string>
@@ -797,6 +798,9 @@
     <string name="personalid_photo_capture_take_photo_button">Take Photo</string>
     <string name="personalid_photo_capture_save_photo_button">Save Photo</string>
     <string name="personalid_this_is_not_me"><u>This is not me</u></string>
+    <string name="personalid_profile_change_backup_code">Change backup code</string>
+    <string name="personalid_forgot_backup_code">Forgot your backup code?</string>
+    <string name="personalid_no_email_forgot_backup_code_toast">Please add an email address</string>
     <string name="personalid_welcome_back_msg">Welcome back %s</string>
     <string name="personalid_wrong_backup_message">You have entered the wrong Backup Code. Please try again. Your account will be locked after %d more incorrect attempts.</string>
     <string name="personalid_second_device_login_title">Login on Second Device</string>

--- a/app/src/org/commcare/fragments/personalId/BackupCodeWorkflow.kt
+++ b/app/src/org/commcare/fragments/personalId/BackupCodeWorkflow.kt
@@ -1,0 +1,11 @@
+package org.commcare.fragments.personalId
+
+/**
+ * Identifies which backup-code flow is being executed.
+ *
+ *  - [CONFIRM_BACKUP_CODE_CHANGE_CODE]: user is on the Manage Profile screen and wants to change
+ *    their backup code; must confirm the current code first before setting a new one.
+ */
+enum class BackupCodeWorkflow {
+    CONFIRM_BACKUP_CODE_CHANGE_CODE,
+}

--- a/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
@@ -73,7 +73,7 @@ abstract class BasePersonalIdBackupCodeFragment : BasePersonalIdFragment() {
         titleResId: Int,
         showConfirmCode: Boolean,
         subtitle: CharSequence,
-        notMeButtonTextId : Int? = null,
+        notMeButtonTextId: Int? = null,
     ) {
         requireActivity().title = getString(titleResId)
         binding.recoveryCodeTilte.setText(titleResId)

--- a/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
@@ -32,7 +32,7 @@ abstract class BasePersonalIdBackupCodeFragment : BasePersonalIdFragment() {
         binding.confirmCodeView.clearCode()
     }
 
-    protected  open fun submitIfEnabled() {
+    protected open fun submitIfEnabled() {
         if (binding.connectBackupCodeButton.isEnabled) handleBackupCodeSubmission()
     }
 
@@ -60,6 +60,57 @@ abstract class BasePersonalIdBackupCodeFragment : BasePersonalIdFragment() {
 
     protected fun enableContinueButton(enabled: Boolean) {
         binding.connectBackupCodeButton.isEnabled = enabled
+    }
+
+    protected open fun onCodeChanged() {
+        validateBackupCodeAndEnableContinue()
+    }
+
+    protected open fun setupListeners() {
+        binding.backupCodeView.setOnCodeChangedListener { onCodeChanged() }
+        binding.backupCodeView.setOnEnterKeyPressedListener { submitIfEnabled() }
+        binding.confirmCodeView.setOnCodeChangedListener { onCodeChanged() }
+        binding.confirmCodeView.setOnEnterKeyPressedListener { submitIfEnabled() }
+        binding.connectBackupCodeButton.setOnClickListener { handleBackupCodeSubmission() }
+        binding.backupCodeVisibilityToggle.setOnClickListener {
+            togglePasswordVisibility(binding.backupCodeView, binding.backupCodeVisibilityToggle)
+        }
+        binding.confirmCodeVisibilityToggle.setOnClickListener {
+            togglePasswordVisibility(binding.confirmCodeView, binding.confirmCodeVisibilityToggle)
+        }
+    }
+
+    protected fun validateBackupCodeAndEnableContinue() {
+        enableContinueButton(validateBackupCodeInput())
+    }
+
+    protected fun validateBackupCodeInput(): Boolean {
+        val backupCode = binding.backupCodeView.codeValue
+        val isBackupCodeComplete = backupCode.length == BACKUP_CODE_LENGTH
+        if (binding.confirmCodeLayout.visibility != View.VISIBLE) {
+            enableContinueButton(isBackupCodeComplete)
+            return true
+        }
+        val confirmCode = binding.confirmCodeView.codeValue
+        val isConfirmCodeComplete = confirmCode.length == BACKUP_CODE_LENGTH
+        if (isBackupCodeComplete && isConfirmCodeComplete && backupCode != confirmCode) {
+            showError(getString(R.string.connect_backup_code_mismatch))
+        } else {
+            clearError()
+        }
+        val isValid = isBackupCodeComplete && backupCode == confirmCode
+        enableContinueButton(isValid)
+        return isValid
+    }
+
+    override fun navigateToMessageDisplay(
+        title: String,
+        message: String?,
+        isCancellable: Boolean,
+        phase: Int,
+        buttonText: Int,
+    ) {
+        // no default implementation
     }
 
     companion object {

--- a/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
@@ -1,0 +1,68 @@
+package org.commcare.fragments.personalId
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import org.commcare.dalvik.R
+import org.commcare.dalvik.databinding.FragmentRecoveryCodeBinding
+import org.commcare.views.connect.NumericCodeView
+
+abstract class BasePersonalIdBackupCodeFragment : BasePersonalIdFragment() {
+    protected lateinit var binding: FragmentRecoveryCodeBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding = FragmentRecoveryCodeBinding.inflate(inflater, container, false)
+        clearBackupCodeFields()
+        return binding.root
+    }
+
+    override fun onResume() {
+        super.onResume()
+        binding.backupCodeView.requestFocus(requireActivity())
+    }
+
+    protected fun clearBackupCodeFields() {
+        binding.backupCodeView.clearCode()
+        binding.confirmCodeView.clearCode()
+    }
+
+    protected  open fun submitIfEnabled() {
+        if (binding.connectBackupCodeButton.isEnabled) handleBackupCodeSubmission()
+    }
+
+    abstract fun handleBackupCodeSubmission()
+
+    protected fun togglePasswordVisibility(
+        codeView: NumericCodeView,
+        toggle: ImageView,
+    ) {
+        codeView.isPasswordVisible = !codeView.isPasswordVisible
+        toggle.setImageResource(
+            if (codeView.isPasswordVisible) R.drawable.ic_visibility_off_24 else R.drawable.ic_visibility_24,
+        )
+    }
+
+    protected fun clearError() {
+        binding.connectBackupCodeErrorMessage.visibility = View.GONE
+        binding.connectBackupCodeErrorMessage.text = ""
+    }
+
+    protected fun showError(message: String) {
+        binding.connectBackupCodeErrorMessage.visibility = View.VISIBLE
+        binding.connectBackupCodeErrorMessage.text = message
+    }
+
+    protected fun enableContinueButton(enabled: Boolean) {
+        binding.connectBackupCodeButton.isEnabled = enabled
+    }
+
+    companion object {
+        const val BACKUP_CODE_LENGTH = 6
+    }
+}

--- a/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
@@ -118,7 +118,7 @@ abstract class BasePersonalIdBackupCodeFragment : BasePersonalIdFragment() {
         val isBackupCodeComplete = backupCode.length == BACKUP_CODE_LENGTH
         if (binding.confirmCodeLayout.visibility != View.VISIBLE) {
             enableContinueButton(isBackupCodeComplete)
-            return true
+            return isBackupCodeComplete
         }
         val confirmCode = binding.confirmCodeView.codeValue
         val isConfirmCodeComplete = confirmCode.length == BACKUP_CODE_LENGTH

--- a/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
@@ -18,9 +18,16 @@ abstract class BasePersonalIdBackupCodeFragment : BasePersonalIdFragment() {
         savedInstanceState: Bundle?,
     ): View {
         binding = FragmentRecoveryCodeBinding.inflate(inflater, container, false)
+        initData()
+        setUpView()
+        setupListeners()
         clearBackupCodeFields()
         return binding.root
     }
+
+    open fun initData() {}
+
+    abstract fun setUpView()
 
     override fun onResume() {
         super.onResume()
@@ -60,6 +67,28 @@ abstract class BasePersonalIdBackupCodeFragment : BasePersonalIdFragment() {
 
     protected fun enableContinueButton(enabled: Boolean) {
         binding.connectBackupCodeButton.isEnabled = enabled
+    }
+
+    protected fun setUpInitialState(
+        titleResId: Int,
+        showConfirmCode: Boolean,
+        subtitle: CharSequence,
+        notMeButtonTextId : Int? = null,
+    ) {
+        requireActivity().title = getString(titleResId)
+        binding.recoveryCodeTilte.setText(titleResId)
+        binding.backupCodeLayout.visibility = View.VISIBLE
+        binding.welcomeBackLayout.visibility = View.GONE
+        binding.notMeButton.visibility = View.GONE
+        val confirmVisibility = if (showConfirmCode) View.VISIBLE else View.GONE
+        binding.confirmCodeLayout.visibility = confirmVisibility
+        binding.confirmCodeLabel.visibility = confirmVisibility
+        binding.backupCodeSubtitle.text = subtitle
+        notMeButtonTextId?.let {
+            binding.notMeButton.setText(getString(it))
+            binding.notMeButton.visibility = View.VISIBLE
+        }
+        enableContinueButton(false)
     }
 
     protected open fun onCodeChanged() {

--- a/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/BasePersonalIdBackupCodeFragment.kt
@@ -117,7 +117,6 @@ abstract class BasePersonalIdBackupCodeFragment : BasePersonalIdFragment() {
         val backupCode = binding.backupCodeView.codeValue
         val isBackupCodeComplete = backupCode.length == BACKUP_CODE_LENGTH
         if (binding.confirmCodeLayout.visibility != View.VISIBLE) {
-            enableContinueButton(isBackupCodeComplete)
             return isBackupCodeComplete
         }
         val confirmCode = binding.confirmCodeView.codeValue
@@ -128,7 +127,6 @@ abstract class BasePersonalIdBackupCodeFragment : BasePersonalIdFragment() {
             clearError()
         }
         val isValid = isBackupCodeComplete && backupCode == confirmCode
-        enableContinueButton(isValid)
         return isValid
     }
 

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.kt
@@ -134,10 +134,10 @@ class PersonalIdBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
             null,
             PersonalIdWorkflow.CONFIGURATION,
         )
+        personalIdSessionData.backupCode = binding.backupCodeView.codeValue
         if (isRecovery) {
             confirmBackupCode()
         } else {
-            personalIdSessionData.backupCode = binding.backupCodeView.codeValue
             if (ReleaseToggleHelper.isEmailOtpVerificationActive(personalIdSessionData)) {
                 navigateToEmail()
             } else {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.kt
@@ -21,7 +21,6 @@ import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.personalId.PersonalIdRecoveryCompleter
 import org.commcare.personalId.PersonalIdUserPreferences
 import org.commcare.utils.MediaUtil
-import org.commcare.views.connect.NumericCodeView
 import java.util.Date
 
 class PersonalIdBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
@@ -48,7 +47,7 @@ class PersonalIdBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
 
     override fun onResume() {
         super.onResume()
-        validateBackupCodeInputs()
+        validateBackupCodeAndEnableContinue()
     }
 
     private fun configureUiByMode() {
@@ -79,47 +78,11 @@ class PersonalIdBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
         }
     }
 
-    private fun setupListeners() {
-        val codeChangedListener = NumericCodeView.OnCodeChangedListener { validateBackupCodeInputs() }
-
-        binding.backupCodeView.setOnCodeChangedListener(codeChangedListener)
-        binding.confirmCodeView.setOnCodeChangedListener(codeChangedListener)
-
-        binding.backupCodeView.setCodeCompleteListener {
-            if (isRecovery) {
-                submitIfEnabled()
-            }
-        }
-
+    override fun setupListeners() {
+        super.setupListeners()
+        binding.backupCodeView.setCodeCompleteListener { if (isRecovery) submitIfEnabled() }
         binding.confirmCodeView.setCodeCompleteListener { submitIfEnabled() }
-
-        val enterKeyListener = NumericCodeView.OnEnterKeyPressedListener { submitIfEnabled() }
-        binding.backupCodeView.setOnEnterKeyPressedListener(enterKeyListener)
-        binding.confirmCodeView.setOnEnterKeyPressedListener(enterKeyListener)
-
-        binding.connectBackupCodeButton.setOnClickListener { handleBackupCodeSubmission() }
         binding.notMeButton.setOnClickListener { handleNotMeButtonPressed() }
-
-        binding.backupCodeVisibilityToggle.setOnClickListener {
-            togglePasswordVisibility(binding.backupCodeView, binding.backupCodeVisibilityToggle)
-        }
-        binding.confirmCodeVisibilityToggle.setOnClickListener {
-            togglePasswordVisibility(binding.confirmCodeView, binding.confirmCodeVisibilityToggle)
-        }
-    }
-
-    private fun validateBackupCodeInputs() {
-        val backupCode = binding.backupCodeView.codeValue
-        val confirmCode = binding.confirmCodeView.codeValue
-
-        val isCodeComplete = backupCode.length == BACKUP_CODE_LENGTH
-        val isCodeConfirmed = isRecovery || backupCode == confirmCode
-        val showMismatch = isCodeComplete && !isCodeConfirmed && confirmCode.length == BACKUP_CODE_LENGTH
-        val errorText = if (showMismatch) getString(R.string.connect_backup_code_mismatch) else ""
-
-        binding.connectBackupCodeErrorMessage.visibility = if (showMismatch) View.VISIBLE else View.GONE
-        binding.connectBackupCodeErrorMessage.text = errorText
-        enableContinueButton(isCodeComplete && isCodeConfirmed)
     }
 
     private fun handleNotMeButtonPressed() {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavDirections
 import androidx.navigation.findNavController
@@ -27,46 +26,34 @@ class PersonalIdBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
     private lateinit var personalIdSessionData: PersonalIdSessionData
     private var isRecovery = false
 
-    @StringRes
-    private var titleId = 0
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?,
-    ): View {
-        val view = super.onCreateView(inflater, container, savedInstanceState)
-        personalIdSessionData =
-            ViewModelProvider(requireActivity())[PersonalIdSessionDataViewModel::class.java]
-                .personalIdSessionData
-        configureUiByMode()
-        setupListeners()
-        requireActivity().title = getString(titleId)
-        return view
-    }
-
     override fun onResume() {
         super.onResume()
         validateBackupCodeAndEnableContinue()
     }
 
-    private fun configureUiByMode() {
+    override fun initData() {
+        personalIdSessionData =
+            ViewModelProvider(requireActivity())[PersonalIdSessionDataViewModel::class.java]
+                .personalIdSessionData
+    }
+
+    override fun setUpView() {
         isRecovery = personalIdSessionData.accountExists == true
         if (isRecovery) {
-            titleId = R.string.connect_backup_code_title_confirm
+            setUpInitialState(
+                titleResId = R.string.connect_backup_code_title_confirm,
+                showConfirmCode = false,
+                subtitle = getString(R.string.connect_backup_code_message),
+            )
             binding.recoveryCodeTilte.setText(R.string.connect_backup_code_message_title)
-            binding.backupCodeSubtitle.setText(R.string.connect_backup_code_message)
-            binding.backupCodeLayout.visibility = View.VISIBLE
-            binding.confirmCodeLabel.visibility = View.GONE
-            binding.confirmCodeLayout.visibility = View.GONE
+            binding.welcomeBackLayout.visibility = View.VISIBLE
             setUserNameAndPhoto()
         } else {
-            titleId = R.string.connect_backup_code_title_set
-            binding.backupCodeSubtitle.text = getString(R.string.connect_backup_code_remember, BACKUP_CODE_LENGTH)
-            binding.backupCodeLayout.visibility = View.VISIBLE
-            binding.confirmCodeLabel.visibility = View.VISIBLE
-            binding.confirmCodeLayout.visibility = View.VISIBLE
-            binding.welcomeBackLayout.visibility = View.GONE
+            setUpInitialState(
+                titleResId = R.string.connect_backup_code_title_set,
+                showConfirmCode = true,
+                subtitle = getString(R.string.connect_backup_code_remember, BACKUP_CODE_LENGTH),
+            )
         }
     }
 
@@ -88,7 +75,7 @@ class PersonalIdBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
     private fun handleNotMeButtonPressed() {
         personalIdSessionData.accountExists = false
         clearBackupCodeFields()
-        configureUiByMode()
+        setUpView()
     }
 
     override fun handleBackupCodeSubmission() {

--- a/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavDirections
@@ -17,7 +16,6 @@ import org.commcare.connect.network.base.BaseApiHandler.PersonalIdOrConnectApiEr
 import org.commcare.connect.network.base.PersonalIdOrConnectApiErrorHandler
 import org.commcare.connect.network.personalId.PersonalIdApiHandler
 import org.commcare.dalvik.R
-import org.commcare.dalvik.databinding.FragmentRecoveryCodeBinding
 import org.commcare.google.services.analytics.AnalyticsParamValue
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.personalId.PersonalIdRecoveryCompleter
@@ -26,34 +24,31 @@ import org.commcare.utils.MediaUtil
 import org.commcare.views.connect.NumericCodeView
 import java.util.Date
 
-class PersonalIdBackupCodeFragment : BasePersonalIdFragment() {
-    private lateinit var binding: FragmentRecoveryCodeBinding
+class PersonalIdBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
     private lateinit var personalIdSessionData: PersonalIdSessionData
     private var isRecovery = false
 
     @StringRes
     private var titleId = 0
 
-    override fun onResume() {
-        super.onResume()
-        validateBackupCodeInputs()
-        binding.backupCodeView.requestFocus(requireActivity())
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        binding = FragmentRecoveryCodeBinding.inflate(inflater, container, false)
+        val view = super.onCreateView(inflater, container, savedInstanceState)
         personalIdSessionData =
             ViewModelProvider(requireActivity())[PersonalIdSessionDataViewModel::class.java]
                 .personalIdSessionData
         configureUiByMode()
         setupListeners()
-        clearBackupCodeFields()
         requireActivity().title = getString(titleId)
-        return binding.root
+        return view
+    }
+
+    override fun onResume() {
+        super.onResume()
+        validateBackupCodeInputs()
     }
 
     private fun configureUiByMode() {
@@ -113,27 +108,6 @@ class PersonalIdBackupCodeFragment : BasePersonalIdFragment() {
         }
     }
 
-    private fun submitIfEnabled() {
-        if (binding.connectBackupCodeButton.isEnabled) {
-            handleBackupCodeSubmission()
-        }
-    }
-
-    private fun togglePasswordVisibility(
-        codeView: NumericCodeView,
-        toggle: ImageView,
-    ) {
-        codeView.isPasswordVisible = !codeView.isPasswordVisible
-        toggle.setImageResource(
-            if (codeView.isPasswordVisible) R.drawable.ic_visibility_off_24 else R.drawable.ic_visibility_24,
-        )
-    }
-
-    private fun clearBackupCodeFields() {
-        binding.confirmCodeView.clearCode()
-        binding.backupCodeView.clearCode()
-    }
-
     private fun validateBackupCodeInputs() {
         val backupCode = binding.backupCodeView.codeValue
         val confirmCode = binding.confirmCodeView.codeValue
@@ -154,11 +128,7 @@ class PersonalIdBackupCodeFragment : BasePersonalIdFragment() {
         configureUiByMode()
     }
 
-    private fun enableContinueButton(isEnable: Boolean) {
-        binding.connectBackupCodeButton.isEnabled = isEnable
-    }
-
-    private fun handleBackupCodeSubmission() {
+    override fun handleBackupCodeSubmission() {
         FirebaseAnalyticsUtil.reportPersonalIDContinueClicked(
             javaClass.simpleName,
             null,
@@ -214,16 +184,6 @@ class PersonalIdBackupCodeFragment : BasePersonalIdFragment() {
             PersonalIdRecoveryCompleter.finalizeAccountRecovery(requireActivity(), personalIdSessionData)
             navigateToSuccess()
         }
-    }
-
-    private fun clearError() {
-        binding.connectBackupCodeErrorMessage.visibility = View.GONE
-        binding.connectBackupCodeErrorMessage.text = ""
-    }
-
-    private fun showError(message: String) {
-        binding.connectBackupCodeErrorMessage.visibility = View.VISIBLE
-        binding.connectBackupCodeErrorMessage.text = message
     }
 
     private fun handleFailedBackupCodeAttempt() {
@@ -292,9 +252,4 @@ class PersonalIdBackupCodeFragment : BasePersonalIdFragment() {
     }
 
     private fun navigate(directions: NavDirections) = binding.root.findNavController().navigate(directions)
-
-    companion object {
-        // Note: This is brittle, defined in several places
-        private const val BACKUP_CODE_LENGTH = 6
-    }
 }

--- a/app/src/org/commcare/personalId/PersonalIdUserPreferences.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUserPreferences.kt
@@ -10,8 +10,51 @@ object PersonalIdUserPreferences {
     private const val PREFS_NAME = "personalid_prefs"
     private const val KEY_EMAIL_OFFER_COUNT = "email_offer_count"
     private const val KEY_LAST_EMAIL_OFFER_DATE = "last_email_offer_date"
+    private const val KEY_BACKUP_CODE_FAILED_ATTEMPTS = "backup_code_failed_attempts"
+    private const val KEY_BACKUP_CODE_LOCKOUT_START = "backup_code_lockout_start"
+    private const val KEY_BACKUP_CODE_WINDOW_START = "backup_code_window_start"
+    private const val BACKUP_CODE_LOCKOUT_DURATION_MS = 24 * 60 * 60 * 1000L
 
     private fun prefs(): SharedPreferences = CommCareApplication.instance().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * Records a backup-code failure and returns the new failure count within the current 24-hour
+     * window. If the previous failure window has expired, the count resets before incrementing.
+     */
+    fun recordBackupCodeFailure(): Int {
+        val now = System.currentTimeMillis()
+        val windowStart = prefs().getLong(KEY_BACKUP_CODE_WINDOW_START, -1L)
+        val baseCount =
+            if (windowStart == -1L || now - windowStart >= BACKUP_CODE_LOCKOUT_DURATION_MS) {
+                prefs().edit {
+                    putLong(KEY_BACKUP_CODE_WINDOW_START, now)
+                    remove(KEY_BACKUP_CODE_LOCKOUT_START)
+                }
+                0
+            } else {
+                prefs().getInt(KEY_BACKUP_CODE_FAILED_ATTEMPTS, 0)
+            }
+        val next = baseCount + 1
+        prefs().edit { putInt(KEY_BACKUP_CODE_FAILED_ATTEMPTS, next) }
+        return next
+    }
+
+    fun triggerBackupCodeLockout() {
+        prefs().edit { putLong(KEY_BACKUP_CODE_LOCKOUT_START, System.currentTimeMillis()) }
+    }
+
+    fun isBackupCodeLockedOut(): Boolean {
+        val start = prefs().getLong(KEY_BACKUP_CODE_LOCKOUT_START, -1L)
+        return start != -1L && System.currentTimeMillis() - start < BACKUP_CODE_LOCKOUT_DURATION_MS
+    }
+
+    fun clearBackupCodeLockout() {
+        prefs().edit {
+            remove(KEY_BACKUP_CODE_FAILED_ATTEMPTS)
+            remove(KEY_BACKUP_CODE_LOCKOUT_START)
+            remove(KEY_BACKUP_CODE_WINDOW_START)
+        }
+    }
 
     /**
      *  Email Offer Count (Int) — 0 = never offered, 1 = first offer shown, 2 = both offers shown

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
@@ -10,8 +10,22 @@ import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
 import org.commcare.fragments.personalId.BasePersonalIdBackupCodeFragment
 import org.commcare.fragments.personalId.EmailWorkFlow
+import org.commcare.personalId.PersonalIdUserPreferences
 
 class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
+    private val forgotBackupCodeButton get() = binding.notMeButton
+    private var isLocked = false
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        if (PersonalIdUserPreferences.isBackupCodeLockedOut()) {
+            enterLockedState()
+        }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -30,8 +44,8 @@ class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
         binding.confirmCodeLayout.visibility = View.GONE
         binding.confirmCodeLabel.visibility = View.GONE
         binding.welcomeBackLayout.visibility = View.GONE
-        binding.notMeButton.visibility = View.VISIBLE
-        binding.notMeButton.setText(R.string.personalid_forgot_backup_code)
+        forgotBackupCodeButton.visibility = View.VISIBLE
+        forgotBackupCodeButton.setText(R.string.personalid_forgot_backup_code)
         enableContinueButton(false)
         setupListeners()
     }
@@ -40,14 +54,16 @@ class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
         binding.backupCodeView.setOnCodeChangedListener { validateCode() }
         binding.backupCodeView.setOnEnterKeyPressedListener { submitIfEnabled() }
         binding.connectBackupCodeButton.setOnClickListener { handleBackupCodeSubmission() }
-        binding.notMeButton.setOnClickListener { handleForgot() }
+        forgotBackupCodeButton.setOnClickListener { handleForgot() }
         binding.backupCodeVisibilityToggle.setOnClickListener {
             togglePasswordVisibility(binding.backupCodeView, binding.backupCodeVisibilityToggle)
         }
     }
 
     private fun validateCode() {
-        enableContinueButton(binding.backupCodeView.codeValue.length == BACKUP_CODE_LENGTH)
+        if (!isLocked) {
+            enableContinueButton(binding.backupCodeView.codeValue.length == BACKUP_CODE_LENGTH)
+        }
     }
 
     private fun handleForgot() {
@@ -56,9 +72,9 @@ class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
             findNavController().navigate(
                 PersonalIdProfileBackupCodeFragmentDirections
                     .actionProfileBackupCodeToEmailVerification(
-                        email = email,
-                        workflow = EmailWorkFlow.RECOVERY,
-                        emailOtpRequestCount = 0,
+                        email,
+                        EmailWorkFlow.RECOVERY,
+                        0,
                     ),
             )
         } else {
@@ -76,10 +92,24 @@ class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
         val enteredCode = binding.backupCodeView.codeValue
         val storedBackupCode = ConnectUserDatabaseUtil.getUser(requireContext())?.pin
         if (enteredCode == storedBackupCode) {
+            PersonalIdUserPreferences.clearBackupCodeLockout()
             findNavController().navigate(R.id.action_profile_backup_code_to_set_new_backup_code)
         } else {
-            showError(getString(R.string.connect_backup_fail_title))
+            val attempts = PersonalIdUserPreferences.recordBackupCodeFailure()
+            if (attempts >= MAX_ATTEMPTS) {
+                PersonalIdUserPreferences.triggerBackupCodeLockout()
+                enterLockedState()
+            } else {
+                showError(getString(R.string.connect_backup_fail_title))
+            }
         }
+    }
+
+    private fun enterLockedState() {
+        isLocked = true
+        showError(getString(R.string.personalid_backup_code_too_many_attempts))
+        binding.backupCodeView.isEnabled = false
+        enableContinueButton(false)
     }
 
     companion object {

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
@@ -31,7 +31,7 @@ class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
             titleResId = R.string.connect_backup_code_title_confirm,
             showConfirmCode = false,
             subtitle = getString(R.string.connect_backup_code_message),
-            notMeButtonTextId = R.string.personalid_forgot_backup_code
+            notMeButtonTextId = R.string.personalid_forgot_backup_code,
         )
     }
 

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
@@ -26,28 +26,13 @@ class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?,
-    ): View {
-        val view = super.onCreateView(inflater, container, savedInstanceState)
-        setUpView()
-        return view
-    }
-
-    fun setUpView() {
-        requireActivity().title = getString(R.string.connect_backup_code_title_confirm)
-        binding.recoveryCodeTilte.setText(R.string.connect_backup_code_title_confirm)
-        binding.backupCodeSubtitle.setText(R.string.connect_backup_code_message)
-        binding.backupCodeLayout.visibility = View.VISIBLE
-        binding.confirmCodeLayout.visibility = View.GONE
-        binding.confirmCodeLabel.visibility = View.GONE
-        binding.welcomeBackLayout.visibility = View.GONE
-        forgotBackupCodeButton.visibility = View.VISIBLE
-        forgotBackupCodeButton.setText(R.string.personalid_forgot_backup_code)
-        enableContinueButton(false)
-        setupListeners()
+    override fun setUpView() {
+        setUpInitialState(
+            titleResId = R.string.connect_backup_code_title_confirm,
+            showConfirmCode = false,
+            subtitle = getString(R.string.connect_backup_code_message),
+            notMeButtonTextId = R.string.personalid_forgot_backup_code
+        )
     }
 
     override fun onCodeChanged() {

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
@@ -1,0 +1,98 @@
+package org.commcare.personalId.profile
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.navigation.fragment.findNavController
+import org.commcare.connect.database.ConnectUserDatabaseUtil
+import org.commcare.dalvik.R
+import org.commcare.fragments.personalId.BasePersonalIdBackupCodeFragment
+import org.commcare.fragments.personalId.EmailWorkFlow
+
+class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val view = super.onCreateView(inflater, container, savedInstanceState)
+        setUpView()
+        return view
+    }
+
+    fun setUpView() {
+        requireActivity().title = getString(R.string.connect_backup_code_title_confirm)
+        binding.recoveryCodeTilte.setText(R.string.connect_backup_code_title_confirm)
+        binding.backupCodeSubtitle.setText(R.string.connect_backup_code_message)
+        binding.backupCodeLayout.visibility = View.VISIBLE
+        binding.confirmCodeLayout.visibility = View.GONE
+        binding.confirmCodeLabel.visibility = View.GONE
+        binding.welcomeBackLayout.visibility = View.GONE
+        binding.notMeButton.visibility = View.VISIBLE
+        binding.notMeButton.setText(R.string.personalid_forgot_backup_code)
+        enableContinueButton(false)
+        setupListeners()
+    }
+
+    private fun setupListeners() {
+        binding.backupCodeView.setOnCodeChangedListener { validateCode() }
+        binding.backupCodeView.setOnEnterKeyPressedListener { submitIfEnabled() }
+        binding.connectBackupCodeButton.setOnClickListener { handleBackupCodeSubmission() }
+        binding.notMeButton.setOnClickListener { handleForgot() }
+        binding.backupCodeVisibilityToggle.setOnClickListener {
+            togglePasswordVisibility(binding.backupCodeView, binding.backupCodeVisibilityToggle)
+        }
+    }
+
+    private fun validateCode() {
+        enableContinueButton(binding.backupCodeView.codeValue.length == BACKUP_CODE_LENGTH)
+    }
+
+    private fun handleForgot() {
+        val email = ConnectUserDatabaseUtil.getUser(requireContext())?.email
+        if (email != null) {
+            findNavController().navigate(
+                PersonalIdProfileBackupCodeFragmentDirections
+                    .actionProfileBackupCodeToEmailVerification(
+                        email = email,
+                        workflow = EmailWorkFlow.RECOVERY,
+                        emailOtpRequestCount = 0,
+                    ),
+            )
+        } else {
+            Toast
+                .makeText(
+                    requireContext(),
+                    R.string.personalid_no_email_forgot_backup_code_toast,
+                    Toast.LENGTH_LONG,
+                ).show()
+            findNavController().popBackStack()
+        }
+    }
+
+    override fun handleBackupCodeSubmission() {
+        val enteredCode = binding.backupCodeView.codeValue
+        val storedBackupCode = ConnectUserDatabaseUtil.getUser(requireContext())?.pin
+        if (enteredCode == storedBackupCode) {
+            findNavController().navigate(R.id.action_profile_backup_code_to_set_new_backup_code)
+        } else {
+            showError(getString(R.string.connect_backup_fail_title))
+        }
+    }
+
+    companion object {
+        private const val MAX_ATTEMPTS = 3
+    }
+
+    override fun navigateToMessageDisplay(
+        title: String,
+        message: String?,
+        isCancellable: Boolean,
+        phase: Int,
+        buttonText: Int,
+    ) {
+        // unreachable
+    }
+}

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
@@ -50,20 +50,13 @@ class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
         setupListeners()
     }
 
-    private fun setupListeners() {
-        binding.backupCodeView.setOnCodeChangedListener { validateCode() }
-        binding.backupCodeView.setOnEnterKeyPressedListener { submitIfEnabled() }
-        binding.connectBackupCodeButton.setOnClickListener { handleBackupCodeSubmission() }
-        forgotBackupCodeButton.setOnClickListener { handleForgot() }
-        binding.backupCodeVisibilityToggle.setOnClickListener {
-            togglePasswordVisibility(binding.backupCodeView, binding.backupCodeVisibilityToggle)
-        }
+    override fun onCodeChanged() {
+        if (!isLocked) validateBackupCodeAndEnableContinue()
     }
 
-    private fun validateCode() {
-        if (!isLocked) {
-            enableContinueButton(binding.backupCodeView.codeValue.length == BACKUP_CODE_LENGTH)
-        }
+    override fun setupListeners() {
+        super.setupListeners()
+        forgotBackupCodeButton.setOnClickListener { handleForgot() }
     }
 
     private fun handleForgot() {
@@ -114,15 +107,5 @@ class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
 
     companion object {
         private const val MAX_ATTEMPTS = 3
-    }
-
-    override fun navigateToMessageDisplay(
-        title: String,
-        message: String?,
-        isCancellable: Boolean,
-        phase: Int,
-        buttonText: Int,
-    ) {
-        // unreachable
     }
 }

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileFragment.kt
@@ -41,6 +41,9 @@ class PersonalIdProfileFragment : BasePersonalIdProfileFragment() {
         viewModel = ViewModelProvider(this)[PersonalIdProfileViewModel::class.java]
         viewModel.profileDisplayModel.observe(viewLifecycleOwner) { displayProfileDetails(it) }
         binding.profileBtnForgetPersonalid.setOnClickListener { showForgetPersonalIdDialog() }
+        binding.profileChangeBackupCode.setOnClickListener {
+            findNavController().navigate(R.id.action_profile_to_profile_backup_code)
+        }
     }
 
     override fun onResume() {

--- a/app/src/org/commcare/personalId/profile/SetNewBackupCodeFragment.kt
+++ b/app/src/org/commcare/personalId/profile/SetNewBackupCodeFragment.kt
@@ -1,0 +1,16 @@
+package org.commcare.personalId.profile
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+
+class SetNewBackupCodeFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = TextView(requireContext()).apply { text = "Set New Backup Code — TODO" }
+}

--- a/app/src/org/commcare/views/connect/NumericCodeView.java
+++ b/app/src/org/commcare/views/connect/NumericCodeView.java
@@ -289,6 +289,9 @@ public class NumericCodeView extends LinearLayout {
         GradientDrawable drawable = new GradientDrawable();
         drawable.setCornerRadius(borderRadius);
         drawable.setStroke(borderWidth, isErrorState ? errorBorderColor : borderColor);
+        if (!isEnabled()) {
+            drawable.setColor(Color.LTGRAY);
+        }
         return drawable;
     }
 
@@ -380,6 +383,15 @@ public class NumericCodeView extends LinearLayout {
 
     public void setOnEnterKeyPressedListener(OnEnterKeyPressedListener listener) {
         this.enterKeyPressedListener = listener;
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        for (int i = 0; i < getChildCount(); i++) {
+            getChildAt(i).setEnabled(enabled);
+        }
+        updateUi();
     }
 
     public void setCode(String code) {

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentRecoveryTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentRecoveryTest.kt
@@ -164,7 +164,7 @@ class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmen
         assertEquals(TEST_PHOTO_BASE64, storedUser.photo)
         assertEquals(PersonalIdSessionData.PIN, storedUser.requiredLock)
         // Recovery never writes the entered code onto the session data, so the stored record has no pin.
-        assertNull(storedUser.pin)
+        assertEquals(TEST_BACKUP_CODE, storedUser.pin)
 
         assertMessageDisplay(
             title = fragment.getString(R.string.connect_recovery_success_title),

--- a/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragmentTest.kt
@@ -1,0 +1,143 @@
+package org.commcare.personalId.profile
+
+import android.view.View
+import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.button.MaterialButton
+import org.commcare.CommCareTestApplication
+import org.commcare.dalvik.R
+import org.commcare.views.connect.NumericCodeView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+@Config(application = CommCareTestApplication::class)
+@RunWith(AndroidJUnit4::class)
+class PersonalIdProfileBackupCodeFragmentTest : BasePersonalIdProfileTest() {
+    @Before
+    fun navigateToBackupCodeScreen() {
+        user.pin = "123456" // override to 6 digits so the code view can hold it
+        onUiThread {
+            navController.navigate(R.id.action_profile_to_profile_backup_code)
+        }
+    }
+
+    private fun fragment() =
+        navHostFragment.childFragmentManager
+            .primaryNavigationFragment as PersonalIdProfileBackupCodeFragment
+
+    private fun backupCodeView(): NumericCodeView = fragment().requireView().findViewById(R.id.backup_code_view)
+
+    private fun confirmCodeLayout(): View = fragment().requireView().findViewById(R.id.confirm_code_layout)
+
+    private fun confirmCodeLabel(): View = fragment().requireView().findViewById(R.id.confirm_code_label)
+
+    private fun welcomeBackLayout(): View = fragment().requireView().findViewById(R.id.welcome_back_layout)
+
+    private fun continueButton(): MaterialButton = fragment().requireView().findViewById(R.id.connect_backup_code_button)
+
+    private fun errorMessage(): TextView = fragment().requireView().findViewById(R.id.connect_backup_code_error_message)
+
+    private fun forgotButton(): TextView = fragment().requireView().findViewById(R.id.not_me_button)
+
+    // ===== Initial state =====
+
+    @Test
+    fun `confirm code layout is hidden`() {
+        assertEquals(View.GONE, confirmCodeLabel().visibility)
+        assertEquals(View.GONE, confirmCodeLayout().visibility)
+    }
+
+    @Test
+    fun `welcome back layout is hidden`() {
+        assertEquals(View.GONE, welcomeBackLayout().visibility)
+    }
+
+    @Test
+    fun `continue button starts disabled`() {
+        assertFalse(continueButton().isEnabled)
+    }
+
+    @Test
+    fun `error message starts hidden`() {
+        assertEquals(View.GONE, errorMessage().visibility)
+    }
+
+    @Test
+    fun `forgot backup code link is visible`() {
+        assertEquals(View.VISIBLE, forgotButton().visibility)
+    }
+
+    // ===== Validation =====
+
+    @Test
+    fun `continue button enables when 6 digits are entered`() {
+        onUiThread { backupCodeView().setCode("000000") }
+        ShadowLooper.idleMainLooper()
+
+        assertTrue(continueButton().isEnabled)
+    }
+
+    @Test
+    fun `continue button stays disabled until 6 digits`() {
+        onUiThread { backupCodeView().setCode("12345") }
+        ShadowLooper.idleMainLooper()
+
+        assertFalse(continueButton().isEnabled)
+    }
+
+    // ===== Correct code =====
+
+    @Test
+    fun `correct code navigates to set-new-backup-code`() {
+        onUiThread { backupCodeView().setCode("123456") }
+        ShadowLooper.idleMainLooper()
+        onUiThread { continueButton().performClick() }
+
+        assertEquals(R.id.personalid_set_new_backup_code_fragment, currentDestinationId())
+    }
+
+    // ===== Wrong code =====
+
+    @Test
+    fun `wrong code shows error and stays on screen`() {
+        onUiThread { backupCodeView().setCode("000000") }
+        ShadowLooper.idleMainLooper()
+        onUiThread { continueButton().performClick() }
+
+        assertEquals(View.VISIBLE, errorMessage().visibility)
+        assertEquals(R.id.personalid_profile_backup_code_fragment, currentDestinationId())
+    }
+
+    @Test
+    fun `continue button re-enables after wrong code`() {
+        onUiThread { backupCodeView().setCode("000000") }
+        ShadowLooper.idleMainLooper()
+        onUiThread { continueButton().performClick() }
+
+        assertTrue(continueButton().isEnabled)
+    }
+
+    // ===== Forgot =====
+
+    @Test
+    fun `forgot with email navigates to email verification`() {
+        // user.email is "ada@example.com" per BasePersonalIdProfileTest
+        onUiThread { forgotButton().performClick() }
+
+        assertEquals(R.id.personalid_email_verification_fragment, currentDestinationId())
+    }
+
+    @Test
+    fun `forgot with no email pops back to profile`() {
+        user.email = null
+        onUiThread { forgotButton().performClick() }
+
+        assertEquals(R.id.personalid_profile_fragment, currentDestinationId())
+    }
+}

--- a/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragmentTest.kt
@@ -1,11 +1,13 @@
 package org.commcare.personalId.profile
 
+import android.content.Context
 import android.view.View
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.material.button.MaterialButton
 import org.commcare.CommCareTestApplication
 import org.commcare.dalvik.R
+import org.commcare.personalId.PersonalIdUserPreferences
 import org.commcare.views.connect.NumericCodeView
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -15,12 +17,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
+import org.robolectric.shadows.ShadowToast
 
 @Config(application = CommCareTestApplication::class)
 @RunWith(AndroidJUnit4::class)
 class PersonalIdProfileBackupCodeFragmentTest : BasePersonalIdProfileTest() {
     @Before
     fun navigateToBackupCodeScreen() {
+        PersonalIdUserPreferences.clearBackupCodeLockout()
         user.pin = "123456" // override to 6 digits so the code view can hold it
         onUiThread {
             navController.navigate(R.id.action_profile_to_profile_backup_code)
@@ -44,6 +48,11 @@ class PersonalIdProfileBackupCodeFragmentTest : BasePersonalIdProfileTest() {
     private fun errorMessage(): TextView = fragment().requireView().findViewById(R.id.connect_backup_code_error_message)
 
     private fun forgotButton(): TextView = fragment().requireView().findViewById(R.id.not_me_button)
+
+    private fun setCodeAndContinue(code: String = "000000") {
+        onUiThread { backupCodeView().setCode(code) }
+        onUiThread { continueButton().performClick() }
+    }
 
     // ===== Initial state =====
 
@@ -95,9 +104,7 @@ class PersonalIdProfileBackupCodeFragmentTest : BasePersonalIdProfileTest() {
 
     @Test
     fun `correct code navigates to set-new-backup-code`() {
-        onUiThread { backupCodeView().setCode("123456") }
-        ShadowLooper.idleMainLooper()
-        onUiThread { continueButton().performClick() }
+        setCodeAndContinue("123456")
 
         assertEquals(R.id.personalid_set_new_backup_code_fragment, currentDestinationId())
     }
@@ -106,20 +113,79 @@ class PersonalIdProfileBackupCodeFragmentTest : BasePersonalIdProfileTest() {
 
     @Test
     fun `wrong code shows error and stays on screen`() {
-        onUiThread { backupCodeView().setCode("000000") }
-        ShadowLooper.idleMainLooper()
-        onUiThread { continueButton().performClick() }
-
+        setCodeAndContinue()
         assertEquals(View.VISIBLE, errorMessage().visibility)
         assertEquals(R.id.personalid_profile_backup_code_fragment, currentDestinationId())
     }
 
     @Test
     fun `continue button re-enables after wrong code`() {
-        onUiThread { backupCodeView().setCode("000000") }
-        ShadowLooper.idleMainLooper()
-        onUiThread { continueButton().performClick() }
+        setCodeAndContinue()
+        assertTrue(continueButton().isEnabled)
+    }
 
+    // ===== Locked state =====
+
+    @Test
+    fun `wrong code three times enters locked state`() {
+        setCodeAndContinue()
+        setCodeAndContinue()
+        setCodeAndContinue()
+
+        assertEquals(View.VISIBLE, forgotButton().visibility)
+        assertFalse(backupCodeView().isEnabled)
+        assertFalse(continueButton().isEnabled)
+        assertEquals(View.VISIBLE, errorMessage().visibility)
+        assertTrue(PersonalIdUserPreferences.isBackupCodeLockedOut())
+    }
+
+    @Test
+    fun `continue button stays disabled in locked state even if code is set`() {
+        setCodeAndContinue()
+        setCodeAndContinue()
+        setCodeAndContinue()
+
+        onUiThread { backupCodeView().setCode("123456") }
+
+        assertFalse(continueButton().isEnabled)
+    }
+
+    @Test
+    fun `lockout in prefs causes locked state on fragment init`() {
+        PersonalIdUserPreferences.triggerBackupCodeLockout()
+
+        // Navigate back to profile, then forward again so the fragment is recreated
+        onUiThread { navController.popBackStack() }
+        ShadowLooper.idleMainLooper()
+        onUiThread { navController.navigate(R.id.action_profile_to_profile_backup_code) }
+        ShadowLooper.idleMainLooper()
+
+        assertFalse(backupCodeView().isEnabled)
+        assertFalse(continueButton().isEnabled)
+        assertEquals(View.VISIBLE, errorMessage().visibility)
+        assertEquals(View.VISIBLE, forgotButton().visibility)
+    }
+
+    @Test
+    fun `third wrong attempt after 24 hours does not trigger lockout`() {
+        // Two wrong attempts within the window
+        setCodeAndContinue()
+        onUiThread { backupCodeView().clearCode() }
+        setCodeAndContinue()
+        onUiThread { backupCodeView().clearCode() }
+
+        // Backdated the window start to more than 24 hours ago so the next failure resets the count
+        activity
+            .getSharedPreferences("personalid_prefs", Context.MODE_PRIVATE)
+            .edit()
+            .putLong("backup_code_window_start", System.currentTimeMillis() - 25 * 60 * 60 * 1000L)
+            .commit()
+
+        // Third wrong attempt
+        setCodeAndContinue()
+
+        assertFalse(PersonalIdUserPreferences.isBackupCodeLockedOut())
+        assertEquals(View.VISIBLE, errorMessage().visibility)
         assertTrue(continueButton().isEnabled)
     }
 
@@ -138,6 +204,10 @@ class PersonalIdProfileBackupCodeFragmentTest : BasePersonalIdProfileTest() {
         user.email = null
         onUiThread { forgotButton().performClick() }
 
+        assertEquals(
+            activity.getString(R.string.personalid_no_email_forgot_backup_code_toast),
+            ShadowToast.getTextOfLatestToast(),
+        )
         assertEquals(R.id.personalid_profile_fragment, currentDestinationId())
     }
 }

--- a/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileFragmentTest.kt
@@ -71,4 +71,14 @@ class PersonalIdProfileFragmentTest : BasePersonalIdProfileTest() {
         assertNotNull("Forget PersonalID should show a confirmation dialog", dialog)
         assertTrue("The confirmation dialog should be visible", dialog.isShowing)
     }
+
+    @Test
+    fun `tapping change backup code row navigates to backup code screen`() {
+        val changeBackupCodeRow =
+            fragment().requireView().findViewById<TextView>(R.id.profile_change_backup_code)
+
+        onUiThread { changeBackupCodeRow.performClick() }
+
+        assertEquals(R.id.personalid_profile_backup_code_fragment, currentDestinationId())
+    }
 }


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/CCCT-2709

Adds "Change Backup Code" button on manage profile and a confirm backup code screen to go along with it. 

https://github.com/user-attachments/assets/c196a9aa-9508-49d3-926c-da0636b1f74e

The PR also ports [the commit](https://github.com/dimagi/commcare-android/commit/777edf19d037a0af82bf1300b44b4bc7983ef317) to get the tests passing.

Review Commit by Commit

## Safety Assurance

Locally tested and limited impact radius. 
Test Coverage

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
