### PR TITLE
Remove the unused forcesPortrait widget hook

### DIFF
--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -255,24 +255,6 @@ public class FormEntryActivityUIController implements CommCareActivityUIControll
         questionsView.setFocus(activity, indexOfLastChangedWidget);
 
         setupGroupLabel();
-        checkForOrientationRequirements();
-    }
-
-    private void checkForOrientationRequirements() {
-        if (currentScreenShouldForcePortrait()) {
-            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-        } else if (activity.getRequestedOrientation() != ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED) {
-            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
-        }
-    }
-
-    private boolean currentScreenShouldForcePortrait() {
-        for (QuestionWidget w : this.questionsView.getWidgets()) {
-            if (w.forcesPortrait()) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void setupGroupLabel() {

--- a/app/src/org/commcare/activities/FormEntryActivityUIController.java
+++ b/app/src/org/commcare/activities/FormEntryActivityUIController.java
@@ -1,6 +1,5 @@
 package org.commcare.activities;
 
-import android.content.pm.ActivityInfo;
 import android.graphics.Rect;
 import android.os.Bundle;
 import android.text.SpannableStringBuilder;

--- a/app/src/org/commcare/views/widgets/QuestionWidget.java
+++ b/app/src/org/commcare/views/widgets/QuestionWidget.java
@@ -847,10 +847,6 @@ public abstract class QuestionWidget extends LinearLayout implements QuestionExt
                 Toast.LENGTH_LONG).show();
     }
 
-    public boolean forcesPortrait() {
-        return false;
-    }
-
     /**
      * @return Whether this widget is to be shown in compact mode
      */


### PR DESCRIPTION
## Technical Summary

No ticket — dead code noticed while working on [SAAS-20168](https://dimagi.atlassian.net/browse/SAAS-20168).

`QuestionWidget.forcesPortrait()` was added in d0557847c (2017, *"WIP: trying to prevent calendar widget from ever being shown in landscape"*) so that the Gregorian date widget could pin the form entry screen to portrait. Its only override was deleted in 80eab9309 (2020, *"Allow landscape orientation in gregorian date widget"*), and nothing has overridden it since. The base implementation returns `false`, so for the last five years `currentScreenShouldForcePortrait()` has always been `false` and `checkForOrientationRequirements()` has run on every screen change without ever requesting an orientation.

This removes the hook and the two callers it fed:

- `QuestionWidget.forcesPortrait()`
- `FormEntryActivityUIController.checkForOrientationRequirements()` and `currentScreenShouldForcePortrait()`, plus the call in `showView()`

## Safety Assurance

### Safety story

- The removal cannot change behaviour: with no override anywhere in the tree, the only reachable path through `checkForOrientationRequirements()` was the `else if`, and it was guarded to do nothing unless the requested orientation had already been changed away from `SCREEN_ORIENTATION_UNSPECIFIED` — which only that same dead code could have done.
- Confirmed by search that no reference to `forcesPortrait`, `checkForOrientationRequirements` or `currentScreenShouldForcePortrait` remains in `app/src/` or in the instrumentation tests.
- Deletion only, no logic moved or rewritten, and it reverts cleanly if a widget ever does need to pin an orientation.

### Automated test coverage

None, and none is added — no test referenced the hook, and there is no behaviour left to assert. Existing form entry instrumentation tests exercise `showView()` on every screen change and should be unaffected.

## Labels and Review

- [ ] Do we need to enhance the manual QA test coverage ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Does the PR introduce any major changes worth communicating ? If yes,  [RELEASES.md](../RELEASES.md) is updated accordingly
- [ ] Risk label is set correctly
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SAAS-20168]: https://dimagi.atlassian.net/browse/SAAS-20168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ