### PR TITLE
CI-909 Preload A Placeholder Photo On The QA Automation Build

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,8 @@ This file is meant as an easy way for us to collate notes and change logs across
 
 - On a device where PersonalID sign-up previously got stuck due to a Firebase OTP error, a pre-invited user will now receive the OTP via Twilio automatically and can complete the sign-up flow.
 - Confirm that entering an incorrect verification code still displays the "incorrect code" error and does not silently trigger a new OTP.
+- On the QA automation build, the photo step of PersonalID sign-up should open with a placeholder photo already shown and Save Photo enabled, and saving it should create the account without the camera ever opening.
+- On a normal build, the photo step should be unchanged: Save Photo stays disabled until a photo is actually taken.
 
 ## CommCare 2.63.4
 

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
@@ -14,6 +14,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavDirections;
 import androidx.navigation.Navigation;
@@ -26,13 +27,17 @@ import org.commcare.connect.database.ConnectDatabaseHelper;
 import org.commcare.connect.database.ConnectUserDatabaseUtil;
 import org.commcare.connect.network.base.PersonalIdOrConnectApiErrorHandler;
 import org.commcare.connect.network.personalId.PersonalIdApiHandler;
+import org.commcare.dalvik.BuildConfig;
 import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.ScreenPersonalidPhotoCaptureBinding;
 import org.commcare.activities.camera.MicroImageActivity;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
+import org.commcare.utils.ImageSizeTooLargeException;
 import org.commcare.utils.MediaUtil;
+import org.commcare.utils.QaAutomationPlaceholderPhoto;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
 import java.util.Date;
 
 /**
@@ -57,7 +62,29 @@ public class PersonalIdPhotoCaptureFragment extends BasePersonalIdFragment {
                 PersonalIdSessionDataViewModel.class).getPersonalIdSessionData();
         initTakePhotoLauncher();
         setUpUi();
+        if (isQaAutomationBuild()) {
+            applyPlaceholderPhoto();
+        }
         return viewBinding.getRoot();
+    }
+
+    /**
+     * Pre-loads a stand-in photo for QA build (to avoid the camera)
+     */
+    private void applyPlaceholderPhoto() {
+        try {
+            photoAsBase64 = QaAutomationPlaceholderPhoto.generateBase64(requireContext(),
+                    PHOTO_MAX_DIMENSION_PX, PHOTO_MAX_SIZE_BYTES);
+        } catch (IOException | ImageSizeTooLargeException e) {
+            throw new RuntimeException("Failed to generate placeholder photo for QA automation", e);
+        }
+        displayImage(photoAsBase64);
+        enableSaveButton();
+    }
+
+    @VisibleForTesting
+    protected boolean isQaAutomationBuild() {
+        return BuildConfig.IS_QA_AUTOMATION;
     }
 
     private void initTakePhotoLauncher() {

--- a/app/src/org/commcare/utils/QaAutomationPlaceholderPhoto.kt
+++ b/app/src/org/commcare/utils/QaAutomationPlaceholderPhoto.kt
@@ -1,0 +1,49 @@
+package org.commcare.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.util.Base64
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.createBitmap
+import org.commcare.activities.camera.MicroImageActivity
+import org.commcare.dalvik.R
+import java.io.IOException
+
+/**
+ * Builds a stand-in profile photo for the QA build to use on the photo page (to avoid the camera)
+ */
+object QaAutomationPlaceholderPhoto {
+    @JvmStatic
+    @Throws(IOException::class, ImageSizeTooLargeException::class)
+    fun generateBase64(
+        context: Context,
+        maxDimensionPx: Int,
+        maxSizeBytes: Int,
+    ): String {
+        val bitmap = renderSilhouette(context, maxDimensionPx)
+        try {
+            val compressed = MediaUtil.compressBitmapToTargetSize(bitmap, maxSizeBytes)
+            return MicroImageActivity.BASE_64_IMAGE_PREFIX + Base64.encodeToString(compressed, Base64.DEFAULT)
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    private fun renderSilhouette(
+        context: Context,
+        sizePx: Int,
+    ): Bitmap {
+        val silhouette =
+            requireNotNull(ContextCompat.getDrawable(context, R.drawable.baseline_person_24)) {
+                "Placeholder photo drawable could not be loaded"
+            }
+        val bitmap = createBitmap(sizePx, sizePx)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(Color.WHITE)
+        silhouette.setBounds(0, 0, sizePx, sizePx)
+        silhouette.draw(canvas)
+        return bitmap
+    }
+}


### PR DESCRIPTION
### [CI-909](https://dimagi.atlassian.net/browse/CI-909)

## Technical Summary

Adds the ability for the special QA build to avoid using the camera to capture a user photo during PersonalID account registration.
On entering the Photo page (final page in the configuration workflow when registering a new account) when `IS_QA_AUTOMATION` is true, the default placeholder image (already in the codebase, for accounts with no user photo) is rendered and converted to a base64-encoded string that can be sent to the server in `complete_profile`.
After setting the image, the "Save Photo" button is enabled so the user (or automation script) can proceed.

Demo video, note the Save Photo button is enabled immediately when entering the page (0:28), and account creation succeeds when the Save Photo button is pressed:

https://github.com/user-attachments/assets/fc22395b-008e-4f5e-a281-a1d97d89d83b



## Safety Assurance

### Safety story

What gives confidence:

- Manually enabled the `IS_QA_AUTOMATION` flag in code and tested the workflow (see demo video)
- Verified the Photo page still works like before when the flag is false

[CI-909]: https://dimagi.atlassian.net/browse/CI-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ