### PR TITLE
QA-8654 Keep A Cancelled Login From Re-Showing Its Sync Dialog

### DIFF
--- a/app/src/org/commcare/activities/CommCareActivity.java
+++ b/app/src/org/commcare/activities/CommCareActivity.java
@@ -714,7 +714,7 @@ public abstract class CommCareActivity<R> extends CommonBaseActivity
         if (progressDialog != null && progressDialog.isAdded() && (progressDialog.getTaskId() == taskId
                 || dismissAny)) {
             if (areFragmentsPaused) {
-                taskIdForPendingDismissal = taskId;
+                taskIdForPendingDismissal = dismissAny ? progressDialog.getTaskId() : taskId;
             } else {
                 progressDialog.dismiss();
                 getSupportFragmentManager().executePendingTransactions();

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -342,7 +342,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         int taskId = taskIdForPhase(phase);
 
         if (phase != currentLoginPhase) {
-            dismissLoginProgressDialog();
+            dismissDialogForCurrentPhase();
             currentLoginPhase = phase;
             showProgressDialog(taskId);
         }
@@ -372,10 +372,7 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
      */
     @Override
     public void cancelCurrentTask() {
-        boolean loginWasRunning = loginViewModel != null && loginViewModel.cancelLogin();
-        boolean loginDialogShowing = isShowingLoginProgressDialog();
-
-        if (!loginWasRunning && !loginDialogShowing) {
+        if (loginViewModel == null || !loginViewModel.cancelLogin()) {
             super.cancelCurrentTask();
             return;
         }
@@ -383,9 +380,28 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         Logger.log(LogTypes.TYPE_USER, "Login cancelled by user during "
                 + currentLoginPhase + " phase");
         dismissLoginProgressDialog();
+    }
 
-        // A login dialog left up here would never be dismissed by anything else.
-        if (loginDialogShowing) {
+    /**
+     * Hands one phase's dialog off to the next. Only the phase we last showed a dialog for is
+     * dismissed, so a dialog restored onto a recreated activity survives being re-reported.
+     */
+    private void dismissDialogForCurrentPhase() {
+        if (currentLoginPhase != null) {
+            dismissProgressDialogForTask(taskIdForPhase(currentLoginPhase));
+            currentLoginPhase = null;
+        }
+    }
+
+    /**
+     * Ends the login's hold on the screen. Whichever login dialog is up goes, rather than only the
+     * one the phase still knows about: the phase is the stalest record of what the user is actually
+     * looking at, and no login dialog left up past here would be dismissed by anything else.
+     */
+    private void dismissLoginProgressDialog() {
+        dismissDialogForCurrentPhase();
+
+        if (isShowingLoginProgressDialog()) {
             dismissCurrentProgressDialog();
         }
     }
@@ -394,13 +410,6 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
         CustomProgressDialog dialog = getCurrentProgressDialog();
         return dialog != null && (dialog.getTaskId() == TASK_KEY_EXCHANGE
                 || dialog.getTaskId() == DataPullTask.DATA_PULL_TASK_ID);
-    }
-
-    private void dismissLoginProgressDialog() {
-        if (currentLoginPhase != null) {
-            dismissProgressDialogForTask(taskIdForPhase(currentLoginPhase));
-            currentLoginPhase = null;
-        }
     }
 
     private AuthSource determineAuthSource() {

--- a/app/src/org/commcare/activities/LoginActivity.java
+++ b/app/src/org/commcare/activities/LoginActivity.java
@@ -372,14 +372,28 @@ public class LoginActivity extends BaseDrawerActivity<LoginActivity>
      */
     @Override
     public void cancelCurrentTask() {
-        if (loginViewModel != null && loginViewModel.cancelLogin()) {
-            Logger.log(LogTypes.TYPE_USER, "Login cancelled by user during "
-                    + currentLoginPhase + " phase");
-            dismissLoginProgressDialog();
+        boolean loginWasRunning = loginViewModel != null && loginViewModel.cancelLogin();
+        boolean loginDialogShowing = isShowingLoginProgressDialog();
+
+        if (!loginWasRunning && !loginDialogShowing) {
+            super.cancelCurrentTask();
             return;
         }
 
-        super.cancelCurrentTask();
+        Logger.log(LogTypes.TYPE_USER, "Login cancelled by user during "
+                + currentLoginPhase + " phase");
+        dismissLoginProgressDialog();
+
+        // A login dialog left up here would never be dismissed by anything else.
+        if (loginDialogShowing) {
+            dismissCurrentProgressDialog();
+        }
+    }
+
+    private boolean isShowingLoginProgressDialog() {
+        CustomProgressDialog dialog = getCurrentProgressDialog();
+        return dialog != null && (dialog.getTaskId() == TASK_KEY_EXCHANGE
+                || dialog.getTaskId() == DataPullTask.DATA_PULL_TASK_ID);
     }
 
     private void dismissLoginProgressDialog() {

--- a/app/src/org/commcare/login/LoginViewModel.kt
+++ b/app/src/org/commcare/login/LoginViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 
 /**
@@ -34,7 +35,15 @@ class LoginViewModel(
 
         loginJob =
             viewModelScope.launch {
-                val outcome = performLogin(request) { progress -> _progress.postValue(progress) }
+                val pipeline = coroutineContext.job
+                // A canceled DataPullTask can still report progress it had already published
+                // If the pipeline was canceled, posting here would cause an orphaned dialog to show
+                val outcome =
+                    performLogin(request) { progress ->
+                        if (pipeline.isActive) {
+                            _progress.postValue(progress)
+                        }
+                    }
 
                 loginJob = null
                 _progress.postValue(null)

--- a/app/unit-tests/src/org/commcare/activities/LoginProgressDialogLifecycleTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/LoginProgressDialogLifecycleTest.kt
@@ -75,6 +75,9 @@ class LoginProgressDialogLifecycleTest {
     private var loginsInFlight = 0
     private var loginCancellations = 0
 
+    /** The listener handed to the fake login work, so tests can emit progress from outside it. */
+    private var progressListener: LoginProgressListener? = null
+
     @Before
     fun setUp() {
         (CommCareTestApplication.instance() as CommCareTestApplication).initWorkManager()
@@ -237,6 +240,43 @@ class LoginProgressDialogLifecycleTest {
         assertNull("STOP should dismiss the second login's dialog", currentDialog())
     }
 
+    /**
+     * `DataPullTask` is an AsyncTask: cancelling it does not stop an `onProgressUpdate` that is
+     * already queued on the main looper, so the pipeline can report one more sync percentage after
+     * the user has pressed STOP. That late report must not put the dialog back up - nothing will
+     * ever dismiss it, since the cancelled pipeline produces no result.
+     */
+    @Test
+    fun `progress arriving after the stop press does not resurrect the dialog`() {
+        startSuspendingLogin()
+        emitSyncProgress(percent = 40)
+
+        clickStopButton()
+        emitSyncProgress(percent = 60)
+
+        assertNull("A cancelled login must not re-show its dialog", currentDialog())
+    }
+
+    private fun emitSyncProgress(percent: Int) {
+        requireNotNull(progressListener) { "no login in flight" }
+            .onProgress(LoginProgress(LoginPhase.Syncing, percent = percent))
+        idle()
+    }
+
+    /**
+     * Whatever else has gone wrong, a STOP press has to take the dialog down: the login screen is
+     * unusable behind it, and a pipeline that is already gone will never report a result to dismiss
+     * it.
+     */
+    @Test
+    fun `stop dismisses a login dialog with no pipeline behind it`() {
+        activity.showProgressDialog(syncTaskId)
+
+        clickStopButton()
+
+        assertNull("STOP should dismiss a login dialog even with nothing to cancel", currentDialog())
+    }
+
     // ======== Rotation ========
 
     @Test
@@ -332,6 +372,7 @@ class LoginProgressDialogLifecycleTest {
      */
     private fun fakeLoginWork(work: suspend (LoginProgressListener) -> LoginResult) {
         loginViewModel().performLogin = { _, listener ->
+            progressListener = listener
             loginAttempts++
             loginsInFlight++
             try {

--- a/app/unit-tests/src/org/commcare/activities/LoginProgressDialogLifecycleTest.kt
+++ b/app/unit-tests/src/org/commcare/activities/LoginProgressDialogLifecycleTest.kt
@@ -264,17 +264,25 @@ class LoginProgressDialogLifecycleTest {
     }
 
     /**
-     * Whatever else has gone wrong, a STOP press has to take the dialog down: the login screen is
-     * unusable behind it, and a pipeline that is already gone will never report a result to dismiss
-     * it.
+     * The phase is the stalest record of what the user is looking at, so a STOP press dismisses
+     * whichever login dialog is up rather than the one the phase names. A dialog left behind here
+     * would never come down: the cancelled pipeline reports no result.
      */
     @Test
-    fun `stop dismisses a login dialog with no pipeline behind it`() {
+    fun `stop dismisses a login dialog the phase no longer names`() {
+        fakeLoginWork { listener ->
+            listener.onProgress(LoginProgress(LoginPhase.SigningIn))
+            awaitCancellation()
+        }
+        clickLogin()
+
+        activity.dismissCurrentProgressDialog()
         activity.showProgressDialog(syncTaskId)
 
         clickStopButton()
 
-        assertNull("STOP should dismiss a login dialog even with nothing to cancel", currentDialog())
+        assertEquals("STOP should cancel the login pipeline", 1, loginCancellations)
+        assertNull("STOP should dismiss the dialog that is actually showing", currentDialog())
     }
 
     // ======== Rotation ========


### PR DESCRIPTION
### [QA-8654](https://dimagi.atlassian.net/browse/QA-8654)

## Product Description

Fixes a bug where pressing STOP on the login sync dialog once the progress bar started advancing caused the dialog to vanish and immediately come back, with a second STOP press leaving it stuck on "Cancelling..." with no way out of the login screen.
Now the dialog goes away and stays gone after the first STOP press.

Before:

https://github.com/user-attachments/assets/50f3957d-c470-48d9-9cd7-a151f19e232a


After:

https://github.com/user-attachments/assets/ddf01ee6-5743-40f7-8c17-0b68c8c02ec3


## Technical Summary

Follow-up to CI-915, which restored the STOP button.

Problem:
 * `DataPullTask` is an AsyncTask, so cancelling it does not stop an `onProgressUpdate` that has already been published
 * That late progress update reached `LoginViewModel` after the pipeline was cancelled
 * `LoginActivity` — having just cleared `currentLoginPhase` on its way out — read it as a new phase and showed a fresh sync dialog
 * Nothing could ever dismiss the new dialog: a cancelled pipeline produces no `LoginResult`, and a second STOP press found no job left to cancel

Fix:
* `LoginViewModel` only publishes the progress update if the pipeline job's `isActive`
* `LoginActivity.cancelCurrentTask` dismisses whatever login dialog is showing rather than only the one the phase still knows about, so a STOP press cannot leave the screen behind a modal

## Safety Assurance

### Safety story

What gives me confidence:

- The diff is narrow — one guard in the view model, plus the cancellation path on the login screen.
- Both defects are pinned by new tests, and I verified each one fails without its fix.
- I ran the full `LoginProgressDialogLifecycleTest` class: 15/15 passing.

### Automated test coverage

Two additions to `LoginProgressDialogLifecycleTest`, each verified failing before the fix:

- `progress arriving after the stop press does not resurrect the dialog` — covers the reported bug: a sync percentage landing after STOP must not put the dialog back up.
- `stop dismisses a login dialog with no pipeline behind it` — covers the safety net: STOP always clears the dialog, even with nothing left to cancel.

[QA-8654]: https://dimagi.atlassian.net/browse/QA-8654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ