### PR TITLE
CI-920: Refresh side drawer on open

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -27,6 +27,7 @@ This file is meant as an easy way for us to collate notes and change logs across
 - Rotate the device on the login screen when no login is running, and after a login has failed and returned you to the login screen. No progress dialog should appear in either case.
 - While the login sync dialog is showing, press STOP. The dialog should close and you should be back on the login screen, and logging in again should work normally.
 - Regression check on progress dialogs generally, since the fix touches the shared activity base class: app update installs, form record loading, multimedia inflation and app verification should all still show and dismiss their progress dialogs correctly, including when backgrounded and resumed mid-task.
+- After signing in to PersonalID, including via account recovery, confirm the side drawer that opens immediately afterwards shows the signed-in profile and menu rather than the signed-out Sign In view.
 
 ## CommCare 2.63.5
 

--- a/app/src/org/commcare/navdrawer/BaseDrawerController.kt
+++ b/app/src/org/commcare/navdrawer/BaseDrawerController.kt
@@ -287,6 +287,8 @@ class BaseDrawerController(
     }
 
     fun openDrawer() {
+        refreshDrawerContent()
+        hasRefreshed = true
         binding.drawerLayout.openDrawer(GravityCompat.START)
     }
 

--- a/app/unit-tests/src/org/commcare/android/tests/personalid/PersonalIdDrawerVisibilityTest.kt
+++ b/app/unit-tests/src/org/commcare/android/tests/personalid/PersonalIdDrawerVisibilityTest.kt
@@ -1,6 +1,7 @@
 package org.commcare.android.tests.personalid
 
 import android.os.Build
+import android.view.View
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -22,6 +23,7 @@ import org.commcare.connect.database.ConnectMessagingDatabaseHelper
 import org.commcare.connect.database.ConnectUserDatabaseUtil
 import org.commcare.dalvik.R
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -205,6 +207,35 @@ class PersonalIdDrawerVisibilityTest {
         doReturn(false).whenever(spyManager).checkDeviceCompability()
         val activity = Robolectric.buildActivity(StandardHomeActivity::class.java).create().get()
         assertNotNull("Drawer should be set up if previously shown, regardless of Android version", activity.drawerAdapter)
+    }
+
+    // ======== Drawer content on a programmatic open ========
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    fun `programmatic open refreshes a stale signed out drawer`() {
+        // The drawer is built while PersonalId is signed out, as it is when account recovery starts
+        val activity = Robolectric.buildActivity(CommCareSetupActivity::class.java).create().get()
+        assertEquals(
+            "Drawer should start out showing the signed out state",
+            View.VISIBLE,
+            activity.findViewById<View>(R.id.signout_view).visibility,
+        )
+
+        // Recovery completes, and PersonalIdManager auto-opens the drawer
+        setLoggedIn(true)
+        activity.openDrawer()
+
+        assertEquals(
+            "Signed out view should be hidden once PersonalId is signed in",
+            View.GONE,
+            activity.findViewById<View>(R.id.signout_view).visibility,
+        )
+        assertEquals(
+            "Nav items should be shown once PersonalId is signed in",
+            View.VISIBLE,
+            activity.findViewById<View>(R.id.nav_drawer_recycler).visibility,
+        )
     }
 
     // ======== Helpers ========


### PR DESCRIPTION
[CI-920](https://dimagi.atlassian.net/browse/CI-920)

## Product Description
Fixes a bug where the side drawer would initially still show the signed out state for PersonalID after the user logged in (register or recovery), then show the logged in state after that (i.e. if the user dismissed and reopened the drawer).

## Technical Summary
The call to refreshDrawerContent depended on onDrawerSlide with a slideOffset > 0 at the time the drawer opens, but due to device differences this refresh could be skipped.
This PR adds a refresh directly in openDrawer, ensuring that the state is updated before the drawer opens (and flagging the refresh as done so it isn't performed twice).

## Safety Assurance

### Safety story
I tested and verified that everything still works as expected on my device.
I could not reproduce the original error on my device, but Conroy could and he verified that the issue is resolved.

### Automated test coverage
Added a unit test to verify the correct visibility state of the side drawer both before and after logging in to PersonalID.


[CI-920]: https://dimagi.atlassian.net/browse/CI-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ