### PR TITLE
CI-915 Keep The Login Pipeline Alive Across Rotation

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,7 @@ This file is meant as an easy way for us to collate notes and change logs across
 - Fixed an issue where recovering a PersonalID account via backup code could result in the account being stored without a pin, causing authentication to fail after recovery.
 - Backgrounding the app while logging in no longer crashes the app when the login sync finishes.
 - The STOP button on the login sync dialog cancels the login again, instead of hanging on "Cancelling...".
+- Rotating the device during login no longer cancels the sync and leaves the progress dialog stuck part-way.
 
 ### QA Notes
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,7 +17,10 @@ This file is meant as an easy way for us to collate notes and change logs across
 
 - The login tests below need a login that takes the remote-sync path: clear the app's data first so the user has no local sandbox on the device. Make sure "Don't keep activities" is OFF in developer options, since it destroys the activity and hides the bug.
 - Log in as a traditional CommCare user (not from a Connect opportunity), background the app while the sync dialog is showing, and stay backgrounded until the restore finishes. The app should not crash. On returning to it, the login should either complete or report a failure you can retry from, and no progress dialog should be left stuck on screen.
-- Repeat the same steps but rotate the device or lock/unlock the screen mid-sync; progress dialogs should reappear correctly with no crash.
+- Repeat the same steps but rotate the device mid-sync. The sync should keep running rather than restarting or stalling, the progress dialog should reappear on the rotated screen and keep advancing from where it was, and the login should finish normally. Rotating several times in a row during one sync should behave the same way.
+- Rotate the device mid-sync and then press STOP on the restored dialog. It should cancel the login just as it does without a rotation.
+- Lock/unlock the screen mid-sync; progress dialogs should reappear correctly with no crash.
+- Rotate the device on the login screen when no login is running, and after a login has failed and returned you to the login screen. No progress dialog should appear in either case.
 - While the login sync dialog is showing, press STOP. The dialog should close and you should be back on the login screen, and logging in again should work normally.
 - Regression check on progress dialogs generally, since the fix touches the shared activity base class: app update installs, form record loading, multimedia inflation and app verification should all still show and dismiss their progress dialogs correctly, including when backgrounded and resumed mid-task.
 

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -17,6 +17,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.util.Pair;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.PreferenceManager;
 import androidx.work.WorkManager;
 
@@ -40,13 +41,12 @@ import org.commcare.interfaces.CommCareActivityUIController;
 import org.commcare.interfaces.RuntimePermissionRequester;
 import org.commcare.interfaces.WithUIController;
 import org.commcare.login.AuthSource;
-import org.commcare.login.LoginController;
 import org.commcare.login.LoginError;
 import org.commcare.login.LoginPhase;
 import org.commcare.login.LoginProgress;
-import org.commcare.login.LoginProgressListener;
 import org.commcare.login.LoginRequest;
 import org.commcare.login.LoginResult;
+import org.commcare.login.LoginViewModel;
 import org.commcare.models.database.user.DemoUserBuilder;
 import org.commcare.navdrawer.BaseDrawerActivity;
 import org.commcare.personalId.PersonalIdUnlocker;
@@ -75,9 +75,6 @@ import org.javarosa.core.services.locale.Localization;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
-
-import kotlinx.coroutines.Job;
 
 import static org.commcare.activities.DispatchActivity.REDIRECT_TO_CONNECT_OPPORTUNITY_INFO;
 import static org.commcare.connect.ConnectConstants.PERSONALID_MANAGED_LOGIN;
@@ -137,11 +134,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
 
     private LoginPhase currentLoginPhase;
 
-    /**
-     * Job for the in-flight login pipeline, retained so that the progress dialog's STOP button can
-     * cancel it. Null whenever no login is running.
-     */
-    private Job loginJob;
+    private LoginViewModel loginViewModel;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -156,6 +149,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
 
         uiController.setupUI();
         initPersonaIdManager();
+        observeLoginPipeline();
         presetAppId = getIntent().getStringExtra(EXTRA_APP_ID);
         if (savedInstanceState == null) {
             // Only restore last user on the initial creation
@@ -319,12 +313,28 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
                 dataPullMode
         );
 
-        LoginController controller = new LoginController(this);
-        loginJob = controller.start(this, request, createLoginProgressListener(), this::handleLoginResult);
+        loginViewModel.start(request);
     }
 
-    private LoginProgressListener createLoginProgressListener() {
-        return progress -> runOnUiThread(() -> updateLoginProgressUi(progress));
+    private void observeLoginPipeline() {
+        loginViewModel = new ViewModelProvider(this).get(LoginViewModel.class);
+
+        loginViewModel.getProgress().observe(this, progress -> {
+            if (progress != null) {
+                updateLoginProgressUi(progress);
+            }
+        });
+
+        loginViewModel.getResult().observe(this, result -> {
+            if (result == null) {
+                return;
+            }
+
+            // Claim the result before acting on it; otherwise an activity recreated after login
+            // completes is handed the same outcome again and finishes twice.
+            loginViewModel.consumeResult();
+            handleLoginResult(result);
+        });
     }
 
     private void updateLoginProgressUi(LoginProgress progress) {
@@ -362,11 +372,9 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
      */
     @Override
     public void cancelCurrentTask() {
-        if (loginJob != null) {
+        if (loginViewModel != null && loginViewModel.cancelLogin()) {
             Logger.log(LogTypes.TYPE_USER, "Login cancelled by user during "
                     + currentLoginPhase + " phase");
-            loginJob.cancel(new CancellationException("Login cancelled by user"));
-            loginJob = null;
             dismissLoginProgressDialog();
             return;
         }
@@ -534,7 +542,6 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
     }
 
     private void handleLoginResult(LoginResult result) {
-        loginJob = null;
         dismissLoginProgressDialog();
 
         if (result instanceof LoginResult.Success) {

--- a/app/src/org/commcare/login/LoginController.kt
+++ b/app/src/org/commcare/login/LoginController.kt
@@ -1,11 +1,7 @@
 package org.commcare.login
 
 import android.content.Context
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.commcare.CommCareApplication
 
@@ -25,21 +21,6 @@ class LoginController internal constructor(
         credentialResolver = ConnectCredentialResolver(context),
         postLoginSideEffects = PostLoginSideEffects(context),
     )
-
-    fun interface ResultCallback {
-        fun onResult(result: LoginResult)
-    }
-
-    fun start(
-        lifecycleOwner: LifecycleOwner,
-        request: LoginRequest,
-        listener: LoginProgressListener,
-        callback: ResultCallback,
-    ): Job =
-        lifecycleOwner.lifecycleScope.launch {
-            val result = performLogin(request, listener)
-            callback.onResult(result)
-        }
 
     suspend fun performLogin(
         request: LoginRequest,

--- a/app/src/org/commcare/login/LoginViewModel.kt
+++ b/app/src/org/commcare/login/LoginViewModel.kt
@@ -1,0 +1,57 @@
+package org.commcare.login
+
+import android.app.Application
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the in-flight login pipeline on behalf of `LoginActivity`.
+ */
+class LoginViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+    @VisibleForTesting
+    internal var performLogin: suspend (LoginRequest, LoginProgressListener) -> LoginResult =
+        { request, listener -> LoginController(getApplication()).performLogin(request, listener) }
+
+    private val _progress = MutableLiveData<LoginProgress?>()
+    val progress: LiveData<LoginProgress?> = _progress
+
+    private val _result = MutableLiveData<LoginResult?>()
+    val result: LiveData<LoginResult?> = _result
+
+    private var loginJob: Job? = null
+
+    fun start(request: LoginRequest) {
+        _progress.postValue(null)
+        _result.value = null
+
+        loginJob =
+            viewModelScope.launch {
+                val outcome = performLogin(request) { progress -> _progress.postValue(progress) }
+
+                loginJob = null
+                _progress.postValue(null)
+                _result.value = outcome
+            }
+    }
+
+    fun consumeResult() {
+        _result.value = null
+    }
+
+    fun cancelLogin(): Boolean {
+        val job = loginJob ?: return false
+
+        loginJob = null
+        _progress.postValue(null)
+        job.cancel(CancellationException("Login cancelled by user"))
+        return true
+    }
+}

--- a/app/unit-tests/src/org/commcare/activities/LoginProgressDialogLifecycleTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/LoginProgressDialogLifecycleTest.kt
@@ -1,22 +1,23 @@
 package org.commcare.activities
 
 import android.widget.Button
+import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.ViewModelProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.awaitCancellation
 import org.commcare.CommCareTestApplication
-import org.commcare.activities.DataPullController.DataPullMode
 import org.commcare.android.util.ReflectionUtils
 import org.commcare.android.util.TestAppInstaller
 import org.commcare.dalvik.R
-import org.commcare.login.AuthSource
 import org.commcare.login.LoginError
 import org.commcare.login.LoginPhase
 import org.commcare.login.LoginProgress
-import org.commcare.login.LoginRequest
+import org.commcare.login.LoginProgressListener
 import org.commcare.login.LoginResult
 import org.commcare.login.LoginViewModel
+import org.commcare.login.PostLoginOutcome
 import org.commcare.tasks.DataPullTask
 import org.commcare.views.dialogs.CustomProgressDialog
 import org.junit.Assert.assertEquals
@@ -33,8 +34,8 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
 
 /**
- * Regression pins covering both halves of the login progress dialog's behavior when
- * the user backgrounds the app mid-login.
+ * Regression pins covering the login progress dialog's behavior when the user leaves the login
+ * screen mid-login, either by backgrounding the app or by rotating the device.
  *
  * The login engine drives its dialogs by calling `showProgressDialog` directly from
  * `LoginActivity.updateLoginProgressUi`, rather than through the paused-guarded
@@ -65,6 +66,14 @@ class LoginProgressDialogLifecycleTest {
     /** Task id behind the staged-update install, the other connected task on this screen. */
     private val upgradeTaskId: Int
         get() = ReflectionUtils.readField(activity, "TASK_UPGRADE_INSTALL") as Int
+
+    /**
+     * What the fake login work has been asked to do, so the tests can follow the pipeline from
+     * outside instead of inspecting the view model that runs it.
+     */
+    private var loginAttempts = 0
+    private var loginsInFlight = 0
+    private var loginCancellations = 0
 
     @Before
     fun setUp() {
@@ -200,25 +209,32 @@ class LoginProgressDialogLifecycleTest {
 
     @Test
     fun `stop button cancels the login pipeline and dismisses the dialog`() {
-        val job = Job()
-        startFakeSyncPhase(job)
+        startSuspendingLogin()
 
         clickStopButton()
 
-        assertTrue("STOP should cancel the login pipeline's job", job.isCancelled)
+        assertEquals("STOP should cancel the login pipeline", 1, loginCancellations)
         assertNull("STOP should dismiss the sync dialog", currentDialog())
     }
 
+    /**
+     * A cancelled login must not stay latched onto the screen: the next LOGIN press has to start a
+     * pipeline of its own, with its own dialog and its own working STOP button.
+     */
     @Test
-    fun `cancelling clears the retained job so a later stop is inert`() {
-        val job = Job()
-        startFakeSyncPhase(job)
+    fun `a cancelled login leaves the screen able to run and stop another`() {
+        startSuspendingLogin()
+        clickStopButton()
 
-        activity.cancelCurrentTask()
-        activity.cancelCurrentTask()
+        clickLogin()
 
-        assertTrue(job.isCancelled)
-        assertNull("The cancelled job should not be retained", ReflectionUtils.readField(viewModel(), "loginJob"))
+        assertEquals("LOGIN should start a second pipeline", 2, loginAttempts)
+        assertEquals("The second login should get its own dialog", syncTaskId, currentDialog()?.taskId)
+
+        clickStopButton()
+
+        assertEquals("STOP should cancel the second pipeline too", 2, loginCancellations)
+        assertNull("STOP should dismiss the second login's dialog", currentDialog())
     }
 
     // ======== Rotation ========
@@ -227,16 +243,12 @@ class LoginProgressDialogLifecycleTest {
     fun `rotation keeps the login running and puts its dialog back`() {
         startSuspendingLogin()
         assertEquals("The sync dialog should be up before rotating", syncTaskId, currentDialog()?.taskId)
-        val runningJob = ReflectionUtils.readField(viewModel(), "loginJob") as Job
 
         rotate()
 
-        assertTrue("Rotation must not cancel the pipeline", runningJob.isActive)
-        assertSame(
-            "The recreated activity should reattach to the same pipeline",
-            runningJob,
-            ReflectionUtils.readField(viewModel(), "loginJob"),
-        )
+        assertEquals("Rotation must not cancel the pipeline", 0, loginCancellations)
+        assertEquals("Rotation must not start the login over", 1, loginAttempts)
+        assertEquals("The same pipeline should still be running", 1, loginsInFlight)
         assertEquals(
             "The dialog should be rebuilt on the recreated activity",
             syncTaskId,
@@ -247,45 +259,44 @@ class LoginProgressDialogLifecycleTest {
     @Test
     fun `stop button cancels a pipeline that survived rotation`() {
         startSuspendingLogin()
-        val runningJob = ReflectionUtils.readField(viewModel(), "loginJob") as Job
 
         rotate()
         clickStopButton()
 
-        assertTrue("STOP should cancel the surviving pipeline", runningJob.isCancelled)
+        assertEquals("STOP should cancel the surviving pipeline", 1, loginCancellations)
         assertNull("STOP should dismiss the restored dialog", currentDialog())
     }
 
+    /**
+     * A successful login closes the screen, so a result handed to the recreated activity a second
+     * time would close that one too — the user's rotation would eat the screen they came back to.
+     */
     @Test
     fun `a consumed result is not redelivered after rotation`() {
-        val viewModel = viewModel()
-        viewModel.performLogin = { _, _ -> LoginResult.Failed(LoginError.BadCredentials) }
+        fakeLoginWork { successfulLogin() }
 
-        viewModel.start(request())
-        idle()
-        assertNull("The result should have been consumed on delivery", viewModel.result.value)
+        clickLogin()
+        assertTrue("A successful login should close the login screen", activity.isFinishing)
 
         rotate()
 
-        assertNull("A consumed result must not be replayed", viewModel().result.value)
+        assertFalse("A consumed result must not close the recreated screen too", activity.isFinishing)
         assertNull("And it must not rebuild a dialog", currentDialog())
     }
 
     @Test
     fun `a finished login leaves no dialog behind on rotation`() {
-        val viewModel = viewModel()
-        viewModel.performLogin = { _, listener ->
+        fakeLoginWork { listener ->
             listener.onProgress(LoginProgress(LoginPhase.Syncing))
             LoginResult.Failed(LoginError.BadCredentials)
         }
 
-        viewModel.start(request())
-        idle()
+        clickLogin()
 
         rotate()
 
         assertNull("A stale phase should not survive the login that reported it", currentDialog())
-        assertFalse("No pipeline should still be running", isLoginRunning())
+        assertEquals("No pipeline should still be running", 0, loginsInFlight)
     }
 
     // ======== Helpers ========
@@ -300,22 +311,65 @@ class LoginProgressDialogLifecycleTest {
 
     private fun currentDialog(): CustomProgressDialog? = activity.currentProgressDialog
 
-    private fun startFakeSyncPhase(job: Job) {
-        ReflectionUtils.writeField(activity, "currentLoginPhase", LoginPhase.Syncing)
-        ReflectionUtils.writeField(viewModel(), "loginJob", job)
-        activity.showProgressDialog(syncTaskId)
+    /**
+     * The plainest success the activity can act on: no PersonalId link check, so it goes straight
+     * to setting its result and finishing.
+     */
+    private fun successfulLogin(): LoginResult.Success =
+        LoginResult.Success(
+            appId = "test-app",
+            username = TEST_USERNAME,
+            loginMode = LoginMode.PASSWORD,
+            restoreSession = false,
+            personalIdManagedLogin = false,
+            linkPassword = "",
+            postLoginOutcome = PostLoginOutcome(redirectToConnectOpportunityInfo = false),
+        )
+
+    /**
+     * The one seam these tests need: the login work itself, which would otherwise talk to the
+     * server. Everything else — starting a login, stopping it, rotating — goes through the screen.
+     */
+    private fun fakeLoginWork(work: suspend (LoginProgressListener) -> LoginResult) {
+        loginViewModel().performLogin = { _, listener ->
+            loginAttempts++
+            loginsInFlight++
+            try {
+                work(listener)
+            } catch (cancelled: CancellationException) {
+                loginCancellations++
+                throw cancelled
+            } finally {
+                loginsInFlight--
+            }
+        }
     }
 
-    private fun viewModel(): LoginViewModel = ReflectionUtils.readField(activity, "loginViewModel") as LoginViewModel
+    private fun loginViewModel(): LoginViewModel = ViewModelProvider(activity)[LoginViewModel::class.java]
 
-    private fun isLoginRunning(): Boolean = (ReflectionUtils.readField(viewModel(), "loginJob") as Job?)?.isActive == true
-
+    /** Starts a login that reaches the sync phase and stays there until something cancels it. */
     private fun startSuspendingLogin() {
-        viewModel().performLogin = { _, listener ->
+        fakeLoginWork { listener ->
             listener.onProgress(LoginProgress(LoginPhase.Syncing))
             awaitCancellation()
         }
-        viewModel().start(request())
+        clickLogin()
+    }
+
+    private fun clickLogin() {
+        activity.findViewById<EditText>(R.id.edit_username).setText(TEST_USERNAME)
+        activity.findViewById<EditText>(R.id.edit_password).setText(TEST_PASSWORD)
+        activity.findViewById<Button>(R.id.login_button).performClick()
+        idle()
+    }
+
+    private fun clickStopButton() {
+        val dialog = requireNotNull(currentDialog()?.dialog as? AlertDialog) { "sync dialog not showing" }
+        val stopButton =
+            requireNotNull(dialog.findViewById<Button>(R.id.dialog_cancel_button)) {
+                "sync dialog has no STOP button"
+            }
+        stopButton.performClick()
         idle()
     }
 
@@ -328,29 +382,9 @@ class LoginProgressDialogLifecycleTest {
     /** `postValue` hops through the main looper, so values land only once it has been drained. */
     private fun idle() = ShadowLooper.idleMainLooper()
 
-    private fun request(): LoginRequest =
-        LoginRequest(
-            appId = "test-app",
-            username = "test-user",
-            passwordOrPin = "test-password",
-            credentialType = LoginMode.PASSWORD,
-            authSource = AuthSource.Manual,
-            restoreSession = false,
-            triggerMultipleUsersWarning = false,
-            blockRemoteKeyManagement = true,
-            dataPullMode = DataPullMode.NORMAL,
-        )
-
-    private fun clickStopButton() {
-        val dialog = requireNotNull(currentDialog()?.dialog as? AlertDialog) { "sync dialog not showing" }
-        val stopButton =
-            requireNotNull(dialog.findViewById<Button>(R.id.dialog_cancel_button)) {
-                "sync dialog has no STOP button"
-            }
-        stopButton.performClick()
-    }
-
     companion object {
         private const val TEST_APP_PATH = "jr://resource/commcare-apps/form_nav_tests/profile.ccpr"
+        private const val TEST_USERNAME = "test-user"
+        private const val TEST_PASSWORD = "test-password"
     }
 }

--- a/app/unit-tests/src/org/commcare/activities/LoginProgressDialogLifecycleTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/LoginProgressDialogLifecycleTest.kt
@@ -4,14 +4,23 @@ import android.widget.Button
 import androidx.appcompat.app.AlertDialog
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
 import org.commcare.CommCareTestApplication
+import org.commcare.activities.DataPullController.DataPullMode
 import org.commcare.android.util.ReflectionUtils
 import org.commcare.android.util.TestAppInstaller
 import org.commcare.dalvik.R
+import org.commcare.login.AuthSource
+import org.commcare.login.LoginError
 import org.commcare.login.LoginPhase
+import org.commcare.login.LoginProgress
+import org.commcare.login.LoginRequest
+import org.commcare.login.LoginResult
+import org.commcare.login.LoginViewModel
 import org.commcare.tasks.DataPullTask
 import org.commcare.views.dialogs.CustomProgressDialog
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -21,6 +30,7 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.android.controller.ActivityController
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
 
 /**
  * Regression pins covering both halves of the login progress dialog's behavior when
@@ -208,39 +218,128 @@ class LoginProgressDialogLifecycleTest {
         activity.cancelCurrentTask()
 
         assertTrue(job.isCancelled)
-        assertNull("The cancelled job should not be retained", ReflectionUtils.readField(activity, "loginJob"))
+        assertNull("The cancelled job should not be retained", ReflectionUtils.readField(viewModel(), "loginJob"))
+    }
+
+    // ======== Rotation ========
+
+    @Test
+    fun `rotation keeps the login running and puts its dialog back`() {
+        startSuspendingLogin()
+        assertEquals("The sync dialog should be up before rotating", syncTaskId, currentDialog()?.taskId)
+        val runningJob = ReflectionUtils.readField(viewModel(), "loginJob") as Job
+
+        rotate()
+
+        assertTrue("Rotation must not cancel the pipeline", runningJob.isActive)
+        assertSame(
+            "The recreated activity should reattach to the same pipeline",
+            runningJob,
+            ReflectionUtils.readField(viewModel(), "loginJob"),
+        )
+        assertEquals(
+            "The dialog should be rebuilt on the recreated activity",
+            syncTaskId,
+            currentDialog()?.taskId,
+        )
+    }
+
+    @Test
+    fun `stop button cancels a pipeline that survived rotation`() {
+        startSuspendingLogin()
+        val runningJob = ReflectionUtils.readField(viewModel(), "loginJob") as Job
+
+        rotate()
+        clickStopButton()
+
+        assertTrue("STOP should cancel the surviving pipeline", runningJob.isCancelled)
+        assertNull("STOP should dismiss the restored dialog", currentDialog())
+    }
+
+    @Test
+    fun `a consumed result is not redelivered after rotation`() {
+        val viewModel = viewModel()
+        viewModel.performLogin = { _, _ -> LoginResult.Failed(LoginError.BadCredentials) }
+
+        viewModel.start(request())
+        idle()
+        assertNull("The result should have been consumed on delivery", viewModel.result.value)
+
+        rotate()
+
+        assertNull("A consumed result must not be replayed", viewModel().result.value)
+        assertNull("And it must not rebuild a dialog", currentDialog())
+    }
+
+    @Test
+    fun `a finished login leaves no dialog behind on rotation`() {
+        val viewModel = viewModel()
+        viewModel.performLogin = { _, listener ->
+            listener.onProgress(LoginProgress(LoginPhase.Syncing))
+            LoginResult.Failed(LoginError.BadCredentials)
+        }
+
+        viewModel.start(request())
+        idle()
+
+        rotate()
+
+        assertNull("A stale phase should not survive the login that reported it", currentDialog())
+        assertFalse("No pipeline should still be running", isLoginRunning())
     }
 
     // ======== Helpers ========
 
-    /**
-     * Put the activity in the state the crash needs: stopped, so `areFragmentsPaused` is set and
-     * `onSaveInstanceState` has run.
-     */
     private fun background() {
         controller.pause().stop()
     }
 
-    /**
-     * Bring the activity back through `onResumeFragments`, which is what flushes the deferred
-     * dialog work. `resume()` dispatches it once, like a real resume; calling `postResume()` as
-     * well would dispatch a second time and hide ordering bugs between the two deferral slots.
-     */
     private fun foreground() {
         controller.start().resume()
     }
 
     private fun currentDialog(): CustomProgressDialog? = activity.currentProgressDialog
 
-    /**
-     * Stand in for a login that has reached the sync phase: the dialog the STOP button lives on is
-     * showing, and [job] is the pipeline the activity would cancel.
-     */
     private fun startFakeSyncPhase(job: Job) {
         ReflectionUtils.writeField(activity, "currentLoginPhase", LoginPhase.Syncing)
-        ReflectionUtils.writeField(activity, "loginJob", job)
+        ReflectionUtils.writeField(viewModel(), "loginJob", job)
         activity.showProgressDialog(syncTaskId)
     }
+
+    private fun viewModel(): LoginViewModel = ReflectionUtils.readField(activity, "loginViewModel") as LoginViewModel
+
+    private fun isLoginRunning(): Boolean = (ReflectionUtils.readField(viewModel(), "loginJob") as Job?)?.isActive == true
+
+    private fun startSuspendingLogin() {
+        viewModel().performLogin = { _, listener ->
+            listener.onProgress(LoginProgress(LoginPhase.Syncing))
+            awaitCancellation()
+        }
+        viewModel().start(request())
+        idle()
+    }
+
+    private fun rotate() {
+        controller.recreate()
+        activity = controller.get()
+        idle()
+    }
+
+    /** `postValue` hops through the main looper, so values land only once it has been drained. */
+    private fun idle() = ShadowLooper.idleMainLooper()
+
+    private fun request(): LoginRequest =
+        LoginRequest(
+            appId = "test-app",
+            username = "test-user",
+            passwordOrPin = "test-password",
+            credentialType = LoginMode.PASSWORD,
+            authSource = AuthSource.Manual,
+            restoreSession = false,
+            triggerMultipleUsersWarning = false,
+            blockRemoteKeyManagement = true,
+            dataPullMode = DataPullMode.NORMAL,
+        )
 
     private fun clickStopButton() {
         val dialog = requireNotNull(currentDialog()?.dialog as? AlertDialog) { "sync dialog not showing" }

--- a/app/unit-tests/src/org/commcare/android/util/ReflectionUtils.kt
+++ b/app/unit-tests/src/org/commcare/android/util/ReflectionUtils.kt
@@ -3,7 +3,7 @@ package org.commcare.android.util
 import java.lang.reflect.Field
 
 /**
- * Reads and writes private fields by name, walking up the class hierarchy.
+ * Reads private fields by name, walking up the class hierarchy.
  *
  * For state that production exposes no accessor for and no UI surface reflects. Anything observable
  * through a view, an intent or a public method should be asserted there instead.
@@ -13,12 +13,6 @@ object ReflectionUtils {
         target: Any,
         name: String,
     ): Any? = fieldFor(target.javaClass, name).get(target)
-
-    fun writeField(
-        target: Any,
-        name: String,
-        value: Any?,
-    ) = fieldFor(target.javaClass, name).set(target, value)
 
     private fun fieldFor(
         start: Class<*>,


### PR DESCRIPTION
### [CI-915](https://dimagi.atlassian.net/browse/CI-915)

Stacked on [PR #3881](https://github.com/dimagi/commcare-android/pull/3881) that fixes the initial crash when trying to show the dialog on resume.

## Product Description

Rotating the device during login no longer breaks it. Previously, a rotation mid-sync aborted the data pull, left the progress dialog frozen part-way, and never completed or failed the login — the user had to force-quit and start over.

## Technical Summary

* The login pipeline was launched on `LoginActivity`'s `lifecycleScope`, which is cancelled at `onDestroy`
  * A rotation therefore cancelled the coroutine
  * And `SyncOperations` cancelled `DataPullTask` from its `invokeOnCancellation` handler
* So the restore was aborted, no result was ever delivered, and the dialog was orphaned

Pre-2.64 this was handled by the task-connector framework, but the headless login engine opted out of that and uses `HeadlessTaskConnector.connectTask` instead.

This PR introduces `LoginViewModel` to own the job in `viewModelScope` so it can survive configuration changes.

A couple extra notes:
 * `currentLoginPhase` stayed in `LoginActivity` so it gets reset on activity recreation and is used to show the dialog again
 * The result is single-use so complete login doesn't get replayed if the screen rotates after the job completes

## Safety Assurance

### Safety story

* I verified that I am no longer able to reproduce either of the issues before related to sync during login:
1. App does not crash on resume if sent to background during sync
2. Sync dialog is not orphaned if the screen is rotated during sync
 * Did some general usage testing around the login process and made sure everything appears to work normally

### Automated test coverage

Four tests added to `LoginProgressDialogLifecycleTest`:

- `rotation keeps the login running and puts its dialog back`
- `stop button cancels a pipeline that survived rotation`
- `a consumed result is not redelivered after rotation`
- `a finished login leaves no dialog behind on rotation`

[CI-915]: https://dimagi.atlassian.net/browse/CI-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ