### PR TITLE
SAAS-20168 Fix Gregorian Date Widget fields losing focus in landscape edit mode

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,18 @@
 This file is meant as an easy way for us to collate notes and change logs across releases. 
 -->
 
+## CommCare 2.65
+
+### Release Notes
+
+#### Important Bug Fixes
+
+- Fixed an issue where the day and year fields of the date widget used by date questions with a `gregorian` appearance could not be edited with the keyboard in landscape.
+
+### QA Notes
+
+- Gregorian Date Widget: set a date in portrait, rotate to landscape, and update it with the keyboard. Tapping the day or the year field should bring up the keyboard's own full-width editor with a DONE key, and the value typed there should apply to the widget once DONE is pressed.
+
 ## CommCare 2.63.5
 
 ### Release Notes

--- a/app/res/layout/list_gregorian_widget.xml
+++ b/app/res/layout/list_gregorian_widget.xml
@@ -66,7 +66,7 @@
                 android:inputType="number"
                 android:maxLength="2"
                 android:selectAllOnFocus="true"
-                android:imeOptions="flagNoExtractUi"/>
+                android:imeOptions="actionDone"/>
 
             <Button
                 android:id="@+id/daydownbtn"
@@ -160,7 +160,7 @@
                 android:inputType="number"
                 android:maxLength="4"
                 android:selectAllOnFocus="true"
-                android:imeOptions="flagNoExtractUi"
+                android:imeOptions="actionDone"
                 android:layout_marginStart="5dp" />
 
             <Button


### PR DESCRIPTION
### [SAAS-20168](https://dimagi.atlassian.net/browse/SAAS-20168)

## Product Description

In landscape, the `day` and `year` fields of the Gregorian Date Widget could not be edited as expected. Tapping either field brought up the keyboard, which left the form a thin strip tall and causing the question pane to collapse to a zero-height state. A zero-sized ancestor strips the focus from its children. As a result, anything entered via the keyboard would not be reflected in the view.

Now tapping either field brings up the keyboard's own full-width editor with a `DONE` key — the same behaviour the stock date widget (`DateWidget`) already has in landscape.

## Technical Summary

Both fields declared `android:imeOptions="flagNoExtractUi"`. That flag suppresses the IME's extracted-text editor, but it does **not** stop the IME entering fullscreen mode. So the IME went fullscreen, drew no editor of its own, and left the app to host the editing while `adjustResize` shrank it to nothing.
The fix was to set the `imeOptions` of both fields to `IME_ACTION_DONE`. This ensures that the extracted editor is triggered correctly.

## Safety Assurance

### Safety story

- Tested locally on the day and year fields, on an emulator in landscape: tapping it opens the extracted editor and the value applies to the widget.

## Labels and Review

- [x] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SAAS-20168]: https://dimagi.atlassian.net/browse/SAAS-20168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
