### PR TITLE
CCCT-2791 Add Sync Status Card To Learn And Delivery Progress

### DIFF
--- a/app/res/layout/fragment_connect_delivery_dashboard.xml
+++ b/app/res/layout/fragment_connect_delivery_dashboard.xml
@@ -85,6 +85,13 @@
                 app:contentDisabledColor="?attr/connectOnSurfaceVariant"
                 app:contentPrimaryColor="?attr/connectOnSurfaceVariant" />
 
+            <org.commcare.views.connect.ConnectSyncStatusCard
+                android:id="@+id/delivery_sync_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/connect_space_sm"
+                android:layout_marginTop="@dimen/connect_space_md" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/res/layout/view_connect_learn_progress.xml
+++ b/app/res/layout/view_connect_learn_progress.xml
@@ -86,6 +86,13 @@
                 android:layout_marginTop="@dimen/standard_title_margin_bottom"
                 tools:linearProgressLabel="@string/connect_learn_modules_completed_label" />
 
+            <org.commcare.views.connect.ConnectSyncStatusCard
+                android:id="@+id/learn_progress_sync_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/standard_spacer_double"
+                android:layout_marginTop="@dimen/standard_title_margin_bottom" />
+
             <TextView
                 android:id="@+id/learn_progress_continue_heading"
                 android:layout_width="match_parent"

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -683,6 +683,7 @@
     <string name="connect_last_synced">Última sincronización: %s</string>
     <string name="connect_sync_successful">Última sincronización: Justo ahora</string>
     <string name="connect_sync_failed">Sincronización fallida, última sincronización: %s</string>
+    <string name="connect_sync_card_press_to_sync">Haga clic aquí para sincronizar</string>
     <string name="connect_offline">Sin conexión</string>
     <string name="connect_back_online">De vuelta en línea</string>
     <string name="connect_never">Nunca</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -682,6 +682,7 @@ License.
     <string name="connect_last_synced">Dernière synchronisation : %s</string>
     <string name="connect_sync_successful">Dernière synchronisation : À l\'instant</string>
     <string name="connect_sync_failed">Échec de synchronisation, dernière synchronisation : %s</string>
+    <string name="connect_sync_card_press_to_sync">Cliquez ici pour synchroniser</string>
     <string name="connect_offline">Hors ligne</string>
     <string name="connect_back_online">De retour en ligne</string>
     <string name="connect_never">Jamais</string>

--- a/app/res/values-ha/strings.xml
+++ b/app/res/values-ha/strings.xml
@@ -677,6 +677,7 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="connect_last_synced">Aiki na ƙarshe: %s</string>
     <string name="connect_sync_successful">Aiki na ƙarshe: Yanzu haka</string>
     <string name="connect_sync_failed">Daidaitawa ta kasa, aiki na ƙarshe: %s</string>
+    <string name="connect_sync_card_press_to_sync">Danna nan don daidaitawa</string>
     <string name="connect_offline">Babu haɗi</string>
     <string name="connect_back_online">An Sake Haɗawa</string>
     <string name="connect_never">Ba taɓa</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -679,6 +679,7 @@ License.
     <string name="connect_last_synced">अंतिम सिंक: %s</string>
     <string name="connect_sync_successful">अंतिम सिंक: अभी-अभी</string>
     <string name="connect_sync_failed">सिंक विफल, अंतिम सिंक: %s</string>
+    <string name="connect_sync_card_press_to_sync">सिंक करने के लिए यहां क्लिक करें</string>
     <string name="connect_offline">ऑफ़लाइन</string>
     <string name="connect_back_online">वापस ऑनलाइन</string>
     <string name="connect_never">कभी नहीं</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -293,6 +293,7 @@
     <string name="connect_last_synced">Paskutinė sinchronizacija: %s</string>
     <string name="connect_sync_successful">Paskutinė sinchronizacija: Ką tik</string>
     <string name="connect_sync_failed">Sinchronizacija nepavyko, paskutinė sinchronizacija: %s</string>
+    <string name="connect_sync_card_press_to_sync">Norėdami sinchronizuoti, spustelėkite čia</string>
     <string name="connect_offline">Neprisijungęs</string>
     <string name="connect_back_online">Vėl prisijungta</string>
     <string name="connect_never">Niekada</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -281,6 +281,7 @@
     <string name="connect_last_synced">Sist synkronisert: %s</string>
     <string name="connect_sync_successful">Sist synkronisert: Akkurat nå</string>
     <string name="connect_sync_failed">Synkronisering mislyktes, sist synkronisert: %s</string>
+    <string name="connect_sync_card_press_to_sync">Klikk her for å synkronisere</string>
     <string name="connect_offline">Frakoblet</string>
     <string name="connect_back_online">Tilbake på nett</string>
     <string name="connect_never">Aldri</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -689,6 +689,7 @@
     <string name="connect_last_synced">Última sincronização: %s</string>
     <string name="connect_sync_successful">Última sincronização: Agora mesmo</string>
     <string name="connect_sync_failed">Sincronização falhou, última sincronização: %s</string>
+    <string name="connect_sync_card_press_to_sync">Clique aqui para sincronizar</string>
     <string name="connect_offline">Offline</string>
     <string name="connect_back_online">De volta online</string>
     <string name="connect_never">Nunca</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -687,6 +687,7 @@
     <string name="connect_last_synced">Ilisawazishwa mwisho: %s</string>
     <string name="connect_sync_successful">Ilisawazishwa mwisho: Sasa hivi</string>
     <string name="connect_sync_failed">Usawazishaji Umeshindwa, ilisawazishwa mwisho: %s</string>
+    <string name="connect_sync_card_press_to_sync">Bofya hapa kusawazisha</string>
     <string name="connect_offline">Nje ya mtandao</string>
     <string name="connect_back_online">Umerudi mtandaoni</string>
     <string name="connect_never">Kamwe</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -671,6 +671,7 @@
     <string name="connect_last_synced">ናይ መወዳእታ ምስንኻል: %s</string>
     <string name="connect_sync_successful">ናይ መወዳእታ ምስንኻል: ሕጂ ሕጂ</string>
     <string name="connect_sync_failed">ምስንኻል ኣይሰለጠን, ናይ መወዳእታ ምስንኻል: %s</string>
+    <string name="connect_sync_card_press_to_sync">ንምስንኻል ኣብዚ ጠውቑ</string>
     <string name="connect_offline">ኦፍላይን</string>
     <string name="connect_back_online">ናብ ኦንላይን ተመሊሱ</string>
     <string name="connect_never">ፈጺሙ</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -481,6 +481,7 @@
     <string name="connect_last_synced">Last synced: %s</string>
     <string name="connect_sync_successful">Last synced: Just Now</string>
     <string name="connect_sync_failed">Sync Failed, last synced: %s</string>
+    <string name="connect_sync_card_press_to_sync">Press here to sync</string>
     <string name="connect_app_launch_dialog_title">Launching App</string>
     <string name="connect_app_launch_dialog_seating_message">Loading your app…</string>
     <string name="connect_app_launch_dialog_signing_in_message">Logging in…</string>

--- a/app/res/values/styles.xml
+++ b/app/res/values/styles.xml
@@ -337,7 +337,7 @@
         <item name="syncOkStrokeColor">@color/connect_light_grey</item>
         <item name="syncWarningBadgeColor">@color/pale_buttery_cream</item>
         <item name="syncWarningIconColor">@color/burnt_amber</item>
-        <item name="syncWarningStrokeColor">@color/burnt_amber</item>
+        <item name="syncWarningStrokeColor">@color/connect_light_grey</item>
         <item name="syncOkIcon">@drawable/check_update</item>
         <item name="syncWarningIcon">@drawable/ic_connect_directory_sync</item>
     </style>

--- a/app/src/org/commcare/fragments/base/BaseConnectFragment.kt
+++ b/app/src/org/commcare/fragments/base/BaseConnectFragment.kt
@@ -27,6 +27,7 @@ import org.commcare.dalvik.R
 import org.commcare.dalvik.databinding.LoadingBinding
 import org.commcare.dalvik.databinding.NetworkStatusBarLayoutBinding
 import org.commcare.fragments.RefreshableFragment
+import org.commcare.fragments.extensions.hasLiveView
 import org.commcare.interfaces.base.BaseConnectView
 import org.commcare.utils.ConnectivityStatus
 import org.commcare.views.NetworkStatusBarViewController
@@ -51,6 +52,7 @@ abstract class BaseConnectFragment<B : ViewBinding> :
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
     private var lastDataState: DataState<*>? = null
     private var wasOffline: Boolean = false
+    private var _syncStatus: CharSequence? = null
 
     /**
      * Implement this method in child fragments to inflate their specific binding.
@@ -78,6 +80,38 @@ abstract class BaseConnectFragment<B : ViewBinding> :
     fun getLastSyncTime(): Date? {
         val endpoint = getEndpoint() ?: return null
         return ConnectSyncPreferences.getInstance().getLastSyncTime(endpoint)
+    }
+
+    /**
+     * The sync status last reported through [informSyncStatus], falling back to the stored last sync
+     * time for a fragment that has not observed a sync yet.
+     */
+    val syncStatus: CharSequence
+        get() = _syncStatus ?: getString(R.string.connect_last_synced, getRelativeLastSyncTime())
+
+    /** Whether what is on screen came from a sync that has landed, rather than an older one. */
+    var isSynced: Boolean = false
+        private set
+
+    /**
+     * Reports this fragment's sync status once its view exists and again whenever a sync settles,
+     * so a screen showing it never has to work out for itself whether a sync is still in flight.
+     */
+    protected open fun informSyncStatus(
+        lastSyncStatus: CharSequence,
+        synced: Boolean,
+    ) {
+    }
+
+    private fun setSyncStatus(
+        lastSyncStatus: CharSequence,
+        synced: Boolean,
+    ) {
+        _syncStatus = lastSyncStatus
+        isSynced = synced
+        if (hasLiveView()) {
+            informSyncStatus(lastSyncStatus, synced)
+        }
     }
 
     override fun onCreateView(
@@ -145,6 +179,14 @@ abstract class BaseConnectFragment<B : ViewBinding> :
         return rootView
     }
 
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        informSyncStatus(syncStatus, isSynced)
+    }
+
     override fun onStart() {
         super.onStart()
         if (shouldMonitorNetwork()) {
@@ -164,6 +206,8 @@ abstract class BaseConnectFragment<B : ViewBinding> :
         _binding = null
         progressBar.visibility = View.GONE
         lastDataState = null
+        _syncStatus = null
+        isSynced = false
     }
 
     override fun showLoading() {
@@ -222,6 +266,7 @@ abstract class BaseConnectFragment<B : ViewBinding> :
 
                 is DataState.Error -> {
                     hideLoading()
+                    setSyncStatus(getString(R.string.connect_last_synced, getRelativeLastSyncTime()), false)
                     if (state.errorCode == BaseApiHandler.PersonalIdOrConnectApiErrorCodes.TOKEN_DENIED_ERROR) {
                         handleTokenDeniedException()
                     } else if (state.isNetworkError() &&
@@ -238,10 +283,12 @@ abstract class BaseConnectFragment<B : ViewBinding> :
     }
 
     private fun showSyncSuccess() {
+        setSyncStatus(getString(R.string.connect_sync_successful), true)
         mNetworkStatusBarViewController!!.showMessage(getString(R.string.connect_sync_successful))
     }
 
     private fun showBackOnline() {
+        setSyncStatus(getString(R.string.connect_sync_successful), true)
         mNetworkStatusBarViewController!!.showBackOnline(getString(R.string.connect_sync_successful))
     }
 

--- a/app/src/org/commcare/fragments/base/BaseConnectFragment.kt
+++ b/app/src/org/commcare/fragments/base/BaseConnectFragment.kt
@@ -55,6 +55,17 @@ abstract class BaseConnectFragment<B : ViewBinding> :
     private var _syncStatus: CharSequence? = null
 
     /**
+     * The sync status last reported through [informSyncStatus], falling back to the stored last sync
+     * time for a fragment that has not observed a sync yet.
+     */
+    val syncStatus: CharSequence
+        get() = _syncStatus ?: getString(R.string.connect_last_synced, getRelativeLastSyncTime())
+
+    /** Whether what is on screen came from a sync that has landed, rather than an older one. */
+    var isSynced: Boolean = false
+        private set
+
+    /**
      * Implement this method in child fragments to inflate their specific binding.
      */
     protected abstract fun inflateBinding(
@@ -83,19 +94,7 @@ abstract class BaseConnectFragment<B : ViewBinding> :
     }
 
     /**
-     * The sync status last reported through [informSyncStatus], falling back to the stored last sync
-     * time for a fragment that has not observed a sync yet.
-     */
-    val syncStatus: CharSequence
-        get() = _syncStatus ?: getString(R.string.connect_last_synced, getRelativeLastSyncTime())
-
-    /** Whether what is on screen came from a sync that has landed, rather than an older one. */
-    var isSynced: Boolean = false
-        private set
-
-    /**
-     * Reports this fragment's sync status once its view exists and again whenever a sync settles,
-     * so a screen showing it never has to work out for itself whether a sync is still in flight.
+     * Reports this fragment's sync status once its view exists and again whenever a sync settles.
      */
     protected open fun informSyncStatus(
         lastSyncStatus: CharSequence,

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryDashboardFragment.kt
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryDashboardFragment.kt
@@ -27,7 +27,6 @@ import java.text.DateFormat
 class ConnectDeliveryDashboardFragment :
     ConnectJobFragment<FragmentConnectDeliveryDashboardBinding>(),
     RefreshableTab {
-    /** The tab has no endpoint of its own; delivery is synced by the host, which owns the status. */
     private val host get() = requireParentFragment() as ConnectDeliveryHomeFragment
 
     override fun onCreateView(

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryDashboardFragment.kt
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryDashboardFragment.kt
@@ -14,11 +14,12 @@ import org.commcare.dalvik.databinding.FragmentConnectDeliveryDashboardBinding
 import org.commcare.fragments.RefreshableTab
 import org.commcare.views.connect.ConnectInfoHalfCard
 import org.commcare.views.connect.ConnectProgressCard
+import org.commcare.views.connect.ConnectSyncStatusCard
 import java.text.DateFormat
 
 /**
- * Dashboard tab of a delivery opportunity: visit progress and a per-payment-unit breakdown of the
- * worker's own progress.
+ * Dashboard tab of a delivery opportunity: visit progress, a sync card that re-syncs on tap, and a
+ * per-payment-unit breakdown of the worker's own progress.
  *
  * Figures render disabled once no further work earns progress, and an individual payment unit's card
  * also dims on its own once that unit is out of visits.
@@ -26,6 +27,9 @@ import java.text.DateFormat
 class ConnectDeliveryDashboardFragment :
     ConnectJobFragment<FragmentConnectDeliveryDashboardBinding>(),
     RefreshableTab {
+    /** The tab has no endpoint of its own; delivery is synced by the host, which owns the status. */
+    private val host get() = requireParentFragment() as ConnectDeliveryHomeFragment
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -41,6 +45,7 @@ class ConnectDeliveryDashboardFragment :
         val contentEnabled = !job.isFurtherWorkBlocked
         bindHeader()
         bindVisitProgress(contentEnabled)
+        bindSyncCard(host.syncStatus, host.isSynced)
         bindProgressGrid(contentEnabled)
     }
 
@@ -85,6 +90,28 @@ class ConnectDeliveryDashboardFragment :
                     ),
             ),
         )
+    }
+
+    /** Called by the host, which owns the delivery sync and so learns its status first. */
+    fun updateSyncStatus(
+        syncStatus: CharSequence,
+        synced: Boolean,
+    ) {
+        bindSyncCard(syncStatus, synced)
+    }
+
+    private fun bindSyncCard(
+        syncStatus: CharSequence,
+        synced: Boolean,
+    ) {
+        binding.deliverySyncCard.bind(
+            ConnectSyncStatusCard.State(
+                statusText = getString(R.string.connect_sync_card_press_to_sync),
+                statusSubtext = syncStatus,
+                warning = !synced,
+            ),
+        )
+        binding.deliverySyncCard.onCardClick = { host.refresh(true) }
     }
 
     private fun bindProgressGrid(contentEnabled: Boolean) {

--- a/app/src/org/commcare/fragments/connect/ConnectDeliveryHomeFragment.kt
+++ b/app/src/org/commcare/fragments/connect/ConnectDeliveryHomeFragment.kt
@@ -191,6 +191,18 @@ class ConnectDeliveryHomeFragment :
         viewModel.loadDeliveryProgress(job, forceRefresh)
     }
 
+    /** Delivery is synced here rather than per tab, so the status has to reach the tabs showing it. */
+    override fun informSyncStatus(
+        lastSyncStatus: CharSequence,
+        synced: Boolean,
+    ) {
+        childFragmentManager.fragments.forEach { fragment ->
+            if (fragment.view != null && fragment is ConnectDeliveryDashboardFragment) {
+                fragment.updateSyncStatus(lastSyncStatus, synced)
+            }
+        }
+    }
+
     /**
      * Learning finished before delivery began, so its records are fetched only for a device that is
      * missing them, and only once delivery progress has landed: both write the opportunity row, and

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.kt
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.kt
@@ -60,6 +60,13 @@ class ConnectLearningProgressFragment :
         viewModel.loadLearningProgress(job, forceRefresh)
     }
 
+    override fun informSyncStatus(
+        lastSyncStatus: CharSequence,
+        synced: Boolean,
+    ) {
+        binding.learnProgressView.updateSyncStatus(lastSyncStatus, synced)
+    }
+
     private fun observeLearningProgress() {
         observeDataState(
             viewModel.learningProgress,
@@ -88,7 +95,11 @@ class ConnectLearningProgressFragment :
                 View.OnClickListener { onDeliveryCtaClicked() },
             )
         } else {
-            binding.learnProgressView.bind(job, View.OnClickListener { navigateToLearnAppHome() })
+            binding.learnProgressView.bind(
+                job,
+                View.OnClickListener { navigateToLearnAppHome() },
+                { refresh(true) },
+            )
         }
     }
 

--- a/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.kt
+++ b/app/src/org/commcare/fragments/connect/ConnectLearningProgressFragment.kt
@@ -92,12 +92,12 @@ class ConnectLearningProgressFragment :
                 job,
                 job.latestLearningActivityDate ?: Date(),
                 ConnectUserDatabaseUtil.getUser().name,
-                View.OnClickListener { onDeliveryCtaClicked() },
+                { onDeliveryCtaClicked() },
             )
         } else {
             binding.learnProgressView.bind(
                 job,
-                View.OnClickListener { navigateToLearnAppHome() },
+                { navigateToLearnAppHome() },
                 { refresh(true) },
             )
         }

--- a/app/src/org/commcare/views/connect/ConnectLearnProgressView.kt
+++ b/app/src/org/commcare/views/connect/ConnectLearnProgressView.kt
@@ -17,9 +17,10 @@ import java.text.DateFormat
  * everything short of a passed assessment, which [ConnectLearnCompleteView] renders instead.
  *
  * Shows the opportunity header, a [ConnectProgressCard] carrying the module count and the
- * failed-assessment banner, a non-interactive "Continue Learning" card, and a [ConnectCtaBar]
- * pinned below the scrolling content. Call [bind] to populate it; the view derives its whole
- * appearance from the job and holds no state of its own, so re-binding fully re-renders.
+ * failed-assessment banner, a [ConnectSyncStatusCard] that re-syncs on tap, a non-interactive
+ * "Continue Learning" card, and a [ConnectCtaBar] pinned below the scrolling content. Call [bind]
+ * to populate it; the view derives its whole appearance from the job and holds no state of its
+ * own, so re-binding fully re-renders.
  */
 class ConnectLearnProgressView
     @JvmOverloads
@@ -38,11 +39,30 @@ class ConnectLearnProgressView
         fun bind(
             job: ConnectJobRecord,
             onCtaClick: OnClickListener,
+            onSyncClick: () -> Unit,
         ) {
             bindHeader(job)
             bindProgressCard(job)
+            binding.learnProgressSyncCard.onCardClick = onSyncClick
             bindContinueCard(job)
             bindCtaBar(job, onCtaClick)
+        }
+
+        /**
+         * Captions the sync card with [syncStatus], which the hosting fragment is told about, and
+         * warns while [synced] is false so stale figures read as stale.
+         */
+        fun updateSyncStatus(
+            syncStatus: CharSequence,
+            synced: Boolean,
+        ) {
+            binding.learnProgressSyncCard.bind(
+                ConnectSyncStatusCard.State(
+                    statusText = context.getString(R.string.connect_sync_card_press_to_sync),
+                    statusSubtext = syncStatus,
+                    warning = !synced,
+                ),
+            )
         }
 
         private fun bindHeader(job: ConnectJobRecord) {

--- a/app/src/org/commcare/views/connect/ConnectSyncStatusCard.kt
+++ b/app/src/org/commcare/views/connect/ConnectSyncStatusCard.kt
@@ -69,7 +69,6 @@ class ConnectSyncStatusCard
             radius = resources.getDimension(R.dimen.connect_radius_card)
             cardElevation = resources.getDimension(R.dimen.connect_info_card_elevation)
             strokeWidth = resources.getDimensionPixelSize(R.dimen.connect_stroke_hairline)
-            useCompatPadding = true
             setCardBackgroundColor(ContextCompat.getColor(context, R.color.white))
 
             var initialState = State()

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryDashboardFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryDashboardFragmentTest.kt
@@ -197,9 +197,11 @@ class ConnectDeliveryDashboardFragmentTest {
         val requestsBefore = deliveryProgressRequests
         deliveryProgressBody = progressResponse(deliveries = deliveriesToday(unit = 1, count = 3))
         activity.runOnUiThread { syncCard.performClick() }
-        // The response is applied on the IO dispatcher before it reaches the main looper, which is
-        // the hand-off awaitRequest covers and drainHttp does not.
-        mockApi.awaitRequest()
+        // The response is applied on the IO dispatcher before it reaches the main looper, so the
+        // refreshed figures are waited for rather than assumed to have landed.
+        idleUntil("The tapped sync never refreshed the delivery figures") {
+            view.findViewById<SemiCircleProgressBar>(R.id.progress_card_semi_circle).current == 3
+        }
 
         assertEquals("The tap asks for delivery progress", requestsBefore + 1, deliveryProgressRequests)
         assertEquals(
@@ -433,11 +435,22 @@ class ConnectDeliveryDashboardFragmentTest {
     private fun awaitDeliverySync() {
         val syncKey = ConnectRepository.SYNC_KEY_DELIVERY_PREFIX + ConnectLearnJobTestData.JOB_UUID
         val prefs = ConnectSyncPreferences.getInstance()
+        idleUntil("Delivery progress was never synced") { prefs.getLastSyncTime(syncKey) != null }
+    }
+
+    /**
+     * Drains the main looper until [condition] holds, bounded so a response that never arrives
+     * fails with [description] rather than hanging.
+     */
+    private fun idleUntil(
+        description: String,
+        condition: () -> Boolean,
+    ) {
         val deadline = System.currentTimeMillis() + SYNC_TIMEOUT_MS
 
-        while (prefs.getLastSyncTime(syncKey) == null) {
+        while (!condition()) {
             if (System.currentTimeMillis() > deadline) {
-                throw AssertionError("Delivery progress was never synced within ${SYNC_TIMEOUT_MS}ms")
+                throw AssertionError("$description within ${SYNC_TIMEOUT_MS}ms")
             }
             ShadowLooper.idleMainLooper()
             Thread.sleep(POLL_INTERVAL_MS)

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryDashboardFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectDeliveryDashboardFragmentTest.kt
@@ -12,8 +12,10 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
@@ -34,7 +36,9 @@ import org.commcare.connect.repository.ConnectRepository
 import org.commcare.connect.repository.ConnectSyncPreferences
 import org.commcare.dalvik.R
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
+import org.commcare.utils.coroutines.DispatcherProvider
 import org.commcare.views.connect.ConnectInfoHalfCard
+import org.commcare.views.connect.ConnectSyncStatusCard
 import org.commcare.views.connect.SemiCircleProgressBar
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -68,6 +72,9 @@ class ConnectDeliveryDashboardFragmentTest {
     @Volatile
     private var deliveryProgressBody: String = "{}"
 
+    @Volatile
+    private var deliveryProgressRequests: Int = 0
+
     private val visitDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US)
     private val navController: NavController get() = navHostFragment.navController
     private val appContext get() = ApplicationProvider.getApplicationContext<CommCareTestApplication>()
@@ -79,6 +86,9 @@ class ConnectDeliveryDashboardFragmentTest {
         mockApi.start()
         mockApi.server.dispatcher = pathRoutingDispatcher()
         ConnectSyncPreferences.getInstance().clearAll()
+
+        mockkObject(DispatcherProvider)
+        every { DispatcherProvider.io() } returns UnconfinedTestDispatcher()
 
         mockkStatic(MessageManager::class)
         every { MessageManager.retrieveMessages(any(), any()) } returns Unit
@@ -170,6 +180,33 @@ class ConnectDeliveryDashboardFragmentTest {
             activity.getString(R.string.connect_delivery_total_visits_completed),
             semiCircle.descriptionText.toString(),
         )
+    }
+
+    /**
+     * The sync card is the in-page equivalent of the action bar's sync, so the click has to make the
+     * same delivery-progress call and land its result on the figures.
+     */
+    @Test
+    fun `tapping the sync card refreshes delivery progress`() {
+        val dashboard = launch(progressResponse(deliveries = deliveriesToday(unit = 1, count = 1)))
+        val view = dashboard.requireView()
+        val syncCard = view.findViewById<ConnectSyncStatusCard>(R.id.delivery_sync_card)
+
+        assertTrue("The sync card invites a tap", syncCard.isClickable)
+
+        val requestsBefore = deliveryProgressRequests
+        deliveryProgressBody = progressResponse(deliveries = deliveriesToday(unit = 1, count = 3))
+        activity.runOnUiThread { syncCard.performClick() }
+        // The response is applied on the IO dispatcher before it reaches the main looper, which is
+        // the hand-off awaitRequest covers and drainHttp does not.
+        mockApi.awaitRequest()
+
+        assertEquals("The tap asks for delivery progress", requestsBefore + 1, deliveryProgressRequests)
+        assertEquals(
+            "3 of ${ConnectLearnJobTestData.MAX_DAILY_VISITS}",
+            view.findViewById<TextView>(R.id.progress_card_bar_count).text.toString(),
+        )
+        assertEquals(3, view.findViewById<SemiCircleProgressBar>(R.id.progress_card_semi_circle).current)
     }
 
     @Test
@@ -380,6 +417,7 @@ class ConnectDeliveryDashboardFragmentTest {
             override fun dispatch(request: RecordedRequest): MockResponse {
                 val body =
                     if (request.path?.endsWith(DELIVERY_PROGRESS_PATH) == true) {
+                        deliveryProgressRequests++
                         deliveryProgressBody
                     } else {
                         ""

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectLearningProgressFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectLearningProgressFragmentTest.kt
@@ -263,8 +263,7 @@ class ConnectLearningProgressFragmentTest {
             MockResponse().setResponseCode(200).setBody("""{"completed_modules": [], "assessments": []}"""),
         )
         activity.runOnUiThread { syncCard.performClick() }
-        val request = mockApi.drainHttp()
-        ShadowLooper.idleMainLooper()
+        val request = mockApi.awaitRequest()
 
         assertEquals("/api/opportunity/${job.jobUUID}/learn_progress", request.path)
         assertEquals(
@@ -303,9 +302,9 @@ class ConnectLearningProgressFragmentTest {
             )
         }
         ShadowLooper.idleMainLooper()
-        // Drain the getLearningProgress request so it doesn't sit ahead of the claim request in the queue.
-        mockApi.drainHttp()
-        ShadowLooper.idleMainLooper()
+        // getLearningProgress finishes on ConnectRequestManager's background scope, so the result
+        // needs awaiting rather than a single drain; it also clears the request queue for the claim.
+        mockApi.awaitRequest()
         return navHostFragment.childFragmentManager.primaryNavigationFragment
             as ConnectLearningProgressFragment
     }

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectLearningProgressFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectLearningProgressFragmentTest.kt
@@ -3,6 +3,8 @@ package org.commcare.fragments.connect
 import android.content.Context
 import android.os.Build
 import android.view.View
+import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.test.core.app.ApplicationProvider
@@ -37,6 +39,7 @@ import org.commcare.dalvik.R
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil
 import org.commcare.utils.coroutines.DispatcherProvider
 import org.commcare.views.connect.ConnectSuccessFailureCard
+import org.commcare.views.connect.ConnectSyncStatusCard
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -238,6 +241,55 @@ class ConnectLearningProgressFragmentTest {
             navController.currentDestination?.id,
         )
         assertEquals(ConnectJobRecord.STATUS_LEARNING, job.status)
+    }
+
+    /**
+     * The sync card is the in-page equivalent of the action bar's sync, so the click has to make the
+     * same learn-progress call and leave the card reporting the sync that landed.
+     */
+    @Test
+    fun `tapping the sync card reloads learning progress and clears the warning`() {
+        val job = seedLearningJob()
+        val fragment = launch(job)
+        val syncCard = fragment.requireView().findViewById<ConnectSyncStatusCard>(R.id.learn_progress_sync_card)
+
+        // The launch refresh fails, so the card starts out warning about the sync it could not make.
+        assertEquals(
+            ContextCompat.getColor(activity, R.color.burnt_amber),
+            syncCard.strokeColorStateList?.defaultColor,
+        )
+
+        mockApi.server.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"completed_modules": [], "assessments": []}"""),
+        )
+        activity.runOnUiThread { syncCard.performClick() }
+        val request = mockApi.drainHttp()
+        ShadowLooper.idleMainLooper()
+
+        assertEquals("/api/opportunity/${job.jobUUID}/learn_progress", request.path)
+        assertEquals(
+            activity.getString(R.string.connect_sync_successful),
+            syncCard.findViewById<TextView>(R.id.sync_card_subtext).text.toString(),
+        )
+        assertEquals(
+            activity.getString(R.string.connect_sync_card_press_to_sync),
+            syncCard.findViewById<TextView>(R.id.sync_card_text).text.toString(),
+        )
+        assertEquals(
+            "a landed sync leaves no warning on the card",
+            ContextCompat.getColor(activity, R.color.connect_light_grey),
+            syncCard.strokeColorStateList?.defaultColor,
+        )
+    }
+
+    /**
+     * A successful learn-progress sync writes the opportunity and reads it back, so unlike the
+     * failure the other tests drive, the job has to exist in the database.
+     */
+    private fun seedLearningJob(): ConnectJobRecord {
+        val seeded = ConnectLearnJobTestData.job(completedModules = 1, assessmentScore = null)
+        ConnectJobUtils.storeJobs(ApplicationProvider.getApplicationContext(), listOf(seeded), true)
+        return ConnectJobUtils.getCompositeJob(ConnectLearnJobTestData.JOB_UUID)!!
     }
 
     private fun launch(job: ConnectJobRecord): ConnectLearningProgressFragment {

--- a/app/unit-tests/src/org/commcare/fragments/connect/ConnectLearningProgressFragmentTest.kt
+++ b/app/unit-tests/src/org/commcare/fragments/connect/ConnectLearningProgressFragmentTest.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Build
 import android.view.View
 import android.widget.TextView
-import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.test.core.app.ApplicationProvider
@@ -42,6 +41,7 @@ import org.commcare.views.connect.ConnectSuccessFailureCard
 import org.commcare.views.connect.ConnectSyncStatusCard
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -254,10 +254,7 @@ class ConnectLearningProgressFragmentTest {
         val syncCard = fragment.requireView().findViewById<ConnectSyncStatusCard>(R.id.learn_progress_sync_card)
 
         // The launch refresh fails, so the card starts out warning about the sync it could not make.
-        assertEquals(
-            ContextCompat.getColor(activity, R.color.burnt_amber),
-            syncCard.strokeColorStateList?.defaultColor,
-        )
+        assertTrue("a failed refresh leaves the card warning", syncCard.state.warning)
 
         mockApi.server.enqueue(
             MockResponse().setResponseCode(200).setBody("""{"completed_modules": [], "assessments": []}"""),
@@ -274,11 +271,7 @@ class ConnectLearningProgressFragmentTest {
             activity.getString(R.string.connect_sync_card_press_to_sync),
             syncCard.findViewById<TextView>(R.id.sync_card_text).text.toString(),
         )
-        assertEquals(
-            "a landed sync leaves no warning on the card",
-            ContextCompat.getColor(activity, R.color.connect_light_grey),
-            syncCard.strokeColorStateList?.defaultColor,
-        )
+        assertFalse("a landed sync leaves no warning on the card", syncCard.state.warning)
     }
 
     /**

--- a/app/unit-tests/src/org/commcare/views/connect/ConnectLearnProgressViewTest.kt
+++ b/app/unit-tests/src/org/commcare/views/connect/ConnectLearnProgressViewTest.kt
@@ -144,7 +144,7 @@ class ConnectLearnProgressViewTest {
         onCta: () -> Unit = {},
     ): ConnectLearnProgressView =
         ConnectLearnProgressView(context).also { view ->
-            view.bind(job) { onCta() }
+            view.bind(job, { onCta() }, {})
         }
 
     private fun ConnectLearnProgressView.text(id: Int) = findViewById<TextView>(id).text.toString()
@@ -364,7 +364,7 @@ class ConnectLearnProgressViewTest {
         val view = bind(inProgressJob(moduleOneId).withoutModuleIds())
         assertEquals(View.GONE, view.visibility(R.id.learn_progress_continue_card))
 
-        view.bind(inProgressJob(moduleOneId)) {}
+        view.bind(inProgressJob(moduleOneId), {}, {})
 
         assertEquals(View.VISIBLE, view.visibility(R.id.learn_progress_continue_heading))
         assertEquals(View.VISIBLE, view.visibility(R.id.learn_progress_continue_card))

--- a/app/unit-tests/src/org/commcare/views/connect/ConnectSyncStatusCardTest.kt
+++ b/app/unit-tests/src/org/commcare/views/connect/ConnectSyncStatusCardTest.kt
@@ -82,18 +82,6 @@ class ConnectSyncStatusCardTest {
     }
 
     @Test
-    fun `warning switches the card outline`() {
-        val card = newCard()
-
-        card.bind(ConnectSyncStatusCard.State(warning = true))
-
-        assertEquals(
-            ContextCompat.getColor(card.context, R.color.burnt_amber),
-            card.strokeColorStateList?.defaultColor,
-        )
-    }
-
-    @Test
     fun `the badge trails the status text`() {
         val card = newCard()
         val row = card.findViewById<ImageView>(R.id.sync_card_icon).parent as ViewGroup


### PR DESCRIPTION
### [CCCT-2791](https://dimagi.atlassian.net/browse/CCCT-2791)



https://github.com/user-attachments/assets/eb1f575f-748d-40b6-8db0-2647310ba92f


Whenever a sync fails:

<img width="200" height="445" alt="WIthout Orange Border In Warning" src="https://github.com/user-attachments/assets/03d53173-2e21-4cc1-993f-e6bbd5800350" />


## Product Description

A sync card now sits below the progress card on the learn and delivery progress screens. It shows when the opportunity last synced, and tapping it syncs again like the toolbar button.

## Technical Summary

The card does not track syncing itself — `BaseConnectFragment`'s existing sync handling reports each outcome it already drives the status bar with, so the card and the bar cannot disagree.

## Safety Assurance

### Safety story

**What gives confidence**

- I tested the learn and delivery screens manually on a device.
- Robolectric tests drive both cards through a real tap and sync.

### Automated test coverage

Tapping either card issues the refresh request; the learn test also covers the warning-to-green flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CCCT-2791]: https://dimagi.atlassian.net/browse/CCCT-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ