### PR TITLE
CI-911 Require All Learn Modules Before Claiming A Job

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           # Only lint changed files in PR
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: ${{ github.base_ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
           # File handling

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,12 @@ This file is meant as an easy way for us to collate notes and change logs across
 - Fixed an issue where recovering a PersonalID account via backup code could result in the account being stored without a pin, causing authentication to fail after recovery.
 - Fixed an issue where a worker who passed the learning assessment before completing all learn modules was shown as ready to claim the opportunity, and then hit a failure when trying to claim it. They are now directed back to finish the remaining modules first.
 
+### QA Notes
+
+- On an opportunity where the assessment can be reached before all learn modules are done, pass the assessment with modules still outstanding and confirm the app keeps directing you to the remaining learning rather than offering to claim the job.
+- With all modules completed and the assessment passed, confirm claiming the opportunity and downloading the delivery app still works as before.
+- Confirm a worker who passed the assessment with modules still outstanding now sees their module progress on the learning screen rather than a blank progress area.
+
 ## CommCare 2.63.5
 
 ### Release Notes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@ This file is meant as an easy way for us to collate notes and change logs across
 #### Important Bug Fixes
 
 - Fixed an issue where recovering a PersonalID account via backup code could result in the account being stored without a pin, causing authentication to fail after recovery.
+- Fixed an issue where a worker who passed the learning assessment before completing all learn modules was shown as ready to claim the opportunity, and then hit a failure when trying to claim it. They are now directed back to finish the remaining modules first.
 
 ## CommCare 2.63.5
 

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -542,7 +542,7 @@ public class ConnectJobRecord extends Persisted implements Serializable {
     }
 
     /**
-     * Whether the user has finished everything requiresd before claiming the job:
+     * Whether the user has finished everything required before claiming the job:
      * every learn module submitted, and a passing assessment score
      */
     public boolean isLearningComplete() {

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -541,6 +541,14 @@ public class ConnectJobRecord extends Persisted implements Serializable {
                 || getAssessmentScore() >= getLearnAppInfo().getPassingScore();
     }
 
+    /**
+     * Whether the user has finished everything requiresd before claiming the job:
+     * every learn module submitted, and a passing assessment score
+     */
+    public boolean isLearningComplete() {
+        return getLearningPercentComplete(false) >= 100 && passedAssessment();
+    }
+
     public int getAssessmentScore() {
         int mostRecentFailingScore = 0;
         int firstPassingScore = -1;
@@ -644,7 +652,7 @@ public class ConnectJobRecord extends Persisted implements Serializable {
     }
 
     public boolean readyToTransitionToDelivery() {
-        return status == STATUS_LEARNING && passedAssessment();
+        return status == STATUS_LEARNING && isLearningComplete();
     }
 
     @Nullable

--- a/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectJobRecord.java
@@ -377,7 +377,7 @@ public class ConnectJobRecord extends Persisted implements Serializable {
      */
     public int getLearningPercentComplete(boolean includeAssessmentModule) {
         int totalModules = numLearningModules;
-        int modulesCompleted = learningModulesCompleted;
+        int modulesCompleted = Math.min(learningModulesCompleted, numLearningModules);
 
         if (includeAssessmentModule) {
             // Add 1 to the calculation to represent the assessment module.
@@ -546,7 +546,7 @@ public class ConnectJobRecord extends Persisted implements Serializable {
      * every learn module submitted, and a passing assessment score
      */
     public boolean isLearningComplete() {
-        return getLearningPercentComplete(false) >= 100 && passedAssessment();
+        return getLearningPercentComplete(true) >= 100;
     }
 
     public int getAssessmentScore() {

--- a/app/src/org/commcare/fragments/connect/ConnectJobDetailBottomSheetDialogFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobDetailBottomSheetDialogFragment.java
@@ -133,7 +133,7 @@ public class ConnectJobDetailBottomSheetDialogFragment extends BottomSheetDialog
                 R.drawable.ic_disabled_learn
         );
 
-        boolean reviewEnabled = job.passedAssessment();
+        boolean reviewEnabled = job.isLearningComplete();
         setProgressIconState(
                 binding.includeJobProgress.pbReview,
                 binding.includeJobProgress.ivReview,

--- a/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
@@ -161,9 +161,9 @@ public class ConnectJobsListsFragment extends BaseConnectFragment<FragmentConnec
 
         if (job.deliveryComplete()) {
             navigateToDeliveryProgress();
-        } else if (!job.passedAssessment()) {
+        } else if (!job.isLearningComplete()) {
             navigateToLearnProgress();
-        } else if (isLearning && job.passedAssessment()) {
+        } else if (isLearning) {
             navigateToDeliveryDetails();
         } else if (AppUtils.isAppInstalled(appId)) {
             new ConnectAppLaunchController(this).launchApp(appId, isLearning);

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.java
@@ -108,10 +108,10 @@ public class ConnectLearningProgressFragment extends ConnectJobFragment<Fragment
 
         updateProgressViews(
                 job.getLearningPercentComplete(true),
-                passedAssessment
+                job.isLearningComplete()
         );
-        updateCertificateView(learningComplete, passedAssessment);
-        updateButtons(learningComplete, passedAssessment);
+        updateCertificateView();
+        updateButtons(learningComplete);
         updateLearningStatus(learningComplete, passedAssessment, attemptedAssessment);
     }
 
@@ -130,12 +130,13 @@ public class ConnectLearningProgressFragment extends ConnectJobFragment<Fragment
         }
     }
 
-    private void updateCertificateView(boolean learningComplete, boolean passedAssessment) {
+    private void updateCertificateView() {
+        boolean showCertificate = job.isLearningComplete();
         getBinding().connectLearningCertificateContainer.setVisibility(
-                learningComplete && passedAssessment ? View.VISIBLE : View.GONE
+                showCertificate ? View.VISIBLE : View.GONE
         );
 
-        if (learningComplete && passedAssessment) {
+        if (showCertificate) {
             getBinding().connectLearnCertSubject.setText(job.getTitle());
             getBinding().connectLearnCertPerson.setText(
                     ConnectUserDatabaseUtil.getUser(requireContext()).getName()
@@ -172,12 +173,12 @@ public class ConnectLearningProgressFragment extends ConnectJobFragment<Fragment
         return latestDate != null ? latestDate : new Date();
     }
 
-    private void updateButtons(boolean learningComplete, boolean passedAssessment) {
+    private void updateButtons(boolean learningComplete) {
         getBinding().connectLearningReviewButton.setVisibility(View.GONE); // reserved for future logic
         getBinding().connectLearningButton.setVisibility(showAppLaunch ? View.VISIBLE : View.GONE);
 
         if (showAppLaunch) {
-            if (learningComplete && passedAssessment) {
+            if (job.isLearningComplete()) {
                 configureJobDetailsButton();
             } else if (!AppUtils.isAppInstalled(job.getLearnAppInfo().getAppId())) {
                 // This case needs to come before any that would launch the learn app


### PR DESCRIPTION
### [CI-911](https://dimagi.atlassian.net/browse/CI-911)

## Product Description

Fixes a bug where the user could potentially proceed to claim an opportunity (i.e. start delivery) before they were ready to do so (not all learn modules submitted yet). For this scenario to occur the following had to happen:
* Learn app designed such that the assessment is visible before all learn modules have been submitted
* User submits and passes the assessment before submitting all learn modules (i.e. they skip some modules)

At that point, some logic points in the mobile code would allow the user to proceed to the Delivery Details page and attempt to claim the job, even though the server would not allow that until all learn modules had been submitted.

The changes in this PR fix those logic points, so mobile won't advance the user in the workflow until the assessment has been passed AND al learn modules have been submitted.

An extra thing addressed by this fix: If the user gets into this special state, the progress bar will now still be visible in the Learning Progress page (before it was hidden once `passedAssessment` became true).

## Demos
Note Sample Job 7 reports 66% done with 1 of 2 learn modules submitted and the assessment passed (2/3 = 66%)

Old behavior (v2.64), incorrectly navigates to Delivery Details:

https://github.com/user-attachments/assets/2d924651-5999-4872-af29-62fd8e58d7bc



New behavior, navigates to Learning Progress and shows progress bar with 66% complete:

https://github.com/user-attachments/assets/d885f9c5-49bc-425a-b0a8-bd7909ea9888



## Technical Summary

* Added `ConnectJobRecord.isLearningComplete()` as the single point of truth (SPOT)
* Swapped the new function in (in place of `passedAssessment`) at several places in the code
* Replaced a couple places with identical logic to use the SPOT helper instead
* Added bug fix and QA notes in RELEASES.md

## Safety story

- Small code change, affects logic in very specific and easily-verifiable places
- Tested the change by completing assessment before submitting all modules in a test app and verifying behavior.

[CI-911]: https://dimagi.atlassian.net/browse/CI-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ