### PR TITLE
CCCT-2653 Remove CommCare Logo From PersonalID Screens

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,14 @@
 This file is meant as an easy way for us to collate notes and change logs across releases. 
 -->
 
+## CommCare 2.65
+
+### Release Notes
+
+#### What's New
+
+- The CommCare logo now appears only on the first screen of PersonalID sign-up and account recovery, rather than on every screen.
+
 ## CommCare 2.63.5
 
 ### Release Notes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,11 @@ This file is meant as an easy way for us to collate notes and change logs across
 
 - The CommCare logo now appears only on the first screen of PersonalID sign-up and account recovery, rather than on every screen.
 
+### QA Notes
+
+- Step through PersonalID sign-up and account recovery and verify the CommCare logo shows only on the phone number screen.
+  - Confirm the name screen's app bar title reads "Name" and not "App Lock".
+
 ## CommCare 2.63.5
 
 ### Release Notes

--- a/app/res/layout/fragment_personalid_email.xml
+++ b/app/res/layout/fragment_personalid_email.xml
@@ -12,16 +12,6 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <include layout="@layout/grid_header_top_banner" />
-
-        <View
-            android:id="@+id/divider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="40dp"
-            android:background="@color/connect_light_grey" />
-
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/res/layout/fragment_personalid_email_verification.xml
+++ b/app/res/layout/fragment_personalid_email_verification.xml
@@ -13,16 +13,6 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <include layout="@layout/grid_header_top_banner" />
-
-        <View
-            android:id="@+id/divider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="40dp"
-            android:background="@color/connect_light_grey" />
-
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/res/layout/fragment_personalid_send_email_otp.xml
+++ b/app/res/layout/fragment_personalid_send_email_otp.xml
@@ -11,15 +11,6 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <include layout="@layout/grid_header_top_banner" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="40dp"
-            android:background="@color/connect_light_grey" />
-
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/res/layout/fragment_recovery_code.xml
+++ b/app/res/layout/fragment_recovery_code.xml
@@ -14,16 +14,6 @@
             android:layout_width="match_parent"
             android:orientation="vertical">
 
-        <include layout="@layout/grid_header_top_banner"/>
-
-        <View
-            android:id="@+id/divider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="40dp"
-            android:background="@android:color/darker_gray" />
-
         <LinearLayout
             android:id="@+id/welcome_back_layout"
             android:layout_width="match_parent"

--- a/app/res/layout/screen_personalid_name.xml
+++ b/app/res/layout/screen_personalid_name.xml
@@ -16,16 +16,6 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <include layout="@layout/grid_header_top_banner"/>
-
-                <View
-                    android:id="@+id/divider"
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_marginHorizontal="20dp"
-                    android:layout_marginTop="40dp"
-                    android:background="@color/connect_light_grey" />
-
                 <TextView
                     android:id="@+id/name_fragment_subtitle"
                     android:layout_width="wrap_content"

--- a/app/res/layout/screen_personalid_phone_verify.xml
+++ b/app/res/layout/screen_personalid_phone_verify.xml
@@ -9,16 +9,6 @@
         android:background="@color/white"
         android:orientation="vertical">
 
-        <include layout="@layout/grid_header_top_banner"/>
-
-        <View
-            android:id="@+id/divider"
-            android:layout_width="fill_parent"
-            android:layout_height="1dp"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="40dp"
-            android:background="@color/connect_light_grey" />
-
         <TextView
             android:id="@+id/connect_phone_verify_title"
             android:layout_width="wrap_content"

--- a/app/res/layout/screen_personalid_photo_capture.xml
+++ b/app/res/layout/screen_personalid_photo_capture.xml
@@ -9,15 +9,6 @@
         android:background="@color/white"
         android:orientation="vertical">
 
-        <include layout="@layout/grid_header_top_banner"/>
-
-        <View
-            android:id="@+id/divider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginHorizontal="20dp"
-            android:background="@color/connect_light_grey" />
-
         <TextView
             android:id="@+id/title"
             android:layout_width="wrap_content"

--- a/app/res/values-es/strings.xml
+++ b/app/res/values-es/strings.xml
@@ -513,6 +513,7 @@
     <string name="connect_corrupt_job_text">No se pudo cargar esta oportunidad</string>
     <string name="personalid_login_via_connect">¡Listo para iniciar sesión!\n</string>
     <string name="personalid_failed_to_login_with_connectid">Estamos experimentando un error irrecuperable al iniciar sesión con tu PersonalId. Por favor, inicia sesión con tu contraseña o recupera tu PersonalId.</string>
+    <string name="personalid_name_appbar_title">Nombre</string>
     <string name="personalid_name_fragment_subtitle">Por favor, ingresa tu nombre tal como aparece en tu identificación emitida por el gobierno</string>
     <string name="personalid_configuration_process_failed_title">Proceso fallido</string>
     <string name="personalid_configuration_process_failed_subtitle">Lamentablemente, este dispositivo no pasó las comprobaciones de seguridad necesarias para registrarse en PersonalID. Por favor, inténtalo de nuevo en un dispositivo diferente.</string>

--- a/app/res/values-fr/strings.xml
+++ b/app/res/values-fr/strings.xml
@@ -512,6 +512,7 @@ License.
     <string name="connect_corrupt_job_text">Impossible de charger cette opportunité</string>
     <string name="personalid_login_via_connect">Prêt à vous connecter !\n</string>
     <string name="personalid_failed_to_login_with_connectid">Nous rencontrons une erreur irrécupérable lors de la connexion avec votre identifiant personnel. Veuillez vous connecter avec votre mot de passe ou restaurer votre identifiant personnel.</string>
+    <string name="personalid_name_appbar_title">Nom</string>
     <string name="personalid_name_fragment_subtitle">Veuillez saisir votre nom tel qu\'il apparaît sur votre pièce d\'identité émise par le gouvernement</string>
     <string name="personalid_configuration_process_failed_title">Échec du processus</string>
     <string name="personalid_configuration_locked_account">Votre compte a été bloqué. Veuillez contacter le support</string>

--- a/app/res/values-ha/strings.xml
+++ b/app/res/values-ha/strings.xml
@@ -352,6 +352,7 @@ Don cikakken aiki na wurin zama na aikace-aikace da yawa, da fatan za a yi sabon
     <string name="personalid_generic_error_title">An fita daga PersonalID</string>
     <string name="personalid_login_via_connect">A shirye don shiga!\n</string>
     <string name="personalid_failed_to_login_with_connectid">Muna fuskantar kuskuren da ba za a iya gyarawa ba yayin da muke haɗa shiga ta amfani da ID ɗinka na Sirri. Da fatan za a shiga da kalmar sirri ko a dawo da shiga ID ɗinka na Sirri</string>
+    <string name="personalid_name_appbar_title">Suna</string>
     <string name="personalid_name_fragment_subtitle">Da fatan za a shigar da sunanka kamar yadda ya bayyana a katin shaidar da gwamnati ta bayar</string>
     <string name="personalid_configuration_process_failed_title">Tsarin aiki ya gaza</string>
     <string name="personalid_configuration_locked_account">An kulle asusunka. Da fatan za a tuntuɓi tallafi</string>

--- a/app/res/values-hi/strings.xml
+++ b/app/res/values-hi/strings.xml
@@ -509,6 +509,7 @@ License.
     <string name="connect_corrupt_job_text">इस अवसर को लोड करने में असमर्थ</string>
     <string name="personalid_login_via_connect">लॉग इन करने के लिए तैयार!\n</string>
     <string name="personalid_failed_to_login_with_connectid">आपके व्यक्तिगत आईडी से लॉग इन करते समय हमें एक अप्राप्य त्रुटि का सामना करना पड़ रहा है। कृपया अपने पासवर्ड से लॉग इन करें या अपनी व्यक्तिगत आईडी पुनर्स्थापित करें।</string>
+    <string name="personalid_name_appbar_title">नाम</string>
     <string name="personalid_name_fragment_subtitle">कृपया अपना नाम दर्ज करें जैसा कि आपके सरकार द्वारा जारी आईडी पर दिखाई देता है</string>
     <string name="personalid_configuration_process_failed_title">प्रक्रिया विफल</string>
     <string name="personalid_configuration_process_failed_subtitle">दुर्भाग्य से, यह डिवाइस PersonalID के लिए साइन अप करने हेतु आवश्यक सुरक्षा जांच में विफल रहा। कृपया किसी दूसरे डिवाइस पर पुनः प्रयास करें।</string>

--- a/app/res/values-lt/strings.xml
+++ b/app/res/values-lt/strings.xml
@@ -189,6 +189,7 @@
     <string name="connect_backup_code_mismatch">Įvesti atsarginiai kodai turi sutapti.</string>
     <string name="personalid_network_response_parsing_error">Klaida analizuojant duomenis iš serverio. Jei problema išlieka, susisiekite su klientų aptarnavimo tarnyba.</string>
     <string name="personalid_email_appbar_title">El. paštas</string>
+    <string name="personalid_name_appbar_title">Vardas</string>
     <string name="personalid_email_title">Pridėkite savo el. paštą (neprivaloma)</string>
     <string name="personalid_email_description">Jūsų el. paštas padės atkurti paskyrą, jei prarasite prieigą prie telefono.</string>
     <string name="personalid_email_hint">El. pašto adresas</string>

--- a/app/res/values-no/strings.xml
+++ b/app/res/values-no/strings.xml
@@ -189,6 +189,7 @@
     <string name="connect_backup_code_mismatch">Reservekodene du taster inn, må stemme overens.</string>
     <string name="personalid_network_response_parsing_error">Feil ved lesing av data fra serveren. Kontakt kundestøtte.</string>
     <string name="personalid_email_appbar_title">E-post</string>
+    <string name="personalid_name_appbar_title">Navn</string>
     <string name="personalid_email_title">Legg til e-postadressen din (valgfritt)</string>
     <string name="personalid_email_description">E-postadressen din hjelper deg å gjenopprette kontoen din hvis du mister tilgang til telefonen.</string>
     <string name="personalid_email_hint">E-postadresse</string>

--- a/app/res/values-pt/strings.xml
+++ b/app/res/values-pt/strings.xml
@@ -519,6 +519,7 @@
     <string name="connect_results_summary_approved">Aprovado</string>
     <string name="personalid_login_via_connect">Pronto para fazer login!\n</string>
     <string name="personalid_failed_to_login_with_connectid">Estamos a deparar-nos com um erro irrecuperável ao tentar fazer login usando o seu ID Pessoal. Faça login com a sua palavra-passe ou restaure o seu login com o ID Pessoal.</string>
+    <string name="personalid_name_appbar_title">Nome</string>
     <string name="personalid_name_fragment_subtitle">Por favor, insira o seu nome tal como aparece na sua identificação emitida pelo governo</string>
     <string name="personalid_configuration_process_failed_title">Falha no processo</string>
     <string name="personalid_configuration_locked_account">A sua conta foi bloqueada. Entre em contacto com o suporte</string>

--- a/app/res/values-sw/strings.xml
+++ b/app/res/values-sw/strings.xml
@@ -518,6 +518,7 @@
     <string name="connect_corrupt_job_text">Imeshindwa kupakia fursa hii</string>
     <string name="personalid_login_via_connect">Tayari kuingia!\n</string>
     <string name="personalid_failed_to_login_with_connectid">Tunakabiliwa na hitilafu isiyoweza kurekebishwa wakati wa kuunganisha kuingia kwa kutumia Kitambulisho chako cha Kibinafsi. Tafadhali ingia na nenosiri lako au urejeshe kuingia kwa Kitambulisho chako cha Kibinafsi</string>
+    <string name="personalid_name_appbar_title">Jina</string>
     <string name="personalid_name_fragment_subtitle">Tafadhali ingiza jina lako jinsi linavyoonekana kwenye kitambulisho chako kilichotolewa na serikali</string>
     <string name="personalid_configuration_process_failed_title">Mchakato Umeshindwa</string>
     <string name="personalid_configuration_locked_account">Akaunti yako imefungwa. Tafadhali wasiliana na usaidizi</string>

--- a/app/res/values-ti/strings.xml
+++ b/app/res/values-ti/strings.xml
@@ -504,6 +504,7 @@
     <string name="connect_results_summary_approved">ጸዲቑ</string>
     <string name="personalid_login_via_connect">ንምእታው ድሉው!\n</string>
     <string name="personalid_failed_to_login_with_connectid">ውልቃዊ መለለዪ መንነትካ ተጠቒምካ ንምእታው ኣብ እንኣስረሉ እዋን ዘይምለስ ጌጋ የጋጥመና ኣሎ። በጃኻ ብፓስዎርድካ እቶ ወይ ድማ ውልቃዊ መለለዪ መእተዊኻ ምምላስ</string>
+    <string name="personalid_name_appbar_title">ስም</string>
     <string name="personalid_name_fragment_subtitle">በጃኹም ኣብቲ ብመንግስቲ ዝተዋህበኩም መለለዪ መንነትኩም ከም ዝረአ ስምኩም ኣእትዉ</string>
     <string name="personalid_configuration_process_failed_title">መስርሕ ፈሺሉ።</string>
     <string name="personalid_configuration_locked_account">ኣካውንትካ ተዓጽዩ ኣሎ። በጃኹም ንደገፍ ተወከሱ</string>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -791,6 +791,7 @@
     <string name="personalid_generic_error_title">Logged out of PersonalID</string>
     <string name="personalid_login_via_connect">Ready to login!\n</string>
     <string name="personalid_failed_to_login_with_connectid">We are facing an unrecoverable error when trying to login using your PersonalID. Please login with your password or restore your PersonalID login</string>
+    <string name="personalid_name_appbar_title">Name</string>
     <string name="personalid_name_fragment_subtitle">Please enter your name as it appears on your government-issued identification</string>
     <string name="personalid_configuration_process_failed_title">Process Failed</string>
     <string name="personalid_configuration_locked_account">Your account has been locked. Please contact support</string>

--- a/app/src/org/commcare/fragments/personalId/PersonalIdNameFragment.java
+++ b/app/src/org/commcare/fragments/personalId/PersonalIdNameFragment.java
@@ -19,6 +19,7 @@ import org.commcare.activities.connect.viewmodel.PersonalIdSessionDataViewModel;
 import org.commcare.android.database.connect.models.PersonalIdSessionData;
 import org.commcare.connect.network.base.PersonalIdOrConnectApiErrorHandler;
 import org.commcare.connect.network.personalId.PersonalIdApiHandler;
+import org.commcare.dalvik.R;
 import org.commcare.dalvik.databinding.ScreenPersonalidNameBinding;
 import org.commcare.google.services.analytics.FirebaseAnalyticsUtil;
 import org.commcare.utils.KeyboardHelper;
@@ -41,6 +42,7 @@ public class PersonalIdNameFragment extends BasePersonalIdFragment {
                 PersonalIdSessionDataViewModel.class).getPersonalIdSessionData();
 
         activity = requireActivity();
+        activity.setTitle(R.string.personalid_name_appbar_title);
         activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
         setListeners();
         setUpEnterKeyAction(binding.nameTextValue);


### PR DESCRIPTION
### [CCCT-2653](https://dimagi.atlassian.net/browse/CCCT-2653)

## Product Description

The CommCare logo now shows only on the phone number screen during PersonalID sign-up and account recovery.

<img width="200" alt="Screenshot_20260911-141003_CommCare Debug" src="https://github.com/user-attachments/assets/95d8e932-b448-441e-8c90-0cffcdfc0fe0" />
<img width="200" alt="Screenshot_20260911-141020_CommCare Debug" src="https://github.com/user-attachments/assets/72b304ee-4138-422e-acec-79a03b1372d5" />
<img width="200" alt="Screenshot_20260911-141027_CommCare Debug" src="https://github.com/user-attachments/assets/b1875e60-29e4-41d0-be99-d005dc3e13ee" />
<img width="200" alt="Screenshot_20260911-141034_CommCare Debug" src="https://github.com/user-attachments/assets/c2674baf-7f3b-49b0-84dc-f5edf2830e85" />
<img width="200" alt="Screenshot_20260911-141137_CommCare Debug" src="https://github.com/user-attachments/assets/8144dc5e-d1df-4e48-8ee0-b3f6c6d89468" />
<img width="200" alt="Screenshot_20260911-141048_CommCare Debug" src="https://github.com/user-attachments/assets/6fdd724e-c1e7-42cd-a150-5666f1689a02" />
<img width="200" alt="Screenshot_20260911-141223_CommCare Debug" src="https://github.com/user-attachments/assets/08bf9c90-c9b9-4e56-8b92-e5419476762f" />
<img width="200" alt="Screenshot_20260911-141055_CommCare Debug" src="https://github.com/user-attachments/assets/0c63481e-d1d9-45ed-bf15-e5b574b12fcd" />
<img width="200" alt="Screenshot_20260915-084109_CommCare Debug" src="https://github.com/user-attachments/assets/201140ee-6f15-412d-98dd-10e7e22b982f" />

## Technical Summary

Each screen's divider existed only to close off the banner, so both were removed together.

Also, the name fragment never set an app bar title, so it inherited the name "App Lock" from the biometric config page — a pre-existing bug fixed here.

## Safety Assurance

### Safety story

**What gives confidence**
- I stepped through every affected screen on a device.
- Layout-only change plus one title call; no logic touched.

**Risks to review**
- Non-English app bar titles for the name screen are machine-translated.

[CCCT-2653]: https://dimagi.atlassian.net/browse/CCCT-2653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ