### PR TITLE
SAAS-20146 - Support device rotation during Wi-Fi Direct transfers

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -534,9 +534,7 @@
         <activity
             android:name="org.commcare.activities.ConnectionDiagnosticActivity"
             android:windowSoftInputMode="adjustResize" />
-        <activity
-            android:name="org.commcare.activities.CommCareWiFiDirectActivity"
-            android:screenOrientation="portrait" />
+        <activity android:name="org.commcare.activities.CommCareWiFiDirectActivity" />
         <activity android:name="org.commcare.activities.RecoveryActivity" />
         <activity
             android:name="org.commcare.print.TemplatePrinterActivity"

--- a/app/res/layout/wifi_direct_main.xml
+++ b/app/res/layout/wifi_direct_main.xml
@@ -98,7 +98,7 @@
 
                 <org.commcare.views.SquareButtonWithText
                     android:id="@+id/send"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_margin="4dp"
                     android:layout_weight="1"
@@ -110,7 +110,7 @@
 
                 <org.commcare.views.SquareButtonWithText
                     android:id="@+id/discover"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_margin="4dp"
                     android:layout_weight="1"
@@ -122,7 +122,7 @@
 
                 <org.commcare.views.SquareButtonWithText
                     android:id="@+id/submit"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_margin="4dp"
                     android:layout_weight="1"
@@ -134,7 +134,7 @@
 
                 <org.commcare.views.SquareButtonWithText
                     android:id="@+id/mode"
-                    android:layout_width="match_parent"
+                    android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_margin="4dp"
                     android:layout_weight="1"

--- a/app/res/layout/wifi_direct_main.xml
+++ b/app/res/layout/wifi_direct_main.xml
@@ -49,6 +49,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_margin="5dp"
+            android:freezesText="true"
             android:text=" ">
         </TextView>
 

--- a/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
@@ -96,12 +96,12 @@ public class CommCareWiFiDirectActivity
 
     private WiFiDirectUIController uiController;
 
-    private static String baseDirectory;
-    private static String toBeTransferredDirectory;
-    private static String zipFilePath;
-    private static String receiveDirectory;
-    private static String receiveZipDirectory;
-    private static String toBeSubmittedDirectory;
+    private String baseDirectory;
+    private String toBeTransferredDirectory;
+    private String zipFilePath;
+    private String receiveDirectory;
+    private String receiveZipDirectory;
+    private String toBeSubmittedDirectory;
 
     private TextView myStatusText;
     private TextView formCountText;

--- a/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
@@ -27,6 +27,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModelProvider;
 
 
 import org.commcare.CommCareApplication;
@@ -40,6 +41,7 @@ import org.commcare.fragments.FileServerFragment;
 import org.commcare.fragments.FileServerFragment.FileServerListener;
 import org.commcare.fragments.WiFiDirectManagementFragment;
 import org.commcare.fragments.WiFiDirectManagementFragment.WifiDirectManagerListener;
+import org.commcare.fragments.WiFiDirectSessionViewModel;
 import org.commcare.interfaces.CommCareActivityUIController;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.models.database.SqlStorage;
@@ -112,7 +114,7 @@ public class CommCareWiFiDirectActivity
 
     private wdState mState = wdState.send;
 
-    private FormRecord[] cachedRecords;
+    private WiFiDirectSessionViewModel sessionViewModel;
 
     private final int NEARBY_WIFI_PERM_REQUEST = 2;
     private final String SHOW_PERMISSION_DIALOG = "show-permission-dialog";
@@ -175,7 +177,11 @@ public class CommCareWiFiDirectActivity
         mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION);
         mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION);
         mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION);
-        if (savedInstanceState == null) {
+        sessionViewModel = new ViewModelProvider(this).get(WiFiDirectSessionViewModel.class);
+        if (sessionViewModel.getState() != null) {
+            mState = sessionViewModel.getState();
+        }
+        if (sessionViewModel.getState() == null || sessionViewModel.isModeDialogShowing()) {
             showChangeStateDialog();
         }
         uiController.setupUI();
@@ -211,6 +217,8 @@ public class CommCareWiFiDirectActivity
     }
 
     public void showChangeStateDialog() {
+        dismissAlertDialog();
+        sessionViewModel.setModeDialogShowing(true);
         showDialog(localize("wifi.direct.change.state.title").toString(),
                 localize("wifi.direct.change.state.text").toString());
     }
@@ -231,6 +239,7 @@ public class CommCareWiFiDirectActivity
         }
 
         fragment.startReceiver(mManager, mChannel);
+        fragment.refreshConnectionInfo();
 
         changeState();
     }
@@ -247,12 +256,9 @@ public class CommCareWiFiDirectActivity
     private void hostGroup() {
         Logger.log(TAG, "Hosting Wi-fi direct group");
 
-        final FileServerFragment fsFragment = (FileServerFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.file_server_fragment);
-        fsFragment.startServer(receiveZipDirectory);
+        fileServerFragment().startServer(receiveZipDirectory);
 
-        WiFiDirectManagementFragment fragment = (WiFiDirectManagementFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.wifi_manager_fragment);
+        WiFiDirectManagementFragment fragment = wifiManagementFragment();
 
         if (!fragment.isWifiP2pEnabled()) {
             Logger.log(TAG, "returning because Wi-fi direct is not available");
@@ -264,23 +270,45 @@ public class CommCareWiFiDirectActivity
         mManager.createGroup(mChannel, fragment);
     }
 
+    private void setState(wdState state) {
+        mState = state;
+        sessionViewModel.setState(state);
+        changeState();
+    }
+
     private void changeState() {
+        renderState();
         updateStatusText();
         uiController.refreshView();
+    }
+
+    private void renderState() {
+        switch (mState) {
+            case send:
+                renderSender();
+                break;
+            case receive:
+                renderReceiver();
+                break;
+            case submit:
+                renderSubmitter();
+                break;
+        }
     }
 
     private void showDialog(String title, String message) {
         StandardAlertDialog d = new StandardAlertDialog(title, message);
         DialogInterface.OnClickListener listener = (dialog, which) -> {
+            sessionViewModel.setModeDialogShowing(false);
             switch (which) {
                 case AlertDialog.BUTTON_POSITIVE:
-                    beSubmitter();
+                    enterSubmitter();
                     break;
                 case AlertDialog.BUTTON_NEUTRAL:
-                    beReceiver();
+                    enterReceiver();
                     break;
                 case AlertDialog.BUTTON_NEGATIVE:
-                    beSender();
+                    enterSender();
                     break;
             }
             dialog.dismiss();
@@ -291,104 +319,86 @@ public class CommCareWiFiDirectActivity
         showAlertDialog(d);
     }
 
-    private void beSender() {
-
+    private void enterSender() {
         myStatusText.setText(localize("wifi.direct.enter.send.mode"));
 
-        WiFiDirectManagementFragment wifiFragment = (WiFiDirectManagementFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.wifi_manager_fragment);
-
-        DeviceListFragment fragmentList = (DeviceListFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.frag_list);
-
-        DeviceDetailFragment fragmentDetails = (DeviceDetailFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.frag_detail);
-
-        FileServerFragment fsFragment = (FileServerFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.file_server_fragment);
-
-        FragmentTransaction tr = getSupportFragmentManager().beginTransaction();
-
-        tr.show(wifiFragment);
-        tr.show(fragmentList);
-        tr.show(fragmentDetails);
-        tr.hide(fsFragment);
-        tr.commit();
-
-        wifiFragment.setIsHost(false);
-        wifiFragment.resetConnectionGroup();
-
+        wifiManagementFragment().resetConnectionGroup();
 
         Logger.log(TAG, "Device designated as sender");
         resetData();
-        mState = wdState.send;
-        changeState();
+        setState(wdState.send);
     }
 
-    private void beReceiver() {
-        myStatusText.setText(localize("wifi.direct.enter.receive.mode"));
-
-        WiFiDirectManagementFragment wifiFragment = (WiFiDirectManagementFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.wifi_manager_fragment);
-
-        DeviceListFragment fragmentList = (DeviceListFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.frag_list);
-
-        DeviceDetailFragment fragmentDetails = (DeviceDetailFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.frag_detail);
-
-        FileServerFragment fsFragment = (FileServerFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.file_server_fragment);
-
+    private void renderSender() {
         FragmentTransaction tr = getSupportFragmentManager().beginTransaction();
-
-        tr.show(wifiFragment);
-        tr.show(fragmentList);
-        tr.show(fragmentDetails);
-        tr.show(fsFragment);
+        tr.show(wifiManagementFragment());
+        tr.show(deviceListFragment());
+        tr.show(deviceDetailFragment());
+        tr.hide(fileServerFragment());
         tr.commit();
 
-        wifiFragment.setIsHost(true);
-        wifiFragment.resetConnectionGroup();
+        wifiManagementFragment().setIsHost(false);
+    }
+
+    private void enterReceiver() {
+        myStatusText.setText(localize("wifi.direct.enter.receive.mode"));
+
+        wifiManagementFragment().resetConnectionGroup();
 
         Logger.log(TAG, "Device designated as receiver");
         resetData();
+        setState(wdState.receive);
         hostGroup();
-
-        mState = wdState.receive;
-        changeState();
     }
 
-    private void beSubmitter() {
+    private void renderReceiver() {
+        FragmentTransaction tr = getSupportFragmentManager().beginTransaction();
+        tr.show(wifiManagementFragment());
+        tr.show(deviceListFragment());
+        tr.show(deviceDetailFragment());
+        tr.show(fileServerFragment());
+        tr.commit();
+
+        wifiManagementFragment().setIsHost(true);
+    }
+
+    private void enterSubmitter() {
         unzipFilesHelper();
         myStatusText.setText(localize("wifi.direct.enter.submit.mode"));
 
-        WiFiDirectManagementFragment wifiFragment = (WiFiDirectManagementFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.wifi_manager_fragment);
-
-        DeviceListFragment fragmentList = (DeviceListFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.frag_list);
-
-        DeviceDetailFragment fragmentDetails = (DeviceDetailFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.frag_detail);
-
-        FileServerFragment fsFragment = (FileServerFragment)getSupportFragmentManager()
-                .findFragmentById(R.id.file_server_fragment);
-
-        FragmentTransaction tr = getSupportFragmentManager().beginTransaction();
-
-        tr.hide(fsFragment);
-        tr.hide(wifiFragment);
-        tr.hide(fragmentList);
-        tr.hide(fragmentDetails);
-        tr.commit();
-
-        wifiFragment.setIsHost(false);
-        wifiFragment.resetConnectionGroup();
+        wifiManagementFragment().resetConnectionGroup();
 
         Logger.log(TAG, "Device designated as submitter");
-        mState = wdState.submit;
-        changeState();
+        setState(wdState.submit);
+    }
+
+    private void renderSubmitter() {
+        FragmentTransaction tr = getSupportFragmentManager().beginTransaction();
+        tr.hide(fileServerFragment());
+        tr.hide(wifiManagementFragment());
+        tr.hide(deviceListFragment());
+        tr.hide(deviceDetailFragment());
+        tr.commit();
+
+        wifiManagementFragment().setIsHost(false);
+    }
+
+    private WiFiDirectManagementFragment wifiManagementFragment() {
+        return (WiFiDirectManagementFragment)getSupportFragmentManager()
+                .findFragmentById(R.id.wifi_manager_fragment);
+    }
+
+    private DeviceListFragment deviceListFragment() {
+        return (DeviceListFragment)getSupportFragmentManager().findFragmentById(R.id.frag_list);
+    }
+
+    private DeviceDetailFragment deviceDetailFragment() {
+        return (DeviceDetailFragment)getSupportFragmentManager().findFragmentById(R.id.frag_detail);
+    }
+
+    private FileServerFragment fileServerFragment() {
+        return (FileServerFragment)getSupportFragmentManager()
+                .findFragmentById(R.id.file_server_fragment);
     }
 
     private void cleanPostSend() {
@@ -397,7 +407,7 @@ public class CommCareWiFiDirectActivity
 
         // remove Forms from CC
 
-        WipeTask mWipeTask = new WipeTask(getApplicationContext(), this.cachedRecords) {
+        WipeTask mWipeTask = new WipeTask(getApplicationContext(), sessionViewModel.getCachedRecords()) {
             @Override
             protected void deliverResult(CommCareWiFiDirectActivity receiver,
                                          Boolean result) {
@@ -425,7 +435,7 @@ public class CommCareWiFiDirectActivity
 
         Logger.log(TAG, "Deleting dirs " + toBeTransferredDirectory + " and " + zipFilePath);
 
-        this.cachedRecords = null;
+        sessionViewModel.setCachedRecords(null);
 
     }
 
@@ -719,7 +729,7 @@ public class CommCareWiFiDirectActivity
                         R.layout.template_text_notification_problem);
                 return;
             }
-            this.cachedRecords = result.second;
+            sessionViewModel.setCachedRecords(result.second);
         }
         updateStatusText();
         moveReceivedFiles();

--- a/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
@@ -12,7 +12,6 @@ import android.net.wifi.p2p.WifiP2pDevice;
 import android.net.wifi.p2p.WifiP2pManager;
 import android.net.wifi.p2p.WifiP2pManager.ActionListener;
 import android.net.wifi.p2p.WifiP2pManager.Channel;
-import android.net.wifi.p2p.WifiP2pManager.PeerListListener;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -241,6 +240,10 @@ public class CommCareWiFiDirectActivity
 
         fragment.startReceiver(mManager, mChannel);
         fragment.refreshConnectionInfo();
+        updatePeers();
+        if (sessionViewModel.getThisDevice() != null) {
+            deviceListFragment().updateThisDevice(sessionViewModel.getThisDevice());
+        }
 
         changeState();
     }
@@ -912,19 +915,21 @@ public class CommCareWiFiDirectActivity
     @Override
     public void updatePeers() {
         Logger.log(TAG, "Wi-Fi direct peers updating");
-        mManager.requestPeers(mChannel, (PeerListListener)this.getSupportFragmentManager()
-                .findFragmentById(R.id.frag_list));
-
+        if (mManager == null || mChannel == null) {
+            return;
+        }
+        try {
+            mManager.requestPeers(mChannel, deviceListFragment());
+        } catch (SecurityException e) {
+            Logger.log(TAG, "Cannot read Wi-fi direct peers without permission");
+        }
     }
 
     @Override
     public void updateDeviceStatus(WifiP2pDevice mDevice) {
         Logger.log(TAG, "Wi-fi direct status updating");
-        DeviceListFragment fragment = (DeviceListFragment)this.getSupportFragmentManager()
-                .findFragmentById(R.id.frag_list);
-
-        fragment.updateThisDevice(mDevice);
-
+        sessionViewModel.setThisDevice(mDevice);
+        deviceListFragment().updateThisDevice(mDevice);
     }
 
     /**

--- a/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
@@ -921,7 +921,7 @@ public class CommCareWiFiDirectActivity
         try {
             mManager.requestPeers(mChannel, deviceListFragment());
         } catch (SecurityException e) {
-            Logger.log(TAG, "Cannot read Wi-fi direct peers without permission");
+            Logger.exception("Cannot read Wi-fi direct peers without permission", e);
         }
     }
 

--- a/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
+++ b/app/src/org/commcare/activities/CommCareWiFiDirectActivity.java
@@ -170,14 +170,15 @@ public class CommCareWiFiDirectActivity
         receiveDirectory = baseDirectory + "/receive";
         receiveZipDirectory = receiveDirectory + "/zipDest";
 
-        mManager = (WifiP2pManager)getSystemService(Context.WIFI_P2P_SERVICE);
-        mChannel = mManager.initialize(this, getMainLooper(), null);
+        sessionViewModel = new ViewModelProvider(this).get(WiFiDirectSessionViewModel.class);
+        mManager = sessionViewModel.getManager();
+        mChannel = sessionViewModel.getChannel();
+
         mIntentFilter = new IntentFilter();
         mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION);
         mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION);
         mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION);
         mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION);
-        sessionViewModel = new ViewModelProvider(this).get(WiFiDirectSessionViewModel.class);
         if (sessionViewModel.getState() != null) {
             mState = sessionViewModel.getState();
         }

--- a/app/src/org/commcare/fragments/FileServerFragment.java
+++ b/app/src/org/commcare/fragments/FileServerFragment.java
@@ -1,7 +1,6 @@
 package org.commcare.fragments;
 
 import android.annotation.SuppressLint;
-import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -31,24 +30,12 @@ import java.net.Socket;
 public class FileServerFragment extends Fragment {
     private static final String TAG = FileServerFragment.class.getSimpleName();
 
-    private static CommCareWiFiDirectActivity mActivity;
-
-    private static TextView mStatusText;
+    private TextView mStatusText;
     private View mView;
 
-    private static String receiveZipDirectory;
+    private String receiveZipDirectory;
 
     private FileServerAsyncTask mFileServer;
-
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        try {
-            mActivity = (CommCareWiFiDirectActivity)context;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(context.toString() + " must implement fileServerListener");
-        }
-    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -67,6 +54,10 @@ public class FileServerFragment extends Fragment {
         void onFormsCopied(String result);
     }
 
+    private void onFormsCopied(String result) {
+        ((CommCareWiFiDirectActivity)requireActivity()).onFormsCopied(result);
+    }
+
     public void startServer(String mReceiveZipDirectory) {
         Logger.log(TAG, "File Server starting...");
 
@@ -76,9 +67,9 @@ public class FileServerFragment extends Fragment {
             mFileServer.cancel(true);
         }
 
-        mFileServer = new FileServerAsyncTask(this);
-
         receiveZipDirectory = mReceiveZipDirectory;
+
+        mFileServer = new FileServerAsyncTask(this);
 
         //Execute on a true multithreaded chain. We should probably replace all of our calls with this
         //but this is the big one for now.
@@ -108,7 +99,7 @@ public class FileServerFragment extends Fragment {
             try {
                 ServerSocket serverSocket = new ServerSocket(8988);
                 long time = System.currentTimeMillis();
-                String finalFileName = receiveZipDirectory + time + ".zip";
+                String finalFileName = mListener.receiveZipDirectory + time + ".zip";
 
                 try {
                     publishProgress("Ready to accept new file transfer.", null);
@@ -161,10 +152,10 @@ public class FileServerFragment extends Fragment {
             }
 
             if (result != null) {
-                mActivity.onFormsCopied(result);
+                mListener.onFormsCopied(result);
             }
             Logger.log(TAG, "file server post-execute, relaunching server");
-            mListener.startServer(receiveZipDirectory);
+            mListener.startServer(mListener.receiveZipDirectory);
         }
 
         @Override
@@ -174,7 +165,7 @@ public class FileServerFragment extends Fragment {
 
         @Override
         protected void onProgressUpdate(String... params) {
-            mStatusText.setText(params[0]);
+            mListener.mStatusText.setText(params[0]);
         }
 
     }

--- a/app/src/org/commcare/fragments/FileServerFragment.java
+++ b/app/src/org/commcare/fragments/FileServerFragment.java
@@ -1,41 +1,33 @@
 package org.commcare.fragments;
 
 import android.annotation.SuppressLint;
-import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
-import androidx.fragment.app.Fragment;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+
 import org.commcare.activities.CommCareWiFiDirectActivity;
 import org.commcare.dalvik.R;
-import org.javarosa.core.services.Logger;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.ServerSocket;
-import java.net.Socket;
-
-/**
- * A fragment that manages a particular peer and allows interaction with device
- * i.e. setting up network connection and transferring data.
- */
 @SuppressLint("NewApi")
 public class FileServerFragment extends Fragment {
-    private static final String TAG = FileServerFragment.class.getSimpleName();
 
     private TextView mStatusText;
     private View mView;
 
-    private String receiveZipDirectory;
+    private FileServerViewModel viewModel;
 
-    private FileServerAsyncTask mFileServer;
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        viewModel = new ViewModelProvider(requireActivity()).get(FileServerViewModel.class);
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -49,128 +41,23 @@ public class FileServerFragment extends Fragment {
         return contentView;
     }
 
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        mView.setVisibility(viewModel.isRunning() ? View.VISIBLE : View.GONE);
+
+        viewModel.getStatusText().observe(getViewLifecycleOwner(), mStatusText::setText);
+        viewModel.getReceivedZipPath().observe(getViewLifecycleOwner(), path ->
+                ((CommCareWiFiDirectActivity)requireActivity()).onFormsCopied(path));
+    }
 
     public interface FileServerListener {
         void onFormsCopied(String result);
     }
 
-    private void onFormsCopied(String result) {
-        CommCareWiFiDirectActivity activity = (CommCareWiFiDirectActivity)getActivity();
-        if (activity != null) {
-            activity.onFormsCopied(result);
-        }
-    }
-
-    public void startServer(String mReceiveZipDirectory) {
-        Logger.log(TAG, "File Server starting...");
-
-        mStatusText.setText("Starting server");
+    public void startServer(String receiveZipDirectory) {
         mView.setVisibility(View.VISIBLE);
-        if (mFileServer != null) {
-            mFileServer.cancel(true);
-        }
-
-        receiveZipDirectory = mReceiveZipDirectory;
-
-        mFileServer = new FileServerAsyncTask(this);
-
-        //Execute on a true multithreaded chain. We should probably replace all of our calls with this
-        //but this is the big one for now.
-        mFileServer.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        viewModel.startServer(receiveZipDirectory);
     }
-
-    /**
-     * A simple server socket that accepts connection and writes some data on
-     * the stream.
-     */
-    static class FileServerAsyncTask extends AsyncTask<Void, String, String> {
-
-        private final FileServerFragment mListener;
-        private boolean socketOccupied;
-
-        FileServerAsyncTask(FileServerFragment mListener) {
-            this.mListener = mListener;
-
-        }
-
-        @Override
-        protected String doInBackground(Void... params) {
-
-            Logger.log(TAG, "Executing FileServerAsyncTask");
-            socketOccupied = false;
-
-            try {
-                ServerSocket serverSocket = new ServerSocket(8988);
-                long time = System.currentTimeMillis();
-                String finalFileName = mListener.receiveZipDirectory + time + ".zip";
-
-                try {
-                    publishProgress("Ready to accept new file transfer.", null);
-                    Socket client = serverSocket.accept();
-                    Logger.log(TAG, "Ready in wi-fi direct file server receive loop");
-
-                    final File f = new File(finalFileName);
-
-                    File dirs = new File(f.getParent());
-
-                    dirs.mkdirs();
-
-                    f.createNewFile();
-
-                    Log.d(TAG, "server: copying files " + f.toString());
-                    InputStream inputstream = client.getInputStream();
-                    CommCareWiFiDirectActivity.copyFile(inputstream, new FileOutputStream(f));
-                    publishProgress("copied files: " + f.getAbsolutePath(), f.getAbsolutePath());
-                    publishProgress("File Server Resetting", null);
-                    return f.getAbsolutePath();
-
-                } catch (IOException e) {
-                    String errorMessage = "File Server crashed after transfer with IO Exception: " + e.getMessage();
-                    Logger.exception(errorMessage, e);
-                    publishProgress(errorMessage);
-                    return null;
-                } finally {
-                    try {
-                        serverSocket.close();
-                    } catch(IOException e) {
-                        // Can ignore
-                        e.printStackTrace();
-                    }
-                }
-            } catch (IOException ioe) {
-                publishProgress("Ready to accept new file transfer.", null);
-                Logger.log(TAG, "couldn't open socket!");
-                socketOccupied = true;
-                return null;
-            }
-        }
-
-        @Override
-        protected void onPostExecute(String result) {
-            Log.e(TAG, "file server task post execute");
-
-            if (socketOccupied) {
-                Logger.log(TAG, "socket busy, cancelling this thread cycle");
-                return;
-            }
-
-            if (result != null) {
-                mListener.onFormsCopied(result);
-            }
-            Logger.log(TAG, "file server post-execute, relaunching server");
-            mListener.startServer(mListener.receiveZipDirectory);
-        }
-
-        @Override
-        protected void onPreExecute() {
-            Logger.log(TAG, "pre-execute of file server launch");
-        }
-
-        @Override
-        protected void onProgressUpdate(String... params) {
-            mListener.mStatusText.setText(params[0]);
-        }
-
-    }
-
 }

--- a/app/src/org/commcare/fragments/FileServerFragment.java
+++ b/app/src/org/commcare/fragments/FileServerFragment.java
@@ -48,8 +48,13 @@ public class FileServerFragment extends Fragment {
         mView.setVisibility(viewModel.isRunning() ? View.VISIBLE : View.GONE);
 
         viewModel.getStatusText().observe(getViewLifecycleOwner(), mStatusText::setText);
-        viewModel.getReceivedZipPath().observe(getViewLifecycleOwner(), path ->
-                ((CommCareWiFiDirectActivity)requireActivity()).onFormsCopied(path));
+        viewModel.getReceivedZipPaths().observe(getViewLifecycleOwner(), paths -> {
+            CommCareWiFiDirectActivity activity = (CommCareWiFiDirectActivity)requireActivity();
+            for (String path : paths) {
+                viewModel.onReceivedZipHandled(path);
+                activity.onFormsCopied(path);
+            }
+        });
     }
 
     public interface FileServerListener {

--- a/app/src/org/commcare/fragments/FileServerFragment.java
+++ b/app/src/org/commcare/fragments/FileServerFragment.java
@@ -55,7 +55,10 @@ public class FileServerFragment extends Fragment {
     }
 
     private void onFormsCopied(String result) {
-        ((CommCareWiFiDirectActivity)requireActivity()).onFormsCopied(result);
+        CommCareWiFiDirectActivity activity = (CommCareWiFiDirectActivity)getActivity();
+        if (activity != null) {
+            activity.onFormsCopied(result);
+        }
     }
 
     public void startServer(String mReceiveZipDirectory) {

--- a/app/src/org/commcare/fragments/FileServerViewModel.kt
+++ b/app/src/org/commcare/fragments/FileServerViewModel.kt
@@ -131,7 +131,7 @@ class FileServerViewModel : ViewModel() {
     }
 
     companion object {
-        private val TAG = LogTypes.TYPE_WIFI_DIRECT
+        private const val TAG = LogTypes.TYPE_WIFI_DIRECT
         private const val PORT = 8988
     }
 }

--- a/app/src/org/commcare/fragments/FileServerViewModel.kt
+++ b/app/src/org/commcare/fragments/FileServerViewModel.kt
@@ -1,0 +1,125 @@
+package org.commcare.fragments
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.commcare.activities.CommCareWiFiDirectActivity
+import org.commcare.util.LogTypes
+import org.javarosa.core.services.Logger
+import java.io.Closeable
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.net.ServerSocket
+import java.net.Socket
+
+class FileServerViewModel : ViewModel() {
+    private val _statusText = MutableLiveData<String>()
+    val statusText: LiveData<String> = _statusText
+
+    private val _receivedZipPath = MutableLiveData<String>()
+    val receivedZipPath: LiveData<String> = _receivedZipPath
+
+    @Volatile
+    private var running = false
+
+    @Volatile
+    private var serverSocket: ServerSocket? = null
+
+    val isRunning: Boolean
+        get() = running
+
+    fun startServer(receiveZipDirectory: String) {
+        if (running) {
+            Logger.log(TAG, "File server already running, keeping the existing socket")
+            return
+        }
+        Logger.log(TAG, "File Server starting...")
+        running = true
+        _statusText.value = "Starting server"
+        viewModelScope.launch(Dispatchers.IO) { serve(receiveZipDirectory) }
+    }
+
+    fun stopServer() {
+        running = false
+        serverSocket.closeQuietly()
+    }
+
+    private fun serve(receiveZipDirectory: String) {
+        val socket =
+            try {
+                ServerSocket(PORT)
+            } catch (e: IOException) {
+                Logger.exception("Wi-fi direct file server could not bind port $PORT", e)
+                _statusText.postValue("Could not start the file server, the port is in use.")
+                running = false
+                return
+            }
+        serverSocket = socket
+
+        try {
+            while (running) {
+                _statusText.postValue("Ready to accept new file transfer.")
+                val client =
+                    try {
+                        socket.accept()
+                    } catch (e: IOException) {
+                        if (running) {
+                            Logger.exception("Wi-fi direct file server stopped accepting connections", e)
+                            _statusText.postValue("File server stopped.")
+                        }
+                        break
+                    }
+                Logger.log(TAG, "Ready in wi-fi direct file server receive loop")
+                receive(client, receiveZipDirectory)
+            }
+        } finally {
+            running = false
+            socket.closeQuietly()
+            serverSocket = null
+        }
+    }
+
+    private fun receive(
+        client: Socket,
+        receiveZipDirectory: String,
+    ) {
+        try {
+            val f = File(receiveZipDirectory + System.currentTimeMillis() + ".zip")
+            f.parentFile?.mkdirs()
+            f.createNewFile()
+
+            Logger.log(TAG, "server: copying files $f")
+            CommCareWiFiDirectActivity.copyFile(client.getInputStream(), FileOutputStream(f))
+
+            _statusText.postValue("copied files: ${f.absolutePath}")
+            _receivedZipPath.postValue(f.absolutePath)
+        } catch (e: IOException) {
+            val errorMessage = "File Server crashed after transfer with IO Exception: ${e.message}"
+            Logger.exception(errorMessage, e)
+            _statusText.postValue(errorMessage)
+        } finally {
+            client.closeQuietly()
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        stopServer()
+    }
+
+    companion object {
+        private val TAG = LogTypes.TYPE_WIFI_DIRECT
+        private const val PORT = 8988
+    }
+}
+
+private fun Closeable?.closeQuietly() {
+    try {
+        this?.close()
+    } catch (e: IOException) {
+    }
+}

--- a/app/src/org/commcare/fragments/FileServerViewModel.kt
+++ b/app/src/org/commcare/fragments/FileServerViewModel.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.commcare.activities.CommCareWiFiDirectActivity
 import org.commcare.util.LogTypes
+import org.commcare.utils.closeQuietly
 import org.javarosa.core.services.Logger
-import java.io.Closeable
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -126,12 +126,5 @@ class FileServerViewModel : ViewModel() {
     companion object {
         private val TAG = LogTypes.TYPE_WIFI_DIRECT
         private const val PORT = 8988
-    }
-}
-
-private fun Closeable?.closeQuietly() {
-    try {
-        this?.close()
-    } catch (e: IOException) {
     }
 }

--- a/app/src/org/commcare/fragments/FileServerViewModel.kt
+++ b/app/src/org/commcare/fragments/FileServerViewModel.kt
@@ -15,13 +15,15 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.net.ServerSocket
 import java.net.Socket
+import java.util.concurrent.ConcurrentLinkedQueue
 
 class FileServerViewModel : ViewModel() {
     private val _statusText = MutableLiveData<String>()
     val statusText: LiveData<String> = _statusText
 
-    private val _receivedZipPath = MutableLiveData<String>()
-    val receivedZipPath: LiveData<String> = _receivedZipPath
+    private val pendingZips = ConcurrentLinkedQueue<String>()
+    private val _receivedZipPaths = MutableLiveData<List<String>>(emptyList())
+    val receivedZipPaths: LiveData<List<String>> = _receivedZipPaths
 
     @Volatile
     private var running = false
@@ -31,6 +33,15 @@ class FileServerViewModel : ViewModel() {
 
     val isRunning: Boolean
         get() = running
+
+    fun onReceivedZipHandled(path: String) {
+        pendingZips.remove(path)
+        publishPendingZips()
+    }
+
+    private fun publishPendingZips() {
+        _receivedZipPaths.postValue(pendingZips.toList())
+    }
 
     fun startServer(receiveZipDirectory: String) {
         if (running) {
@@ -96,7 +107,8 @@ class FileServerViewModel : ViewModel() {
             CommCareWiFiDirectActivity.copyFile(client.getInputStream(), FileOutputStream(f))
 
             _statusText.postValue("copied files: ${f.absolutePath}")
-            _receivedZipPath.postValue(f.absolutePath)
+            pendingZips.add(f.absolutePath)
+            publishPendingZips()
         } catch (e: IOException) {
             val errorMessage = "File Server crashed after transfer with IO Exception: ${e.message}"
             Logger.exception(errorMessage, e)

--- a/app/src/org/commcare/fragments/FileServerViewModel.kt
+++ b/app/src/org/commcare/fragments/FileServerViewModel.kt
@@ -17,6 +17,13 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.util.concurrent.ConcurrentLinkedQueue
 
+/**
+ * ViewModel for the file server fragment. Owns the Wi-Fi Direct receive socket for the activity rather than the
+ * fragment that starts it. The fragment is recreated on rotation, and a socket dying with it would leave port
+ * 8988 bound. onCleared is the only place the port is released.
+ *
+ * @author avazirna
+ */
 class FileServerViewModel : ViewModel() {
     private val _statusText = MutableLiveData<String>()
     val statusText: LiveData<String> = _statusText

--- a/app/src/org/commcare/fragments/WiFiDirectManagementFragment.java
+++ b/app/src/org/commcare/fragments/WiFiDirectManagementFragment.java
@@ -137,7 +137,7 @@ public class WiFiDirectManagementFragment extends Fragment
         try {
             mManager.requestConnectionInfo(mChannel, this);
         } catch (SecurityException e) {
-            Logger.log(TAG, "Cannot read Wi-fi direct connection info without permission");
+            Logger.exception("Cannot read Wi-fi direct connection info without permission", e);
         }
     }
 

--- a/app/src/org/commcare/fragments/WiFiDirectManagementFragment.java
+++ b/app/src/org/commcare/fragments/WiFiDirectManagementFragment.java
@@ -178,7 +178,7 @@ public class WiFiDirectManagementFragment extends Fragment
             if (isHost) {
                 setStatusText("You are the host but didn't form a group. Restart the Wi-fi functionality.");
             } else {
-                setStatusText("YWaiting to join new group...");
+                setStatusText("Waiting to join new group...");
             }
         }
     }

--- a/app/src/org/commcare/fragments/WiFiDirectManagementFragment.java
+++ b/app/src/org/commcare/fragments/WiFiDirectManagementFragment.java
@@ -207,7 +207,10 @@ public class WiFiDirectManagementFragment extends Fragment
 
     @Override
     public void onChannelDisconnected() {
-        CommCareWiFiDirectActivity activity = requireWiFiDirectActivity();
+        CommCareWiFiDirectActivity activity = (CommCareWiFiDirectActivity)getActivity();
+        if (activity == null) {
+            return;
+        }
         // we will try once more
         if (mManager != null) {
             Toast.makeText(activity, "Channel lost. Trying again", Toast.LENGTH_LONG).show();

--- a/app/src/org/commcare/fragments/WiFiDirectManagementFragment.java
+++ b/app/src/org/commcare/fragments/WiFiDirectManagementFragment.java
@@ -130,6 +130,17 @@ public class WiFiDirectManagementFragment extends Fragment
         this.mManager = mManager;
     }
 
+    public void refreshConnectionInfo() {
+        if (mManager == null || mChannel == null) {
+            return;
+        }
+        try {
+            mManager.requestConnectionInfo(mChannel, this);
+        } catch (SecurityException e) {
+            Logger.log(TAG, "Cannot read Wi-fi direct connection info without permission");
+        }
+    }
+
     @Override
     public void onConnectionInfoAvailable(WifiP2pInfo info) {
 

--- a/app/src/org/commcare/fragments/WiFiDirectManagementFragment.java
+++ b/app/src/org/commcare/fragments/WiFiDirectManagementFragment.java
@@ -1,7 +1,6 @@
 package org.commcare.fragments;
 
 import android.annotation.SuppressLint;
-import android.content.Context;
 import android.content.Intent;
 import android.net.wifi.p2p.WifiP2pDevice;
 import android.net.wifi.p2p.WifiP2pInfo;
@@ -32,7 +31,6 @@ import org.javarosa.core.services.Logger;
 public class WiFiDirectManagementFragment extends Fragment
         implements ConnectionInfoListener, ActionListener, ChannelListener {
     private static final String TAG = LogTypes.TYPE_WIFI_DIRECT;
-    private static CommCareWiFiDirectActivity mActivity;
 
     private TextView mStatusText;
 
@@ -44,16 +42,6 @@ public class WiFiDirectManagementFragment extends Fragment
 
     private WifiP2pManager mManager;
     private Channel mChannel;
-
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        try {
-            mActivity = (CommCareWiFiDirectActivity)context;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(context.toString() + " must implement fileServerListener");
-        }
-    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -69,12 +57,16 @@ public class WiFiDirectManagementFragment extends Fragment
     }
 
     public void resetData() {
-        ((WifiDirectManagerListener)this.getActivity()).resetData();
+        requireWiFiDirectActivity().resetData();
+    }
+
+    private CommCareWiFiDirectActivity requireWiFiDirectActivity() {
+        return (CommCareWiFiDirectActivity)requireActivity();
     }
 
     public void onPeersChanged() {
         Logger.log(TAG, "Wi-fi direct peers changed");
-        mActivity.updatePeers();
+        requireWiFiDirectActivity().updatePeers();
     }
 
     public void onP2PConnectionChanged(boolean isConnected) {
@@ -106,7 +98,7 @@ public class WiFiDirectManagementFragment extends Fragment
             mManager.createGroup(mChannel, this);
         }
 
-        mActivity.updateDeviceStatus(mDevice);
+        requireWiFiDirectActivity().updateDeviceStatus(mDevice);
     }
 
     public String getHostAddress() {
@@ -215,13 +207,14 @@ public class WiFiDirectManagementFragment extends Fragment
 
     @Override
     public void onChannelDisconnected() {
+        CommCareWiFiDirectActivity activity = requireWiFiDirectActivity();
         // we will try once more
         if (mManager != null) {
-            Toast.makeText(mActivity, "Channel lost. Trying again", Toast.LENGTH_LONG).show();
+            Toast.makeText(activity, "Channel lost. Trying again", Toast.LENGTH_LONG).show();
             //resetData();
-            mManager.initialize(mActivity, mActivity.getMainLooper(), this);
+            mManager.initialize(activity, activity.getMainLooper(), this);
         } else {
-            Toast.makeText(mActivity,
+            Toast.makeText(activity,
                     "Severe! Channel is probably lost premanently. Try Disable/Re-Enable P2P.",
                     Toast.LENGTH_LONG).show();
         }

--- a/app/src/org/commcare/fragments/WiFiDirectSessionViewModel.kt
+++ b/app/src/org/commcare/fragments/WiFiDirectSessionViewModel.kt
@@ -9,6 +9,12 @@ import androidx.lifecycle.AndroidViewModel
 import org.commcare.activities.CommCareWiFiDirectActivity
 import org.commcare.android.database.user.models.FormRecord
 
+/**
+ * Retains the Wi-Fi Direct session across activity recreation, and owns the Channel for the entire lifetime.
+ * onCleared is the only place the channel is released.
+ *
+ * @author avazirna
+ */
 class WiFiDirectSessionViewModel(
     application: Application,
 ) : AndroidViewModel(application) {

--- a/app/src/org/commcare/fragments/WiFiDirectSessionViewModel.kt
+++ b/app/src/org/commcare/fragments/WiFiDirectSessionViewModel.kt
@@ -1,13 +1,30 @@
 package org.commcare.fragments
 
-import androidx.lifecycle.ViewModel
+import android.app.Application
+import android.net.wifi.p2p.WifiP2pManager
+import android.os.Build
+import android.os.Looper
+import androidx.lifecycle.AndroidViewModel
 import org.commcare.activities.CommCareWiFiDirectActivity
 import org.commcare.android.database.user.models.FormRecord
 
-class WiFiDirectSessionViewModel : ViewModel() {
+class WiFiDirectSessionViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
     var state: CommCareWiFiDirectActivity.wdState? = null
 
     var isModeDialogShowing = false
 
     var cachedRecords: Array<FormRecord>? = null
+
+    val manager: WifiP2pManager? = application.getSystemService(WifiP2pManager::class.java)
+
+    val channel: WifiP2pManager.Channel? = manager?.initialize(application, Looper.getMainLooper(), null)
+
+    override fun onCleared() {
+        super.onCleared()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            channel?.close()
+        }
+    }
 }

--- a/app/src/org/commcare/fragments/WiFiDirectSessionViewModel.kt
+++ b/app/src/org/commcare/fragments/WiFiDirectSessionViewModel.kt
@@ -1,6 +1,7 @@
 package org.commcare.fragments
 
 import android.app.Application
+import android.net.wifi.p2p.WifiP2pDevice
 import android.net.wifi.p2p.WifiP2pManager
 import android.os.Build
 import android.os.Looper
@@ -16,6 +17,8 @@ class WiFiDirectSessionViewModel(
     var isModeDialogShowing = false
 
     var cachedRecords: Array<FormRecord>? = null
+
+    var thisDevice: WifiP2pDevice? = null
 
     val manager: WifiP2pManager? = application.getSystemService(WifiP2pManager::class.java)
 

--- a/app/src/org/commcare/fragments/WiFiDirectSessionViewModel.kt
+++ b/app/src/org/commcare/fragments/WiFiDirectSessionViewModel.kt
@@ -1,0 +1,13 @@
+package org.commcare.fragments
+
+import androidx.lifecycle.ViewModel
+import org.commcare.activities.CommCareWiFiDirectActivity
+import org.commcare.android.database.user.models.FormRecord
+
+class WiFiDirectSessionViewModel : ViewModel() {
+    var state: CommCareWiFiDirectActivity.wdState? = null
+
+    var isModeDialogShowing = false
+
+    var cachedRecords: Array<FormRecord>? = null
+}

--- a/app/src/org/commcare/utils/StreamExtensions.kt
+++ b/app/src/org/commcare/utils/StreamExtensions.kt
@@ -3,14 +3,14 @@
 package org.commcare.utils
 
 import org.javarosa.core.services.Logger
+import java.io.Closeable
 import java.io.IOException
-import java.io.OutputStream
 
-/** Closes the stream, logging any [IOException] as a non-fatal instead of throwing. */
-fun OutputStream.closeQuietly() {
+/** Closes the resource, logging any [IOException] as a non-fatal instead of throwing. */
+fun Closeable?.closeQuietly() {
     try {
-        close()
+        this?.close()
     } catch (e: IOException) {
-        Logger.exception("Failed to close output stream", e)
+        Logger.exception("Failed to close ${this?.javaClass?.simpleName}", e)
     }
 }


### PR DESCRIPTION
## Product Description

This PR adds support to device rotation to Wi-Fi Direct form transfer. It now rotates, and rotating mid-transfer no longer loses the session. Previously rotation was prevented rather than supported. It now works while choosing a mode, discovering peers, hosting, transfer and unzip, and the screen comes back with the same mode, peer list, connection status, device row and in-flight transfer.
<table>
<tr>
<td>
Sender
</td>
<td>
Receiver
</td>
</tr>
<tr>
<td>
<video width="200px" src="https://github.com/user-attachments/assets/085e36ae-ed08-4ca1-be4d-2e7b869814be"></video>
</td>
<td>
<video width="200px" src="https://github.com/user-attachments/assets/cbcf17af-a56f-46ae-a5e5-eeb17e3984ab"></video>
</td>
</tr>
</table>

## Technical Summary

Ticket: https://dimagi.atlassian.net/browse/SAAS-20146

The changes were:

1. **Remove the static state** — under a recreation, `static mActivity` / `mStatusText` / `receiveZipDirectory` were become correctness bugs, since the old instance's callbacks write into whichever instance last overwrote the static.
2. **Move the file server into a ViewModel** — the receive socket was owned by a non-retained XML fragment and bound port 8988. Rotating while hosting orphaned the task with the port held, so re-entering receive mode hit `BindException` until the process restarted. The self-relaunching `AsyncTask` becomes an accept loop whose socket is a field, which is what makes stopping it possible at all.
3. **Split entering a mode from rendering it** — `beSender`/`beReceiver`/`beSubmitter` each mixed rendering with side effects, so restoring a mode by replaying one would also remove the P2P group, clear the peer list and re-run the unzip. Now `enter*` (side effects, from the dialog only) and `render*` (view state, every create).
4. **One channel per session** — `initialize()` used to run on every create and the old `Channel` was never closed, leaking one per rotation.
5. **Restore the rest of the screen** — peer list, this device's name/status, and the status line, all of which were written only from broadcast callbacks that a recreated activity is never sent again.
6. **One data-loss fix beyond rotation**  - the receive loop keeps accepting while the activity is stopped, and a single-value `LiveData` was holding only the latest. So two transfers with the receiver backgrounded dropped the first, considering that the delivered zip's unzip deletes the whole receive directory which takes the dropped one with it. Received zips are now published as a queue the observer acknowledges entry by entry.

Design decisions worth a reviewer's attention:

- **Session state lives in ViewModels, not the saved-instance bundle.**  - the P2P group and the receive socket both die with the process, so a mode restored from a bundle after process death would be in an inconsistent state. A ViewModel dies with them, which makes "no state" a reliable signal to ask for a mode again rather than fake a restore. 
- **Re-derive from the system service in preference to carrying state across.** - the group and peer list are owned by the framework, not the activity, so we are not saving them to use in a restore. One exception: this device's own name and status are retained, because `requestDeviceInfo` is API 29 and the min SDK is 23. That row is display-only and the broadcast corrects it on the next real change.
- **The channel is built against the application context.** A `Channel` retains the `Context` it was made with, so hoisting one built from the activity would have swapped a leaked channel per rotation for a pinned dead activity.

## Safety Assurance

### Safety story

- **Blast radius is one screen**, reached from Advanced Actions. No shared code paths are touched; nothing outside `CommCareWiFiDirectActivity` and its four fragments changes behaviour. 
- These changes were successfully tested locally on two devices, one running Android 16 and the other Android 15. The tests covered:
  - Rotation mid-transfer on the sender, and mid-unzip on the receiver
  - Multiple rotations during a single transfer
  - Sending two batches back to back with the receiver backgrounded

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

