### PR TITLE
CCCT-2778 Anchor The Connect CTA Bar To The Bottom Of The Screen

### DIFF
--- a/app/res/drawable/connect_cta_bar_background.xml
+++ b/app/res/drawable/connect_cta_bar_background.xml
@@ -1,0 +1,9 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/connect_light_indigo" />
+    <corners
+        android:topLeftRadius="@dimen/connect_radius_card"
+        android:topRightRadius="@dimen/connect_radius_card"
+        android:bottomLeftRadius="0dp"
+        android:bottomRightRadius="0dp" />
+</shape>

--- a/app/res/layout/fragment_connect_delivery_home.xml
+++ b/app/res/layout/fragment_connect_delivery_home.xml
@@ -53,7 +53,7 @@
         android:id="@+id/connect_delivery_cta_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="10dp"
+        android:layout_marginTop="10dp"
         app:buttonText="@string/connect_delivery_start"
         app:subtitleText="@string/connect_delivery_continue_visits_subtitle"
         app:titleText="@string/connect_delivery_continue_visits" />

--- a/app/res/layout/view_connect_cta_bar.xml
+++ b/app/res/layout/view_connect_cta_bar.xml
@@ -21,14 +21,12 @@
         tools:text="Further visits will not count towards progress or payments"
         tools:visibility="visible" />
 
-    <androidx.cardview.widget.CardView
-        android:id="@+id/cta_bar"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:cardBackgroundColor="@color/connect_light_indigo"
-        app:cardCornerRadius="@dimen/connect_radius_card"
-        app:cardElevation="@dimen/connect_info_card_elevation"
-        app:contentPadding="@dimen/connect_space_lg">
+        android:background="@drawable/connect_cta_bar_background"
+        android:elevation="@dimen/connect_info_card_elevation"
+        android:padding="@dimen/connect_space_lg">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
@@ -124,5 +122,5 @@
                 app:constraint_referenced_ids="cta_button,cta_progress_cluster" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.cardview.widget.CardView>
+    </FrameLayout>
 </merge>


### PR DESCRIPTION
### [CCCT-2778](https://dimagi.atlassian.net/browse/CCCT-2778)

Before:
<img width="200" height="445" alt="Without Edge to Edge Correction" src="https://github.com/user-attachments/assets/ce66da90-503a-494a-8686-e01d52767f25" />

After:

<img width="200" height="445" alt="Screenshot_20260901_155315" src="https://github.com/user-attachments/assets/c9268f1b-4233-4e0e-b246-63cb34e0ab38" />

<img width="200" height="445" alt="Screenshot_20260901_155416" src="https://github.com/user-attachments/assets/c2f09901-62f8-43da-b93a-56f4523092e8" />

<img width="200" height="445" alt="Screenshot_20260901_155520" src="https://github.com/user-attachments/assets/c9f118fa-ff2a-4531-8b8c-2b0fc4c4003d" />

<img width="200" height="445" alt="Screenshot_20260901_160614" src="https://github.com/user-attachments/assets/1baf36ba-b9ce-428f-84d3-d2493142e59a" />


## Product Description

The Connect bottom action bar now reads as attached to the bottom of the screen: it spans the full width, its bottom corners are square, and there is no gap between it and the navigation bar. Affects Delivery Home, Job Intro, Learn Progress and Learn Complete.

## Technical Summary

The bar's bottom edge was always in the right place — the existing inset listener puts it at the top of the navigation bar. It only *looked* wrong because rounded bottom corners plus a margin on all four sides made it read as a floating card. So the fix is layout-only, with no window-inset handling at all.


Three heavier approaches were built and set aside first, recorded here because the reasoning is not visible in the diff:

**Per-fragment bottom-inset delegation.** An `appliesRootBottomInset()` hook let `ConnectActivity` opt out of the blanket padding, and each screen declared its bar via a `bottomInsetTarget()` override so the bar could draw to the physical screen edge.

Rejected: it needed an override per screen, and it regressed the Dashboard, Payment and Visits tabs. The listener lived on `BaseConnectFragment`, so every ViewPager2 page reserved a navigation-bar's worth of padding at its own bottom, inside the pager — per-instance inset listeners double-apply wherever fragments nest.

**Theme-scoped inset ownership with consumer discovery.** A `screenOwnsWindowInsets` attribute set only on `ConnectTheme` selected a second listener that put the top inset on the `AppBarLayout` and walked the tree for the first visible `BottomInsetConsumer`.

This removed all per-screen code and confined the blast radius to one activity, and it was not broken — 73 Connect tests passed. Set aside as disproportionate: a theme attribute, a second listener, a tree walk per inset dispatch and a new interface, for a purely visual problem.


**Claude kept suggesting Option #1, but it involved way too many code changes that weren't even generic. Every time a new design was added, we'd have to implement that open function—even with theming logic in place. After making the changes, something still felt off; it shouldn't require that much work given that AndroidUtil.attachWindowInsetsListener already handles window insets. So, I took matters into my own hands and hunted down the actual root cause. This is the first time in a couple of months that I coded myself instead of Claude!**


## Safety Assurance

### Safety story

What gives confidence:

- I ran the app on a device and verified all four screens that host the bar: Delivery Home, Job Intro, Learn Progress and Learn Complete.
- Resource files only. No Kotlin or Java changed, and the inset listener in `CommonBaseActivity` is untouched, so every other activity and the form-entry flow are unaffected.
- The `CardView` → `FrameLayout` swap is behaviour-preserving: `contentPadding` maps to `padding`, the background colour is retained via the shape's `solid`, and `connect_info_card_elevation` is `0dp` so no shadow was lost.
- 85 existing tests pass across `ConnectDelivery*`, `ConnectLearn*` and `ConnectJobIntro*`.

Risks to review:

- The change is to the shared `view_connect_cta_bar.xml`, so it lands on all four host screens rather than only the one that prompted it. All four are full-width, bottom-anchored last children outside their scroll containers, and all four were checked on device.

### Automated test coverage

No new tests. The change is purely visual, and Robolectric cannot meaningfully assert corner radii or system-bar positioning; `ConnectDeliveryHomeFragmentTest`'s existing footer-CTA assertions cover the bar and its button still being present and visible.

[CCCT-2778]: https://dimagi.atlassian.net/browse/CCCT-2778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ