### PR TITLE
CCCT-2769 Fix Blank Connect Screen On Returning To Opportunity List

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,11 @@ This file is meant as an easy way for us to collate notes and change logs across
 
 - The Connect opportunity list no longer appears blank after returning to it from another Connect screen.
 
+### QA Notes
+
+- From the Connect opportunity list, download an opportunity's delivery app, tap View Status, press back from the bottom navigation bar, then log out of the CommCare app: the opportunity list must show its opportunities and must never appear blank.
+- Returning to any Connect screen should show its content immediately and should not flash a "sync successful" banner for data that was already loaded.
+
 ## CommCare 2.63.5
 
 ### Release Notes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,14 @@
 This file is meant as an easy way for us to collate notes and change logs across releases. 
 -->
 
+## CommCare 2.65
+
+### Release Notes
+
+#### Important Bug Fixes
+
+- The Connect opportunity list no longer appears blank after returning to it from another Connect screen.
+
 ## CommCare 2.63.5
 
 ### Release Notes

--- a/app/src/org/commcare/fragments/base/BaseConnectFragment.kt
+++ b/app/src/org/commcare/fragments/base/BaseConnectFragment.kt
@@ -193,11 +193,14 @@ abstract class BaseConnectFragment<B : ViewBinding> :
         onSuccess: DataStateConsumer<T>,
     ) {
         liveData.observe(viewLifecycleOwner) { state ->
-            if (lastDataState == null && (state is DataState.Success || state is DataState.Error)) {
-                // terminal states should not be shown on initial load to avoid jarring UX
-                // this happens when LiveData emits a cached value immediately upon observation
-                return@observe
-            }
+            // A terminal state arriving as the first update of a view is a value replayed from a
+            // previous one: the fragment outlives its view, so the LiveData still holds whatever
+            // it last emitted while nothing was observing. The data is still good; only the
+            // banner announcing a sync that already happened is not.
+            val isStaleReplay =
+                lastDataState == null &&
+                    (state is DataState.Success || state is DataState.Error)
+
             when (state) {
                 is DataState.Loading -> {
                     hideError()
@@ -211,25 +214,31 @@ abstract class BaseConnectFragment<B : ViewBinding> :
                 is DataState.Success -> {
                     hideLoading()
                     hideError()
-                    if (wasOffline) {
-                        showBackOnline()
-                    } else {
-                        showSyncSuccess()
+                    if (!isStaleReplay) {
+                        if (wasOffline) {
+                            showBackOnline()
+                        } else {
+                            showSyncSuccess()
+                        }
+                        wasOffline = false
                     }
-                    wasOffline = false
                     onSuccess.accept(state.data)
                 }
 
                 is DataState.Error -> {
-                    hideLoading()
-                    if (state.errorCode == BaseApiHandler.PersonalIdOrConnectApiErrorCodes.TOKEN_DENIED_ERROR) {
-                        handleTokenDeniedException()
-                    } else if (state.isNetworkError() &&
-                        !ConnectivityStatus.isNetworkAvailable(requireContext())
-                    ) {
-                        showOfflineIndicator()
-                    } else {
-                        showError(getString(R.string.connect_sync_failed, getRelativeLastSyncTime()))
+                    // Suppressed entirely for a replay: there is no data to deliver, and a stale
+                    // TOKEN_DENIED would otherwise re-trigger the global error on every return.
+                    if (!isStaleReplay) {
+                        hideLoading()
+                        if (state.errorCode == BaseApiHandler.PersonalIdOrConnectApiErrorCodes.TOKEN_DENIED_ERROR) {
+                            handleTokenDeniedException()
+                        } else if (state.isNetworkError() &&
+                            !ConnectivityStatus.isNetworkAvailable(requireContext())
+                        ) {
+                            showOfflineIndicator()
+                        } else {
+                            showError(getString(R.string.connect_sync_failed, getRelativeLastSyncTime()))
+                        }
                     }
                 }
             }

--- a/app/unit-tests/src/org/commcare/fragments/base/BaseConnectFragmentReplayTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/base/BaseConnectFragmentReplayTest.kt
@@ -1,0 +1,158 @@
+package org.commcare.fragments.base
+
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.MutableLiveData
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.commcare.CommCareTestApplication
+import org.commcare.connect.repository.DataState
+import org.commcare.dalvik.R
+import org.commcare.dalvik.databinding.LoadingBinding
+import org.commcare.fragments.RefreshableFragment
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * A fragment outlives its view, so its LiveData can still hold whatever it last emitted while
+ * nothing was observing. Re-attaching the view replays that value as the first update the new
+ * view sees, and [BaseConnectFragment.observeDataState] used to discard it — which left screens
+ * that only render from a delivery, such as the opportunity list, completely blank.
+ */
+@Config(application = CommCareTestApplication::class, sdk = [Build.VERSION_CODES.Q])
+@RunWith(AndroidJUnit4::class)
+class BaseConnectFragmentReplayTest {
+    private lateinit var activity: HostActivity
+    private val fragmentManager: FragmentManager get() = activity.supportFragmentManager
+
+    @Before
+    fun setUp() {
+        activity =
+            Robolectric
+                .buildActivity(HostActivity::class.java)
+                .create()
+                .start()
+                .resume()
+                .get()
+    }
+
+    @Test
+    fun `a state delivered while the view is alive reaches the consumer`() {
+        val fragment = show()
+
+        emit(fragment, DataState.Loading)
+        emit(fragment, DataState.Success("first"))
+
+        assertEquals(listOf("first"), fragment.delivered)
+    }
+
+    @Test
+    fun `a success replayed to a re-created view is still delivered`() {
+        val fragment = show()
+        emit(fragment, DataState.Loading)
+        emit(fragment, DataState.Success("first"))
+
+        recreateView(fragment)
+
+        assertEquals(
+            "the replayed value must reach the consumer, or the screen renders nothing",
+            listOf("first", "first"),
+            fragment.delivered,
+        )
+    }
+
+    @Test
+    fun `a replayed success does not leave later states treated as replays`() {
+        val fragment = show()
+        emit(fragment, DataState.Success("first"))
+        recreateView(fragment)
+
+        emit(fragment, DataState.Success("second"))
+
+        assertEquals(listOf("first", "first", "second"), fragment.delivered)
+    }
+
+    @Test
+    fun `an error replayed to a re-created view is not surfaced`() {
+        val fragment = show()
+        emit(fragment, DataState.Loading)
+        emit(fragment, DataState.Error())
+
+        recreateView(fragment)
+
+        assertEquals(emptyList<String>(), fragment.delivered)
+        assertEquals(emptyList<String>(), fragment.cached)
+    }
+
+    // ---------- helpers ----------
+
+    private fun show(): ProbeFragment {
+        val fragment = ProbeFragment()
+        fragmentManager.beginTransaction().add(CONTAINER_ID, fragment).commitNow()
+        ShadowLooper.idleMainLooper()
+        return fragment
+    }
+
+    private fun emit(
+        fragment: ProbeFragment,
+        state: DataState<String>,
+    ) {
+        activity.runOnUiThread { fragment.liveData.value = state }
+        ShadowLooper.idleMainLooper()
+    }
+
+    /** Detach destroys the view and keeps the fragment; attach builds a new view on the same one. */
+    private fun recreateView(fragment: ProbeFragment) {
+        fragmentManager.beginTransaction().detach(fragment).commitNow()
+        ShadowLooper.idleMainLooper()
+        fragmentManager.beginTransaction().attach(fragment).commitNow()
+        ShadowLooper.idleMainLooper()
+    }
+
+    class HostActivity : AppCompatActivity() {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            setTheme(R.style.ConnectTheme)
+            super.onCreate(savedInstanceState)
+            setContentView(FrameLayout(this).apply { id = CONTAINER_ID })
+        }
+    }
+
+    class ProbeFragment :
+        BaseConnectFragment<LoadingBinding>(),
+        RefreshableFragment {
+        val liveData = MutableLiveData<DataState<String>>()
+        val cached = mutableListOf<String>()
+        val delivered = mutableListOf<String>()
+
+        override fun inflateBinding(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+        ): LoadingBinding = LoadingBinding.inflate(inflater, container, false)
+
+        override fun getEndpoint(): String? = null
+
+        override fun refresh(forceRefresh: Boolean) = Unit
+
+        override fun onViewCreated(
+            view: View,
+            savedInstanceState: Bundle?,
+        ) {
+            super.onViewCreated(view, savedInstanceState)
+            observeDataState(liveData, { cached += it }, { delivered += it })
+        }
+    }
+
+    private companion object {
+        const val CONTAINER_ID = 0x00ff0001
+    }
+}


### PR DESCRIPTION
### [CCCT-2769](https://dimagi.atlassian.net/browse/CCCT-2769)

## Product Description

The Connect opportunity list could come back completely blank — no cards, no section headers and no "no opportunities" message — after returning to it from another Connect screen. The data was already loaded; only the rendering was lost. Pressing sync recovered it.

## Technical Summary

Issue was [here](https://github.com/dimagi/commcare-android/blob/1062524bf39272e978030961d10c333d7e30f889/app/src/org/commcare/fragments/base/BaseConnectFragment.kt#L199).


**The fragment comes back, but its memory of what it showed does not.**

When you leave the opportunity list, Android does not throw the fragment away. It keeps the fragment object on the navigation stack and only destroys its views — that's `onDestroyView`. Later, when you come back, the same fragment builds fresh views.

`lastDataState` is the fragment's note to itself saying "here's the last thing I displayed". That note is wiped in `onDestroyView`:

```kotlin
override fun onDestroyView() {
    …
    lastDataState = null   // note wiped
}
```

But the data lives somewhere else — in the ViewModel, which belongs to the fragment, not to its views. So the data survives the round trip while the note does not.

Result: the fragment returns holding its old data but with a blank note. It can't tell "this is old data I already showed you" from "this is the very first data I've ever received". And there's a rule that says don't display a finished result that arrives as the very first thing — because on a genuine first load that would flash a "synced!" banner for stale data. So the returning fragment's own data gets thrown away as if it were that case.

Two further details shaped the fix. The discard happened before the note was written, so once a lastDataState was dropped every later terminal state was dropped too — the screen could not recover on its own, which is why only sync (which emits a non-terminal state first) brought it back. And the error branch is still suppressed for a replay, because letting it through would re-trigger the global "lost configuration" error on every return to a screen holding a stale token failure.

## Safety Assurance

### Safety story

- I ran the fix on a device and repeated the reproduction steps; the opportunity list rendered instead of going blank.
- Instrumented logging captured the exact failing condition occurring with the fix in place and the data being delivered, where previously nothing followed it.
- A regression test drives the real fragment lifecycle and fails without this change.

Risks to review:

- The change is in `BaseConnectFragment`, shared by seven Connect screens, so it alters when each of them acts on a replayed state.
- Screens that render only from a delivery are the ones affected; screens that also rebind from retained fields in `onCreateView` were masking this and will now deliver as well.

### Automated test coverage

`BaseConnectFragmentReplayTest` destroys and re-creates a fragment's view with a terminal state retained, and asserts the replayed data is delivered while an error replay stays suppressed. Two of its four tests fail without this change.

[CCCT-2769]: https://dimagi.atlassian.net/browse/CCCT-2769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ