### PR TITLE
Abstract PersonalID Recovery Logic

### DIFF
--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -223,7 +223,7 @@ public class CommCareApplication extends Application implements LifecycleEventOb
     @Override
     public void onCreate() {
         super.onCreate();
-        ConnectSyncPreferences.Companion.getInstance(this).markSessionStart();
+        ConnectSyncPreferences.Companion.getInstance().markSessionStart();
 
         turnOnStrictMode();
 
@@ -1248,13 +1248,13 @@ public class CommCareApplication extends Application implements LifecycleEventOb
         }
     }
 
-    public IDatabase getConnectDbOpenHelper(Context context) {
-        byte[] passphrase = ConnectDatabaseUtils.getConnectDbPassphrase(context);
+    public IDatabase getConnectDbOpenHelper() {
+        byte[] passphrase = ConnectDatabaseUtils.getConnectDbPassphrase();
         if (passphrase == null || passphrase.length == 0) {
             throw new IllegalStateException("Attempting to access Connect DB without a passphrase");
         }
         return new EncryptedDatabaseAdapter(new DatabaseConnectOpenHelper(
-                context, UserSandboxUtils.getSqlCipherEncodedKey(passphrase)));
+                this, UserSandboxUtils.getSqlCipherEncodedKey(passphrase)));
     }
 
     public IDatabase getGlobalDbOpenHelper() {

--- a/app/src/org/commcare/CommCareApplication.java
+++ b/app/src/org/commcare/CommCareApplication.java
@@ -223,11 +223,10 @@ public class CommCareApplication extends Application implements LifecycleEventOb
     @Override
     public void onCreate() {
         super.onCreate();
-        ConnectSyncPreferences.Companion.getInstance().markSessionStart();
-
         turnOnStrictMode();
-
         CommCareApplication.app = this;
+
+        ConnectSyncPreferences.Companion.getInstance().markSessionStart();
         CrashUtil.init();
         DataChangeLogger.init(this);
         if (!BuildConfig.DEBUG) {

--- a/app/src/org/commcare/activities/CommCareSetupActivity.java
+++ b/app/src/org/commcare/activities/CommCareSetupActivity.java
@@ -68,7 +68,6 @@ import java.util.List;
 import java.util.Map;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -513,7 +512,7 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
         if (refreshItem != null) {
             boolean showRefreshMenu = !fromExternal &&
                     PersonalIdManager.getInstance().isloggedIn() &&
-                    !ConnectUserDatabaseUtil.hasConnectAccess(this);
+                    !ConnectUserDatabaseUtil.hasConnectAccess();
             refreshItem.setVisible(showRefreshMenu);
         }
         return true;
@@ -667,7 +666,7 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
 
     private void updateConnectButton() {
         boolean isConnectEnabled = !fromManager && !fromExternal && PersonalIdManager.getInstance().isloggedIn()
-                && ConnectUserDatabaseUtil.hasConnectAccess(this);
+                && ConnectUserDatabaseUtil.hasConnectAccess();
         installFragment.updateConnectButton(isConnectEnabled, v -> {
             ConnectNavHelper.INSTANCE.unlockAndGoToConnectJobsList(this, UnlockPolicy.SESSION_WITH_TIME_THRESHOLD, (success, error) -> {
             });
@@ -998,13 +997,13 @@ public class CommCareSetupActivity extends BaseDrawerActivity<CommCareSetupActiv
     }
 
     private void refreshOpportunities() {
-        ConnectRepository.getInstance(this).retrieveOpportunitiesForJava(
+        ConnectRepository.getInstance().retrieveOpportunitiesForJava(
                 (success, error) -> {
                     if (success) {
                         boolean connectAccess = !ConnectJobUtils.getCompositeJobs(
-                                this, ConnectJobRecord.STATUS_ALL_JOBS, null).isEmpty();
+                                ConnectJobRecord.STATUS_ALL_JOBS, null).isEmpty();
                         if (connectAccess) {
-                            ConnectUserDatabaseUtil.turnOnConnectAccess(this);
+                            ConnectUserDatabaseUtil.turnOnConnectAccess();
                             updateConnectButton();
                             refreshDrawer();
                         }

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -631,7 +631,6 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         if (loginManagedByPersonalId()) {
             ApplicationRecord record = CommCareApplication.instance().getCurrentApp().getAppRecord();
             PersonalIdManager.ConnectAppMangement appState = personalIdManager.evaluateAppState(
-                    this,
                     record.getUniqueId(),
                     getUniformUsername()
             );
@@ -1038,7 +1037,6 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         if (personalIdManager.isloggedIn()) {
             String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
             PersonalIdManager.ConnectAppMangement appState = personalIdManager.evaluateAppState(
-                    this,
                     seatedAppId,
                     uiController.getEnteredUsername()
             );

--- a/app/src/org/commcare/activities/LoginActivityUIController.java
+++ b/app/src/org/commcare/activities/LoginActivityUIController.java
@@ -51,9 +51,6 @@ import javax.annotation.Nullable;
 
 import androidx.preference.PreferenceManager;
 
-import static org.commcare.connect.PersonalIdManager.ConnectAppMangement.Connect;
-import static org.commcare.connect.PersonalIdManager.ConnectAppMangement.Unmanaged;
-
 /**
  * Handles login activity UI
  *
@@ -574,12 +571,12 @@ public class LoginActivityUIController implements CommCareActivityUIController {
         if (isPersonalIdLoggedIn) {
             setWelcomeMessage();
         }
-        setConnectButtonVisible(isPersonalIdLoggedIn && ConnectUserDatabaseUtil.hasConnectAccess(activity));
+        setConnectButtonVisible(isPersonalIdLoggedIn && ConnectUserDatabaseUtil.hasConnectAccess());
     }
 
     private void setWelcomeMessage() {
         String welcomeText = activity.getString(R.string.personalid_welcome_user,
-                ConnectUserDatabaseUtil.getUser(activity).getName());
+                ConnectUserDatabaseUtil.getUser().getName());
         welcomeMessage.setText(welcomeText);
     }
 }

--- a/app/src/org/commcare/activities/StandardHomeActivity.java
+++ b/app/src/org/commcare/activities/StandardHomeActivity.java
@@ -374,7 +374,7 @@ public class StandardHomeActivity
     public void fetchJobProgressOverNetwork() {
         ConnectJobRecord job = getActiveJob();
         if(job != null && job.getStatus() == ConnectJobRecord.STATUS_DELIVERING) {
-            ConnectRepository.getInstance(this).updateDeliveryProgressForJava(job, (success, error) -> {
+            ConnectRepository.getInstance().updateDeliveryProgressForJava(job, (success, error) -> {
                 if (success) {
                     uiController.updateConnectJobProgress();
                 }

--- a/app/src/org/commcare/activities/StandardHomeActivityUIController.java
+++ b/app/src/org/commcare/activities/StandardHomeActivityUIController.java
@@ -164,7 +164,7 @@ public class StandardHomeActivityUIController implements CommCareActivityUIContr
     private void updateConnectJobMessage() {
         String messageText = null;
         String appId = CommCareApplication.instance().getCurrentApp().getUniqueId();
-        ConnectAppRecord record = ConnectJobUtils.getAppRecord(activity, appId);
+        ConnectAppRecord record = ConnectJobUtils.getAppRecord(appId);
         ConnectJobRecord job = activity.getActiveJob();
 
         if (job != null && record != null) {

--- a/app/src/org/commcare/activities/connect/ConnectActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectActivity.java
@@ -64,7 +64,7 @@ public class ConnectActivity extends NavigationHostCommCareActivity<ConnectActiv
         if (savedInstanceState != null) {
             String savedJobUuid = savedInstanceState.getString(OPPORTUNITY_UUID);
             if (savedJobUuid != null) {
-                job = ConnectJobUtils.getCompositeJob(this, savedJobUuid);
+                job = ConnectJobUtils.getCompositeJob(savedJobUuid);
             }
         }
 
@@ -132,7 +132,7 @@ public class ConnectActivity extends NavigationHostCommCareActivity<ConnectActiv
         redirectionAction = getIntent().getStringExtra(REDIRECT_ACTION);
         opportunityUuid = getIntent().getStringExtra(OPPORTUNITY_UUID);
         if (job == null && !TextUtils.isEmpty(opportunityUuid)) {
-            job = ConnectJobUtils.getCompositeJob(this, opportunityUuid);
+            job = ConnectJobUtils.getCompositeJob(opportunityUuid);
         }
     }
 

--- a/app/src/org/commcare/activities/connect/ConnectMessagingActivity.java
+++ b/app/src/org/commcare/activities/connect/ConnectMessagingActivity.java
@@ -24,8 +24,6 @@ import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.views.dialogs.CustomProgressDialog;
 import org.commcare.views.dialogs.DialogController;
 
-import java.util.Objects;
-
 import static org.commcare.connect.ConnectConstants.CCC_MESSAGE;
 import static org.commcare.connect.ConnectConstants.NETWORK_ACTIVITY_MESSAGING_CHANNEL_ID;
 import static org.commcare.connect.ConnectConstants.NOTIFICATION_ID;
@@ -170,7 +168,7 @@ public class ConnectMessagingActivity extends NavigationHostCommCareActivity<Con
 
     private void handleChannelForValidity(String channelId) {
         ConnectMessagingChannelRecord connectMessagingChannelRecord =
-                ConnectMessagingDatabaseHelper.getMessagingChannel(this, channelId);
+                ConnectMessagingDatabaseHelper.getMessagingChannel(channelId);
         if (connectMessagingChannelRecord == null) {
             handleNoChannel(channelId); //This happens if local DB doesn't have the channel yet
         } else {
@@ -182,7 +180,7 @@ public class ConnectMessagingActivity extends NavigationHostCommCareActivity<Con
         MessageManager.retrieveMessages(this, (success, error) -> {
             // This is required to update the local DB for channels
             ConnectMessagingChannelRecord connectMessagingChannelRecord =
-                    ConnectMessagingDatabaseHelper.getMessagingChannel(this, channelId);
+                    ConnectMessagingDatabaseHelper.getMessagingChannel(channelId);
             if (connectMessagingChannelRecord == null) {
                 showFailureMessage(getString(R.string.connect_messaging_pn_wrong_channel));
             } else {

--- a/app/src/org/commcare/activities/connect/viewmodel/PersonalIdWorkHistoryViewModel.kt
+++ b/app/src/org/commcare/activities/connect/viewmodel/PersonalIdWorkHistoryViewModel.kt
@@ -15,7 +15,6 @@ import org.commcare.connect.ConnectDateUtils.parseIsoDateForSorting
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.connect.network.base.BaseApiHandler
 import org.commcare.connect.network.personalId.PersonalIdApiHandler
-import org.commcare.personalId.PersonalIdFeatureFlagChecker
 import org.commcare.personalId.PersonalIdFeatureFlagChecker.Companion.isFeatureEnabled
 import org.commcare.personalId.PersonalIdFeatureFlagChecker.FeatureFlag.Companion.WORK_HISTORY_PENDING_TAB
 import org.commcare.utils.MultipleAppsUtil
@@ -35,7 +34,7 @@ class PersonalIdWorkHistoryViewModel(
 
     private lateinit var installedAppsWorkHistory: List<PersonalIdWorkHistory>
 
-    private val user = ConnectUserDatabaseUtil.getUser(application)
+    private val user = ConnectUserDatabaseUtil.getUser()
     val userName: String = user.name
     val profilePhoto: String? = user.photo
 

--- a/app/src/org/commcare/android/database/connect/models/ConnectUserRecord.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectUserRecord.java
@@ -89,7 +89,7 @@ public class ConnectUserRecord extends Persisted {
     private String email;
 
     public ConnectUserRecord() {
-        registrationPhase = ConnectConstants.PERSONALID_NO_ACTIVITY;
+        registrationPhase = ConnectConstants.PERSONAL_ID_USER_STATUS_REGISTERED;
         lastPasswordDate = new Date();
         connectTokenExpiration = new Date();
         secondaryPhoneVerified = true;

--- a/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV13.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV13.java
@@ -54,7 +54,7 @@ public class ConnectUserRecordV13 extends Persisted {
     private Date verifySecondaryPhoneByDate;
 
     public ConnectUserRecordV13() {
-        registrationPhase = ConnectConstants.PERSONALID_NO_ACTIVITY;
+        registrationPhase = ConnectConstants.PERSONAL_ID_USER_STATUS_REGISTERED;
         lastPasswordDate = new Date();
         connectTokenExpiration = new Date();
         secondaryPhoneVerified = true;

--- a/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV14.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV14.java
@@ -64,7 +64,7 @@ public class ConnectUserRecordV14 extends Persisted {
     private boolean isDemo;
 
     public ConnectUserRecordV14() {
-        registrationPhase = ConnectConstants.PERSONALID_NO_ACTIVITY;
+        registrationPhase = ConnectConstants.PERSONAL_ID_USER_STATUS_REGISTERED;
         lastPasswordDate = new Date();
         connectTokenExpiration = new Date();
         secondaryPhoneVerified = true;

--- a/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV16.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV16.java
@@ -68,7 +68,7 @@ public class ConnectUserRecordV16 extends Persisted {
     private String requiredLock;
 
     public ConnectUserRecordV16() {
-        registrationPhase = ConnectConstants.PERSONALID_NO_ACTIVITY;
+        registrationPhase = ConnectConstants.PERSONAL_ID_USER_STATUS_REGISTERED;
         lastPasswordDate = new Date();
         connectTokenExpiration = new Date();
         secondaryPhoneVerified = true;

--- a/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV25.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV25.java
@@ -73,7 +73,7 @@ public class ConnectUserRecordV25 extends Persisted {
     private boolean hasConnectAccess;
 
     public ConnectUserRecordV25() {
-        registrationPhase = ConnectConstants.PERSONALID_NO_ACTIVITY;
+        registrationPhase = ConnectConstants.PERSONAL_ID_USER_STATUS_REGISTERED;
         lastPasswordDate = new Date();
         connectTokenExpiration = new Date();
         secondaryPhoneVerified = true;

--- a/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV5.java
+++ b/app/src/org/commcare/android/database/connect/models/ConnectUserRecordV5.java
@@ -75,7 +75,7 @@ public class ConnectUserRecordV5 extends Persisted {
     private Date connectTokenExpiration;
 
     public ConnectUserRecordV5() {
-        registrationPhase = ConnectConstants.PERSONALID_NO_ACTIVITY;
+        registrationPhase = ConnectConstants.PERSONAL_ID_USER_STATUS_REGISTERED;
         lastPasswordDate = new Date();
         connectTokenExpiration = new Date();
     }

--- a/app/src/org/commcare/android/database/connect/models/PersonalIdSessionData.kt
+++ b/app/src/org/commcare/android/database/connect/models/PersonalIdSessionData.kt
@@ -12,7 +12,7 @@ data class PersonalIdSessionData(
     // Tells which device auth is required for the given user
     @DeviceAuthType var requiredLock: String? = null,
     // states whether it is a demo user or normal user
-    var demoUser: Boolean? = null,
+    var demoUser: Boolean = false,
     // session token
     var token: String? = null,
     // Reason code to tell why user is not allowed to move forward with the flow

--- a/app/src/org/commcare/android/logging/ReportingUtils.java
+++ b/app/src/org/commcare/android/logging/ReportingUtils.java
@@ -153,7 +153,7 @@ public class ReportingUtils {
     public static String getPersonalID() {
         try {
             if (PersonalIdManager.getInstance().isloggedIn()) {
-                return PersonalIdManager.getInstance().getUser(CommCareApplication.instance()).getUserId();
+                return PersonalIdManager.getInstance().getUser().getUserId();
             }
         } catch (Exception ignored) {
         }
@@ -164,7 +164,7 @@ public class ReportingUtils {
         try {
             PersonalIdManager manager = PersonalIdManager.getInstance();
             if (manager.isloggedIn()) {
-                return manager.getUser(CommCareApplication.instance()).getIsDemo();
+                return manager.getUser().getIsDemo();
             }
         } catch (Exception e) {
             Logger.exception("Error checking if PersonalID user is a demo user", e);

--- a/app/src/org/commcare/connect/ConnectAppLauncher.kt
+++ b/app/src/org/commcare/connect/ConnectAppLauncher.kt
@@ -59,7 +59,7 @@ class ConnectAppLauncher internal constructor(
     constructor() : this(
         seatApp = { appId, listener -> AppSeater().seatIfNeeded(appId, listener) },
         performLogin = { context, request, listener -> LoginController(context).performLogin(request, listener) },
-        connectUsername = { context -> ConnectUserDatabaseUtil.getUser(context)?.userId },
+        connectUsername = { context -> ConnectUserDatabaseUtil.getUser()?.userId },
         isLoggedIntoApp = { appId -> PersonalIdManager.getInstance().isSessionLoggedIntoApp(appId) },
     )
 

--- a/app/src/org/commcare/connect/ConnectAppUtils.kt
+++ b/app/src/org/commcare/connect/ConnectAppUtils.kt
@@ -61,10 +61,10 @@ object ConnectAppUtils {
         appId: String,
         username: String,
     ) {
-        val record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(context, appId, username)
+        val record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(appId, username)
         if (record != null) {
             record.lastAccessed = Date()
-            ConnectAppDatabaseUtil.storeApp(context, record)
+            ConnectAppDatabaseUtil.storeApp(record)
         }
     }
 }

--- a/app/src/org/commcare/connect/ConnectConstants.java
+++ b/app/src/org/commcare/connect/ConnectConstants.java
@@ -59,6 +59,8 @@ public class ConnectConstants {
             ConnectConstants.PERSONAL_ID_TASK_ID_OFFSET + 11;
     public final static int PERSONALID_DEVICE_CONFIGURATION_ISSUE_WARNING =
             ConnectConstants.PERSONAL_ID_TASK_ID_OFFSET + 12;
+    public final static int PERSONALID_RECOVERY_EMAIL_OTP_FAILED =
+            ConnectConstants.PERSONAL_ID_TASK_ID_OFFSET + 13;
     public final static String NOTIFICATION_TITLE = "title";
     public final static String NOTIFICATION_BODY = "body";
     public final static String NOTIFICATION_ID = "notification_id";

--- a/app/src/org/commcare/connect/ConnectConstants.java
+++ b/app/src/org/commcare/connect/ConnectConstants.java
@@ -39,8 +39,7 @@ public class ConnectConstants {
     public static final String NEW_APP = "new-app";
     public static final String LEARN_APP = "learn-app";
     public static final String DELIVERY_APP = "delivery-app";
-    public final static int PERSONALID_NO_ACTIVITY =
-            ConnectConstants.PERSONAL_ID_TASK_ID_OFFSET;
+    public final static int PERSONAL_ID_USER_STATUS_REGISTERED = 1000;
     public final static int PERSONALID_REGISTRATION_SUCCESS =
             ConnectConstants.PERSONAL_ID_TASK_ID_OFFSET + 1;
     public final static int PERSONALID_RECOVERY_SUCCESS =

--- a/app/src/org/commcare/connect/ConnectNavHelper.kt
+++ b/app/src/org/commcare/connect/ConnectNavHelper.kt
@@ -106,13 +106,13 @@ object ConnectNavHelper {
     }
 
     private fun checkConnectAccess(context: Context) {
-        if (!ConnectUserDatabaseUtil.hasConnectAccess(context)) {
+        if (!ConnectUserDatabaseUtil.hasConnectAccess()) {
             throw IllegalStateException("Cannot navigate to Connect Jobs List without access")
         }
     }
 
     fun goToConnectJobsListChecked(context: Context) {
-        if (ConnectUserDatabaseUtil.hasConnectAccess(context)) {
+        if (ConnectUserDatabaseUtil.hasConnectAccess()) {
             goToConnectJobsList(context)
         }
     }

--- a/app/src/org/commcare/connect/EmailOfferHelper.kt
+++ b/app/src/org/commcare/connect/EmailOfferHelper.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import org.commcare.activities.CommCareActivity
 import org.commcare.activities.connect.PersonalIdActivity
 import org.commcare.connect.database.ConnectUserDatabaseUtil
-import org.commcare.dalvik.BuildConfig
 import org.commcare.dalvik.R
 import org.commcare.google.services.analytics.AnalyticsParamValue
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
@@ -26,7 +25,7 @@ object EmailOfferHelper {
             return false
         }
 
-        val user = ConnectUserDatabaseUtil.getUser(context)
+        val user = ConnectUserDatabaseUtil.getUser()
         if (user.email != null) {
             return false
         }

--- a/app/src/org/commcare/connect/MessageManager.java
+++ b/app/src/org/commcare/connect/MessageManager.java
@@ -29,7 +29,7 @@ public class MessageManager {
 
     public static void updateChannelConsent(Context context, ConnectMessagingChannelRecord channel,
                                             ConnectActivityCompleteListener listener) {
-        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(context);
+        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser();
         new PersonalIdApiHandler<Boolean>() {
             @Override
             public void onSuccess(Boolean success) {
@@ -51,7 +51,7 @@ public class MessageManager {
 
     public static void getChannelEncryptionKey(Context context, ConnectMessagingChannelRecord channel,
                                                ConnectActivityCompleteListener listener) {
-        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(context);
+        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser();
         new PersonalIdApiHandler<Boolean>() {
             @Override
             public void onSuccess(Boolean success) {
@@ -67,7 +67,7 @@ public class MessageManager {
     }
 
     public static void sendUnsentMessages(Context context) {
-        List<ConnectMessagingMessageRecord> messages = ConnectMessagingDatabaseHelper.getMessagingMessagesAll(context);
+        List<ConnectMessagingMessageRecord> messages = ConnectMessagingDatabaseHelper.getMessagingMessagesAll();
         for (ConnectMessagingMessageRecord message : messages) {
             if (message.getIsOutgoing() && !message.getConfirmed()) {
                 sendMessage(context, message, (success,error) -> {
@@ -80,10 +80,11 @@ public class MessageManager {
 
     public static void sendMessage(Context context, ConnectMessagingMessageRecord message,
                                    ConnectActivityCompleteListener listener) {
-        ConnectMessagingChannelRecord channel = ConnectMessagingDatabaseHelper.getMessagingChannel(context, message.getChannelId());
+        ConnectMessagingChannelRecord channel = ConnectMessagingDatabaseHelper.getMessagingChannel(
+                message.getChannelId());
 
         if (!channel.getKey().isEmpty()) {
-            ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(context);
+            ConnectUserRecord user = ConnectUserDatabaseUtil.getUser();
 
             new PersonalIdApiHandler<Boolean>() {
                 @Override

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -157,14 +157,6 @@ public class PersonalIdManager {
         return personalIdSatus == PersonalIdStatus.LoggedIn;
     }
 
-    public void completeSignin() {
-        personalIdSatus = PersonalIdStatus.LoggedIn;
-        userUnlockedPersonalId();
-        if (parentActivity instanceof BaseDrawerActivity) {
-            ((BaseDrawerActivity<?>)parentActivity).openDrawer();
-        }
-    }
-
     public void userUnlockedPersonalId() {
         scheduleHeartbeat();
         NotificationsSyncWorkerManager.schedulePeriodicPushNotificationRetrieval(CommCareApplication.instance());
@@ -175,7 +167,9 @@ public class PersonalIdManager {
     public void handleFinishedActivity(CommCareActivity<?> activity, int resultCode) {
         parentActivity = activity;
         if (resultCode == AppCompatActivity.RESULT_OK) {
-            completeSignin();
+            if (parentActivity instanceof BaseDrawerActivity) {
+                ((BaseDrawerActivity<?>)parentActivity).openDrawer();
+            }
         }
     }
 
@@ -503,6 +497,7 @@ public class PersonalIdManager {
             ConnectAppDatabaseUtil.storeReleaseToggles(toggles);
         }
         ConnectSyncPreferences.Companion.getInstance().markSessionStart();
+        userUnlockedPersonalId();
     }
 
     private void createAndSaveConnectUser(PersonalIdSessionData sessionData) {

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -22,11 +22,14 @@ import org.commcare.activities.connect.PersonalIdActivity;
 import org.commcare.android.database.app.models.UserKeyRecord;
 import org.commcare.android.database.connect.models.ConnectAppRecord;
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
+import org.commcare.android.database.connect.models.ConnectReleaseToggleRecord;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
+import org.commcare.android.database.connect.models.PersonalIdSessionData;
 import org.commcare.connect.database.ConnectAppDatabaseUtil;
 import org.commcare.connect.database.ConnectDatabaseHelper;
 import org.commcare.connect.database.ConnectJobUtils;
 import org.commcare.connect.database.ConnectUserDatabaseUtil;
+import org.commcare.connect.repository.ConnectSyncPreferences;
 import org.commcare.connect.network.personalId.ConnectSsoHelper;
 import org.commcare.connect.network.personalId.ConnectSsoSyncHelper;
 import org.commcare.connect.network.personalId.TokenExceptionHandler;
@@ -49,6 +52,7 @@ import org.commcare.views.dialogs.StandardAlertDialog;
 import org.javarosa.core.services.Logger;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.Vector;
 import java.util.concurrent.TimeUnit;
@@ -494,6 +498,20 @@ public class PersonalIdManager {
 
     public void setStatus(PersonalIdStatus status) {
         personalIdSatus = status;
+    }
+
+    public void successFlow(android.app.Activity activity, PersonalIdSessionData sessionData) {
+        setStatus(PersonalIdStatus.LoggedIn);
+        ConnectDatabaseHelper.setRegistrationPhase(activity, ConnectConstants.PERSONALID_NO_ACTIVITY);
+        if (sessionData != null) {
+            List<ConnectReleaseToggleRecord> toggles = sessionData.getFeatureReleaseToggles();
+            if (toggles != null) {
+                ConnectAppDatabaseUtil.storeReleaseToggles(activity, toggles);
+            }
+        }
+        ConnectSyncPreferences.Companion.getInstance(activity).markSessionStart();
+        activity.setResult(android.app.Activity.RESULT_OK);
+        activity.finish();
     }
 
     public void setParent(Context parent) {

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -115,7 +115,7 @@ public class PersonalIdManager {
     public void init(Context parent) {
         parentActivity = parent;
         if (personalIdSatus == PersonalIdStatus.NotIntroduced) {
-            ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(parentActivity);
+            ConnectUserRecord user = ConnectUserDatabaseUtil.getUser();
             if (user != null) {
                 boolean registering = user.getRegistrationPhase() != ConnectConstants.PERSONAL_ID_USER_STATUS_REGISTERED;
                 personalIdSatus = registering ? PersonalIdStatus.Registering : PersonalIdStatus.LoggedIn;
@@ -202,7 +202,7 @@ public class PersonalIdManager {
 
     public AuthInfo.TokenAuth getConnectToken() {
         if (isloggedIn()) {
-            ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(parentActivity);
+            ConnectUserRecord user = ConnectUserDatabaseUtil.getUser();
             Date currentDate = new Date();
             if (user != null && currentDate.compareTo(user.getConnectTokenExpiration()) < 0) {
                 Logger.log(
@@ -232,7 +232,7 @@ public class PersonalIdManager {
             String password,
             ConnectActivityCompleteListener callback
     ) {
-        switch (evaluateAppState(activity, appId, username)) {
+        switch (evaluateAppState(appId, username)) {
             case Unmanaged ->
                     promptTolinkUnmanagedApp(activity, appId, username, password, callback);
             case PersonalId -> promptToDelinkPersonalIdApp(
@@ -254,7 +254,6 @@ public class PersonalIdManager {
             ConnectActivityCompleteListener callback
     ) {
         ConnectLinkedAppRecord linkedApp = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
-                activity,
                 appId,
                 username
         );
@@ -267,7 +266,6 @@ public class PersonalIdManager {
 
         if (linkedApp == null) {
             linkedApp = ConnectAppDatabaseUtil.storeApp(
-                    activity,
                     appId,
                     username,
                     false,
@@ -340,7 +338,7 @@ public class PersonalIdManager {
         dialog.setNegativeButton(
                 activity.getString(R.string.personalid_link_app_no), (d, w) -> {
                     activity.dismissAlertDialog();
-                    ConnectAppDatabaseUtil.storeApp(activity, linkedApp);
+                    ConnectAppDatabaseUtil.storeApp(linkedApp);
                     FirebaseAnalyticsUtil.reportPersonalIDLinking(
                             linkedApp.getAppId(),
                             FAILURE_USER_DENIED
@@ -375,9 +373,9 @@ public class PersonalIdManager {
                             linkedApp.getAppId(),
                             SYNC_SUCCESS
                     );
-                    ConnectAppDatabaseUtil.storeApp(activity, linkedApp);
+                    ConnectAppDatabaseUtil.storeApp(linkedApp);
 
-                    ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(activity);
+                    ConnectUserRecord user = ConnectUserDatabaseUtil.getUser();
                     ConnectSsoHelper.retrieveHqSsoToken(
                             activity, user, linkedApp, username, true,
                             new ConnectSsoHelper.TokenCallback() {
@@ -426,12 +424,11 @@ public class PersonalIdManager {
                             activity, UnlockPolicy.ALWAYS, success -> {
                                 if (success) {
                                     ConnectLinkedAppRecord linkedApp = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
-                                            activity,
                                             appId, username
                                     );
                                     if (linkedApp != null) {
                                         linkedApp.severPersonalIdLink();
-                                        ConnectAppDatabaseUtil.storeApp(activity, linkedApp);
+                                        ConnectAppDatabaseUtil.storeApp(linkedApp);
                                     }
                                 }
                                 callback.connectActivityComplete(false);
@@ -455,8 +452,8 @@ public class PersonalIdManager {
         return auth != null;
     }
 
-    private ConnectAppRecord getAppRecord(Context context, String appId) {
-        return ConnectJobUtils.getAppRecord(context, appId);
+    private ConnectAppRecord getAppRecord(String appId) {
+        return ConnectJobUtils.getAppRecord(appId);
     }
 
     public String getStoredPasswordForApp(String appId, String userId) {
@@ -467,7 +464,6 @@ public class PersonalIdManager {
     @Nullable
     public AuthInfo.ProvidedAuth getCredentialsForApp(String appId, String userId) {
         ConnectLinkedAppRecord record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
-                parentActivity,
                 appId,
                 userId
         );
@@ -480,7 +476,6 @@ public class PersonalIdManager {
     public AuthInfo.TokenAuth getTokenCredentialsForApp(String appId, String userId) {
         if (isloggedIn()) {
             ConnectLinkedAppRecord record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
-                    parentActivity,
                     appId,
                     userId
             );
@@ -500,18 +495,18 @@ public class PersonalIdManager {
         personalIdSatus = status;
     }
 
-    public void onAccountConfigurationSuccess(android.app.Activity activity, PersonalIdSessionData sessionData) {
-        createAndSaveConnectUser(activity, sessionData);
+    public void onAccountConfigurationSuccess(PersonalIdSessionData sessionData) {
+        createAndSaveConnectUser(sessionData);
         setStatus(PersonalIdStatus.LoggedIn);
         List<ConnectReleaseToggleRecord> toggles = sessionData.getFeatureReleaseToggles();
         if (toggles != null) {
-            ConnectAppDatabaseUtil.storeReleaseToggles(activity, toggles);
+            ConnectAppDatabaseUtil.storeReleaseToggles(toggles);
         }
-        ConnectSyncPreferences.Companion.getInstance(activity).markSessionStart();
+        ConnectSyncPreferences.Companion.getInstance().markSessionStart();
     }
 
-    private void createAndSaveConnectUser(android.app.Activity activity, PersonalIdSessionData sessionData) {
-        ConnectDatabaseHelper.handleReceivedDbPassphrase(activity, sessionData.getDbKey());
+    private void createAndSaveConnectUser(PersonalIdSessionData sessionData) {
+        ConnectDatabaseHelper.handleReceivedDbPassphrase(sessionData.getDbKey());
         ConnectUserRecord user = new ConnectUserRecord(sessionData.getPhoneNumber(),
                 sessionData.getPersonalId(),
                 sessionData.getOauthPassword(), sessionData.getUserName(),
@@ -520,19 +515,19 @@ public class PersonalIdManager {
                 sessionData.getInvitedUser());
         user.setEmail(sessionData.getEmail());
         user.setRegistrationPhase(ConnectConstants.PERSONAL_ID_USER_STATUS_REGISTERED);
-        ConnectUserDatabaseUtil.storeUser(activity, user);
+        ConnectUserDatabaseUtil.storeUser(user);
     }
 
     public void setParent(Context parent) {
         parentActivity = parent;
     }
 
-    public ConnectUserRecord getUser(Context context) {
-        return ConnectUserDatabaseUtil.getUser(context);
+    public ConnectUserRecord getUser() {
+        return ConnectUserDatabaseUtil.getUser();
     }
 
-    public String getConnectUsername(Context context) {
-        return ConnectUserDatabaseUtil.getUser(context).getUserId();
+    public String getConnectUsername() {
+        return ConnectUserDatabaseUtil.getUser().getUserId();
     }
 
     public boolean isSeatedAppCongigureWithPersonalId(String username) {
@@ -540,7 +535,7 @@ public class PersonalIdManager {
             if (isloggedIn()) {
                 String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
                 ConnectLinkedAppRecord appRecord = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
-                        CommCareApplication.instance(), seatedAppId, username);
+                        seatedAppId, username);
                 return appRecord != null && appRecord.getWorkerLinked();
             }
         } catch (Exception e) {
@@ -550,8 +545,8 @@ public class PersonalIdManager {
         return false;
     }
 
-    public ConnectAppMangement evaluateAppState(Context context, String appId, String userId) {
-        ConnectAppRecord record = getAppRecord(context, appId);
+    public ConnectAppMangement evaluateAppState(String appId, String userId) {
+        ConnectAppRecord record = getAppRecord(appId);
         if (record != null) {
             return ConnectAppMangement.Connect;
         }
@@ -560,16 +555,15 @@ public class PersonalIdManager {
                 : ConnectAppMangement.Unmanaged;
     }
 
-    private boolean isConnectApp(Context context, String appId) {
+    private boolean isConnectApp(String appId) {
         return evaluateAppState(
-                context,
                 appId,
                 ""
         ) == PersonalIdManager.ConnectAppMangement.Connect;
     }
 
-    public boolean isLoggedInWithConnectApp(Context context, String appId) {
-        return isloggedIn() && isConnectApp(context, appId);
+    public boolean isLoggedInWithConnectApp(String appId) {
+        return isloggedIn() && isConnectApp(appId);
     }
 
     /**
@@ -593,7 +587,7 @@ public class PersonalIdManager {
             return false;
         }
 
-        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(instance);
+        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser();
         if (user == null || user.getUserId() == null) {
             return false;
         }
@@ -615,7 +609,7 @@ public class PersonalIdManager {
     private boolean isPersonalIdLinkedApp(String appId, String username) {
         if (isloggedIn()) {
             ConnectLinkedAppRecord record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
-                    manager.parentActivity, appId, username);
+                    appId, username);
             return record != null && record.getPersonalIdLinked();
         }
         return false;
@@ -634,7 +628,7 @@ public class PersonalIdManager {
             return null;
         }
 
-        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(manager.parentActivity);
+        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser();
         if (user == null) {
             return null;
         }
@@ -646,7 +640,6 @@ public class PersonalIdManager {
         }
 
         ConnectLinkedAppRecord appRecord = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
-                manager.parentActivity,
                 seatedAppId,
                 username
         );

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -500,18 +500,27 @@ public class PersonalIdManager {
         personalIdSatus = status;
     }
 
-    public void successFlow(android.app.Activity activity, PersonalIdSessionData sessionData) {
+    public void onAccountConfigurationSuccess(android.app.Activity activity, PersonalIdSessionData sessionData) {
+        createAndSaveConnectUser(activity, sessionData);
         setStatus(PersonalIdStatus.LoggedIn);
-        ConnectDatabaseHelper.setRegistrationPhase(activity, ConnectConstants.PERSONALID_NO_ACTIVITY);
-        if (sessionData != null) {
-            List<ConnectReleaseToggleRecord> toggles = sessionData.getFeatureReleaseToggles();
-            if (toggles != null) {
-                ConnectAppDatabaseUtil.storeReleaseToggles(activity, toggles);
-            }
+        List<ConnectReleaseToggleRecord> toggles = sessionData.getFeatureReleaseToggles();
+        if (toggles != null) {
+            ConnectAppDatabaseUtil.storeReleaseToggles(activity, toggles);
         }
         ConnectSyncPreferences.Companion.getInstance(activity).markSessionStart();
-        activity.setResult(android.app.Activity.RESULT_OK);
-        activity.finish();
+    }
+
+    private void createAndSaveConnectUser(android.app.Activity activity, PersonalIdSessionData sessionData) {
+        ConnectDatabaseHelper.handleReceivedDbPassphrase(activity, sessionData.getDbKey());
+        ConnectUserRecord user = new ConnectUserRecord(sessionData.getPhoneNumber(),
+                sessionData.getPersonalId(),
+                sessionData.getOauthPassword(), sessionData.getUserName(),
+                String.valueOf(sessionData.getBackupCode()), new Date(), sessionData.getPhotoBase64(),
+                sessionData.getDemoUser(),sessionData.getRequiredLock(),
+                sessionData.getInvitedUser());
+        user.setEmail(sessionData.getEmail());
+        user.setRegistrationPhase(ConnectConstants.PERSONALID_NO_ACTIVITY);
+        ConnectUserDatabaseUtil.storeUser(activity, user);
     }
 
     public void setParent(Context parent) {

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -668,6 +668,10 @@ public class PersonalIdManager {
         failedPinAttempts = failureAttempt;
     }
 
+    public static void clearInstance() {
+        manager = null;
+    }
+
     /**
      * Interface for handling callbacks when a PersonalId activity finishes
      */

--- a/app/src/org/commcare/connect/PersonalIdManager.java
+++ b/app/src/org/commcare/connect/PersonalIdManager.java
@@ -117,7 +117,7 @@ public class PersonalIdManager {
         if (personalIdSatus == PersonalIdStatus.NotIntroduced) {
             ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(parentActivity);
             if (user != null) {
-                boolean registering = user.getRegistrationPhase() != ConnectConstants.PERSONALID_NO_ACTIVITY;
+                boolean registering = user.getRegistrationPhase() != ConnectConstants.PERSONAL_ID_USER_STATUS_REGISTERED;
                 personalIdSatus = registering ? PersonalIdStatus.Registering : PersonalIdStatus.LoggedIn;
                 CrashUtil.registerUserData();
             } else if (ConnectDatabaseHelper.isDbBroken()) {
@@ -519,7 +519,7 @@ public class PersonalIdManager {
                 sessionData.getDemoUser(),sessionData.getRequiredLock(),
                 sessionData.getInvitedUser());
         user.setEmail(sessionData.getEmail());
-        user.setRegistrationPhase(ConnectConstants.PERSONALID_NO_ACTIVITY);
+        user.setRegistrationPhase(ConnectConstants.PERSONAL_ID_USER_STATUS_REGISTERED);
         ConnectUserDatabaseUtil.storeUser(activity, user);
     }
 

--- a/app/src/org/commcare/connect/ReleaseToggleHelper.kt
+++ b/app/src/org/commcare/connect/ReleaseToggleHelper.kt
@@ -16,7 +16,7 @@ object ReleaseToggleHelper {
     fun isToggleActive(
         context: Context,
         slug: String,
-    ): Boolean = evaluate(ConnectAppDatabaseUtil.getReleaseToggles(context), slug)
+    ): Boolean = evaluate(ConnectAppDatabaseUtil.getReleaseToggles(), slug)
 
     private fun evaluate(
         toggles: List<ConnectReleaseToggleRecord>?,

--- a/app/src/org/commcare/connect/database/ConnectAppDatabaseUtil.java
+++ b/app/src/org/commcare/connect/database/ConnectAppDatabaseUtil.java
@@ -1,7 +1,5 @@
 package org.commcare.connect.database;
 
-import android.content.Context;
-
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
 import org.commcare.android.database.connect.models.ConnectReleaseToggleRecord;
 import org.commcare.android.database.connect.models.PersonalIdWorkHistory;
@@ -9,16 +7,16 @@ import org.commcare.connect.PersonalIdManager;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.models.database.SqlStorage;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
 public class ConnectAppDatabaseUtil {
-    public static ConnectLinkedAppRecord getConnectLinkedAppRecord(Context context, String appId, String username) {
+    public static ConnectLinkedAppRecord getConnectLinkedAppRecord(String appId, String username) {
         if (PersonalIdManager.getInstance().isloggedIn()) {
-            Vector<ConnectLinkedAppRecord> records = ConnectDatabaseHelper.getConnectStorage(context, ConnectLinkedAppRecord.class)
+            Vector<ConnectLinkedAppRecord> records = ConnectDatabaseHelper.getConnectStorage(
+                            ConnectLinkedAppRecord.class)
                     .getRecordsForValues(
                             new String[]{ConnectLinkedAppRecord.META_APP_ID, ConnectLinkedAppRecord.META_USER_ID},
                             new Object[]{appId, username});
@@ -27,15 +25,15 @@ public class ConnectAppDatabaseUtil {
         return null;
     }
 
-    public static void deleteAppData(Context context, ConnectLinkedAppRecord record) {
-        SqlStorage<ConnectLinkedAppRecord> storage = ConnectDatabaseHelper.getConnectStorage(context, ConnectLinkedAppRecord.class);
+    public static void deleteAppData(ConnectLinkedAppRecord record) {
+        SqlStorage<ConnectLinkedAppRecord> storage = ConnectDatabaseHelper.getConnectStorage(
+                ConnectLinkedAppRecord.class);
         storage.remove(record);
     }
 
     /**
      * Stores or updates a ConnectLinkedAppRecord in the database.
      *
-     * @param context         The Android context
      * @param appId           Application identifier
      * @param userId          User identifier
      * @param connectIdLinked Whether the app is linked to ConnectID
@@ -44,9 +42,9 @@ public class ConnectAppDatabaseUtil {
      * @return The stored record
      * throw error if storage operations fail
      */
-    public static ConnectLinkedAppRecord storeApp(Context context, String appId, String userId, boolean connectIdLinked, String passwordOrPin, boolean workerLinked) {
+    public static ConnectLinkedAppRecord storeApp(String appId, String userId, boolean connectIdLinked, String passwordOrPin, boolean workerLinked) {
 
-        ConnectLinkedAppRecord record = getConnectLinkedAppRecord(context, appId, userId);
+        ConnectLinkedAppRecord record = getConnectLinkedAppRecord(appId, userId);
         if (record == null) {
             record = new ConnectLinkedAppRecord(appId, userId, connectIdLinked, passwordOrPin);
         } else if (!record.getPassword().equals(passwordOrPin)) {
@@ -61,18 +59,18 @@ public class ConnectAppDatabaseUtil {
             record.setWorkerLinked(true);
         }
 
-        storeApp(context, record);
+        storeApp(record);
 
         return record;
     }
 
-    public static void storeApp(Context context, ConnectLinkedAppRecord record) {
-        ConnectDatabaseHelper.getConnectStorage(context, ConnectLinkedAppRecord.class).write(record);
+    public static void storeApp(ConnectLinkedAppRecord record) {
+        ConnectDatabaseHelper.getConnectStorage(ConnectLinkedAppRecord.class).write(record);
     }
 
-    public static void storeCredentialDataInTable(Context context, List<PersonalIdWorkHistory> validCredentials) {
+    public static void storeCredentialDataInTable(List<PersonalIdWorkHistory> validCredentials) {
         SqlStorage<PersonalIdWorkHistory> storage =
-                ConnectDatabaseHelper.getConnectStorage(context, PersonalIdWorkHistory.class);
+                ConnectDatabaseHelper.getConnectStorage(PersonalIdWorkHistory.class);
 
         storage.removeAll();
 
@@ -82,18 +80,17 @@ public class ConnectAppDatabaseUtil {
     }
 
     public static void storeReleaseToggles(
-            Context context,
             List<ConnectReleaseToggleRecord> incomingToggles
     ) {
         boolean togglesChanged = false;
 
         try {
             SqlStorage<ConnectReleaseToggleRecord> toggleStorage =
-                    ConnectDatabaseHelper.getConnectStorage(context, ConnectReleaseToggleRecord.class);
+                    ConnectDatabaseHelper.getConnectStorage(ConnectReleaseToggleRecord.class);
             ConnectDatabaseHelper.connectDatabase.beginTransaction();
 
             // Create map of existing toggles for easy comparison to incoming toggles.
-            List<ConnectReleaseToggleRecord> existingToggles = getReleaseToggles(context);
+            List<ConnectReleaseToggleRecord> existingToggles = getReleaseToggles();
             Map<String, ConnectReleaseToggleRecord> existingTogglesMap = new HashMap<>();
             for (ConnectReleaseToggleRecord existingToggle : existingToggles) {
                 existingTogglesMap.put(existingToggle.getSlug(), existingToggle);
@@ -120,9 +117,9 @@ public class ConnectAppDatabaseUtil {
         }
     }
 
-    public static List<ConnectReleaseToggleRecord> getReleaseToggles(Context context) {
+    public static List<ConnectReleaseToggleRecord> getReleaseToggles() {
         SqlStorage<ConnectReleaseToggleRecord> toggleStorage =
-                ConnectDatabaseHelper.getConnectStorage(context, ConnectReleaseToggleRecord.class);
+                ConnectDatabaseHelper.getConnectStorage(ConnectReleaseToggleRecord.class);
 
         return toggleStorage.getRecordsForValues(new String[]{}, new Object[]{});
     }

--- a/app/src/org/commcare/connect/database/ConnectAppDatabaseUtil.java
+++ b/app/src/org/commcare/connect/database/ConnectAppDatabaseUtil.java
@@ -84,10 +84,10 @@ public class ConnectAppDatabaseUtil {
     ) {
         boolean togglesChanged = false;
 
+        SqlStorage<ConnectReleaseToggleRecord> toggleStorage =
+                ConnectDatabaseHelper.getConnectStorage(ConnectReleaseToggleRecord.class);
+        ConnectDatabaseHelper.connectDatabase.beginTransaction();
         try {
-            SqlStorage<ConnectReleaseToggleRecord> toggleStorage =
-                    ConnectDatabaseHelper.getConnectStorage(ConnectReleaseToggleRecord.class);
-            ConnectDatabaseHelper.connectDatabase.beginTransaction();
 
             // Create map of existing toggles for easy comparison to incoming toggles.
             List<ConnectReleaseToggleRecord> existingToggles = getReleaseToggles();

--- a/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
@@ -31,8 +31,8 @@ public class ConnectDatabaseHelper {
     public static IDatabase connectDatabase;
     static boolean dbBroken = false;
 
-    public static void handleReceivedDbPassphrase(Context context, String passphrase) {
-        ConnectDatabaseUtils.storeConnectDbPassphrase(context, passphrase);
+    public static void handleReceivedDbPassphrase(String passphrase) {
+        ConnectDatabaseUtils.storeConnectDbPassphrase(passphrase);
     }
 
     public static boolean dbExists() {
@@ -43,14 +43,15 @@ public class ConnectDatabaseHelper {
         return dbBroken;
     }
 
-    public static <T extends Persistable> SqlStorage<T> getConnectStorage(Context context, Class<T> c) {
+    public static <T extends Persistable> SqlStorage<T> getConnectStorage(Class<T> c) {
+        Context context = CommCareApplication.instance().getApplicationContext();
         return new SqlStorage<>(c.getAnnotation(Table.class).value(), c, new AndroidDbHelper(context) {
             @Override
             public IDatabase getHandle() {
                 synchronized (connectDbHandleLock) {
                     if (connectDatabase == null || !connectDatabase.isOpen()) {
                         try {
-                            connectDatabase = CommCareApplication.instance().getConnectDbOpenHelper(context);
+                            connectDatabase = CommCareApplication.instance().getConnectDbOpenHelper();
                         } catch (Exception e) {
                             //Flag the DB as broken if we hit an error opening it (usually means corrupted or bad encryption)
                             dbBroken = true;
@@ -78,9 +79,9 @@ public class ConnectDatabaseHelper {
         PersonalIdManager.getInstance().forgetUser(AnalyticsParamValue.PERSONAL_ID_FORGOT_USER_DB_ERROR);
     }
 
-    public static void storeHqToken(Context context, String appId, String userId, SsoToken token) {
-        ConnectLinkedAppRecord record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(context, appId, userId);
+    public static void storeHqToken(String appId, String userId, SsoToken token) {
+        ConnectLinkedAppRecord record = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(appId, userId);
         record.updateHqToken(token);
-        getConnectStorage(context, ConnectLinkedAppRecord.class).write(record);
+        getConnectStorage(ConnectLinkedAppRecord.class).write(record);
     }
 }

--- a/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseHelper.java
@@ -3,7 +3,6 @@ package org.commcare.connect.database;
 import android.content.Context;
 
 import org.commcare.android.database.connect.models.ConnectLinkedAppRecord;
-import org.commcare.android.database.connect.models.ConnectUserRecord;
 import org.commcare.android.database.global.models.GlobalErrorRecord;
 import org.commcare.connect.PersonalIdManager;
 import org.commcare.connect.network.personalId.SsoToken;
@@ -84,14 +83,4 @@ public class ConnectDatabaseHelper {
         record.updateHqToken(token);
         getConnectStorage(context, ConnectLinkedAppRecord.class).write(record);
     }
-
-    public static void setRegistrationPhase(Context context, int phase) {
-        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(context);
-        if (user != null) {
-            user.setRegistrationPhase(phase);
-            ConnectUserDatabaseUtil.storeUser(context, user);
-        }
-    }
-
-
 }

--- a/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectDatabaseUtils.java
@@ -9,17 +9,17 @@ import org.commcare.util.Base64DecoderException;
 import org.commcare.util.EncryptionUtils;
 import org.commcare.utils.EncryptionKeyAndTransform;
 import org.commcare.utils.EncryptionKeyProvider;
-import org.jetbrains.annotations.NotNull;
 
 public class ConnectDatabaseUtils {
     // the value of the key should not be renamed due to backward compatibility
     private static final String SECRET_NAME = "secret";
-    public static void storeConnectDbPassphrase(@NotNull Context context, byte[] passphrase) {
+    public static void storeConnectDbPassphrase(byte[] passphrase) {
         try {
             if (passphrase == null || passphrase.length == 0) {
                 throw new IllegalArgumentException("Passphrase must not be null or empty");
             }
 
+            Context context = CommCareApplication.instance().getApplicationContext();
             EncryptionKeyProvider encryptionKeyProvider = new EncryptionKeyProvider(context, false, SECRET_NAME);
             EncryptionKeyAndTransform keyAndTransform = encryptionKeyProvider.getKeyForEncryption();
             String encoded = EncryptionUtils.encrypt(passphrase, keyAndTransform.getKey(),
@@ -48,16 +48,16 @@ public class ConnectDatabaseUtils {
         return null;
     }
 
-    public static void storeConnectDbPassphrase(Context context, String base64EncodedPassphrase) {
+    public static void storeConnectDbPassphrase(String base64EncodedPassphrase) {
         try {
             byte[] bytes = Base64.decode(base64EncodedPassphrase);
-            storeConnectDbPassphrase(context, bytes);
+            storeConnectDbPassphrase(bytes);
         } catch (Base64DecoderException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static byte[] getConnectDbPassphrase(Context context) {
+    public static byte[] getConnectDbPassphrase() {
         try {
             ConnectKeyRecord record = ConnectDatabaseUtils.getKeyRecord();
             if (record == null) {
@@ -65,7 +65,7 @@ public class ConnectDatabaseUtils {
             }
 
             byte[] encrypted = Base64.decode(record.getEncryptedPassphrase());
-
+            Context context = CommCareApplication.instance().getApplicationContext();
             EncryptionKeyProvider encryptionKeyProvider = new EncryptionKeyProvider(context, false,
                     SECRET_NAME);
             EncryptionKeyAndTransform keyAndTransform = encryptionKeyProvider.getKeyForDecryption();

--- a/app/src/org/commcare/connect/database/ConnectJobUtils.java
+++ b/app/src/org/commcare/connect/database/ConnectJobUtils.java
@@ -42,43 +42,41 @@ public class ConnectJobUtils {
         Context context = CommCareApplication.instance();
         List<ConnectJobRecord> list = new ArrayList<>();
         list.add(job);
-        new JobStoreManager(context).storeJobs(context, list, false);
+        new JobStoreManager().storeJobs(context, list, false);
     }
 
     public static ConnectJobPreferences getJobPreferences(String jobUUID) {
         return new ConnectJobPreferences(jobUUID);
     }
 
-    public static ConnectJobRecord getCompositeJob(Context context, String jobUUID) {
+    public static ConnectJobRecord getCompositeJob(String jobUUID) {
         Vector<ConnectJobRecord> jobs = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobRecord.class
         ).getRecordsForValues(
                 new String[]{ConnectJobRecord.META_JOB_UUID},
                 new Object[]{jobUUID}
         );
 
-        populateJobs(context, jobs);
+        populateJobs(jobs);
 
         return jobs.isEmpty() ? null : jobs.firstElement();
     }
 
     public static ConnectJobRecord getJobForApp(Context context, String appId) {
-        ConnectAppRecord appRecord = getAppRecord(context, appId);
+        ConnectAppRecord appRecord = getAppRecord(appId);
         if (appRecord == null) {
             return null;
         }
 
-        return getCompositeJob(context, appRecord.getJobUUID());
+        return getCompositeJob(appRecord.getJobUUID());
     }
 
     public static List<ConnectJobRecord> getCompositeJobs(
-            Context context,
             int status,
             SqlStorage<ConnectJobRecord> jobStorage
     ) {
         if (jobStorage == null) {
-            jobStorage = ConnectDatabaseHelper.getConnectStorage(context, ConnectJobRecord.class);
+            jobStorage = ConnectDatabaseHelper.getConnectStorage(ConnectJobRecord.class);
         }
 
         Vector<ConnectJobRecord> jobs;
@@ -91,7 +89,7 @@ public class ConnectJobUtils {
             jobs = jobStorage.getRecordsForValues(new String[]{}, new Object[]{});
         }
 
-        populateJobs(context, jobs);
+        populateJobs(jobs);
 
         return new ArrayList<>(jobs);
     }
@@ -101,36 +99,29 @@ public class ConnectJobUtils {
             List<ConnectJobRecord> jobs,
             boolean pruneMissing
     ) {
-        return new JobStoreManager(context).storeJobs(context, jobs, pruneMissing);
+        return new JobStoreManager().storeJobs(context, jobs, pruneMissing);
     }
 
-    private static void populateJobs(Context context, Vector<ConnectJobRecord> jobs) {
+    private static void populateJobs(Vector<ConnectJobRecord> jobs) {
         SqlStorage<ConnectAppRecord> appInfoStorage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectAppRecord.class
         );
         SqlStorage<ConnectLearnModuleSummaryRecord> moduleStorage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectLearnModuleSummaryRecord.class
         );
         SqlStorage<ConnectJobDeliveryRecord> deliveryStorage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobDeliveryRecord.class
         );
         SqlStorage<ConnectJobPaymentRecord> paymentStorage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobPaymentRecord.class
         );
         SqlStorage<ConnectJobLearningRecord> learningStorage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobLearningRecord.class
         );
         SqlStorage<ConnectJobAssessmentRecord> assessmentStorage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobAssessmentRecord.class
         );
         SqlStorage<ConnectPaymentUnitRecord> paymentUnitStorage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectPaymentUnitRecord.class
         );
         for (ConnectJobRecord job : jobs) {
@@ -183,10 +174,10 @@ public class ConnectJobUtils {
             ));
 
             //Retrieve related data
-            job.setDeliveries(getDeliveries(context, job.getJobUUID(), deliveryStorage));
-            job.setPayments(getPayments(context, job.getJobUUID(), paymentStorage));
-            job.setLearnings(getLearnings(context, job.getJobUUID(), learningStorage));
-            job.setAssessments(getAssessments(context, job.getJobUUID(), assessmentStorage));
+            job.setDeliveries(getDeliveries(job.getJobUUID(), deliveryStorage));
+            job.setPayments(getPayments(job.getJobUUID(), paymentStorage));
+            job.setLearnings(getLearnings(job.getJobUUID(), learningStorage));
+            job.setAssessments(getAssessments(job.getJobUUID(), assessmentStorage));
         }
     }
 
@@ -197,12 +188,10 @@ public class ConnectJobUtils {
             boolean pruneMissing
     ) {
         SqlStorage<ConnectJobDeliveryRecord> storage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobDeliveryRecord.class
         );
 
         List<ConnectJobDeliveryRecord> existingDeliveries = getDeliveries(
-                context,
                 jobUUID,
                 storage
         );
@@ -237,17 +226,15 @@ public class ConnectJobUtils {
             //Now insert/update the delivery
             storage.write(incomingRecord);
 
-            storeDeliveryFlags(context, incomingRecord.getFlags(), incomingRecord.getDeliveryId());
+            storeDeliveryFlags(incomingRecord.getFlags(), incomingRecord.getDeliveryId());
         }
     }
 
     public static void storeDeliveryFlags(
-            Context context,
             List<ConnectJobDeliveryFlagRecord> flags,
             int deliveryId
     ) {
         SqlStorage<ConnectJobDeliveryFlagRecord> storage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobDeliveryFlagRecord.class
         );
         ConnectDatabaseHelper.connectDatabase.beginTransaction();
@@ -266,9 +253,8 @@ public class ConnectJobUtils {
         }
     }
 
-    public static void storePayment(Context context, ConnectJobPaymentRecord payment) {
+    public static void storePayment(ConnectJobPaymentRecord payment) {
         SqlStorage<ConnectJobPaymentRecord> storage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobPaymentRecord.class
         );
         storage.write(payment);
@@ -281,11 +267,10 @@ public class ConnectJobUtils {
             boolean pruneMissing
     ) {
         SqlStorage<ConnectJobPaymentRecord> storage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobPaymentRecord.class
         );
 
-        List<ConnectJobPaymentRecord> existingList = getPayments(context, jobUUID, storage);
+        List<ConnectJobPaymentRecord> existingList = getPayments(jobUUID, storage);
         Set<String> matchedIncomingIds = new HashSet<>();
 
         //Delete payments that are no longer available
@@ -328,13 +313,11 @@ public class ConnectJobUtils {
     }
 
     public static List<ConnectJobDeliveryRecord> getDeliveries(
-            Context context,
             String jobUUID,
             SqlStorage<ConnectJobDeliveryRecord> deliveryStorage
     ) {
         if (deliveryStorage == null) {
             deliveryStorage = ConnectDatabaseHelper.getConnectStorage(
-                    context,
                     ConnectJobDeliveryRecord.class
             );
         }
@@ -348,13 +331,11 @@ public class ConnectJobUtils {
     }
 
     public static List<ConnectJobPaymentRecord> getPayments(
-            Context context,
             String jobUUID,
             SqlStorage<ConnectJobPaymentRecord> paymentStorage
     ) {
         if (paymentStorage == null) {
             paymentStorage = ConnectDatabaseHelper.getConnectStorage(
-                    context,
                     ConnectJobPaymentRecord.class
             );
         }
@@ -368,13 +349,11 @@ public class ConnectJobUtils {
     }
 
     public static List<ConnectJobLearningRecord> getLearnings(
-            Context context,
             String jobUUID,
             SqlStorage<ConnectJobLearningRecord> learningStorage
     ) {
         if (learningStorage == null) {
             learningStorage = ConnectDatabaseHelper.getConnectStorage(
-                    context,
                     ConnectJobLearningRecord.class
             );
         }
@@ -388,13 +367,11 @@ public class ConnectJobUtils {
     }
 
     public static List<ConnectJobAssessmentRecord> getAssessments(
-            Context context,
             String jobUUID,
             SqlStorage<ConnectJobAssessmentRecord> assessmentStorage
     ) {
         if (assessmentStorage == null) {
             assessmentStorage = ConnectDatabaseHelper.getConnectStorage(
-                    context,
                     ConnectJobAssessmentRecord.class
             );
         }
@@ -414,11 +391,10 @@ public class ConnectJobUtils {
             boolean pruneMissing
     ) {
         SqlStorage<ConnectJobAssessmentRecord> storage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobAssessmentRecord.class
         );
 
-        List<ConnectJobAssessmentRecord> existingList = getAssessments(context, jobUUID, storage);
+        List<ConnectJobAssessmentRecord> existingList = getAssessments(jobUUID, storage);
 
         //Delete records that are no longer available
         Vector<Integer> recordIdsToDelete = new Vector<>();
@@ -454,7 +430,6 @@ public class ConnectJobUtils {
 
     public static void updateJobLearnProgress(Context context, ConnectJobRecord job) {
         SqlStorage<ConnectJobRecord> jobStorage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobRecord.class
         );
 
@@ -486,11 +461,10 @@ public class ConnectJobUtils {
             boolean pruneMissing
     ) {
         SqlStorage<ConnectJobLearningRecord> storage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectJobLearningRecord.class
         );
 
-        List<ConnectJobLearningRecord> existingList = getLearnings(context, jobUUID, storage);
+        List<ConnectJobLearningRecord> existingList = getLearnings(jobUUID, storage);
 
         //Delete records that are no longer available
         Vector<Integer> recordIdsToDelete = new Vector<>();
@@ -525,10 +499,9 @@ public class ConnectJobUtils {
         }
     }
 
-    public static ConnectAppRecord getAppRecord(Context context, String appId) {
+    public static ConnectAppRecord getAppRecord(String appId) {
         if (PersonalIdManager.getInstance().isloggedIn()) {
             Vector<ConnectAppRecord> records = ConnectDatabaseHelper.getConnectStorage(
-                    context,
                     ConnectAppRecord.class
             ).getRecordsForValues(
                     new String[]{ConnectAppRecord.META_APP_ID},
@@ -550,7 +523,7 @@ public class ConnectJobUtils {
         if (TextUtils.isEmpty(opportunityID)) {
             throw new IllegalArgumentException("opportunityID can't be empty");
         }
-        ConnectJobRecord job = getCompositeJob(context, opportunityID);
+        ConnectJobRecord job = getCompositeJob(opportunityID);
         if (job == null) {
             throw new IllegalArgumentException("No Opportunity found for given opportunityID " + opportunityID);
         }
@@ -585,15 +558,15 @@ public class ConnectJobUtils {
 
     public static ConnectJobRecord getJobForSeatedApp(Context context) {
         String appId = CommCareApplication.instance().getCurrentApp().getUniqueId();
-        ConnectAppRecord appRecord = getAppRecord(context, appId);
+        ConnectAppRecord appRecord = getAppRecord(appId);
         if (appRecord == null) {
             return null;
         }
-        return getCompositeJob(context, appRecord.getJobUUID());
+        return getCompositeJob(appRecord.getJobUUID());
     }
 
     public static boolean shouldShowJobStatus(Context context, String appId) {
-        ConnectAppRecord record = getAppRecord(context, appId);
+        ConnectAppRecord record = getAppRecord(appId);
         if (record == null) {
             return false;
         }

--- a/app/src/org/commcare/connect/database/ConnectMessagingDatabaseHelper.java
+++ b/app/src/org/commcare/connect/database/ConnectMessagingDatabaseHelper.java
@@ -23,14 +23,14 @@ import static android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE;
 public class ConnectMessagingDatabaseHelper {
     public static List<ConnectMessagingChannelRecord> getMessagingChannels(Context context) {
         List<ConnectMessagingChannelRecord> channels = ConnectDatabaseHelper
-                .getConnectStorage(context, ConnectMessagingChannelRecord.class)
+                .getConnectStorage(ConnectMessagingChannelRecord.class)
                 .getRecordsForValues(new String[]{}, new Object[]{});
 
         Map<String, ConnectMessagingChannelRecord> channelMap = new HashMap<>();
         for (ConnectMessagingChannelRecord c : channels) {
             channelMap.put(c.getChannelId(), c);
         }
-        for (ConnectMessagingMessageRecord connectMessagingMessageRecord : getMessagingMessagesAll(context)) {
+        for (ConnectMessagingMessageRecord connectMessagingMessageRecord : getMessagingMessagesAll()) {
             ConnectMessagingChannelRecord connectMessagingChannelRecord =
                     channelMap.get(connectMessagingMessageRecord.getChannelId());
             connectMessagingChannelRecord.getMessages().add(connectMessagingMessageRecord);
@@ -77,11 +77,10 @@ public class ConnectMessagingDatabaseHelper {
     }
 
     public static ConnectMessagingChannelRecord getMessagingChannel(
-            Context context,
             String channelId
     ) {
         List<ConnectMessagingChannelRecord> channels = ConnectDatabaseHelper
-                .getConnectStorage(context, ConnectMessagingChannelRecord.class)
+                .getConnectStorage(ConnectMessagingChannelRecord.class)
                 .getRecordsForValues(
                         new String[]{ConnectMessagingChannelRecord.META_CHANNEL_ID},
                         new Object[]{channelId}
@@ -99,13 +98,13 @@ public class ConnectMessagingDatabaseHelper {
             ConnectMessagingChannelRecord channel
     ) {
         ConnectMessagingChannelRecord existing =
-                getMessagingChannel(context, channel.getChannelId());
+                getMessagingChannel(channel.getChannelId());
         if (existing != null) {
             channel.setID(existing.getID());
         }
 
         ConnectDatabaseHelper
-                .getConnectStorage(context, ConnectMessagingChannelRecord.class)
+                .getConnectStorage(ConnectMessagingChannelRecord.class)
                 .write(channel);
     }
 
@@ -115,7 +114,6 @@ public class ConnectMessagingDatabaseHelper {
             boolean pruneMissing
     ) {
         SqlStorage<ConnectMessagingChannelRecord> storage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectMessagingChannelRecord.class
         );
 
@@ -160,27 +158,26 @@ public class ConnectMessagingDatabaseHelper {
         }
     }
 
-    public static List<ConnectMessagingMessageRecord> getMessagingMessagesAll(Context context) {
+    public static List<ConnectMessagingMessageRecord> getMessagingMessagesAll() {
         return ConnectDatabaseHelper
-                .getConnectStorage(context, ConnectMessagingMessageRecord.class)
+                .getConnectStorage(ConnectMessagingMessageRecord.class)
                 .getRecordsForValues(new String[]{}, new Object[]{});
     }
 
     public static List<ConnectMessagingMessageRecord> getMessagingMessagesForChannel(
-            Context context,
             String channelId
     ) {
         return ConnectDatabaseHelper
-                .getConnectStorage(context, ConnectMessagingMessageRecord.class)
+                .getConnectStorage(ConnectMessagingMessageRecord.class)
                 .getRecordsForValues(
                         new String[]{ConnectMessagingMessageRecord.META_MESSAGE_CHANNEL_ID},
                         new Object[]{channelId}
                 );
     }
 
-    public static List<ConnectMessagingMessageRecord> getUnviewedMessages(Context context) {
+    public static List<ConnectMessagingMessageRecord> getUnviewedMessages() {
         return ConnectDatabaseHelper
-                .getConnectStorage(context, ConnectMessagingMessageRecord.class)
+                .getConnectStorage(ConnectMessagingMessageRecord.class)
                 .getRecordsForValues(
                         new String[]{ConnectMessagingMessageRecord.META_MESSAGE_USER_VIEWED},
                         new Object[]{false}
@@ -192,12 +189,11 @@ public class ConnectMessagingDatabaseHelper {
             ConnectMessagingMessageRecord message
     ) {
         SqlStorage<ConnectMessagingMessageRecord> storage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectMessagingMessageRecord.class
         );
 
         List<ConnectMessagingMessageRecord> existingList =
-                getMessagingMessagesForChannel(context, message.getChannelId());
+                getMessagingMessagesForChannel(message.getChannelId());
         for (ConnectMessagingMessageRecord existing : existingList) {
             if (existing.getMessageId().equals(message.getMessageId())) {
                 message.setID(existing.getID());
@@ -214,11 +210,10 @@ public class ConnectMessagingDatabaseHelper {
             boolean pruneMissing
     ) {
         SqlStorage<ConnectMessagingMessageRecord> storage = ConnectDatabaseHelper.getConnectStorage(
-                context,
                 ConnectMessagingMessageRecord.class
         );
 
-        List<ConnectMessagingMessageRecord> existingList = getMessagingMessagesAll(context);
+        List<ConnectMessagingMessageRecord> existingList = getMessagingMessagesAll();
 
         //Delete payments that are no longer available
         Vector<Integer> recordIdsToDelete = new Vector<>();

--- a/app/src/org/commcare/connect/database/ConnectTaskUtils.kt
+++ b/app/src/org/commcare/connect/database/ConnectTaskUtils.kt
@@ -3,7 +3,6 @@ package org.commcare.connect.database
 import android.content.Context
 import org.commcare.android.database.connect.models.ConnectJobRecord
 import org.commcare.android.database.connect.models.ConnectTaskRecord
-import org.commcare.connect.database.ConnectJobUtils
 import org.commcare.models.database.SqlStorage
 import org.commcare.preferences.ConnectJobPreferences
 import org.commcare.utils.SyncDetailCalculations
@@ -27,7 +26,7 @@ object ConnectTaskUtils {
         incoming: List<ConnectTaskRecord>,
         jobUUID: String,
     ) {
-        val storage = ConnectDatabaseHelper.getConnectStorage(context, ConnectTaskRecord::class.java)
+        val storage = ConnectDatabaseHelper.getConnectStorage(ConnectTaskRecord::class.java)
         val existing = getTasksForJob(context, jobUUID, storage)
         var changed = false
 
@@ -155,7 +154,7 @@ object ConnectTaskUtils {
         jobUUID: String,
         storage: SqlStorage<ConnectTaskRecord>?,
     ): List<ConnectTaskRecord> {
-        val taskStorage = storage ?: ConnectDatabaseHelper.getConnectStorage(context, ConnectTaskRecord::class.java)
+        val taskStorage = storage ?: ConnectDatabaseHelper.getConnectStorage(ConnectTaskRecord::class.java)
         return taskStorage
             .getRecordsForValues(
                 arrayOf(ConnectTaskRecord.META_JOB_UUID),

--- a/app/src/org/commcare/connect/database/ConnectUserDatabaseUtil.java
+++ b/app/src/org/commcare/connect/database/ConnectUserDatabaseUtil.java
@@ -1,7 +1,5 @@
 package org.commcare.connect.database;
 
-import android.content.Context;
-
 import org.commcare.CommCareApplication;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
 import org.commcare.android.database.global.models.ConnectKeyRecord;
@@ -9,29 +7,23 @@ import org.commcare.models.database.connect.DatabaseConnectOpenHelper;
 
 public class ConnectUserDatabaseUtil {
 
-    public static ConnectUserRecord getUser(Context context) {
-        if (context == null) {
-            throw new IllegalArgumentException("Context must not be null");
-        }
+    public static ConnectUserRecord getUser() {
         if (!ConnectDatabaseHelper.dbExists()) {
             return null;
         }
         Iterable<ConnectUserRecord> records = ConnectDatabaseHelper.getConnectStorage(
-                context, ConnectUserRecord.class);
+                ConnectUserRecord.class);
         if (records.iterator().hasNext()) {
             return records.iterator().next();
         }
         return null;
     }
 
-    public static void storeUser(Context context, ConnectUserRecord user) {
-        if (context == null) {
-            throw new IllegalArgumentException("Context must not be null");
-        }
+    public static void storeUser(ConnectUserRecord user) {
         if (user == null) {
             throw new IllegalArgumentException("User must not be null");
         }
-        ConnectDatabaseHelper.getConnectStorage(context, ConnectUserRecord.class).write(user);
+        ConnectDatabaseHelper.getConnectStorage(ConnectUserRecord.class).write(user);
     }
 
     public static void forgetUser() {
@@ -41,16 +33,16 @@ public class ConnectUserDatabaseUtil {
         ConnectDatabaseHelper.teardown();
     }
 
-    public static boolean hasConnectAccess(Context context) {
-        ConnectUserRecord user = getUser(context);
+    public static boolean hasConnectAccess() {
+        ConnectUserRecord user = getUser();
         return user != null && user.hasConnectAccess();
     }
 
-    public static void turnOnConnectAccess(Context context) {
-        ConnectUserRecord user = getUser(context);
+    public static void turnOnConnectAccess() {
+        ConnectUserRecord user = getUser();
         if (user != null && !user.hasConnectAccess()) {
             user.setHasConnectAccess(true);
-            storeUser(context, user);
+            storeUser(user);
         }
     }
 }

--- a/app/src/org/commcare/connect/database/JobStoreManager.java
+++ b/app/src/org/commcare/connect/database/JobStoreManager.java
@@ -1,9 +1,7 @@
 package org.commcare.connect.database;
 
 import android.content.Context;
-import android.text.TextUtils;
 
-import org.commcare.CommCareApplication;
 import org.commcare.android.database.connect.models.ConnectAppRecord;
 import org.commcare.android.database.connect.models.ConnectJobAssessmentRecord;
 import org.commcare.android.database.connect.models.ConnectJobDeliveryRecord;
@@ -25,11 +23,11 @@ public class JobStoreManager {
     private final SqlStorage<ConnectLearnModuleSummaryRecord> moduleStorage;
     private final SqlStorage<ConnectPaymentUnitRecord> paymentUnitStorage;
 
-    public JobStoreManager(Context context) {
-        this.jobStorage = ConnectDatabaseHelper.getConnectStorage(context, ConnectJobRecord.class);
-        this.appInfoStorage = ConnectDatabaseHelper.getConnectStorage(context, ConnectAppRecord.class);
-        this.moduleStorage = ConnectDatabaseHelper.getConnectStorage(context, ConnectLearnModuleSummaryRecord.class);
-        this.paymentUnitStorage = ConnectDatabaseHelper.getConnectStorage(context, ConnectPaymentUnitRecord.class);
+    public JobStoreManager() {
+        this.jobStorage = ConnectDatabaseHelper.getConnectStorage(ConnectJobRecord.class);
+        this.appInfoStorage = ConnectDatabaseHelper.getConnectStorage(ConnectAppRecord.class);
+        this.moduleStorage = ConnectDatabaseHelper.getConnectStorage(ConnectLearnModuleSummaryRecord.class);
+        this.paymentUnitStorage = ConnectDatabaseHelper.getConnectStorage(ConnectPaymentUnitRecord.class);
     }
 
     public int storeJobs(Context context, List<ConnectJobRecord> jobs, boolean pruneMissing) {
@@ -150,7 +148,8 @@ public class JobStoreManager {
         try {
             ConnectDatabaseHelper.connectDatabase.beginTransaction();
 
-            SqlStorage<ConnectJobRecord> connectJobStorage = ConnectDatabaseHelper.getConnectStorage(CommCareApplication.instance(), ConnectJobRecord.class);
+            SqlStorage<ConnectJobRecord> connectJobStorage = ConnectDatabaseHelper.getConnectStorage(
+                    ConnectJobRecord.class);
             Vector<ConnectJobRecord> connectJobRecords = connectJobStorage.getRecordsForValues(
                     new String[]{ConnectJobRecord.META_JOB_ID},
                     new Object[]{jobId});
@@ -158,42 +157,50 @@ public class JobStoreManager {
                 return; // UUID already up-to-date, no migration needed
             }
 
-            SqlStorage<ConnectAppRecord> appInfoStorage = ConnectDatabaseHelper.getConnectStorage(CommCareApplication.instance(), ConnectAppRecord.class);
+            SqlStorage<ConnectAppRecord> appInfoStorage = ConnectDatabaseHelper.getConnectStorage(
+                    ConnectAppRecord.class);
             Vector<ConnectAppRecord> existingAppInfos = appInfoStorage.getRecordsForValues(
                     new String[]{ConnectAppRecord.META_JOB_ID},
                     new Object[]{jobId});
 
-            SqlStorage<ConnectLearnModuleSummaryRecord> moduleStorage = ConnectDatabaseHelper.getConnectStorage(CommCareApplication.instance(), ConnectLearnModuleSummaryRecord.class);
+            SqlStorage<ConnectLearnModuleSummaryRecord> moduleStorage = ConnectDatabaseHelper.getConnectStorage(
+                    ConnectLearnModuleSummaryRecord.class);
             Vector<ConnectLearnModuleSummaryRecord> connectLearnModuleSummaryRecords = moduleStorage.getRecordsForValues(
                     new String[]{ConnectLearnModuleSummaryRecord.META_JOB_ID},
                     new Object[]{jobId});
 
-            SqlStorage<ConnectJobDeliveryRecord> deliveryStorage = ConnectDatabaseHelper.getConnectStorage(CommCareApplication.instance(), ConnectJobDeliveryRecord.class);
+            SqlStorage<ConnectJobDeliveryRecord> deliveryStorage = ConnectDatabaseHelper.getConnectStorage(
+                    ConnectJobDeliveryRecord.class);
             Vector<ConnectJobDeliveryRecord> deliveries = deliveryStorage.getRecordsForValues(
                     new String[]{ConnectJobDeliveryRecord.META_JOB_ID},
                     new Object[]{jobId});
 
-            SqlStorage<ConnectJobLearningRecord> learningStorage = ConnectDatabaseHelper.getConnectStorage(CommCareApplication.instance(), ConnectJobLearningRecord.class);
+            SqlStorage<ConnectJobLearningRecord> learningStorage = ConnectDatabaseHelper.getConnectStorage(
+                    ConnectJobLearningRecord.class);
             Vector<ConnectJobLearningRecord> learnings = learningStorage.getRecordsForValues(
                     new String[]{ConnectJobLearningRecord.META_JOB_ID},
                     new Object[]{jobId});
 
-            SqlStorage<ConnectJobPaymentRecord> paymentStorage = ConnectDatabaseHelper.getConnectStorage(CommCareApplication.instance(), ConnectJobPaymentRecord.class);
+            SqlStorage<ConnectJobPaymentRecord> paymentStorage = ConnectDatabaseHelper.getConnectStorage(
+                    ConnectJobPaymentRecord.class);
             Vector<ConnectJobPaymentRecord> payments = paymentStorage.getRecordsForValues(
                     new String[]{ConnectJobPaymentRecord.META_JOB_ID},
                     new Object[]{jobId});
 
-            SqlStorage<ConnectJobAssessmentRecord> assessmentStorage = ConnectDatabaseHelper.getConnectStorage(CommCareApplication.instance(), ConnectJobAssessmentRecord.class);
+            SqlStorage<ConnectJobAssessmentRecord> assessmentStorage = ConnectDatabaseHelper.getConnectStorage(
+                    ConnectJobAssessmentRecord.class);
             Vector<ConnectJobAssessmentRecord> assessments = assessmentStorage.getRecordsForValues(
                     new String[]{ConnectJobAssessmentRecord.META_JOB_ID},
                     new Object[]{jobId});
 
-            SqlStorage<ConnectPaymentUnitRecord> paymentUnitStorage = ConnectDatabaseHelper.getConnectStorage(CommCareApplication.instance(), ConnectPaymentUnitRecord.class);
+            SqlStorage<ConnectPaymentUnitRecord> paymentUnitStorage = ConnectDatabaseHelper.getConnectStorage(
+                    ConnectPaymentUnitRecord.class);
             Vector<ConnectPaymentUnitRecord> paymentUnitRecords = paymentUnitStorage.getRecordsForValues(
                     new String[]{ConnectPaymentUnitRecord.META_JOB_ID},
                     new Object[]{jobId});
 
-            SqlStorage<PushNotificationRecord> notificationStorage = ConnectDatabaseHelper.getConnectStorage(CommCareApplication.instance(), PushNotificationRecord.class);
+            SqlStorage<PushNotificationRecord> notificationStorage = ConnectDatabaseHelper.getConnectStorage(
+                    PushNotificationRecord.class);
             Vector<PushNotificationRecord> pushNotificationRecords = notificationStorage.getRecordsForValues(
                     new String[]{PushNotificationRecord.META_OPPORTUNITY_ID},
                     new Object[]{Integer.toString(jobId)});
@@ -349,6 +356,6 @@ public class JobStoreManager {
 
     private List<ConnectJobRecord> getCompositeJobs(Context context, int limit, SqlStorage<ConnectJobRecord> jobStorage) {
         // Placeholder for job retrieval logic
-        return ConnectJobUtils.getCompositeJobs(context, ConnectJobRecord.STATUS_ALL_JOBS, jobStorage);
+        return ConnectJobUtils.getCompositeJobs(ConnectJobRecord.STATUS_ALL_JOBS, jobStorage);
     }
 }

--- a/app/src/org/commcare/connect/database/NotificationRecordDatabaseHelper.kt
+++ b/app/src/org/commcare/connect/database/NotificationRecordDatabaseHelper.kt
@@ -8,7 +8,7 @@ import org.commcare.models.database.SqlStorage
 
 object NotificationRecordDatabaseHelper {
     private fun getStorage(context: Context): SqlStorage<PushNotificationRecord> =
-        ConnectDatabaseHelper.getConnectStorage(context, PushNotificationRecord::class.java)
+        ConnectDatabaseHelper.getConnectStorage(PushNotificationRecord::class.java)
 
     /**
      * Fetch all notifications

--- a/app/src/org/commcare/connect/network/connect/parser/ConnectReleaseTogglesParser.kt
+++ b/app/src/org/commcare/connect/network/connect/parser/ConnectReleaseTogglesParser.kt
@@ -1,6 +1,5 @@
 package org.commcare.connect.network.connect.parser
 
-import android.content.Context
 import org.commcare.android.database.connect.models.ConnectReleaseToggleRecord
 import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectAppDatabaseUtil
@@ -19,7 +18,7 @@ class ConnectReleaseTogglesParser : BaseApiResponseParser<List<ConnectReleaseTog
 
         return ConnectReleaseToggleRecord.releaseTogglesFromJson(responseJson).also {
             if (PersonalIdManager.getInstance().isloggedIn()) {
-                ConnectAppDatabaseUtil.storeReleaseToggles(anyInputObject as Context, it)
+                ConnectAppDatabaseUtil.storeReleaseToggles(it)
             }
         }
     }

--- a/app/src/org/commcare/connect/network/personalId/ConnectSsoHelper.java
+++ b/app/src/org/commcare/connect/network/personalId/ConnectSsoHelper.java
@@ -55,7 +55,7 @@ public class ConnectSsoHelper {
 
             @Override
             public void onSuccess(AuthInfo.TokenAuth tokenAuth) {
-                ConnectUserDatabaseUtil.storeUser(context, user);
+                ConnectUserDatabaseUtil.storeUser(user);
                 callback.tokenRetrieved(tokenAuth);
             }
         }.retrievePersonalIdToken(context, user);
@@ -126,23 +126,24 @@ public class ConnectSsoHelper {
         }.retrieveHqToken(context, hqUsername, personalIdToken);
     }
 
-    public static void discardTokens(Context context, String username) {
+    public static void discardTokens(String username) {
         String seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId();
 
         Logger.log(LogTypes.TYPE_MAINTENANCE, "Clearing SSO tokens");
 
         if (username != null) {
-            ConnectLinkedAppRecord appRecord = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(context, seatedAppId, username);
+            ConnectLinkedAppRecord appRecord = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
+                    seatedAppId, username);
             if (appRecord != null) {
                 appRecord.clearHqToken();
-                ConnectAppDatabaseUtil.storeApp(context, appRecord);
+                ConnectAppDatabaseUtil.storeApp(appRecord);
             }
         }
 
-        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(context);
+        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser();
         if (user != null) {
             user.clearConnectToken();
-            ConnectUserDatabaseUtil.storeUser(context, user);
+            ConnectUserDatabaseUtil.storeUser(user);
         }
     }
 

--- a/app/src/org/commcare/connect/network/personalId/parser/LinkHqWorkerResponseParser.kt
+++ b/app/src/org/commcare/connect/network/personalId/parser/LinkHqWorkerResponseParser.kt
@@ -16,7 +16,7 @@ class LinkHqWorkerResponseParser<T>(
     ): T {
         val appRecord: ConnectLinkedAppRecord = anyInputObject as ConnectLinkedAppRecord
         appRecord.setWorkerLinked(true)
-        ConnectAppDatabaseUtil.storeApp(context, appRecord)
+        ConnectAppDatabaseUtil.storeApp(appRecord)
         return true as T
     }
 }

--- a/app/src/org/commcare/connect/network/personalId/parser/RetrieveHqTokenResponseParser.kt
+++ b/app/src/org/commcare/connect/network/personalId/parser/RetrieveHqTokenResponseParser.kt
@@ -38,7 +38,7 @@ class RetrieveHqTokenResponseParser<T>(
 
             val seatedAppId = CommCareApplication.instance().getCurrentApp().getUniqueId()
             val ssoToken = SsoToken(token, expiration)
-            ConnectDatabaseHelper.storeHqToken(context, seatedAppId, hqUsername, ssoToken)
+            ConnectDatabaseHelper.storeHqToken(seatedAppId, hqUsername, ssoToken)
 
             return TokenAuth(token) as T
         } catch (e: JSONException) {

--- a/app/src/org/commcare/connect/network/personalId/parser/RetrieveWorkHistoryResponseParser.kt
+++ b/app/src/org/commcare/connect/network/personalId/parser/RetrieveWorkHistoryResponseParser.kt
@@ -22,7 +22,7 @@ class RetrieveWorkHistoryResponseParser<T>(
         val jsonObject = JSONObject(jsonText)
         val jsonArray = jsonObject.getJSONArray("credentials")
         val result = PersonalIdWorkHistory.fromJsonArray(jsonArray)
-        storeCredentialDataInTable(context, result)
+        storeCredentialDataInTable(result)
         return result as T
     }
 }

--- a/app/src/org/commcare/connect/repository/ConnectRepository.kt
+++ b/app/src/org/commcare/connect/repository/ConnectRepository.kt
@@ -220,8 +220,7 @@ class ConnectRepository
                     }
             }.flowOn(DispatcherProvider.io())
 
-        private fun getConnectUser(): ConnectUserRecord =
-            requireNotNull(ConnectUserDatabaseUtil.getUser()) { "No Connect user found" }
+        private fun getConnectUser(): ConnectUserRecord = requireNotNull(ConnectUserDatabaseUtil.getUser()) { "No Connect user found" }
 
         private suspend fun fetchOpportunitiesFromNetwork(): Result<List<ConnectJobRecord>> =
             networkClient.getConnectOpportunities(getConnectUser())

--- a/app/src/org/commcare/connect/repository/ConnectRepository.kt
+++ b/app/src/org/commcare/connect/repository/ConnectRepository.kt
@@ -1,10 +1,8 @@
 package org.commcare.connect.repository
 
-import android.content.Context
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
@@ -44,10 +42,10 @@ class ConnectRepository
             private var instance: ConnectRepository? = null
 
             @JvmStatic
-            fun getInstance(context: Context): ConnectRepository =
+            fun getInstance(): ConnectRepository =
                 instance ?: synchronized(this) {
                     instance ?: ConnectRepository(
-                        ConnectSyncPreferences.getInstance(context),
+                        ConnectSyncPreferences.getInstance(),
                         ConnectNetworkClient.getInstance(),
                     ).also { instance = it }
                 }
@@ -68,7 +66,6 @@ class ConnectRepository
                 policy = policy,
                 loadCache = {
                     getCompositeJobs(
-                        CommCareApplication.instance(),
                         ConnectJobRecord.STATUS_ALL_JOBS,
                         null,
                     )
@@ -87,7 +84,7 @@ class ConnectRepository
                 syncKey = SYNC_KEY_LEARNING_PREFIX + job.jobUUID,
                 forceRefresh = forceRefresh,
                 policy = policy,
-                loadCache = { getCompositeJob(CommCareApplication.instance(), job.jobUUID) },
+                loadCache = { getCompositeJob(job.jobUUID) },
                 networkCall = { fetchLearningProgressFromNetwork(job) },
                 onNetworkSuccess = { responseModel ->
                     responseModel.applyToJob(job, CommCareApplication.instance())
@@ -96,7 +93,7 @@ class ConnectRepository
                     }
                 },
                 onNetworkFailure = { FirebaseAnalyticsUtil.reportCccApiLearnProgress(false) },
-                mapToEmit = { _ -> getCompositeJob(CommCareApplication.instance(), job.jobUUID) },
+                mapToEmit = { _ -> getCompositeJob(job.jobUUID) },
             )
 
         fun getDeliveryProgress(
@@ -108,7 +105,7 @@ class ConnectRepository
                 syncKey = SYNC_KEY_DELIVERY_PREFIX + job.jobUUID,
                 forceRefresh = forceRefresh,
                 policy = policy,
-                loadCache = { getCompositeJob(CommCareApplication.instance(), job.jobUUID) },
+                loadCache = { getCompositeJob(job.jobUUID) },
                 networkCall = { fetchDeliveryProgressFromNetwork(job) },
                 onNetworkSuccess = { responseModel ->
                     val events = mutableSetOf<String?>()
@@ -119,7 +116,7 @@ class ConnectRepository
                     events.forEach { event -> FirebaseAnalyticsUtil.reportCccApiDeliveryProgress(true, event) }
                 },
                 onNetworkFailure = { FirebaseAnalyticsUtil.reportCccApiDeliveryProgress(false, null) },
-                mapToEmit = { _ -> getCompositeJob(CommCareApplication.instance(), job.jobUUID) },
+                mapToEmit = { _ -> getCompositeJob(job.jobUUID) },
             )
 
         fun startLearning(jobUUID: String): Flow<DataState<Unit>> =
@@ -140,7 +137,7 @@ class ConnectRepository
                 onNetworkSuccess = {
                     for (paymentConfirmation in paymentConfirmations) {
                         paymentConfirmation.payment.confirmed = paymentConfirmation.toConfirm
-                        ConnectJobUtils.storePayment(CommCareApplication.instance(), paymentConfirmation.payment)
+                        ConnectJobUtils.storePayment(paymentConfirmation.payment)
                     }
                     FirebaseAnalyticsUtil.reportCccApiPaymentConfirmation(true)
                 },
@@ -224,7 +221,7 @@ class ConnectRepository
             }.flowOn(DispatcherProvider.io())
 
         private fun getConnectUser(): ConnectUserRecord =
-            requireNotNull(ConnectUserDatabaseUtil.getUser(CommCareApplication.instance())) { "No Connect user found" }
+            requireNotNull(ConnectUserDatabaseUtil.getUser()) { "No Connect user found" }
 
         private suspend fun fetchOpportunitiesFromNetwork(): Result<List<ConnectJobRecord>> =
             networkClient.getConnectOpportunities(getConnectUser())

--- a/app/src/org/commcare/connect/repository/ConnectSyncPreferences.kt
+++ b/app/src/org/commcare/connect/repository/ConnectSyncPreferences.kt
@@ -2,6 +2,7 @@ package org.commcare.connect.repository
 
 import android.content.Context
 import android.content.SharedPreferences
+import org.commcare.CommCareApplication
 import java.util.Date
 
 /**
@@ -9,7 +10,7 @@ import java.util.Date
  * Stores per-endpoint last sync times and session start time for refresh policies.
  */
 class ConnectSyncPreferences(
-    context: Context,
+    context: Context = CommCareApplication.instance().applicationContext,
 ) {
     companion object {
         private const val PREFS_NAME = "connect_sync_prefs"
@@ -19,9 +20,9 @@ class ConnectSyncPreferences(
         @Volatile
         private var instance: ConnectSyncPreferences? = null
 
-        fun getInstance(context: Context): ConnectSyncPreferences =
+        fun getInstance(): ConnectSyncPreferences =
             instance ?: synchronized(this) {
-                instance ?: ConnectSyncPreferences(context.applicationContext).also {
+                instance ?: ConnectSyncPreferences().also {
                     instance = it
                 }
             }

--- a/app/src/org/commcare/connect/viewmodel/ConnectDeliveryHomeViewModel.kt
+++ b/app/src/org/commcare/connect/viewmodel/ConnectDeliveryHomeViewModel.kt
@@ -15,7 +15,7 @@ class ConnectDeliveryHomeViewModel(
     application: Application,
 ) : AndroidViewModel(application) {
     @VisibleForTesting
-    internal var repository: ConnectRepository = ConnectRepository.getInstance(application)
+    internal var repository: ConnectRepository = ConnectRepository.getInstance()
 
     private val _deliveryProgress = MutableLiveData<DataState<ConnectJobRecord>>()
     val deliveryProgress: LiveData<DataState<ConnectJobRecord>> = _deliveryProgress

--- a/app/src/org/commcare/connect/viewmodel/ConnectJobIntroViewModel.kt
+++ b/app/src/org/commcare/connect/viewmodel/ConnectJobIntroViewModel.kt
@@ -12,7 +12,7 @@ class ConnectJobIntroViewModel(
     application: Application,
     private val repository: ConnectRepository,
 ) : AndroidViewModel(application) {
-    constructor(application: Application) : this(application, ConnectRepository.getInstance(application))
+    constructor(application: Application) : this(application, ConnectRepository.getInstance())
 
     private val _startLearning = MutableLiveData<DataState<Unit>>()
     val startLearning: LiveData<DataState<Unit>> = _startLearning

--- a/app/src/org/commcare/connect/viewmodel/ConnectJobsListViewModel.kt
+++ b/app/src/org/commcare/connect/viewmodel/ConnectJobsListViewModel.kt
@@ -9,13 +9,12 @@ import kotlinx.coroutines.Job
 import org.commcare.android.database.connect.models.ConnectJobRecord
 import org.commcare.connect.repository.ConnectRepository
 import org.commcare.connect.repository.DataState
-import org.commcare.connect.repository.RefreshPolicy
 
 class ConnectJobsListViewModel(
     application: Application,
 ) : AndroidViewModel(application) {
     @VisibleForTesting
-    internal var repository: ConnectRepository = ConnectRepository.getInstance(application)
+    internal var repository: ConnectRepository = ConnectRepository.getInstance()
 
     private val _opportunities = MutableLiveData<DataState<List<ConnectJobRecord>>>()
     val opportunities: LiveData<DataState<List<ConnectJobRecord>>> = _opportunities

--- a/app/src/org/commcare/connect/viewmodel/ConnectLearningProgressViewModel.kt
+++ b/app/src/org/commcare/connect/viewmodel/ConnectLearningProgressViewModel.kt
@@ -15,7 +15,7 @@ class ConnectLearningProgressViewModel(
     application: Application,
 ) : AndroidViewModel(application) {
     @VisibleForTesting
-    internal var repository: ConnectRepository = ConnectRepository.getInstance(application)
+    internal var repository: ConnectRepository = ConnectRepository.getInstance()
 
     private val _learningProgress = MutableLiveData<DataState<ConnectJobRecord>>()
     val learningProgress: LiveData<DataState<ConnectJobRecord>> = _learningProgress

--- a/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
+++ b/app/src/org/commcare/connect/workers/ConnectHeartbeatWorker.kt
@@ -17,7 +17,7 @@ class ConnectHeartbeatWorker(
         if (!personalIdManager.isloggedIn()) {
             return Result.failure()
         }
-        val user = personalIdManager.getUser(applicationContext)
+        val user = personalIdManager.getUser()
 
         return suspendCoroutine { continuation ->
             object : PersonalIdApiHandler<Boolean>() {

--- a/app/src/org/commcare/connect/workers/ConnectReleaseTogglesWorker.kt
+++ b/app/src/org/commcare/connect/workers/ConnectReleaseTogglesWorker.kt
@@ -28,7 +28,7 @@ class ConnectReleaseTogglesWorker(
             return Result.failure()
         }
 
-        val user = personalIdManager.getUser(context)
+        val user = personalIdManager.getUser()
 
         return suspendCoroutine { continuation ->
             object : PersonalIdApiHandler<List<ConnectReleaseToggleRecord>>() {

--- a/app/src/org/commcare/fragments/base/BaseConnectFragment.kt
+++ b/app/src/org/commcare/fragments/base/BaseConnectFragment.kt
@@ -77,7 +77,7 @@ abstract class BaseConnectFragment<B : ViewBinding> :
 
     fun getLastSyncTime(): Date? {
         val endpoint = getEndpoint() ?: return null
-        return ConnectSyncPreferences.getInstance(requireContext()).getLastSyncTime(endpoint)
+        return ConnectSyncPreferences.getInstance().getLastSyncTime(endpoint)
     }
 
     override fun onCreateView(

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryPaymentFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryPaymentFragment.java
@@ -163,7 +163,7 @@ public class ConnectDeliveryPaymentFragment extends ConnectJobFragment<FragmentC
                 ConnectJobPaymentRecord payment,
                 boolean result
         ) {
-            ConnectRepository.getInstance(context).updatePaymentsConfirmedForJava(
+            ConnectRepository.getInstance().updatePaymentsConfirmedForJava(
                     Collections.singletonList(
                             new ConnectPaymentConfirmationModel(payment, result)
                     ),

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryProgressFragment.java
@@ -195,7 +195,7 @@ public class ConnectDeliveryProgressFragment extends ConnectJobFragment<Fragment
         }
 
         FirebaseAnalyticsUtil.reportCccPaymentConfirmationInteraction(true);
-        ConnectRepository.getInstance(requireContext()).updatePaymentsConfirmedForJava(
+        ConnectRepository.getInstance().updatePaymentsConfirmedForJava(
                 paymentsToConfirm,
                 (success, error) -> {
                     if (isAdded()) {

--- a/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectJobsListsFragment.java
@@ -211,7 +211,7 @@ public class ConnectJobsListsFragment extends BaseConnectFragment<FragmentConnec
             boolean isDeliverAppInstalled =
                     AppUtils.isAppInstalled(job.getDeliveryAppInfo().getAppId());
             ConnectJobRecord compositeJob =
-                    ConnectJobUtils.getCompositeJob(requireActivity(), job.getJobUUID());
+                    ConnectJobUtils.getCompositeJob(job.getJobUUID());
             Objects.requireNonNull(compositeJob);
             boolean userCompletedDelivery =
                     compositeJob.getStatus() == STATUS_DELIVERING &&
@@ -372,12 +372,11 @@ public class ConnectJobsListsFragment extends BaseConnectFragment<FragmentConnec
             ConnectJobRecord job,
             ConnectLoginJobListModel.JobListEntryType jobType
     ) {
-        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser(requireActivity());
+        ConnectUserRecord user = ConnectUserDatabaseUtil.getUser();
 
         String appId = getAppRecord(job, jobType).getAppId();
 
-        ConnectLinkedAppRecord appRecord = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(
-                requireActivity(), appId, user.getUserId());
+        ConnectLinkedAppRecord appRecord = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(appId, user.getUserId());
 
         return appRecord != null ? appRecord.getLastAccessed() : new Date();
     }

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.kt
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.kt
@@ -84,7 +84,7 @@ class ConnectLearningProgressFragment :
             binding.learnCompleteView.bind(
                 job,
                 latestCompletionDate(),
-                ConnectUserDatabaseUtil.getUser(requireContext()).name,
+                ConnectUserDatabaseUtil.getUser().name,
                 View.OnClickListener { onDeliveryCtaClicked() },
             )
         } else {

--- a/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
+++ b/app/src/org/commcare/fragments/connect/ConnectUnlockFragment.java
@@ -89,12 +89,12 @@ public class ConnectUnlockFragment extends Fragment {
     }
 
     private void retrieveOpportunities() {
-        ConnectRepository.getInstance(requireContext()).retrieveOpportunitiesForJava(
+        ConnectRepository.getInstance().retrieveOpportunitiesForJava(
                 (success, error) -> {
                     if (!isAdded()) return;
                     if (success && !ConnectJobUtils.getCompositeJobs(
-                            requireContext(), ConnectJobRecord.STATUS_ALL_JOBS, null).isEmpty()) {
-                        ConnectUserDatabaseUtil.turnOnConnectAccess(requireContext());
+                            ConnectJobRecord.STATUS_ALL_JOBS, null).isEmpty()) {
+                        ConnectUserDatabaseUtil.turnOnConnectAccess();
                     }
                     tryToLoadInvitedOpp(success);
                     setFragmentRedirection();
@@ -103,8 +103,7 @@ public class ConnectUnlockFragment extends Fragment {
     }
 
     private void tryToLoadInvitedOpp(boolean refreshSucceeded) {
-        ConnectJobRecord requested = ConnectJobUtils.getCompositeJob(
-                requireContext(), requestedOpportunityUuid);
+        ConnectJobRecord requested = ConnectJobUtils.getCompositeJob(requestedOpportunityUuid);
         if (requested == null) {
             String failure = refreshSucceeded ?
                     AnalyticsParamValue.OPP_INVITE_LINK_OPPORTUNITY_NOT_FOUND :

--- a/app/src/org/commcare/fragments/connectMessaging/ConnectMessageChannelListFragment.java
+++ b/app/src/org/commcare/fragments/connectMessaging/ConnectMessageChannelListFragment.java
@@ -73,7 +73,7 @@ public class ConnectMessageChannelListFragment extends Fragment {
         if (channelId != null) {
             getArguments().remove(CHANNEL_ID);
             ConnectMessagingChannelRecord channel =
-                    ConnectMessagingDatabaseHelper.getMessagingChannel(requireContext(), channelId);
+                    ConnectMessagingDatabaseHelper.getMessagingChannel(channelId);
             selectChannel(channel);
         }
     }

--- a/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
+++ b/app/src/org/commcare/fragments/connectMessaging/ConnectMessageFragment.java
@@ -82,7 +82,7 @@ public class ConnectMessageFragment extends Fragment {
         ConnectMessageFragmentArgs args = ConnectMessageFragmentArgs.fromBundle(getArguments());
         channelId = args.getChannelId();
 
-        channel = ConnectMessagingDatabaseHelper.getMessagingChannel(requireContext(), channelId);
+        channel = ConnectMessagingDatabaseHelper.getMessagingChannel(channelId);
 
         handleSendButtonListener();
         setChatAdapter();
@@ -297,7 +297,7 @@ public class ConnectMessageFragment extends Fragment {
         Context context = getContext();
         if (context != null) {
             List<ConnectMessagingMessageRecord> messages = ConnectMessagingDatabaseHelper
-                    .getMessagingMessagesForChannel(context, channelId);
+                    .getMessagingMessagesForChannel(channelId);
             List<ConnectMessageChatData> chats = new ArrayList<>();
 
             for (ConnectMessagingMessageRecord message : messages) {
@@ -467,7 +467,6 @@ public class ConnectMessageFragment extends Fragment {
                     if (!isAdded()) return;
 
                     channel = ConnectMessagingDatabaseHelper.getMessagingChannel(
-                            requireContext(),
                             channelId
                     );
                     activity.dismissProgressDialogForTask(

--- a/app/src/org/commcare/fragments/personalId/EmailHelper.kt
+++ b/app/src/org/commcare/fragments/personalId/EmailHelper.kt
@@ -11,7 +11,6 @@ import org.commcare.connect.network.personalId.PersonalIdApiHandler
 import org.commcare.dalvik.R
 import org.commcare.google.services.analytics.AnalyticsParamValue
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
-import org.commcare.personalId.PersonalIdRecoveryCompleter
 import org.commcare.utils.OtpAnalyticsMapper
 import org.commcare.utils.StringUtils
 
@@ -35,7 +34,7 @@ object EmailHelper {
         sessionData: PersonalIdSessionData?,
     ): Pair<String?, ConnectUserRecord?> =
         when (workflow) {
-            EmailWorkFlow.EXISTING_USER -> null to ConnectUserDatabaseUtil.getUser(activity)
+            EmailWorkFlow.EXISTING_USER -> null to ConnectUserDatabaseUtil.getUser()
             EmailWorkFlow.REGISTRATION, EmailWorkFlow.RECOVERY -> sessionData?.token to null
         }
 

--- a/app/src/org/commcare/fragments/personalId/PersonalIdEmailVerificationFragment.kt
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdEmailVerificationFragment.kt
@@ -193,9 +193,9 @@ class PersonalIdEmailVerificationFragment : BasePersonalIdFragment() {
     private fun onEmailVerified() {
         when (workflow) {
             EmailWorkFlow.EXISTING_USER -> {
-                val user = ConnectUserDatabaseUtil.getUser(requireActivity())
+                val user = ConnectUserDatabaseUtil.getUser()
                 user.email = enteredEmail
-                ConnectUserDatabaseUtil.storeUser(requireActivity(), user)
+                ConnectUserDatabaseUtil.storeUser(user)
                 showEmailAddedSuccessDialog()
             }
 

--- a/app/src/org/commcare/fragments/personalId/PersonalIdMessageFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdMessageFragment.java
@@ -17,24 +17,11 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 import org.commcare.activities.SettingsHelper;
 import org.commcare.activities.connect.viewmodel.PersonalIdSessionDataViewModel;
-import org.commcare.android.database.connect.models.ConnectReleaseToggleRecord;
 import org.commcare.android.database.connect.models.PersonalIdSessionData;
 import org.commcare.connect.ConnectConstants;
 import org.commcare.connect.PersonalIdManager;
-import org.commcare.connect.database.ConnectAppDatabaseUtil;
-import org.commcare.connect.database.ConnectDatabaseHelper;
-import org.commcare.connect.repository.ConnectSyncPreferences;
 import org.commcare.dalvik.databinding.ScreenPersonalidMessageBinding;
 import org.commcare.utils.GeoUtils;
-
-import androidx.annotation.NonNull;
-import androidx.lifecycle.ViewModelProvider;
-import androidx.navigation.NavDirections;
-import androidx.navigation.fragment.NavHostFragment;
-
-import java.util.List;
-
-import static android.app.Activity.RESULT_OK;
 
 public class PersonalIdMessageFragment extends BottomSheetDialogFragment {
     private String title;
@@ -155,6 +142,9 @@ public class PersonalIdMessageFragment extends BottomSheetDialogFragment {
                 GeoUtils.goToProperLocationSettingsScreen(activity);
                 activity.finish();
                 break;
+            case ConnectConstants.PERSONALID_RECOVERY_EMAIL_OTP_FAILED:
+                directions = navigateToBackupCode();
+                break;
             default:
                 NavHostFragment.findNavController(this).navigateUp();
                 break;
@@ -173,19 +163,6 @@ public class PersonalIdMessageFragment extends BottomSheetDialogFragment {
     }
 
     private void successFlow(Activity activity) {
-        PersonalIdManager.getInstance().setStatus(PersonalIdManager.PersonalIdStatus.LoggedIn);
-        ConnectDatabaseHelper.setRegistrationPhase(getActivity(), ConnectConstants.PERSONALID_NO_ACTIVITY);
-        storeFeatureReleaseToggles();
-        ConnectSyncPreferences.Companion.getInstance(activity).markSessionStart();
-        activity.setResult(RESULT_OK);
-        activity.finish();
-    }
-
-    private void storeFeatureReleaseToggles() {
-        List<ConnectReleaseToggleRecord> featureReleaseToggles =
-                personalIdSessionData.getFeatureReleaseToggles();
-        if (featureReleaseToggles != null) {
-            ConnectAppDatabaseUtil.storeReleaseToggles(requireContext(), featureReleaseToggles);
-        }
+        PersonalIdManager.getInstance().successFlow(activity, personalIdSessionData);
     }
 }

--- a/app/src/org/commcare/fragments/personalId/PersonalIdMessageFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdMessageFragment.java
@@ -115,7 +115,8 @@ public class PersonalIdMessageFragment extends BottomSheetDialogFragment {
         Activity activity = requireActivity();
         switch (callingClass) {
             case ConnectConstants.PERSONALID_REGISTRATION_SUCCESS, ConnectConstants.PERSONALID_RECOVERY_SUCCESS:
-                successFlow(activity);
+                activity.setResult(android.app.Activity.RESULT_OK);
+                activity.finish();
                 break;
             case ConnectConstants.PERSONALID_BIOMETRIC_ENROLL_FAIL:
                 SettingsHelper.launchSecuritySettings(activity);
@@ -160,9 +161,5 @@ public class PersonalIdMessageFragment extends BottomSheetDialogFragment {
 
     private NavDirections navigateToBackupCode() {
         return PersonalIdMessageFragmentDirections.actionPersonalidMessageToPersonalidBackupcode();
-    }
-
-    private void successFlow(Activity activity) {
-        PersonalIdManager.getInstance().successFlow(activity, personalIdSessionData);
     }
 }

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
@@ -156,7 +156,7 @@ public class PersonalIdPhotoCaptureFragment extends BasePersonalIdFragment {
         enableTakePhotoButton();
         disableSaveButton();
         personalIdSessionData.setPhotoBase64(photoAsBase64);
-        PersonalIdManager.getInstance().onAccountConfigurationSuccess(requireActivity(), personalIdSessionData);
+        PersonalIdManager.getInstance().onAccountConfigurationSuccess(personalIdSessionData);
         logAndShowAccountComplete();
     }
 

--- a/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragment.java
@@ -23,6 +23,7 @@ import org.commcare.activities.connect.viewmodel.PersonalIdSessionDataViewModel;
 import org.commcare.android.database.connect.models.ConnectUserRecord;
 import org.commcare.android.database.connect.models.PersonalIdSessionData;
 import org.commcare.connect.ConnectConstants;
+import org.commcare.connect.PersonalIdManager;
 import org.commcare.connect.database.ConnectDatabaseHelper;
 import org.commcare.connect.database.ConnectUserDatabaseUtil;
 import org.commcare.connect.network.base.PersonalIdOrConnectApiErrorHandler;
@@ -154,20 +155,9 @@ public class PersonalIdPhotoCaptureFragment extends BasePersonalIdFragment {
     private void onPhotoUploadSuccess(String photoAsBase64) {
         enableTakePhotoButton();
         disableSaveButton();
-        createAndSaveConnectUser(photoAsBase64);
+        personalIdSessionData.setPhotoBase64(photoAsBase64);
+        PersonalIdManager.getInstance().onAccountConfigurationSuccess(requireActivity(), personalIdSessionData);
         logAndShowAccountComplete();
-    }
-
-    private void createAndSaveConnectUser(String photoAsBase64) {
-        ConnectDatabaseHelper.handleReceivedDbPassphrase(requireActivity(), personalIdSessionData.getDbKey());
-        ConnectUserRecord user = new ConnectUserRecord(personalIdSessionData.getPhoneNumber(),
-                personalIdSessionData.getPersonalId(),
-                personalIdSessionData.getOauthPassword(), personalIdSessionData.getUserName(),
-                String.valueOf(personalIdSessionData.getBackupCode()), new Date(), photoAsBase64,
-                personalIdSessionData.getDemoUser(),personalIdSessionData.getRequiredLock(),
-                personalIdSessionData.getInvitedUser());
-        user.setEmail(personalIdSessionData.getEmail());
-        ConnectUserDatabaseUtil.storeUser(requireActivity(), user);
     }
 
     private void clearError() {

--- a/app/src/org/commcare/login/ConnectCredentialResolver.kt
+++ b/app/src/org/commcare/login/ConnectCredentialResolver.kt
@@ -15,7 +15,7 @@ class ConnectCredentialResolver(
         username: String,
         createIfNeeded: Boolean,
     ): ConnectLinkedAppRecord {
-        val existing = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(context, appId, username)
+        val existing = ConnectAppDatabaseUtil.getConnectLinkedAppRecord(appId, username)
         val record =
             existing ?: run {
                 if (!createIfNeeded) {
@@ -38,7 +38,6 @@ class ConnectCredentialResolver(
         username: String,
     ): ConnectLinkedAppRecord =
         ConnectAppDatabaseUtil.storeApp(
-            context,
             appId,
             username,
             true,

--- a/app/src/org/commcare/login/PostLoginSideEffects.kt
+++ b/app/src/org/commcare/login/PostLoginSideEffects.kt
@@ -16,7 +16,7 @@ import org.commcare.utils.CrashUtil
 internal class PostLoginSideEffects(
     private val context: Context,
     private val personalIdManager: PersonalIdManager = PersonalIdManager.getInstance(),
-    private val repository: ConnectRepository = ConnectRepository.getInstance(context),
+    private val repository: ConnectRepository = ConnectRepository.getInstance(),
 ) {
     suspend fun runOnSuccess(username: String): PostLoginOutcome {
         CrashUtil.registerUserData()

--- a/app/src/org/commcare/navdrawer/BaseDrawerController.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerController.kt
@@ -175,7 +175,7 @@ class BaseDrawerController(
             setSignedInState(true)
             binding.ivNotification.setImageResource(getNotificationIcon(activity))
 
-            val user = ConnectUserDatabaseUtil.getUser(activity)
+            val user = ConnectUserDatabaseUtil.getUser()
             binding.userName.text = user.name
             user.photo?.let { loadUserPhoto(it) }
 
@@ -187,7 +187,7 @@ class BaseDrawerController(
                 }
             binding.userImageOverlayIcon.setImageResource(userImageOverlayIconRes)
 
-            val hasConnectAccess = ConnectUserDatabaseUtil.hasConnectAccess(activity)
+            val hasConnectAccess = ConnectUserDatabaseUtil.hasConnectAccess()
 
             val items = ArrayList<NavDrawerItem>()
             if (hasConnectAccess) {
@@ -210,7 +210,7 @@ class BaseDrawerController(
 
             val unreadCount =
                 if (ConnectMessagingDatabaseHelper.getMessagingChannels(activity).isNotEmpty()) {
-                    ConnectMessagingDatabaseHelper.getUnviewedMessages(activity).size
+                    ConnectMessagingDatabaseHelper.getUnviewedMessages().size
                 } else {
                     0
                 }

--- a/app/src/org/commcare/network/CommcareRequestGenerator.java
+++ b/app/src/org/commcare/network/CommcareRequestGenerator.java
@@ -200,7 +200,7 @@ public class CommcareRequestGenerator implements CommcareRequestEndpoints {
     private void checkForTokenError(Response<ResponseBody> response, AuthInfo auth) {
         if(response.code() == 401 && auth instanceof AuthInfo.TokenAuth) {
             Logger.exception("Invalid HQ SSO token", new Exception("Invalid HQ token"));
-            ConnectSsoHelper.discardTokens(CommCareApplication.instance(), username);
+            ConnectSsoHelper.discardTokens(username);
         }
     }
 

--- a/app/src/org/commcare/personalId/PersonalIdRecoveryCompleter.kt
+++ b/app/src/org/commcare/personalId/PersonalIdRecoveryCompleter.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import org.commcare.CommCareNoficationManager
 import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.android.database.connect.models.PersonalIdSessionData
+import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.database.ConnectDatabaseHelper
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
@@ -26,24 +27,7 @@ object PersonalIdRecoveryCompleter {
         activity: Activity,
         sessionData: PersonalIdSessionData,
     ) {
-        ConnectDatabaseHelper.handleReceivedDbPassphrase(activity, sessionData.dbKey)
-
-        val user =
-            ConnectUserRecord(
-                sessionData.phoneNumber,
-                sessionData.personalId,
-                sessionData.oauthPassword,
-                sessionData.userName,
-                sessionData.backupCode,
-                Date(),
-                sessionData.photoBase64,
-                sessionData.demoUser ?: false,
-                sessionData.requiredLock,
-                sessionData.invitedUser,
-            )
-        user.email = sessionData.email
-        ConnectUserDatabaseUtil.storeUser(activity, user)
-
+        PersonalIdManager.getInstance().onAccountConfigurationSuccess(activity, sessionData)
         logRecoverySuccessResult()
         notifySecondDeviceLoginIfApplicable(activity, sessionData)
     }

--- a/app/src/org/commcare/personalId/PersonalIdRecoveryCompleter.kt
+++ b/app/src/org/commcare/personalId/PersonalIdRecoveryCompleter.kt
@@ -2,17 +2,13 @@ package org.commcare.personalId
 
 import android.app.Activity
 import org.commcare.CommCareNoficationManager
-import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.android.database.connect.models.PersonalIdSessionData
 import org.commcare.connect.PersonalIdManager
-import org.commcare.connect.database.ConnectDatabaseHelper
-import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
 import org.commcare.google.services.analytics.AnalyticsParamValue
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.NotificationUtil
 import org.javarosa.core.model.utils.DateUtils
-import java.util.Date
 
 /**
  * Finalises account recovery.
@@ -27,7 +23,7 @@ object PersonalIdRecoveryCompleter {
         activity: Activity,
         sessionData: PersonalIdSessionData,
     ) {
-        PersonalIdManager.getInstance().onAccountConfigurationSuccess(activity, sessionData)
+        PersonalIdManager.getInstance().onAccountConfigurationSuccess(sessionData)
         logRecoverySuccessResult()
         notifySecondDeviceLoginIfApplicable(activity, sessionData)
     }

--- a/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
+++ b/app/src/org/commcare/personalId/PersonalIdUnlocker.kt
@@ -70,7 +70,7 @@ object PersonalIdUnlocker {
 
         logBiometricInvalidations(activity)
         val bioManager = personalIdManager.getBiometricManager(activity)
-        val user = ConnectUserDatabaseUtil.getUser(activity)
+        val user = ConnectUserDatabaseUtil.getUser()
 
         val callbacks =
             object : BiometricPrompt.AuthenticationCallback() {

--- a/app/src/org/commcare/personalId/photo/PersonalIdPhotoUpdater.kt
+++ b/app/src/org/commcare/personalId/photo/PersonalIdPhotoUpdater.kt
@@ -90,11 +90,11 @@ class PersonalIdPhotoUpdater(
     }
 
     private fun uploadUserPhoto(photoBase64: String) {
-        val user = ConnectUserDatabaseUtil.getUser(activity)
+        val user = ConnectUserDatabaseUtil.getUser()
         object : PersonalIdApiHandler<Boolean>() {
             override fun onSuccess(success: Boolean) {
                 user.photo = photoBase64
-                ConnectUserDatabaseUtil.storeUser(activity, user)
+                ConnectUserDatabaseUtil.storeUser(user)
                 val toastMessage = activity.getString(R.string.personalid_user_photo_update_success)
                 Toast.makeText(activity, toastMessage, Toast.LENGTH_LONG).show()
                 this@PersonalIdPhotoUpdater.onSuccess(photoBase64)

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileBackupCodeFragment.kt
@@ -1,9 +1,7 @@
 package org.commcare.personalId.profile
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.Toast
 import androidx.navigation.fragment.findNavController
 import org.commcare.connect.database.ConnectUserDatabaseUtil
@@ -45,7 +43,7 @@ class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
     }
 
     private fun handleForgot() {
-        val email = ConnectUserDatabaseUtil.getUser(requireContext())?.email
+        val email = ConnectUserDatabaseUtil.getUser()?.email
         if (email != null) {
             findNavController().navigate(
                 PersonalIdProfileBackupCodeFragmentDirections
@@ -68,7 +66,7 @@ class PersonalIdProfileBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
 
     override fun handleBackupCodeSubmission() {
         val enteredCode = binding.backupCodeView.codeValue
-        val storedBackupCode = ConnectUserDatabaseUtil.getUser(requireContext())?.pin
+        val storedBackupCode = ConnectUserDatabaseUtil.getUser()?.pin
         if (enteredCode == storedBackupCode) {
             PersonalIdUserPreferences.clearBackupCodeLockout()
             findNavController().navigate(R.id.action_profile_backup_code_to_set_new_backup_code)

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileEditViewModel.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileEditViewModel.kt
@@ -17,7 +17,7 @@ class PersonalIdProfileEditViewModel(
     application: Application,
     private val savedStateHandle: SavedStateHandle,
 ) : AndroidViewModel(application) {
-    var user: ConnectUserRecord = ConnectUserDatabaseUtil.getUser(application)
+    var user: ConnectUserRecord = ConnectUserDatabaseUtil.getUser()
         private set
     val emailOtpTracker = AttemptTracker()
 
@@ -64,9 +64,9 @@ class PersonalIdProfileEditViewModel(
      * flows since this ViewModel was created (e.g. a photo update) are not clobbered.
      */
     fun commitProfileDetails() {
-        val storedUser = ConnectUserDatabaseUtil.getUser(getApplication())
+        val storedUser = ConnectUserDatabaseUtil.getUser()
         storedUser.name = currentName
-        ConnectUserDatabaseUtil.storeUser(getApplication(), storedUser)
+        ConnectUserDatabaseUtil.storeUser(storedUser)
         user = storedUser
     }
 

--- a/app/src/org/commcare/personalId/profile/PersonalIdProfileViewModel.kt
+++ b/app/src/org/commcare/personalId/profile/PersonalIdProfileViewModel.kt
@@ -13,7 +13,7 @@ class PersonalIdProfileViewModel(
     val profileDisplayModel: LiveData<PersonalIdProfileDisplayModel> = _profileDisplayModel
 
     fun loadProfile() {
-        val user = ConnectUserDatabaseUtil.getUser(getApplication())
+        val user = ConnectUserDatabaseUtil.getUser()
         _profileDisplayModel.value = PersonalIdProfileDisplayModel.fromUserRecord(getApplication(), user)
     }
 }

--- a/app/src/org/commcare/personalId/profile/SetNewBackupCodeFragment.kt
+++ b/app/src/org/commcare/personalId/profile/SetNewBackupCodeFragment.kt
@@ -48,7 +48,7 @@ class SetNewBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
     }
 
     private fun callSetBackupCodeApi(backupCode: String) {
-        val user = ConnectUserDatabaseUtil.getUser(requireContext())!!
+        val user = ConnectUserDatabaseUtil.getUser()!!
 
         object : PersonalIdApiHandler<Boolean>() {
             override fun onSuccess(data: Boolean) {
@@ -69,7 +69,7 @@ class SetNewBackupCodeFragment : BasePersonalIdBackupCodeFragment() {
         user: ConnectUserRecord,
     ) {
         user.pin = backupCode
-        ConnectUserDatabaseUtil.storeUser(requireContext(), user)
+        ConnectUserDatabaseUtil.storeUser(user)
         Toast
             .makeText(
                 requireContext(),

--- a/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
+++ b/app/src/org/commcare/pn/workers/NotificationsSyncWorker.kt
@@ -125,7 +125,7 @@ class NotificationsSyncWorker(
     private suspend fun syncOpportunities(): PNApiResponseStatus {
         var success = false
         ConnectRepository
-            .getInstance(appContext)
+            .getInstance()
             .getOpportunities(forceRefresh = true)
             .collect { state ->
                 when (state) {
@@ -153,7 +153,7 @@ class NotificationsSyncWorker(
         if (job == null) return handleNoConnectJob()
         var success = false
         ConnectRepository
-            .getInstance(appContext)
+            .getInstance()
             .syncJobProgress(job!!)
             .collect { state ->
                 when (state) {
@@ -198,7 +198,6 @@ class NotificationsSyncWorker(
         val opportunityUUID = notificationPayload?.get(OPPORTUNITY_UUID)
         if (!TextUtils.isEmpty(opportunityUUID)) {
             return ConnectJobUtils.getCompositeJob(
-                appContext,
                 opportunityUUID!!,
             )
         }

--- a/app/src/org/commcare/utils/FirebaseMessagingUtil.java
+++ b/app/src/org/commcare/utils/FirebaseMessagingUtil.java
@@ -298,7 +298,7 @@ public class FirebaseMessagingUtil {
              return null;
          }
 
-        ConnectUserDatabaseUtil.turnOnConnectAccess(context);
+        ConnectUserDatabaseUtil.turnOnConnectAccess();
         return switch (fcmMessageData.getAction()) {
             case CCC_MESSAGE -> handleCCCMessageChannelPushNotification(context, fcmMessageData,showNotification);
             case CCC_DEST_PAYMENTS -> handleCCCPaymentPushNotification(context, fcmMessageData,showNotification);

--- a/app/src/org/commcare/utils/PushNotificationApiHelper.kt
+++ b/app/src/org/commcare/utils/PushNotificationApiHelper.kt
@@ -72,7 +72,7 @@ object PushNotificationApiHelper {
     }
 
     private suspend fun callPushNotificationApi(context: Context): Result<List<PushNotificationRecord>> {
-        val user = ConnectUserDatabaseUtil.getUser(context)
+        val user = ConnectUserDatabaseUtil.getUser()
         return suspendCoroutine { continuation ->
 
             object : PersonalIdApiHandler<NotificationParseResult>() {
@@ -165,7 +165,7 @@ object PushNotificationApiHelper {
         if (savedNotificationIds.isEmpty()) {
             return true
         }
-        val user = ConnectUserDatabaseUtil.getUser(context)
+        val user = ConnectUserDatabaseUtil.getUser()
         return suspendCoroutine { continuation ->
             object : PersonalIdApiHandler<Boolean>() {
                 override fun onSuccess(result: Boolean) {

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -76,12 +76,14 @@ public class CommCareTestApplication extends CommCareApplication implements Test
     private String cachedUserPassword;
 
     private final ArrayList<Throwable> asyncExceptions = new ArrayList<>();
-    private boolean skipWorkManager = false;
 
     @Override
     public void onCreate() {
         // set if before calling super to initialte the dataChangeLogger correctly
         setExternalStorageState(Environment.MEDIA_MOUNTED);
+
+        // initialize work manager before super.onCreate() to avoid IllegalStateException when WorkManager is used in onCreate() of CommCareApplication
+        initWorkManager();
 
         super.onCreate();
 
@@ -338,7 +340,6 @@ public class CommCareTestApplication extends CommCareApplication implements Test
     }
 
     public void setSkipWorkManager() {
-        skipWorkManager = true;
     }
 
     @Override

--- a/app/unit-tests/src/org/commcare/CommCareTestApplication.java
+++ b/app/unit-tests/src/org/commcare/CommCareTestApplication.java
@@ -342,7 +342,7 @@ public class CommCareTestApplication extends CommCareApplication implements Test
     }
 
     @Override
-    public IDatabase getConnectDbOpenHelper(Context context) {
+    public IDatabase getConnectDbOpenHelper() {
         return new UnencryptedDatabaseAdapter(new DatabaseConnectOpenHelperMock(this));
     }
 

--- a/app/unit-tests/src/org/commcare/PushNotificationHelperTest.kt
+++ b/app/unit-tests/src/org/commcare/PushNotificationHelperTest.kt
@@ -1,6 +1,5 @@
 package org.commcare
 
-import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.Runs
 import io.mockk.every
@@ -25,7 +24,6 @@ import org.robolectric.annotation.Config
 @Config(application = CommCareTestApplication::class)
 @RunWith(AndroidJUnit4::class)
 class PushNotificationHelperTest {
-    private val context: Context = CommCareTestApplication.instance()
     private val longMessage = "A".repeat(70000)
     private val encryptedKey = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
     private val channelId = "channel-id"
@@ -89,7 +87,7 @@ class PushNotificationHelperTest {
         val mockStorage = mockk<SqlStorage<ConnectMessagingMessageRecord>>()
         mockkStatic(ConnectDatabaseHelper::class)
         every {
-            ConnectDatabaseHelper.getConnectStorage(context, ConnectMessagingMessageRecord::class.java)
+            ConnectDatabaseHelper.getConnectStorage(ConnectMessagingMessageRecord::class.java)
         } returns mockStorage
 
         every { mockStorage.write(capture(slot)) } just Runs
@@ -104,7 +102,6 @@ class PushNotificationHelperTest {
 
     private fun getStorage(): SqlStorage<ConnectMessagingMessageRecord> =
         ConnectDatabaseHelper.getConnectStorage(
-            context,
             ConnectMessagingMessageRecord::class.java,
         )
 

--- a/app/unit-tests/src/org/commcare/activities/HomeConnectJobProgressTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/HomeConnectJobProgressTest.kt
@@ -1,6 +1,5 @@
 package org.commcare.activities
 
-import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import org.commcare.activities.connect.ConnectActivity
 import org.commcare.android.database.connect.models.ConnectJobRecord
@@ -110,7 +109,7 @@ class HomeConnectJobProgressTest : BaseHomeScreenActivityTest() {
     private fun clickSyncButton(home: StandardHomeActivity) = clickHomeButton(home, Localization.get("home.sync"))
 
     private fun seatedJob(): ConnectJobRecord =
-        requireNotNull(ConnectJobUtils.getCompositeJob(ApplicationProvider.getApplicationContext(), JOB_UUID)) {
+        requireNotNull(ConnectJobUtils.getCompositeJob(JOB_UUID)) {
             "the seated job disappeared from the Connect DB"
         }
 

--- a/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/PushNotificationActivityTest.kt
@@ -98,7 +98,7 @@ class PushNotificationActivityTest {
         val user =
             ConnectUserRecord("", "test_user", "test_password", "", "", Date(), "", false, "", true)
         mockkStatic(ConnectUserDatabaseUtil::class)
-        every { ConnectUserDatabaseUtil.getUser(any()) } returns user
+        every { ConnectUserDatabaseUtil.getUser() } returns user
 
         mockkStatic(ConnectMessagingDatabaseHelper::class)
         every { ConnectMessagingDatabaseHelper.getMessagingChannels(any()) } returns emptyList()

--- a/app/unit-tests/src/org/commcare/android/tests/personalid/PersonalIdDrawerVisibilityTest.kt
+++ b/app/unit-tests/src/org/commcare/android/tests/personalid/PersonalIdDrawerVisibilityTest.kt
@@ -73,17 +73,17 @@ class PersonalIdDrawerVisibilityTest {
             ConnectUserDatabaseUtil::class,
         )
         every { ConnectDatabaseHelper.isDbBroken() } returns false
-        every { ConnectJobUtils.getAppRecord(any(), any()) } returns null
+        every { ConnectJobUtils.getAppRecord(any()) } returns null
         every { ConnectMessagingDatabaseHelper.getMessagingChannels(any()) } returns emptyList()
-        every { ConnectAppDatabaseUtil.getReleaseToggles(any()) } returns emptyList()
+        every { ConnectAppDatabaseUtil.getReleaseToggles() } returns emptyList()
 
         // The drawer header reads the signed-in user's name off getUser(). hasConnectAccess() is
         // stubbed rather than left to run its real body (which just re-reads getUser() and checks a
         // flag), because a MockK static mock throws on any method it wasn't told about, and the
         // drawer + setup + login paths all call it.
-        every { ConnectUserDatabaseUtil.getUser(any()) } returns
+        every { ConnectUserDatabaseUtil.getUser() } returns
             ConnectUserRecord("", "", "", "Test User", "", Date(), null, false, "", false)
-        every { ConnectUserDatabaseUtil.hasConnectAccess(any()) } returns false
+        every { ConnectUserDatabaseUtil.hasConnectAccess() } returns false
     }
 
     @After

--- a/app/unit-tests/src/org/commcare/android/util/ConnectTestUtils.kt
+++ b/app/unit-tests/src/org/commcare/android/util/ConnectTestUtils.kt
@@ -97,7 +97,7 @@ object ConnectTestUtils {
         createConnectDbFile()
         val user = ConnectUserRecord("", "", "", "Test User", "", Date(), null, false, "", hasConnectAccess)
         user.updateConnectToken("test-connect-token", daysFromNow(1))
-        ConnectUserDatabaseUtil.storeUser(context, user)
+        ConnectUserDatabaseUtil.storeUser(user)
         PersonalIdManager.getInstance().init(context)
     }
 
@@ -130,5 +130,5 @@ object ConnectTestUtils {
             ).apply { setLastUpdate(Date()) }
 
     private fun <T : Persistable> connectStorage(clazz: Class<T>) =
-        ConnectDatabaseHelper.getConnectStorage(ApplicationProvider.getApplicationContext(), clazz)
+        ConnectDatabaseHelper.getConnectStorage(clazz)
 }

--- a/app/unit-tests/src/org/commcare/android/util/ConnectTestUtils.kt
+++ b/app/unit-tests/src/org/commcare/android/util/ConnectTestUtils.kt
@@ -129,6 +129,5 @@ object ConnectTestUtils {
                 isLearning,
             ).apply { setLastUpdate(Date()) }
 
-    private fun <T : Persistable> connectStorage(clazz: Class<T>) =
-        ConnectDatabaseHelper.getConnectStorage(clazz)
+    private fun <T : Persistable> connectStorage(clazz: Class<T>) = ConnectDatabaseHelper.getConnectStorage(clazz)
 }

--- a/app/unit-tests/src/org/commcare/connect/EmailOfferHelperTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/EmailOfferHelperTest.kt
@@ -157,13 +157,13 @@ class EmailOfferHelperTest {
     // ---------- helpers ------------------------------------------------------------------
 
     private fun setEmailToggle(active: Boolean) {
-        every { ConnectAppDatabaseUtil.getReleaseToggles(any()) } returns
+        every { ConnectAppDatabaseUtil.getReleaseToggles() } returns
             listOf(buildToggle(emailOtpSlug, active))
     }
 
     private fun setUserEmail(email: String?) {
         val user = ConnectUserRecord().apply { setEmail(email) }
-        every { ConnectUserDatabaseUtil.getUser(any()) } returns user
+        every { ConnectUserDatabaseUtil.getUser() } returns user
     }
 
     private fun mockActivity(): CommCareActivity<*> {

--- a/app/unit-tests/src/org/commcare/connect/ReleaseToggleHelperTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/ReleaseToggleHelperTest.kt
@@ -102,7 +102,7 @@ class ReleaseToggleHelperTest {
 
     @Test
     fun `isToggleActive with context returns true when DB contains active toggle for slug`() {
-        every { ConnectAppDatabaseUtil.getReleaseToggles(context) } returns
+        every { ConnectAppDatabaseUtil.getReleaseToggles() } returns
             listOf(buildToggle("feature_a", active = true))
 
         assertTrue(ReleaseToggleHelper.isToggleActive(context, "feature_a"))
@@ -110,7 +110,7 @@ class ReleaseToggleHelperTest {
 
     @Test
     fun `isToggleActive with context returns false when DB contains inactive toggle for slug`() {
-        every { ConnectAppDatabaseUtil.getReleaseToggles(context) } returns
+        every { ConnectAppDatabaseUtil.getReleaseToggles() } returns
             listOf(buildToggle("feature_a", active = false))
 
         assertFalse(ReleaseToggleHelper.isToggleActive(context, "feature_a"))
@@ -118,7 +118,7 @@ class ReleaseToggleHelperTest {
 
     @Test
     fun `isToggleActive with context returns false when slug is missing from DB`() {
-        every { ConnectAppDatabaseUtil.getReleaseToggles(context) } returns
+        every { ConnectAppDatabaseUtil.getReleaseToggles() } returns
             listOf(buildToggle("other_feature", active = true))
 
         assertFalse(ReleaseToggleHelper.isToggleActive(context, "feature_a"))
@@ -126,14 +126,14 @@ class ReleaseToggleHelperTest {
 
     @Test
     fun `isToggleActive with context returns false when DB returns empty list`() {
-        every { ConnectAppDatabaseUtil.getReleaseToggles(context) } returns emptyList()
+        every { ConnectAppDatabaseUtil.getReleaseToggles() } returns emptyList()
 
         assertFalse(ReleaseToggleHelper.isToggleActive(context, "feature_a"))
     }
 
     @Test
     fun `isToggleActive with context returns false when DB returns null`() {
-        every { ConnectAppDatabaseUtil.getReleaseToggles(context) } returns null
+        every { ConnectAppDatabaseUtil.getReleaseToggles() } returns null
 
         assertFalse(ReleaseToggleHelper.isToggleActive(context, "feature_a"))
     }

--- a/app/unit-tests/src/org/commcare/connect/SmsInviteLinkFlowTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/SmsInviteLinkFlowTest.kt
@@ -233,7 +233,7 @@ class SmsInviteLinkFlowTest {
         assertTrue(connectIntent.getBooleanExtra(ConnectConstants.SHOW_LAUNCH_BUTTON, false))
         assertEquals(uuid, connectIntent.getStringExtra(ConnectConstants.OPPORTUNITY_UUID))
 
-        every { ConnectJobUtils.getCompositeJob(any(), eq(uuid)) } returns jobInDb
+        every { ConnectJobUtils.getCompositeJob(eq(uuid)) } returns jobInDb
 
         val connect =
             Robolectric

--- a/app/unit-tests/src/org/commcare/connect/database/ConnectTaskUtilsTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/database/ConnectTaskUtilsTest.kt
@@ -47,7 +47,7 @@ class ConnectTaskUtilsTest {
 
     private fun prefs() = ConnectJobUtils.getJobPreferences(jobUUID)
 
-    private fun storage() = ConnectDatabaseHelper.getConnectStorage(context, ConnectTaskRecord::class.java)
+    private fun storage() = ConnectDatabaseHelper.getConnectStorage(ConnectTaskRecord::class.java)
 
     private fun makeTask(
         taskId: String = "task-1",

--- a/app/unit-tests/src/org/commcare/connect/network/personalId/parser/ConnectReleaseTogglesParserTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/personalId/parser/ConnectReleaseTogglesParserTest.kt
@@ -36,7 +36,7 @@ class ConnectReleaseTogglesParserTest {
         mockkStatic(ConnectAppDatabaseUtil::class)
 
         // Mock the DB storage call so it doesn't try to access a real DB.
-        every { ConnectAppDatabaseUtil.storeReleaseToggles(any(), any()) } returns Unit
+        every { ConnectAppDatabaseUtil.storeReleaseToggles(any()) } returns Unit
     }
 
     @After
@@ -204,7 +204,7 @@ class ConnectReleaseTogglesParserTest {
         val result = parser.parse(200, inputStream, context)
 
         assertEquals(1, result.size)
-        verify(exactly = 1) { ConnectAppDatabaseUtil.storeReleaseToggles(context, result) }
+        verify(exactly = 1) { ConnectAppDatabaseUtil.storeReleaseToggles(result) }
     }
 
     @Test
@@ -216,7 +216,7 @@ class ConnectReleaseTogglesParserTest {
 
         //  the response is still parsed and returned, it just isn't persisted
         assertEquals(1, result.size)
-        verify(exactly = 0) { ConnectAppDatabaseUtil.storeReleaseToggles(any(), any()) }
+        verify(exactly = 0) { ConnectAppDatabaseUtil.storeReleaseToggles(any()) }
     }
 
     @Test

--- a/app/unit-tests/src/org/commcare/connect/network/personalId/parser/LinkHqWorkerResponseParserTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/personalId/parser/LinkHqWorkerResponseParserTest.kt
@@ -75,7 +75,7 @@ class LinkHqWorkerResponseParserTest {
 
         // Assert
         connectAppDatabaseMock.verify(
-            { ConnectAppDatabaseUtil.storeApp(context, appRecord) },
+            { ConnectAppDatabaseUtil.storeApp(appRecord) },
             times(1),
         )
     }

--- a/app/unit-tests/src/org/commcare/connect/network/personalId/parser/RetrieveHqTokenResponseParserTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/personalId/parser/RetrieveHqTokenResponseParserTest.kt
@@ -92,7 +92,6 @@ class RetrieveHqTokenResponseParserTest {
             mockedDb.verify(
                 {
                     ConnectDatabaseHelper.storeHqToken(
-                        eq(context),
                         eq(TEST_APP_ID),
                         eq(TEST_HQ_USERNAME),
                         ssoTokenCaptor.capture(),
@@ -118,7 +117,6 @@ class RetrieveHqTokenResponseParserTest {
             mockedDb.verify(
                 {
                     ConnectDatabaseHelper.storeHqToken(
-                        eq(context),
                         eq(TEST_APP_ID),
                         eq(TEST_HQ_USERNAME),
                         ssoTokenCaptor.capture(),
@@ -143,7 +141,6 @@ class RetrieveHqTokenResponseParserTest {
             mockedDb.verify(
                 {
                     ConnectDatabaseHelper.storeHqToken(
-                        eq(context),
                         eq(TEST_APP_ID),
                         eq(TEST_HQ_USERNAME),
                         ssoTokenCaptor.capture(),

--- a/app/unit-tests/src/org/commcare/connect/network/personalId/parser/RetrieveWorkHistoryResponseParserTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/network/personalId/parser/RetrieveWorkHistoryResponseParserTest.kt
@@ -2,20 +2,16 @@ package org.commcare.connect.network.personalId.parser
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.commcare.CommCareApplication
 import org.commcare.CommCareTestApplication
 import org.commcare.android.database.connect.models.PersonalIdWorkHistory
 import org.commcare.connect.database.ConnectAppDatabaseUtil
 import org.json.JSONException
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.MockedStatic
-import org.mockito.Mockito.eq
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.times
 import org.mockito.MockitoAnnotations
@@ -80,7 +76,7 @@ class RetrieveWorkHistoryResponseParserTest {
     ) {
         val listCaptor = ArgumentCaptor.forClass(List::class.java) as ArgumentCaptor<List<PersonalIdWorkHistory>>
         mockedUtil.verify(
-            { ConnectAppDatabaseUtil.storeCredentialDataInTable(eq(context), listCaptor.capture()) },
+            { ConnectAppDatabaseUtil.storeCredentialDataInTable(listCaptor.capture()) },
             times(1),
         )
 
@@ -187,7 +183,6 @@ class RetrieveWorkHistoryResponseParserTest {
                 ArgumentCaptor.forClass(List::class.java) as ArgumentCaptor<List<PersonalIdWorkHistory>>
             mockedUtil.verify({
                 ConnectAppDatabaseUtil.storeCredentialDataInTable(
-                    eq(context),
                     listCaptor.capture(),
                 )
             }, times(1))

--- a/app/unit-tests/src/org/commcare/connect/repository/ConnectRepositoryTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/repository/ConnectRepositoryTest.kt
@@ -50,7 +50,7 @@ class ConnectRepositoryTest {
         // Static mocks for database utilities
         mockkStatic(ConnectJobUtils::class)
         mockkStatic(ConnectUserDatabaseUtil::class)
-        every { ConnectUserDatabaseUtil.getUser(any()) } returns mockUser
+        every { ConnectUserDatabaseUtil.getUser() } returns mockUser
 
         repository = ConnectRepository(mockSyncPrefs, mockNetworkClient)
     }
@@ -63,7 +63,7 @@ class ConnectRepositoryTest {
     @Test
     fun testGetOpportunities_noCache_emitsLoadingThenSuccess() =
         runBlocking {
-            every { ConnectJobUtils.getCompositeJobs(any(), any(), any()) } returns emptyList()
+            every { ConnectJobUtils.getCompositeJobs(any(), any()) } returns emptyList()
             every { mockSyncPrefs.getLastSyncTime(any()) } returns null
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns false
             mockGetOpportunitiesSuccess()
@@ -83,7 +83,7 @@ class ConnectRepositoryTest {
     fun testGetOpportunities_withCache_shouldRefreshFalse_emitsCachedOnly() =
         runBlocking {
             val cachedJobs = listOf(mockk<ConnectJobRecord>())
-            every { ConnectJobUtils.getCompositeJobs(any(), any(), any()) } returns cachedJobs
+            every { ConnectJobUtils.getCompositeJobs(any(), any()) } returns cachedJobs
             every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns false
 
@@ -101,7 +101,7 @@ class ConnectRepositoryTest {
             val freshJobs = listOf(mockk<ConnectJobRecord>(), mockk())
             mockGetOpportunitiesSuccess(freshJobs)
 
-            every { ConnectJobUtils.getCompositeJobs(any(), any(), any()) } returns cachedJobs
+            every { ConnectJobUtils.getCompositeJobs(any(), any()) } returns cachedJobs
             every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
 
@@ -118,7 +118,7 @@ class ConnectRepositoryTest {
     fun testGetOpportunities_networkFailure_withCache_emitsError_withCachedData() =
         runBlocking {
             val cachedJobs = listOf(mockk<ConnectJobRecord>())
-            every { ConnectJobUtils.getCompositeJobs(any(), any(), any()) } returns cachedJobs
+            every { ConnectJobUtils.getCompositeJobs(any(), any()) } returns cachedJobs
             every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
             coEvery { mockNetworkClient.getConnectOpportunities(any()) } returns
@@ -135,7 +135,7 @@ class ConnectRepositoryTest {
     @Test
     fun testGetOpportunities_networkFailure_neverSynced_emitsError_withEmptyCachedData() =
         runBlocking {
-            every { ConnectJobUtils.getCompositeJobs(any(), any(), any()) } returns emptyList()
+            every { ConnectJobUtils.getCompositeJobs(any(), any()) } returns emptyList()
             every { mockSyncPrefs.getLastSyncTime(any()) } returns null
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
             coEvery { mockNetworkClient.getConnectOpportunities(any()) } returns
@@ -152,7 +152,7 @@ class ConnectRepositoryTest {
     fun testGetOpportunities_syncedEmptyList_emitsCached() =
         runBlocking {
             val syncTime = Date()
-            every { ConnectJobUtils.getCompositeJobs(any(), any(), any()) } returns emptyList()
+            every { ConnectJobUtils.getCompositeJobs(any(), any()) } returns emptyList()
             every { mockSyncPrefs.getLastSyncTime(any()) } returns syncTime
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns false
 
@@ -168,7 +168,7 @@ class ConnectRepositoryTest {
     fun testGetOpportunities_forceRefresh_bypassesShouldRefreshCheck() =
         runBlocking {
             val cachedJobs = listOf(mockk<ConnectJobRecord>())
-            every { ConnectJobUtils.getCompositeJobs(any(), any(), any()) } returns cachedJobs
+            every { ConnectJobUtils.getCompositeJobs(any(), any()) } returns cachedJobs
             every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns false
             val freshJobs = listOf(mockk<ConnectJobRecord>(), mockk())
@@ -185,7 +185,7 @@ class ConnectRepositoryTest {
     @Test
     fun testGetOpportunities_networkSuccess_storesLastSyncTime() =
         runBlocking {
-            every { ConnectJobUtils.getCompositeJobs(any(), any(), any()) } returns emptyList()
+            every { ConnectJobUtils.getCompositeJobs(any(), any()) } returns emptyList()
             every { mockSyncPrefs.getLastSyncTime(any()) } returns null
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
             mockGetOpportunitiesSuccess()
@@ -202,7 +202,7 @@ class ConnectRepositoryTest {
             val mockModel = mockk<LearningAppProgressResponseModel>(relaxed = true)
             every { mockModel.connectJobLearningRecords } returns emptyList()
             every { mockModel.connectJobAssessmentRecords } returns emptyList()
-            every { ConnectJobUtils.getCompositeJob(any(), any()) } returns mockJob
+            every { ConnectJobUtils.getCompositeJob(any()) } returns mockJob
             every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
             coEvery { mockNetworkClient.getLearningProgress(any(), any()) } returns Result.success(mockModel)
@@ -221,7 +221,7 @@ class ConnectRepositoryTest {
         runBlocking {
             val mockJob = mockk<ConnectJobRecord>(relaxed = true)
             val mockModel = DeliveryAppProgressResponseModel()
-            every { ConnectJobUtils.getCompositeJob(any(), any()) } returns mockJob
+            every { ConnectJobUtils.getCompositeJob(any()) } returns mockJob
             every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
             coEvery { mockNetworkClient.getDeliveryProgress(any(), any()) } returns Result.success(mockModel)
@@ -239,7 +239,7 @@ class ConnectRepositoryTest {
         runBlocking {
             val mockJob = mockk<ConnectJobRecord>(relaxed = true)
             val mockModel = DeliveryAppProgressResponseModel()
-            every { ConnectJobUtils.getCompositeJob(any(), any()) } returns mockJob
+            every { ConnectJobUtils.getCompositeJob(any()) } returns mockJob
             every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
             coEvery { mockNetworkClient.getDeliveryProgress(any(), any()) } returns Result.success(mockModel)
@@ -256,7 +256,7 @@ class ConnectRepositoryTest {
     fun testGetDeliveryProgress_networkFailure_withCache_emitsError() =
         runBlocking {
             val mockJob = mockk<ConnectJobRecord>(relaxed = true)
-            every { ConnectJobUtils.getCompositeJob(any(), any()) } returns mockJob
+            every { ConnectJobUtils.getCompositeJob(any()) } returns mockJob
             every { mockSyncPrefs.getLastSyncTime(any()) } returns Date()
             every { mockSyncPrefs.shouldRefresh(any(), any()) } returns true
             coEvery { mockNetworkClient.getDeliveryProgress(any(), any()) } returns
@@ -329,7 +329,7 @@ class ConnectRepositoryTest {
             val paymentRecord = mockk<ConnectJobPaymentRecord>(relaxed = true)
             val paymentConfirmation = ConnectPaymentConfirmationModel(paymentRecord, toConfirm = true)
             coEvery { mockNetworkClient.confirmPayments(any(), any()) } returns Result.success(Unit)
-            every { ConnectJobUtils.storePayment(any(), any()) } just Runs
+            every { ConnectJobUtils.storePayment(any()) } just Runs
 
             val emissions = repository.confirmPayments(listOf(paymentConfirmation)).toList()
 
@@ -337,7 +337,7 @@ class ConnectRepositoryTest {
             assertTrue(emissions[0] is DataState.Loading)
             assertTrue(emissions[1] is DataState.Success)
             verify { paymentRecord.confirmed = true }
-            verify { ConnectJobUtils.storePayment(any(), paymentRecord) }
+            verify { ConnectJobUtils.storePayment(paymentRecord) }
         }
 
     @Test

--- a/app/unit-tests/src/org/commcare/connect/repository/ConnectSyncPreferencesTest.kt
+++ b/app/unit-tests/src/org/commcare/connect/repository/ConnectSyncPreferencesTest.kt
@@ -23,8 +23,7 @@ class ConnectSyncPreferencesTest {
 
     @Before
     fun setup() {
-        context = ApplicationProvider.getApplicationContext()
-        syncPrefs = ConnectSyncPreferences.getInstance(context)
+        syncPrefs = ConnectSyncPreferences.getInstance()
         syncPrefs.clearAll()
     }
 

--- a/app/unit-tests/src/org/commcare/fragments/connect/BaseConnectJobIntroTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/BaseConnectJobIntroTest.kt
@@ -49,7 +49,7 @@ abstract class BaseConnectJobIntroTest {
         // real network call is made (which crashes background coroutines under Robolectric).
         mockkObject(ConnectRepository.Companion)
         val repository = mockk<ConnectRepository>(relaxed = true)
-        every { ConnectRepository.getInstance(any()) } returns repository
+        every { ConnectRepository.getInstance() } returns repository
         every { repository.getOpportunities(any(), any()) } returns emptyFlow()
 
         mockkStatic(FirebaseAnalyticsUtil::class)

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryDashboardFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryDashboardFragmentTest.kt
@@ -78,7 +78,7 @@ class ConnectDeliveryDashboardFragmentTest {
         PersonalIdManager.getInstance().status = PersonalIdManager.PersonalIdStatus.LoggedIn
         mockApi.start()
         mockApi.server.dispatcher = pathRoutingDispatcher()
-        ConnectSyncPreferences.getInstance(appContext).clearAll()
+        ConnectSyncPreferences.getInstance().clearAll()
 
         mockkStatic(MessageManager::class)
         every { MessageManager.retrieveMessages(any(), any()) } returns Unit
@@ -394,7 +394,7 @@ class ConnectDeliveryDashboardFragmentTest {
      */
     private fun awaitDeliverySync() {
         val syncKey = ConnectRepository.SYNC_KEY_DELIVERY_PREFIX + ConnectLearnJobTestData.JOB_UUID
-        val prefs = ConnectSyncPreferences.getInstance(appContext)
+        val prefs = ConnectSyncPreferences.getInstance()
         val deadline = System.currentTimeMillis() + SYNC_TIMEOUT_MS
 
         while (prefs.getLastSyncTime(syncKey) == null) {
@@ -485,7 +485,7 @@ class ConnectDeliveryDashboardFragmentTest {
                 status = ConnectJobRecord.STATUS_DELIVERING
             }
         ConnectJobUtils.storeJobs(appContext, listOf(seeded), true)
-        return ConnectJobUtils.getCompositeJob(appContext, ConnectLearnJobTestData.JOB_UUID)!!
+        return ConnectJobUtils.getCompositeJob(ConnectLearnJobTestData.JOB_UUID)!!
     }
 
     /**
@@ -511,7 +511,7 @@ class ConnectDeliveryDashboardFragmentTest {
                 true,
             )
         user.updateConnectToken("test-token", tomorrow())
-        ConnectUserDatabaseUtil.storeUser(appContext, user)
+        ConnectUserDatabaseUtil.storeUser(user)
     }
 
     private fun tomorrow(): Date = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 1) }.time

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryHomeFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryHomeFragmentTest.kt
@@ -82,7 +82,7 @@ class ConnectDeliveryHomeFragmentTest {
         every { job.status } returns ConnectJobRecord.STATUS_DELIVERING
 
         mockkStatic(ConnectJobUtils::class)
-        every { ConnectJobUtils.getCompositeJob(any(), eq(uuid)) } returns job
+        every { ConnectJobUtils.getCompositeJob(eq(uuid)) } returns job
         every { ConnectJobUtils.getPaymentsSortedByDate(any()) } returns emptyList()
 
         mockkStatic(MessageManager::class)
@@ -91,7 +91,7 @@ class ConnectDeliveryHomeFragmentTest {
         val mockRepository = mockk<ConnectRepository>(relaxed = true)
         every { mockRepository.getDeliveryProgress(any(), any(), any()) } returns flowOf(DataState.Loading)
         mockkObject(ConnectRepository.Companion)
-        every { ConnectRepository.getInstance(any()) } returns mockRepository
+        every { ConnectRepository.getInstance() } returns mockRepository
 
         mockkStatic(AppUtils::class)
         every { AppUtils.isAppInstalled(any()) } returns false

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryVisitsFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryVisitsFragmentTest.kt
@@ -80,7 +80,7 @@ class ConnectDeliveryVisitsFragmentTest {
         PersonalIdManager.getInstance().status = PersonalIdManager.PersonalIdStatus.LoggedIn
         mockApi.start()
         mockApi.server.dispatcher = pathRoutingDispatcher()
-        ConnectSyncPreferences.getInstance(appContext).clearAll()
+        ConnectSyncPreferences.getInstance().clearAll()
 
         mockkStatic(MessageManager::class)
         every { MessageManager.retrieveMessages(any(), any()) } returns Unit
@@ -393,7 +393,7 @@ class ConnectDeliveryVisitsFragmentTest {
      */
     private fun awaitDeliverySync() {
         val syncKey = ConnectRepository.SYNC_KEY_DELIVERY_PREFIX + ConnectLearnJobTestData.JOB_UUID
-        val prefs = ConnectSyncPreferences.getInstance(appContext)
+        val prefs = ConnectSyncPreferences.getInstance()
         val deadline = System.currentTimeMillis() + SYNC_TIMEOUT_MS
 
         while (prefs.getLastSyncTime(syncKey) == null) {
@@ -463,7 +463,7 @@ class ConnectDeliveryVisitsFragmentTest {
                 status = ConnectJobRecord.STATUS_DELIVERING
             }
         ConnectJobUtils.storeJobs(appContext, listOf(seeded), true)
-        return ConnectJobUtils.getCompositeJob(appContext, ConnectLearnJobTestData.JOB_UUID)!!
+        return ConnectJobUtils.getCompositeJob(ConnectLearnJobTestData.JOB_UUID)!!
     }
 
     /**
@@ -489,7 +489,7 @@ class ConnectDeliveryVisitsFragmentTest {
                 true,
             )
         user.updateConnectToken("test-token", tomorrow())
-        ConnectUserDatabaseUtil.storeUser(appContext, user)
+        ConnectUserDatabaseUtil.storeUser(user)
     }
 
     private fun tomorrow(): Date = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 1) }.time

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectJobIntroFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectJobIntroFragmentTest.kt
@@ -5,7 +5,6 @@ import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.material.button.MaterialButton
 import io.mockk.every
-import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import kotlinx.coroutines.flow.flow
@@ -188,7 +187,7 @@ class ConnectJobIntroFragmentTest : BaseConnectJobIntroTest() {
         every { AppUtils.isAppInstalled(any()) } returns false
 
         val jobUuidSlot = slot<String>()
-        val repo = ConnectRepository.getInstance(activity)
+        val repo = ConnectRepository.getInstance()
         every { repo.startLearning(capture(jobUuidSlot)) } returns
             flow {
                 emit(DataState.Success(Unit))
@@ -204,7 +203,7 @@ class ConnectJobIntroFragmentTest : BaseConnectJobIntroTest() {
         assertEquals(ConnectJobRecord.STATUS_LEARNING, job.status)
         assertEquals(
             ConnectJobRecord.STATUS_LEARNING,
-            ConnectJobUtils.getCompositeJob(activity, job.jobUUID)?.status,
+            ConnectJobUtils.getCompositeJob(job.jobUUID)?.status,
         )
         assertEquals(
             R.id.connect_downloading_fragment,
@@ -221,7 +220,6 @@ class ConnectJobIntroFragmentTest : BaseConnectJobIntroTest() {
         mockkStatic(ConnectDatabaseHelper::class)
         every { ConnectDatabaseHelper.dbExists() } returns true
         ConnectUserDatabaseUtil.storeUser(
-            activity,
             ConnectUserRecord(
                 "1234567890",
                 "test-user-id",

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectLearningProgressFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectLearningProgressFragmentTest.kt
@@ -182,7 +182,7 @@ class ConnectLearningProgressFragmentTest {
         assertEquals(ConnectJobRecord.STATUS_DELIVERING, job.status)
         assertEquals(
             ConnectJobRecord.STATUS_DELIVERING,
-            ConnectJobUtils.getCompositeJob(activity, job.jobUUID)?.status,
+            ConnectJobUtils.getCompositeJob(job.jobUUID)?.status,
         )
         assertEquals(R.id.connect_downloading_fragment, navController.currentDestination?.id)
     }
@@ -316,7 +316,7 @@ class ConnectLearningProgressFragmentTest {
                 true,
             )
         user.updateConnectToken("test-token", tomorrow())
-        ConnectUserDatabaseUtil.storeUser(context, user)
+        ConnectUserDatabaseUtil.storeUser(user)
     }
 
     private fun tomorrow(): Date = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 1) }.time

--- a/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdConfigurationTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdConfigurationTest.kt
@@ -19,6 +19,7 @@ import org.commcare.activities.connect.viewmodel.PersonalIdSessionDataViewModel
 import org.commcare.android.CommCareViewModelProvider
 import org.commcare.android.database.connect.models.PersonalIdSessionData
 import org.commcare.android.integrity.IntegrityTokenViewModel
+import org.commcare.connect.PersonalIdManager
 import org.commcare.connect.network.PersonalIdMockApiServer
 import org.commcare.dalvik.R
 import org.junit.After
@@ -74,6 +75,7 @@ abstract class BasePersonalIdConfigurationTest<T : BasePersonalIdFragment> {
         viewModelField.isAccessible = true
         viewModelField.set(null, null)
         mockApiServer.shutdown()
+        PersonalIdManager.clearInstance()
     }
 
     protected fun bootActivity() {

--- a/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdPhotoCaptureFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/BasePersonalIdPhotoCaptureFragmentTest.kt
@@ -14,9 +14,6 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import okhttp3.mockwebserver.MockResponse
 import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.android.database.connect.models.PersonalIdSessionData
-import org.commcare.connect.PersonalIdManager
-import org.commcare.connect.database.ConnectDatabaseHelper
-import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.MediaUtil
@@ -36,14 +33,8 @@ import org.robolectric.shadows.ShadowLooper
 abstract class BasePersonalIdPhotoCaptureFragmentTest : BasePersonalIdConfigurationTest<TestablePersonalIdPhotoCaptureFragment>() {
     protected lateinit var mocksCloseable: AutoCloseable
 
-    protected lateinit var personalIdManagerMock: MockedStatic<PersonalIdManager>
-    protected lateinit var connectDatabaseHelperMock: MockedStatic<ConnectDatabaseHelper>
-    protected lateinit var connectUserDatabaseUtilMock: MockedStatic<ConnectUserDatabaseUtil>
     protected lateinit var firebaseAnalyticsUtilMock: MockedStatic<FirebaseAnalyticsUtil>
     protected lateinit var mediaUtilMock: MockedStatic<MediaUtil>
-
-    @Mock
-    protected lateinit var mockPersonalIdManager: PersonalIdManager
 
     @Mock
     protected lateinit var mockBitmap: Bitmap
@@ -73,13 +64,6 @@ abstract class BasePersonalIdPhotoCaptureFragmentTest : BasePersonalIdConfigurat
     }
 
     private fun openStaticMocks() {
-        personalIdManagerMock = Mockito.mockStatic(PersonalIdManager::class.java)
-        personalIdManagerMock
-            .`when`<PersonalIdManager> { PersonalIdManager.getInstance() }
-            .thenReturn(mockPersonalIdManager)
-
-        connectDatabaseHelperMock = Mockito.mockStatic(ConnectDatabaseHelper::class.java)
-        connectUserDatabaseUtilMock = Mockito.mockStatic(ConnectUserDatabaseUtil::class.java)
         firebaseAnalyticsUtilMock = Mockito.mockStatic(FirebaseAnalyticsUtil::class.java)
         firebaseAnalyticsUtilMock
             .`when`<NavController.OnDestinationChangedListener> {
@@ -130,7 +114,7 @@ abstract class BasePersonalIdPhotoCaptureFragmentTest : BasePersonalIdConfigurat
 
     protected fun enqueueCompleteProfileSuccess(
         personalId: String = "test-personal-id",
-        dbKey: String = "test-db-key",
+        dbKey: String = "dGVzdC1kYi1rZXk=",
         oauthPassword: String = "test-oauth-pwd",
     ) {
         mockWebServer.enqueue(
@@ -168,9 +152,6 @@ abstract class BasePersonalIdPhotoCaptureFragmentTest : BasePersonalIdConfigurat
             { Intents.release() },
             { mediaUtilMock.close() },
             { firebaseAnalyticsUtilMock.close() },
-            { connectUserDatabaseUtilMock.close() },
-            { connectDatabaseHelperMock.close() },
-            { personalIdManagerMock.close() },
             { mocksCloseable.close() },
             { MockAndroidKeyStoreProvider.deregisterProvider() },
             { super.tearDown() },

--- a/app/unit-tests/src/org/commcare/fragments/personalId/EmailHelperTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/EmailHelperTest.kt
@@ -95,7 +95,7 @@ class EmailHelperTest {
 
         mockStatic(ConnectUserDatabaseUtil::class.java).use { mockedDb ->
             mockedDb
-                .`when`<ConnectUserRecord> { ConnectUserDatabaseUtil.getUser(activity) }
+                .`when`<ConnectUserRecord> { ConnectUserDatabaseUtil.getUser() }
                 .thenReturn(user)
 
             mockStatic(ApiPersonalId::class.java).use { mockApi ->
@@ -191,7 +191,7 @@ class EmailHelperTest {
 
         mockStatic(ConnectUserDatabaseUtil::class.java).use { mockedDb ->
             mockedDb
-                .`when`<ConnectUserRecord> { ConnectUserDatabaseUtil.getUser(activity) }
+                .`when`<ConnectUserRecord> { ConnectUserDatabaseUtil.getUser() }
                 .thenReturn(user)
 
             mockStatic(ApiPersonalId::class.java).use { mockApi ->

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentRecoveryTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentRecoveryTest.kt
@@ -10,21 +10,20 @@ import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.android.database.connect.models.PersonalIdSessionData
 import org.commcare.connect.ConnectConstants
 import org.commcare.connect.database.ConnectDatabaseHelper
-import org.commcare.connect.database.ConnectUserDatabaseUtil
+import org.commcare.connect.database.ConnectDatabaseUtils
 import org.commcare.dalvik.R
+import org.commcare.utils.MockAndroidKeyStoreProvider
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
-import org.mockito.MockedStatic
-import org.mockito.Mockito
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 
@@ -34,23 +33,17 @@ import org.robolectric.annotation.Config
 @Config(application = CommCareTestApplication::class)
 @RunWith(AndroidJUnit4::class)
 class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmentTest() {
-    private lateinit var connectDatabaseHelperMock: MockedStatic<ConnectDatabaseHelper>
-    private lateinit var connectUserDatabaseUtilMock: MockedStatic<ConnectUserDatabaseUtil>
-
     @Before
     override fun setUp() {
+        MockAndroidKeyStoreProvider.registerProvider()
         super.setUp()
         launchBackupCodeFragment(buildSessionData(accountExists = true, photoBase64 = TEST_PHOTO_BASE64))
-        // Recovery success writes the account to the DB; stub those statics so no real storage is touched.
-        connectDatabaseHelperMock = Mockito.mockStatic(ConnectDatabaseHelper::class.java)
-        connectUserDatabaseUtilMock = Mockito.mockStatic(ConnectUserDatabaseUtil::class.java)
     }
 
     @After
     override fun tearDown() {
         super.tearDown()
-        connectUserDatabaseUtilMock.close()
-        connectDatabaseHelperMock.close()
+        MockAndroidKeyStoreProvider.deregisterProvider()
     }
 
     // ========== Initial State ==========
@@ -148,21 +141,15 @@ class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmen
         enterBackupCode(TEST_BACKUP_CODE)
         drainHttp()
 
-        connectDatabaseHelperMock.verify {
-            ConnectDatabaseHelper.handleReceivedDbPassphrase(Mockito.eq("test-db-key"))
-        }
+        assertArrayEquals("test-db-key".toByteArray(), ConnectDatabaseUtils.getConnectDbPassphrase())
 
-        val userCaptor = ArgumentCaptor.forClass(ConnectUserRecord::class.java)
-        connectUserDatabaseUtilMock.verify {
-            ConnectUserDatabaseUtil.storeUser(userCaptor.capture())
-        }
-        val storedUser = userCaptor.value
-        assertEquals(TEST_USER_NAME, storedUser.name)
+        val storedUser = storedUser()
+        assertNotNull(storedUser)
+        assertEquals(TEST_USER_NAME, storedUser!!.name)
         assertEquals("test-personal-id", storedUser.userId)
         assertEquals(TEST_PHONE_NUMBER, storedUser.primaryPhone)
         assertEquals(TEST_PHOTO_BASE64, storedUser.photo)
         assertEquals(PersonalIdSessionData.PIN, storedUser.requiredLock)
-        // Recovery never writes the entered code onto the session data, so the stored record has no pin.
         assertEquals(TEST_BACKUP_CODE, storedUser.pin)
 
         assertMessageDisplay(
@@ -189,7 +176,7 @@ class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmen
                 .arguments
                 ?.getSerializable("workflow"),
         )
-        connectUserDatabaseUtilMock.verifyNoInteractions()
+        assertNull("User should not be stored before email verification completes", storedUser())
     }
 
     @Test
@@ -200,9 +187,7 @@ class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmen
         enterBackupCode(TEST_BACKUP_CODE)
         drainHttp()
 
-        connectUserDatabaseUtilMock.verify {
-            ConnectUserDatabaseUtil.storeUser(Mockito.any())
-        }
+        assertNotNull("User should be stored after recovery success", storedUser())
         assertMessageDisplay(
             title = fragment.getString(R.string.connect_recovery_success_title),
             message = fragment.getString(R.string.connect_recovery_success_message),
@@ -225,7 +210,7 @@ class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmen
             message = fragment.getString(R.string.personalid_wrong_backup_message, 2),
             phase = ConnectConstants.PERSONALID_RECOVERY_WRONG_BACKUPCODE,
         )
-        connectUserDatabaseUtilMock.verifyNoInteractions()
+        assertNull("User should not be stored on a wrong code", storedUser())
     }
 
     @Test
@@ -296,11 +281,16 @@ class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmen
 
     // ========== Helpers ==========
 
+    private fun storedUser(): ConnectUserRecord? {
+        val iter = ConnectDatabaseHelper.getConnectStorage(ConnectUserRecord::class.java).iterator()
+        return if (iter.hasNext()) iter.next() else null
+    }
+
     private fun successResponse(email: String? = null): MockResponse {
         val body =
             JSONObject().apply {
                 put("username", "test-personal-id")
-                put("db_key", "test-db-key")
+                put("db_key", "dGVzdC1kYi1rZXk=")
                 put("password", "test-oauth-pwd")
                 if (email != null) put("email", email)
             }

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentRecoveryTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdBackupCodeFragmentRecoveryTest.kt
@@ -18,7 +18,6 @@ import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -150,12 +149,12 @@ class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmen
         drainHttp()
 
         connectDatabaseHelperMock.verify {
-            ConnectDatabaseHelper.handleReceivedDbPassphrase(Mockito.any(), Mockito.eq("test-db-key"))
+            ConnectDatabaseHelper.handleReceivedDbPassphrase(Mockito.eq("test-db-key"))
         }
 
         val userCaptor = ArgumentCaptor.forClass(ConnectUserRecord::class.java)
         connectUserDatabaseUtilMock.verify {
-            ConnectUserDatabaseUtil.storeUser(Mockito.any(), userCaptor.capture())
+            ConnectUserDatabaseUtil.storeUser(userCaptor.capture())
         }
         val storedUser = userCaptor.value
         assertEquals(TEST_USER_NAME, storedUser.name)
@@ -202,7 +201,7 @@ class PersonalIdBackupCodeFragmentRecoveryTest : BasePersonalIdBackupCodeFragmen
         drainHttp()
 
         connectUserDatabaseUtilMock.verify {
-            ConnectUserDatabaseUtil.storeUser(Mockito.any(), Mockito.any())
+            ConnectUserDatabaseUtil.storeUser(Mockito.any())
         }
         assertMessageDisplay(
             title = fragment.getString(R.string.connect_recovery_success_title),

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragmentTest.kt
@@ -174,12 +174,12 @@ class PersonalIdPhotoCaptureFragmentTest : BasePersonalIdPhotoCaptureFragmentTes
 
         // Verify
         connectDatabaseHelperMock.verify {
-            ConnectDatabaseHelper.handleReceivedDbPassphrase(Mockito.any(), Mockito.eq("test-db-key"))
+            ConnectDatabaseHelper.handleReceivedDbPassphrase(Mockito.eq("test-db-key"))
         }
 
         val userCaptor = ArgumentCaptor.forClass(ConnectUserRecord::class.java)
         connectUserDatabaseUtilMock.verify {
-            ConnectUserDatabaseUtil.storeUser(Mockito.any(), userCaptor.capture())
+            ConnectUserDatabaseUtil.storeUser(userCaptor.capture())
         }
         val storedUser = userCaptor.value
         assertEquals("Test User", storedUser.name)

--- a/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/personalId/PersonalIdPhotoCaptureFragmentTest.kt
@@ -13,20 +13,20 @@ import org.commcare.activities.camera.MicroImageActivity
 import org.commcare.android.database.connect.models.ConnectUserRecord
 import org.commcare.connect.ConnectConstants
 import org.commcare.connect.database.ConnectDatabaseHelper
-import org.commcare.connect.database.ConnectUserDatabaseUtil
+import org.commcare.connect.database.ConnectDatabaseUtils
 import org.commcare.dalvik.R
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.MediaUtil
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.allOf
 import org.json.JSONObject
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
 import org.mockito.Mockito
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
@@ -173,16 +173,11 @@ class PersonalIdPhotoCaptureFragmentTest : BasePersonalIdPhotoCaptureFragmentTes
         drainHttp()
 
         // Verify
-        connectDatabaseHelperMock.verify {
-            ConnectDatabaseHelper.handleReceivedDbPassphrase(Mockito.eq("test-db-key"))
-        }
+        assertArrayEquals("test-db-key".toByteArray(), ConnectDatabaseUtils.getConnectDbPassphrase())
 
-        val userCaptor = ArgumentCaptor.forClass(ConnectUserRecord::class.java)
-        connectUserDatabaseUtilMock.verify {
-            ConnectUserDatabaseUtil.storeUser(userCaptor.capture())
-        }
-        val storedUser = userCaptor.value
-        assertEquals("Test User", storedUser.name)
+        val storedUser = storedUser()
+        assertNotNull(storedUser)
+        assertEquals("Test User", storedUser!!.name)
         assertEquals("test-personal-id", storedUser.userId)
         assertEquals("fake-base64-photo", storedUser.photo)
         assertEquals("+11234567890", storedUser.primaryPhone)
@@ -257,6 +252,11 @@ class PersonalIdPhotoCaptureFragmentTest : BasePersonalIdPhotoCaptureFragmentTes
 
         assertTrue("Save button should re-enable on retryable failure", saveButton.isEnabled)
         assertTrue("Take photo button should re-enable on retryable failure", takeButton.isEnabled)
+    }
+
+    private fun storedUser(): ConnectUserRecord? {
+        val iter = ConnectDatabaseHelper.getConnectStorage(ConnectUserRecord::class.java).iterator()
+        return if (iter.hasNext()) iter.next() else null
     }
 
     @Test

--- a/app/unit-tests/src/org/commcare/login/ConnectCredentialResolverTest.kt
+++ b/app/unit-tests/src/org/commcare/login/ConnectCredentialResolverTest.kt
@@ -40,7 +40,7 @@ class ConnectCredentialResolverTest {
     fun `returns existing record password`() {
         val record = recordWith(password = "stored-pw", localPassphrase = false)
         every {
-            ConnectAppDatabaseUtil.getConnectLinkedAppRecord(context, "app-1", "alice")
+            ConnectAppDatabaseUtil.getConnectLinkedAppRecord("app-1", "alice")
         } returns record
 
         val result = resolver.resolve("app-1", "alice", createIfNeeded = false)
@@ -54,7 +54,7 @@ class ConnectCredentialResolverTest {
     fun `reports analytics when existing record uses local passphrase`() {
         val record = recordWith(password = "pw", localPassphrase = true)
         every {
-            ConnectAppDatabaseUtil.getConnectLinkedAppRecord(context, "app-1", "alice")
+            ConnectAppDatabaseUtil.getConnectLinkedAppRecord("app-1", "alice")
         } returns record
 
         resolver.resolve("app-1", "alice", createIfNeeded = false)
@@ -64,10 +64,10 @@ class ConnectCredentialResolverTest {
 
     @Test
     fun `creates a new record when createIfNeeded and none exists`() {
-        every { ConnectAppDatabaseUtil.getConnectLinkedAppRecord(context, "app-1", "alice") } returns null
+        every { ConnectAppDatabaseUtil.getConnectLinkedAppRecord("app-1", "alice") } returns null
         val created = recordWith(password = "generated", localPassphrase = true)
         every {
-            ConnectAppDatabaseUtil.storeApp(context, "app-1", "alice", true, any(), true)
+            ConnectAppDatabaseUtil.storeApp("app-1", "alice", true, any(), true)
         } returns created
 
         val result = resolver.resolve("app-1", "alice", createIfNeeded = true)
@@ -79,7 +79,7 @@ class ConnectCredentialResolverTest {
     @Test(expected = IllegalStateException::class)
     fun `throws when no record exists and createIfNeeded is false`() {
         every {
-            ConnectAppDatabaseUtil.getConnectLinkedAppRecord(context, "app-1", "alice")
+            ConnectAppDatabaseUtil.getConnectLinkedAppRecord("app-1", "alice")
         } returns null
         resolver.resolve("app-1", "alice", createIfNeeded = false)
     }
@@ -88,11 +88,11 @@ class ConnectCredentialResolverTest {
     fun `generated password is 20 characters in the documented alphabet`() {
         val passwordSlot = slot<String>()
         every {
-            ConnectAppDatabaseUtil.getConnectLinkedAppRecord(context, "app-1", "alice")
+            ConnectAppDatabaseUtil.getConnectLinkedAppRecord("app-1", "alice")
         } returns null
         val created = recordWith(password = "ignored", localPassphrase = true)
         every {
-            ConnectAppDatabaseUtil.storeApp(context, "app-1", "alice", true, capture(passwordSlot), true)
+            ConnectAppDatabaseUtil.storeApp("app-1", "alice", true, capture(passwordSlot), true)
         } returns created
 
         resolver.resolve("app-1", "alice", createIfNeeded = true)

--- a/app/unit-tests/src/org/commcare/personalId/profile/BasePersonalIdProfileTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/BasePersonalIdProfileTest.kt
@@ -15,7 +15,6 @@ import org.junit.After
 import org.junit.Before
 import org.mockito.MockedStatic
 import org.mockito.Mockito
-import org.mockito.kotlin.any
 import org.robolectric.Robolectric
 import org.robolectric.android.controller.ActivityController
 import org.robolectric.shadows.ShadowLooper
@@ -58,7 +57,7 @@ abstract class BasePersonalIdProfileTest {
                 email = "ada@example.com"
             }
         connectUserDatabaseUtilMock
-            .`when`<ConnectUserRecord> { ConnectUserDatabaseUtil.getUser(any()) }
+            .`when`<ConnectUserRecord> { ConnectUserDatabaseUtil.getUser() }
             .thenReturn(user)
         firebaseAnalyticsUtilMock = Mockito.mockStatic(FirebaseAnalyticsUtil::class.java)
         firebaseAnalyticsUtilMock

--- a/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/PersonalIdProfileEditFragmentTest.kt
@@ -158,7 +158,7 @@ class PersonalIdProfileEditFragmentTest : BasePersonalIdProfileTest() {
         mockApiServer.drainHttp()
 
         connectUserDatabaseUtilMock.verify {
-            ConnectUserDatabaseUtil.storeUser(any(), any())
+            ConnectUserDatabaseUtil.storeUser(any())
         }
         firebaseAnalyticsUtilMock.verify {
             FirebaseAnalyticsUtil.reportPersonalIdProfileAction(

--- a/app/unit-tests/src/org/commcare/personalId/profile/SetNewBackupCodeFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/personalId/profile/SetNewBackupCodeFragmentTest.kt
@@ -193,7 +193,7 @@ class SetNewBackupCodeFragmentTest : BasePersonalIdProfileTest() {
         performSuccessfulSave()
 
         connectUserDatabaseUtilMock.verify {
-            ConnectUserDatabaseUtil.storeUser(any(), any())
+            ConnectUserDatabaseUtil.storeUser(any())
         }
         assertEquals("654321", user.pin)
     }


### PR DESCRIPTION
## Product Description

No Product changes

## Technical Summary

Does some cleanups/refactors to localize the account creation in one place with 2 objectives - 

1. Decouple PersonalIDMessageFragment from any business logic -> Recovery should not depend on us showing a particular view to the user and also the successfully recovered message should be the final step in the process. 

2. Remove context coupling in the recovery pathway so that we don't need to pass the activity context into  the new PersonalID manager method `onAccountConfigurationSuccess`

Review Note: Commit by commit as amount of file changes are rather large otherwise to go as a whole. 

## Safety Assurance

### Safety story

Locally tested recovery workflow
We have tests that walk through recovery workflows, a bunch of commits in PR focuses on making them run more end to end through the code stack to provide more confidence into test coverage around these changes. 

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
